### PR TITLE
Add HostPromiseRejectionTracker

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34518,7 +34518,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
 
       <!-- es6num="25.4.1.7" -->
       <emu-clause id="sec-rejectpromise" aoid="RejectPromise">
-        <h1>RejectPromise ( _promise_, _reason_)</h1>
+        <h1>RejectPromise ( _promise_, _reason_ )</h1>
         <p>When the RejectPromise abstract operation is called with arguments _promise_ and _reason_ the following steps are taken:</p>
         <emu-alg>
           1. Assert: the value of _promise_'s [[PromiseState]] internal slot is `"pending"`.
@@ -34527,6 +34527,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           1. Set the value of _promise_'s [[PromiseFulfillReactions]] internal slot to *undefined*.
           1. Set the value of _promise_'s [[PromiseRejectReactions]] internal slot to *undefined*.
           1. Set the value of _promise_'s [[PromiseState]] internal slot to `"rejected"`.
+          1. If the value of _promise_'s [[PromiseIsHandled]] internal slot is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
           1. Return TriggerPromiseReactions(_reactions_, _reason_).
         </emu-alg>
       </emu-clause>
@@ -34540,6 +34541,29 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
             1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo;_reaction_, _argument_&raquo;).
           1. Return *undefined*.
         </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-host-promise-rejection-tracker" aoid="HostPromiseRejectionTracker">
+        <h1>HostPromiseRejectionTracker ( promise, operation )</h1>
+
+        <p>HostPromiseRejectionTracker is an implementation-defined abstract operation that allows host environments to track promise rejections.</p>
+
+        <p>An implementation of HostPromiseRejectionTracker must complete normally in all cases. The default implementation of HostPromiseRejectionTracker is to do nothing.</p>
+
+        <emu-note>
+          <p>HostPromiseRejectionTracker is called in two scenarios:</p>
+
+          <ul>
+            <li>When a promise is rejected without any handlers, it is called with its _operation_ argument set to `"reject"`.</li>
+            <li>When a handler is added to a rejected promise for the first time, it is called with its _operation_ argument set to `"handle"`.</li>
+          </ul>
+
+          <p>A typical implementation of HostPromiseRejectionTracker might try to notify developers of unhandled rejections, while also being careful to notify them if such previous notifications are later invalidated by new handlers being attached.</p>
+        </emu-note>
+
+        <emu-note>
+          <p>If _operation_ is `"handle"`, an implementation should not hold a reference to promise in a way that would interfere with garbage collection. An implementation may hold a reference to promise if operation is `"reject"`, since it is expected that rejections will be rare and not on hot code paths.</p>
+        </emu-note>
       </emu-clause>
     </emu-clause>
 
@@ -34597,10 +34621,11 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
-          1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%PromisePrototype%"`, &laquo;[[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]]&raquo; ).
+          1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%PromisePrototype%"`, &laquo;[[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]]&raquo; ).
           1. Set _promise_'s [[PromiseState]] internal slot to `"pending"`.
           1. Set _promise_'s [[PromiseFulfillReactions]] internal slot to a new empty List.
           1. Set _promise_'s [[PromiseRejectReactions]] internal slot to a new empty List.
+          1. Set _promise_'s [[PromiseIsHandled]] internal slot to *false*.
           1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promise_).
           1. Let _completion_ be Call(_executor_, *undefined*, &laquo;_resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]]&raquo;).
           1. If _completion_ is an abrupt completion, then
@@ -34861,7 +34886,9 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
             1. Else,
               1. Assert: The value of _promise_'s [[PromiseState]] internal slot is `"rejected"`.
               1. Let _reason_ be the value of _promise_'s [[PromiseResult]] internal slot.
+              1. If the value of _promise_'s [[PromiseIsHandled]] internal slot is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo;_rejectReaction_, _reason_&raquo;).
+              1. Set _promise_'s [[PromiseIsHandled]] internal slot to *true*.
             1. Return _resultCapability_.[[Promise]].
           </emu-alg>
         </emu-clause>
@@ -34920,6 +34947,14 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
             </td>
             <td>
               A List of PromiseReaction records to be processed when/if the promise transitions from the `"pending"` state to the `"rejected"` state.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[PromiseIsHandled]]
+            </td>
+            <td>
+              A boolean indicating whether the promise has ever had a fulfillment or rejection handler; used in unhandled rejection tracking.
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
This is a non-observable change that will allow HTML to provide events for tracking promise rejections, as outlined in https://github.com/domenic/unhandled-rejections-browser-spec.

On top of #75 for convenience.