### PR TITLE
Remove unnecessary early error restriction in ArrowFunction

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18162,9 +18162,6 @@ a = b + c(d + e).print()
           It is a Syntax Error if |ArrowParameters| Contains |YieldExpression| is *true*.
         </li>
         <li>
-          It is a Syntax Error if |ConciseBody| Contains |YieldExpression| is *true*.
-        </li>
-        <li>
           It is a Syntax Error if any element of the BoundNames of |ArrowParameters| also occurs in the LexicallyDeclaredNames of |ConciseBody|.
         </li>
       </ul>


### PR DESCRIPTION
YieldExpression cannot appear in ConciseBody, because ConciseBody does not have a [Yield] grammar production parameter.

Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4488