### PR TITLE
Remove unnecessary ReturnIfAbrupt calls

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4552,7 +4552,6 @@
         1. ReturnIfAbrupt(_obj_).
         1. If _method_ was not passed, then
           1. Let _method_ be GetMethod(_obj_, @@iterator).
-          1. ReturnIfAbrupt(_method_).
         1. Let _iterator_ be Call(_method_,_obj_).
         1. ReturnIfAbrupt(_iterator_).
         1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
@@ -7149,7 +7148,6 @@ if (!visited.has(protoName)) yield protoName;
           1. Else,
             1. NOTE mapped argument object is only provided for non-strict functions that don't have a rest parameter, any parameter default value initializers, or any destructured parameters .
             1. Let _ao_ be CreateMappedArgumentsObject(_func_, _formals_, _argumentsList_, _env_).
-          1. ReturnIfAbrupt(_ao_).
           1. If _strict_ is *true*, then
             1. Let _status_ be _envRec_.CreateImmutableBinding(`"arguments"`).
           1. Else,
@@ -7188,7 +7186,7 @@ if (!visited.has(protoName)) yield protoName;
               1. If _n_ is not an element of _parameterNames_ or if _n_ is an element of _functionNames_, let _initialValue_ be *undefined*.
               1. else,
                 1. Let _initialValue_ be _envRec_.GetBindingValue(_n_, *false*).
-                1. ReturnIfAbrupt(_initialValue_).
+                1. Assert: _initialValue_ is never an abrupt completion.
               1. Call _varEnvRec_.InitializeBinding(_n_, _initialValue_).
               1. NOTE vars whose names are the same as a formal parameter, initially have the same value as the corresponding initialized parameter.
         1. NOTE: Annex <emu-xref href="#sec-web-compat-functiondeclarationinstantiation"></emu-xref> adds additional steps at this point.
@@ -11387,7 +11385,6 @@ a = b + c(d + e).print()
         <emu-alg>
           1. Let _propName_ be StringValue of |IdentifierReference|.
           1. Let _exprValue_ be the result of evaluating |IdentifierReference|.
-          1. ReturnIfAbrupt(_exprValue_).
           1. Let _propValue_ be GetValue(_exprValue_).
           1. ReturnIfAbrupt(_propValue_).
           1. Assert: _enumerable_ is *true*.


### PR DESCRIPTION
Fixes
https://bugs.ecmascript.org/show_bug.cgi?id=4445
https://bugs.ecmascript.org/show_bug.cgi?id=4460
https://bugs.ecmascript.org/show_bug.cgi?id=4461
https://bugs.ecmascript.org/show_bug.cgi?id=4475

The ReturnIfAbrupt after GetBindingValue is the only where an explicit assertion makes sense.