### PR TITLE
Remove unused HasInitializer definitions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17840,19 +17840,6 @@ a = b + c(d + e).print()
     <emu-clause id="sec-function-definitions-static-semantics-hasinitializer">
       <h1>Static Semantics: HasInitializer</h1>
       <emu-see-also-para op="HasInitializer"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>FormalParameterList : FunctionRestParameter</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>FormalParameterList : FormalsList `,` FunctionRestParameter</emu-grammar>
-      <emu-alg>
-        1. If HasInitializer of |FormalsList| is *true*, return *true*.
-        1. Return *false*.
-      </emu-alg>
       <emu-grammar>FormalsList : FormalsList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. If HasInitializer of |FormalsList| is *true*, return *true*.


### PR DESCRIPTION
HasInitializer is only called with FormalsList or FormalParameter=BindingElement, therefore HasInitializer definitions for FormalParameters and FormalParameterList can be removed.

Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4485