### PR TITLE
Remove unused static and runtime semantics for arrow functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18205,7 +18205,7 @@ a = b + c(d + e).print()
         1. Return |ConciseBody| Contains _symbol_ .
       </emu-alg>
       <emu-note>
-        <p>Normally, Contains does not look inside most function forms However, Contains is used to detect `new.target`, `this`, and `super` usage within an |ArrowFunction|.</p>
+        <p>Normally, Contains does not look inside most function forms. However, Contains is used to detect `new.target`, `this`, and `super` usage within an |ArrowFunction|.</p>
       </emu-note>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
@@ -18222,11 +18222,6 @@ a = b + c(d + e).print()
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return ContainsExpression of _formals_.
-      </emu-alg>
     </emu-clause>
 
     <!-- es6num="14.2.5" -->
@@ -18236,26 +18231,6 @@ a = b + c(d + e).print()
       <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return 1.
-      </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return the ExpectedArgumentCount of _formals_.
-      </emu-alg>
-    </emu-clause>
-
-    <!-- es6num="14.2.6" -->
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-hasinitializer">
-      <h1>Static Semantics: HasInitializer</h1>
-      <emu-see-also-para op="HasInitializer"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return HasInitializer of _formals_.
       </emu-alg>
     </emu-clause>
 
@@ -18277,11 +18252,6 @@ a = b + c(d + e).print()
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return IsSimpleParameterList of _formals_.
-      </emu-alg>
     </emu-clause>
 
     <!-- es6num="14.2.9" -->
@@ -18289,7 +18259,7 @@ a = b + c(d + e).print()
       <h1>Static Semantics: CoveredFormalsList</h1>
       <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
-        1. Return |BindingIdentifier|.
+        1. Return this |ArrowParameters|.
       </emu-alg>
       <emu-grammar>
         CoverParenthesizedExpressionAndArrowParameterList[Yield] :
@@ -18365,11 +18335,6 @@ a = b + c(d + e).print()
           1. ReturnIfAbrupt(_v_).
         1. If _iteratorRecord_.[[done]] is *true*, let _v_ be *undefined*.
         1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
-      </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return the result of performing IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Remove unused ContainsExpression, ExpectedArgumentCount, HasInitializer,
IsSimpleParameterList and IteratorBindingInitialization definitions for
'ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList'.

Change CoveredFormalsList of 'ArrowParameters : BindingIdentifier' to return
ArrowParameters to avoid creating additional ContainsExpression,
ExpectedArgumentCount, IsSimpleParameterList and IteratorBindingInitialization
definitions for 'BindingIdentifier : Identifier' and 'BindingIdentifier : yield'.

Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4490