### PR TITLE
Bump Rest/Spread Properties to Stage 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ES7+ Proposals follow [this process document](https://docs.google.com/document/d
 |🚀| [function.next metaproperty](https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md) |  Allen Wirfs-Brock | 1
 |🚀| [Additional export-from Statements](https://github.com/leebyron/ecmascript-more-export-from)| Lee Byron | 1
 | | [Class and Property Decorators](https://github.com/wycats/javascript-decorators/blob/master/README.md) | Yehuda Katz and Jonathan Turner | 1 |
-| | [Rest/Spread Properties](https://github.com/sebmarkbage/ecmascript-rest-spread) | Sebastian Markbage | 0
+|🚀| [Rest/Spread Properties](https://github.com/sebmarkbage/ecmascript-rest-spread) | Sebastian Markbage | 1
 
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.


### PR DESCRIPTION
Rebase from original PR: https://github.com/tc39/ecma262/pull/14

As per https://github.com/tc39/tc39-notes/blob/master/es6/2014-09/sept-25.md#58-object-rest-destructuring-and-spread-properties

Putting the rocket ship on it since it's ready for Stage 2 at the next meeting.