### PR TITLE
Remove explicit 'yield' in early errors of ExportDeclaration

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21388,7 +21388,7 @@ a = b + c(d + e).print()
         <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
         <ul>
           <li>
-            For each |IdentifierName| _n_ in ReferencedBindings of |ExportClause|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or if the StringValue of _n_ is one of: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, `"static"`, or `"yield"`.
+            For each |IdentifierName| _n_ in ReferencedBindings of |ExportClause|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or if the StringValue of _n_ is one of: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, or `"static"`.
           </li>
         </ul>
         <emu-note>


### PR DESCRIPTION
'yield' is already handled in:
  It is a Syntax Error if StringValue of n is a ReservedWord [...]

Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4502