### PR TITLE
Bump Rest/Spread Properties to Stage 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ES7+ Proposals follow [this process document](https://docs.google.com/document/d
 | | [Async Generator](https://github.com/jhusain/asyncgenerator) | Jafar Husain | 1 |
 | | [Trailing commas in function call expressions](https://github.com/tc39/tc39-notes/raw/master/es6/2014-09/trailing_comma_proposal.pdf) | Jeff Morrison | 1
 | | [ArrayBuffer.transfer](https://gist.github.com/lukewagner/2735af7eea411e18cf20) | Luke Wagneer & Allen Wirfs-Brock | 1
+|🚀| [Rest/Spread Properties](https://github.com/sebmarkbage/ecmascript-rest-spread) | Sebastian Markbage | 1
 |🚀| [Class and Property Decorators](https://github.com/wycats/javascript-decorators/blob/master/README.md) | Yehuda Katz and Jonathan Turner | 0 |
 | | [Defensible Classes](http://wiki.ecmascript.org/doku.php?id=strawman:defensible_classes) | Mark Miller & Doug Crockford | 0
 | | [Relationships](http://wiki.ecmascript.org/doku.php?id=strawman:relationships) | Mark Miller & Waldemar Horwat | 0
@@ -25,7 +26,6 @@ ES7+ Proposals follow [this process document](https://docs.google.com/document/d
 | | [Structured Clone](https://github.com/dslomov-chromium/ecmascript-structured-clone)       |Dmitry Lomov   |0
 | | [Weak References](http://wiki.ecmascript.org/doku.php?id=strawman:weakreferences) | Mark Miller & Dave Herman | 0
 |🚀| [Object.getOwnPropertyDescriptors](https://gist.github.com/WebReflection/9353781) | Rick Waldron & Andrea Giammarchi | 0
-| | [Rest/Spread Properties](https://github.com/sebmarkbage/ecmascript-rest-spread) | Sebastian Markbage | 0
 |🚀| [Set/Map.prototype.toJSON](https://github.com/DavidBruant/Map-Set.prototype.toJSON) | David Bruant ? | 0
 | | Annex B - HTML Attribute Event Handlers| Allen Wirfs-Brock | 0
 
@@ -40,7 +40,7 @@ If you are a TC39 member representative, just submit a pull request for your pro
 Ecma TC39 accepts Strawman Proposals from non-member individuals who have accepted the TC39 copyright and patent policies. Currently all ECMAScript related technical work is done by the TC39 RF TG (Royalty Free Task Group), for which the following IPR Policies apply:
 
   * [TC39 RF Patent Policy](http://www.ecma-international.org/memento/TC39%20policy/Ecma%20Experimental%20TC39%20Royalty-Free%20Patent%20Policy.pdf)
-  * [TC39 Software Copyright Policy](http://www.ecma-international.org/memento/TC39%20experimental%20policy.htm) 
+  * [TC39 Software Copyright Policy](http://www.ecma-international.org/memento/TC39%20experimental%20policy.htm)
 
 If you wish to submit a proposal and are not a representative of a TC39 member, here are the steps you need to take:
 


### PR DESCRIPTION
As per https://github.com/tc39/tc39-notes/blob/master/es6/2014-09/sept-25.md#58-object-rest-destructuring-and-spread-properties

Putting the rocket ship on it since it's possibly ready for Stage 2.