### PR TITLE
Fix ES6 completion reform

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14684,7 +14684,7 @@ a = b + c(d + e).print()
         1. Let _sl_ be the result of evaluating |StatementList|.
         1. ReturnIfAbrupt(_sl_).
         1. Let _s_ be the result of evaluating |StatementListItem|.
-        1. Return Completion(UpdateEmpty(_s_, _sl_.[[value]])).
+        1. Return Completion(UpdateEmpty(_s_, _sl_)).
       </emu-alg>
       <emu-note>
         <p>The value of a |StatementList| is the value of the last value producing item in the |StatementList|. For example, the following calls to the `eval` function all return the value 1:</p>
@@ -15563,9 +15563,7 @@ a = b + c(d + e).print()
           1. Let _stmtCompletion_ be the result of evaluating the first |Statement|.
         1. Else,
           1. Let _stmtCompletion_ be the result of evaluating the second |Statement|.
-        1. ReturnIfAbrupt(_stmtCompletion_).
-        1. If _stmtCompletion_.[[value]] is not ~empty~, return _stmtCompletion_.
-        1. Return NormalCompletion(*undefined*).
+        1. Return Completion(UpdateEmpty(_stmtCompletion_, *undefined*)).
       </emu-alg>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
@@ -15576,9 +15574,7 @@ a = b + c(d + e).print()
           1. Return NormalCompletion(*undefined*).
         1. Else,
           1. Let _stmtCompletion_ be the result of evaluating |Statement|.
-          1. ReturnIfAbrupt(_stmtCompletion_).
-          1. If _stmtCompletion_.[[value]] is not ~empty~, return _stmtCompletion_.
-          1. Return NormalCompletion(*undefined*).
+          1. Return Completion(UpdateEmpty(_stmtCompletion_, *undefined*)).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -16609,8 +16605,7 @@ a = b + c(d + e).print()
         1. Set the running execution context's LexicalEnvironment to _newEnv_.
         1. Let _C_ be the result of evaluating |Statement|.
         1. Set the running execution context's Lexical Environment to _oldEnv_.
-        1. If _C_.[[type]] is ~normal~ and _C_.[[value]] is ~empty~, return NormalCompletion(*undefined*).
-        1. Return Completion(_C_).
+        1. Return Completion(UpdateEmpty(_C_, *undefined*)).
       </emu-alg>
       <emu-note>
         <p>No matter how control leaves the embedded |Statement|, whether normally or by some form of abrupt completion or exception, the LexicalEnvironment is always restored to its former state.</p>


### PR DESCRIPTION
Fix oversights in ES6 completion reform, which messed up `if` and `with`. Also fix incorrect usage of completion values in a couple of cases. Addresses the following bug reports:

https://bugs.ecmascript.org/show_bug.cgi?id=4540
https://bugs.ecmascript.org/show_bug.cgi?id=4541