### PR TITLE
Set parameter map before calling [[DefineOwnProperty]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7770,6 +7770,8 @@ if (!visited.has(protoName)) yield protoName;
           1. Set the remainder of _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set the [[Prototype]] internal slot of _obj_ to %ObjectPrototype%.
           1. Set the [[Extensible]] internal slot of _obj_ to *true*.
+          1. Let _map_ be ObjectCreate(*null*).
+          1. Set the [[ParameterMap]] internal slot of _obj_ to _map_.
           1. Let _parameterNames_ be the BoundNames of _formals_.
           1. Let _numberOfParameters_ be the number of elements in _parameterNames_
           1. Let _index_ be 0.
@@ -7778,7 +7780,6 @@ if (!visited.has(protoName)) yield protoName;
             1. Perform CreateDataProperty(_obj_, ToString(_index_), _val_).
             1. Let _index_ be _index_ + 1
           1. Perform DefinePropertyOrThrow(_obj_, `"length"`, PropertyDescriptor{[[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
-          1. Let _map_ be ObjectCreate(*null*).
           1. Let _mappedNames_ be an empty List.
           1. Let _index_ be _numberOfParameters_ - 1.
           1. Repeat while _index_ &ge; 0 ,
@@ -7788,9 +7789,8 @@ if (!visited.has(protoName)) yield protoName;
               1. If _index_ &lt; _len_, then
                 1. Let _g_ be MakeArgGetter(_name_, _env_).
                 1. Let _p_ be MakeArgSetter(_name_, _env_).
-                1. Call _map_.[[DefineOwnProperty]](ToString(_index_), PropertyDescriptor{[[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
+                1. Perform _map_.[[DefineOwnProperty]](ToString(_index_), PropertyDescriptor{[[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
             1. Let _index_ be _index_ - 1
-          1. Set the [[ParameterMap]] internal slot of _obj_ to _map_.
           1. Perform DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor {[[Value]]:%ArrayProto_values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
           1. Perform DefinePropertyOrThrow(_obj_, `"callee"`, PropertyDescriptor {[[Value]]: _func_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
           1. Assert: the above property definitions will not produce an abrupt completion.


### PR DESCRIPTION
Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4466

Also piggybacked the change for https://bugs.ecmascript.org/show_bug.cgi?id=4468