### PR TITLE
Number, Boolean and String prototypes revert to ES5 semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23527,7 +23527,8 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.3.3" -->
     <emu-clause id="sec-properties-of-the-boolean-prototype-object">
       <h1>Properties of the Boolean Prototype Object</h1>
-      <p>The Boolean prototype object is the intrinsic object %BooleanPrototype%. The Boolean prototype object is an ordinary object. It is not a Boolean instance and does not have a [[BooleanData]] internal slot.</p>
+      <p>The Boolean prototype object is the intrinsic object %BooleanPrototype%.</p>
+      <p>The Boolean prototype object has a [[BooleanData]] internal slot with the value *false*.</p>
       <p>The value of the [[Prototype]] internal slot of the Boolean prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>The abstract operation <emu-formula>thisBooleanValue(_value_)</emu-formula> performs the following steps:</p>
       <emu-alg>
@@ -24232,7 +24233,8 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="20.1.3" -->
     <emu-clause id="sec-properties-of-the-number-prototype-object">
       <h1>Properties of the Number Prototype Object</h1>
-      <p>The Number prototype object is the intrinsic object %NumberPrototype%. The Number prototype object is an ordinary object. It is not a Number instance and does not have a [[NumberData]] internal slot.</p>
+      <p>The Number prototype object is the intrinsic object %NumberPrototype%.</p>
+      <p> The Number prototype object has a [[NumberData]] internal slot with the value *+0*.</p>
       <p>The value of the [[Prototype]] internal slot of the Number prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
       <p>The abstract operation <emu-formula>thisNumberValue(_value_)</emu-formula> performs the following steps:</p>
@@ -26832,7 +26834,8 @@ Date.parse(x.toLocaleString())
     <!-- es6num="21.1.3" -->
     <emu-clause id="sec-properties-of-the-string-prototype-object">
       <h1>Properties of the String Prototype Object</h1>
-      <p>The String prototype object is the intrinsic object %StringPrototype%. The String prototype object is itself an ordinary object. It is not a String instance and does not have a [[StringData]] internal slot.</p>
+      <p>The String prototype object is the intrinsic object %StringPrototype%.</p>
+      <p>The String prototype object has a [[StringData]] internal slot with the value *""*.</p>
       <p>The value of the [[Prototype]] internal slot of the String prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
       <p>The abstract operation <emu-formula>thisStringValue(_value_)</emu-formula> performs the following steps:</p>

--- a/spec.html
+++ b/spec.html
@@ -23527,8 +23527,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.3.3" -->
     <emu-clause id="sec-properties-of-the-boolean-prototype-object">
       <h1>Properties of the Boolean Prototype Object</h1>
-      <p>The Boolean prototype object is the intrinsic object %BooleanPrototype%.</p>
-      <p>The Boolean prototype object has a [[BooleanData]] internal slot with the value *false*.</p>
+      <p>The Boolean prototype object is the intrinsic object %BooleanPrototype%. The Boolean prototype object is an ordinary object. It has a [[BooleanData]] internal slot with the value *false*.</p>
       <p>The value of the [[Prototype]] internal slot of the Boolean prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>The abstract operation <emu-formula>thisBooleanValue(_value_)</emu-formula> performs the following steps:</p>
       <emu-alg>
@@ -24233,8 +24232,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="20.1.3" -->
     <emu-clause id="sec-properties-of-the-number-prototype-object">
       <h1>Properties of the Number Prototype Object</h1>
-      <p>The Number prototype object is the intrinsic object %NumberPrototype%.</p>
-      <p> The Number prototype object has a [[NumberData]] internal slot with the value *+0*.</p>
+      <p>The Number prototype object is the intrinsic object %NumberPrototype%. The Number prototype object is an ordinary object. It has a [[NumberData]] internal slot with the value *+0*.</p>
       <p>The value of the [[Prototype]] internal slot of the Number prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
       <p>The abstract operation <emu-formula>thisNumberValue(_value_)</emu-formula> performs the following steps:</p>
@@ -26834,8 +26832,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="21.1.3" -->
     <emu-clause id="sec-properties-of-the-string-prototype-object">
       <h1>Properties of the String Prototype Object</h1>
-      <p>The String prototype object is the intrinsic object %StringPrototype%.</p>
-      <p>The String prototype object has a [[StringData]] internal slot with the value *""*.</p>
+      <p>The String prototype object is the intrinsic object %StringPrototype%. The String prototype object is an ordinary object. It has a [[StringData]] internal slot with the value *""*.</p>
       <p>The value of the [[Prototype]] internal slot of the String prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
       <p>The abstract operation <emu-formula>thisStringValue(_value_)</emu-formula> performs the following steps:</p>

--- a/spec.html
+++ b/spec.html
@@ -23527,7 +23527,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.3.3" -->
     <emu-clause id="sec-properties-of-the-boolean-prototype-object">
       <h1>Properties of the Boolean Prototype Object</h1>
-      <p>The Boolean prototype object is the intrinsic object %BooleanPrototype%. The Boolean prototype object is an ordinary object. It has a [[BooleanData]] internal slot with the value *false*.</p>
+      <p>The Boolean prototype object is the intrinsic object %BooleanPrototype%. The Boolean prototype object is an ordinary object. The Boolean prototype is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</p>
       <p>The value of the [[Prototype]] internal slot of the Boolean prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>The abstract operation <emu-formula>thisBooleanValue(_value_)</emu-formula> performs the following steps:</p>
       <emu-alg>
@@ -24232,7 +24232,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="20.1.3" -->
     <emu-clause id="sec-properties-of-the-number-prototype-object">
       <h1>Properties of the Number Prototype Object</h1>
-      <p>The Number prototype object is the intrinsic object %NumberPrototype%. The Number prototype object is an ordinary object. It has a [[NumberData]] internal slot with the value *+0*.</p>
+      <p>The Number prototype object is the intrinsic object %NumberPrototype%. The Number prototype object is an ordinary object. The Number prototype is istelf a Number object; it has a [[NumberData]] internal slot with the value *+0*.</p>
       <p>The value of the [[Prototype]] internal slot of the Number prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
       <p>The abstract operation <emu-formula>thisNumberValue(_value_)</emu-formula> performs the following steps:</p>
@@ -26832,7 +26832,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="21.1.3" -->
     <emu-clause id="sec-properties-of-the-string-prototype-object">
       <h1>Properties of the String Prototype Object</h1>
-      <p>The String prototype object is the intrinsic object %StringPrototype%. The String prototype object is an ordinary object. It has a [[StringData]] internal slot with the value *""*.</p>
+      <p>The String prototype object is the intrinsic object %StringPrototype%. The String prototype object is an ordinary object. The String prototype is itself a String object; it has a [[StringData]] internal slot with the value *""*.</p>
       <p>The value of the [[Prototype]] internal slot of the String prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
       <p>The abstract operation <emu-formula>thisStringValue(_value_)</emu-formula> performs the following steps:</p>


### PR DESCRIPTION
At the August 2015 TC39 meeting, we came to consensus that, for web
compatibility reasons, the prototype of Number, Boolean and String
needed to act like in ES5, with [[NumberData]] of +0, etc. This
patch reverts ECMAScript to have those semantics.