### PR TITLE
Handle HoistableDeclaration uniformly in static semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14523,8 +14523,7 @@ a = b + c(d + e).print()
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
-          1. If |HoistableDeclaration| is <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar> , return &laquo; &raquo;.
-          1. If |HoistableDeclaration| is <emu-grammar>HoistableDeclaration : GeneratorDeclaration</emu-grammar> , return &laquo; &raquo;.
+          1. Return &laquo; &raquo;.
         1. Return the BoundNames of |Declaration|.
       </emu-alg>
       <emu-note>
@@ -14553,8 +14552,7 @@ a = b + c(d + e).print()
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
-          1. If |HoistableDeclaration| is <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar> , return &laquo; &raquo;.
-          1. If |HoistableDeclaration| is <emu-grammar>HoistableDeclaration : GeneratorDeclaration</emu-grammar> , return &laquo; &raquo;.
+          1. Return &laquo; &raquo;.
         1. Return a new List containing |Declaration|.
       </emu-alg>
     </emu-clause>
@@ -14576,8 +14574,7 @@ a = b + c(d + e).print()
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
-          1. If |HoistableDeclaration| is <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar> , return the BoundNames of |FunctionDeclaration|.
-          1. If |HoistableDeclaration| is <emu-grammar>HoistableDeclaration : GeneratorDeclaration</emu-grammar> , return the BoundNames of |GeneratorDeclaration|.
+          1. Return the BoundNames of |HoistableDeclaration|.
         1. Return a new empty List.
       </emu-alg>
       <emu-grammar>StatementListItem : Statement</emu-grammar>
@@ -14612,8 +14609,8 @@ a = b + c(d + e).print()
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
-          1. If |HoistableDeclaration| is <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar> , return &laquo; |FunctionDeclaration| &raquo;.
-          1. If |HoistableDeclaration| is <emu-grammar>HoistableDeclaration : GeneratorDeclaration</emu-grammar> , return &laquo; |GeneratorDeclaration| &raquo;.
+          1. Let _declaration_ be DeclarationPart of |HoistableDeclaration|.
+          1. Return &laquo; _declaration_ &raquo;.
         1. Return a new empty List.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
HoistableDeclaration implies the declaration is not lexical at top-level, therefore it is not necessary to special case each concrete HoistableDeclaration in 13.2.7 - 13.2.10.

Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4480