### PR TITLE
Prevent storing -0 in [[ByteOffset]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31863,6 +31863,7 @@ Date.parse(x.toLocaleString())
           1. Let _offset_ be ToInteger(_byteOffset_).
           1. ReturnIfAbrupt(_offset_).
           1. If _offset_ &lt; 0, throw a *RangeError* exception.
+          1. If _offset_ is -0, let _offset_ be +0.
           1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be the value of _buffer_'s [[ArrayBufferByteLength]] internal slot.


### PR DESCRIPTION
Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4544