### PR TITLE
Revert String.prototype.split's to ES5 behavior

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27390,7 +27390,7 @@ Date.parse(x.toLocaleString())
           1. ReturnIfAbrupt(_S_).
           1. Let _A_ be ArrayCreate(0).
           1. Let _lengthA_ be 0.
-          1. If _limit_ is *undefined*, let _lim_ = 2<sup>53</sup>-1; else let _lim_ = ToUint32(_limit_).
+          1. If _limit_ is *undefined*, let _lim_ = 2<sup>32</sup>-1; else let _lim_ = ToUint32(_limit_).
           1. ReturnIfAbrupt(_lim_).
           1. Let _s_ be the number of elements in _S_.
           1. Let _p_ = 0.

--- a/spec.html
+++ b/spec.html
@@ -27390,7 +27390,7 @@ Date.parse(x.toLocaleString())
           1. ReturnIfAbrupt(_S_).
           1. Let _A_ be ArrayCreate(0).
           1. Let _lengthA_ be 0.
-          1. If _limit_ is *undefined*, let _lim_ = 2<sup>53</sup>-1; else let _lim_ = ToLength(_limit_).
+          1. If _limit_ is *undefined*, let _lim_ = 2<sup>53</sup>-1; else let _lim_ = ToUint32(_limit_).
           1. ReturnIfAbrupt(_lim_).
           1. Let _s_ be the number of elements in _S_.
           1. Let _p_ = 0.


### PR DESCRIPTION
ES2015 changed the handling of the second argument to split()
to use ToLength for coercion, which causes problems for callers
that pass -1. As discussed at the July 2015 meeting, the committee
agreed to return to the ES5 behavior.

See https://bugs.ecmascript.org/show_bug.cgi?id=4432 for more details.