### PR TITLE
Consolidate SameValueZero and Strict Equality Comparison steps to delegate to SameValue

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4074,21 +4074,13 @@
             1. ReturnIfAbrupt(_x_).
             1. ReturnIfAbrupt(_y_).
             1. If Type(_x_) is different from Type(_y_), return *false*.
-            1. If Type(_x_) is Undefined, return *true*.
-            1. If Type(_x_) is Null, return *true*.
             1. If Type(_x_) is Number, then
                 1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
                 1. If _x_ is *+0* and _y_ is *-0*, return *true*.
                 1. If _x_ is *-0* and _y_ is *+0*, return *true*.
                 1. If _x_ is the same Number value as _y_, return *true*.
                 1. Return *false*.
-            1. If Type(_x_) is String, then
-                1. If _x_ and _y_ are exactly the same sequence of code units (same length and same code units at corresponding indices) return *true*; otherwise, return *false*.
-            1. If Type(_x_) is Boolean, then
-                1. If _x_ and _y_ are both *true* or both *false*, return *true*; otherwise, return *false*.
-            1. If Type(_x_) is Symbol, then
-                1. If _x_ and _y_ are both the same Symbol value, return *true*; otherwise, return *false*.
-            1. Return *true* if _x_ and _y_ are the same Object value. Otherwise, return *false*.
+            1. Return SameValue(_x_, _y_).
           </emu-alg>
           <emu-note>
             <p>SameValueZero differs from SameValue only in its treatment of *+0* and *-0*.</p>
@@ -4170,8 +4162,6 @@
           <p>The comparison _x_ === _y_, where _x_ and _y_ are values, produces *true* or *false*. Such a comparison is performed as follows:</p>
           <emu-alg>
             1. If Type(_x_) is different from Type(_y_), return *false*.
-            1. If Type(_x_) is Undefined, return *true*.
-            1. If Type(_x_) is Null, return *true*.
             1. If Type(_x_) is Number, then
                 1. If _x_ is *NaN*, return *false*.
                 1. If _y_ is *NaN*, return *false*.
@@ -4179,15 +4169,7 @@
                 1. If _x_ is *+0* and _y_ is *-0*, return *true*.
                 1. If _x_ is *-0* and _y_ is *+0*, return *true*.
                 1. Return *false*.
-            1. If Type(_x_) is String, then
-                1. If _x_ and _y_ are exactly the same sequence of code units (same length and same code units at corresponding indices), return *true*.
-                1. Else, return *false*.
-            1. If Type(_x_) is Boolean, then
-                1. If _x_ and _y_ are both *true* or both *false*, return *true*.
-                1. Else, return *false*.
-            1. If _x_ and _y_ are the same Symbol value, return *true*.
-            1. If _x_ and _y_ are the same Object value, return *true*.
-            1. Return *false*.
+            1. Return SameValue(_x_, _y_).
           </emu-alg>
           <emu-note>
             <p>This algorithm differs from the SameValue Algorithm (<emu-xref href="#sec-samevalue"></emu-xref>) in its treatment of signed zeroes and NaNs.</p>

--- a/spec.html
+++ b/spec.html
@@ -4045,21 +4045,13 @@
             1. ReturnIfAbrupt(_x_).
             1. ReturnIfAbrupt(_y_).
             1. If Type(_x_) is different from Type(_y_), return *false*.
-            1. If Type(_x_) is Undefined, return *true*.
-            1. If Type(_x_) is Null, return *true*.
             1. If Type(_x_) is Number, then
                 1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
                 1. If _x_ is *+0* and _y_ is *-0*, return *false*.
                 1. If _x_ is *-0* and _y_ is *+0*, return *false*.
                 1. If _x_ is the same Number value as _y_, return *true*.
                 1. Return *false*.
-            1. If Type(_x_) is String, then
-                1. If _x_ and _y_ are exactly the same sequence of code units (same length and same code units at corresponding indices) return *true*; otherwise, return *false*.
-            1. If Type(_x_) is Boolean, then
-                1. If _x_ and _y_ are both *true* or both *false*, return *true*; otherwise, return *false*.
-            1. If Type(_x_) is Symbol, then
-                1. If _x_ and _y_ are both the same Symbol value, return *true*; otherwise, return *false*.
-            1. Return *true* if _x_ and _y_ are the same Object value. Otherwise, return *false*.
+            1. Return SameValueNonNumber(_x_, _y_).
           </emu-alg>
           <emu-note>
             <p>This algorithm differs from the Strict Equality Comparison Algorithm (<emu-xref href="#sec-strict-equality-comparison"></emu-xref>) in its treatment of signed zeroes and NaNs.</p>
@@ -4080,11 +4072,31 @@
                 1. If _x_ is *-0* and _y_ is *+0*, return *true*.
                 1. If _x_ is the same Number value as _y_, return *true*.
                 1. Return *false*.
-            1. Return SameValue(_x_, _y_).
+            1. Return SameValueNonNumber(_x_, _y_).
           </emu-alg>
           <emu-note>
             <p>SameValueZero differs from SameValue only in its treatment of *+0* and *-0*.</p>
           </emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-samevaluenonnumber" aoid="SameValueNonNumber">
+          <h1>SameValueNonNumber(x, y)</h1>
+          <p>The internal comparison abstract operation SameValueNonNumber(_x_, _y_), where _x_ and _y_ are non-number ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
+          <emu-alg>
+            1. ReturnIfAbrupt(_x_).
+            1. ReturnIfAbrupt(_y_).
+            1. Assert: Type(_x_) is not Number.
+            1. Assert: Type(_x_) is the same as Type(_y_).
+            1. If Type(_x_) is Undefined, return *true*.
+            1. If Type(_x_) is Null, return *true*.
+            1. If Type(_x_) is String, then
+                1. If _x_ and _y_ are exactly the same sequence of code units (same length and same code units at corresponding indices) return *true*; otherwise, return *false*.
+            1. If Type(_x_) is Boolean, then
+                1. If _x_ and _y_ are both *true* or both *false*, return *true*; otherwise, return *false*.
+            1. If Type(_x_) is Symbol, then
+                1. If _x_ and _y_ are both the same Symbol value, return *true*; otherwise, return *false*.
+            1. Return *true* if _x_ and _y_ are the same Object value. Otherwise, return *false*.
+          </emu-alg>
         </emu-clause>
 
         <!-- es6num="7.2.11" -->
@@ -4169,7 +4181,7 @@
                 1. If _x_ is *+0* and _y_ is *-0*, return *true*.
                 1. If _x_ is *-0* and _y_ is *+0*, return *true*.
                 1. Return *false*.
-            1. Return SameValue(_x_, _y_).
+            1. Return SameValueNonNumber(_x_, _y_).
           </emu-alg>
           <emu-note>
             <p>This algorithm differs from the SameValue Algorithm (<emu-xref href="#sec-samevalue"></emu-xref>) in its treatment of signed zeroes and NaNs.</p>


### PR DESCRIPTION
This avoids repeating a bunch of steps that actually *must* remain the same for backwards compatibility reasons. As new primitive types are added, this reduces the places these changes need to be added from 3 to 1.

Per brief discussion with @bterlson, it may be too soon to PR this, but I figured I'd write it up anyways. Please feel free to let it sit as long as necessary.