### PR TITLE
Fix style violations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2733,7 +2733,7 @@
           1. Let _base_ be GetBase(_V_).
           1. If IsUnresolvableReference(_V_), then
             1. If IsStrictReference(_V_) is *true*, then
-              1. Throw *ReferenceError* exception.
+              1. Throw a *ReferenceError* exception.
             1. Let _globalObj_ be GetGlobalObject().
             1. Return Set(_globalObj_,GetReferencedName(_V_), _W_, *false*).
           1. Else if IsPropertyReference(_V_), then
@@ -3439,7 +3439,7 @@
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
         1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
-        1. If _int32bit_ &ge; 2<sup>31</sup>, return _int32bit_ - 2<sup>32</sup>, otherwise return _int32bit_.
+        1. If _int32bit_ &ge; 2<sup>31</sup>, return _int32bit_ - 2<sup>32</sup>; otherwise return _int32bit_.
       </emu-alg>
       <emu-note>
         <p>Given the above definition of ToInt32:</p>
@@ -3498,7 +3498,7 @@
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
         1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
-        1. If _int16bit_ &ge; 2<sup>15</sup>, return _int16bit_ - 2<sup>16</sup>, otherwise return _int16bit_.
+        1. If _int16bit_ &ge; 2<sup>15</sup>, return _int16bit_ - 2<sup>16</sup>; otherwise return _int16bit_.
       </emu-alg>
     </emu-clause>
 
@@ -3537,7 +3537,7 @@
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
         1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
-        1. If _int8bit_ &ge; 2<sup>7</sup>, return _int8bit_ - 2<sup>8</sup>, otherwise return _int8bit_.
+        1. If _int8bit_ &ge; 2<sup>7</sup>, return _int8bit_ - 2<sup>8</sup>; otherwise return _int8bit_.
       </emu-alg>
     </emu-clause>
 
@@ -4065,7 +4065,7 @@
         1. If Type(_x_) is Undefined, return *true*.
         1. If Type(_x_) is Null, return *true*.
         1. If Type(_x_) is String, then
-          1. If _x_ and _y_ are exactly the same sequence of code units (same length and same code units at corresponding indices) return *true*; otherwise, return *false*.
+          1. If _x_ and _y_ are exactly the same sequence of code units (same length and same code units at corresponding indices), return *true*; otherwise, return *false*.
         1. If Type(_x_) is Boolean, then
           1. If _x_ and _y_ are both *true* or both *false*, return *true*; otherwise, return *false*.
         1. If Type(_x_) is Symbol, then
@@ -4856,14 +4856,14 @@
           <emu-alg>
             1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. If _envRec_ does not have a binding for _N_, then
-              1. If _S_ is *true* throw a *ReferenceError* exception.
+              1. If _S_ is *true*, throw a *ReferenceError* exception.
               1. Perform _envRec_.CreateMutableBinding(_N_, *true*).
               1. Perform _envRec_.InitializeBinding(_N_, _V_).
               1. Return NormalCompletion(~empty~).
             1. If the binding for _N_ in _envRec_ is a strict binding, let _S_ be *true*.
-            1. If the binding for _N_ in _envRec_ has not yet been initialized throw a *ReferenceError* exception.
+            1. If the binding for _N_ in _envRec_ has not yet been initialized, throw a *ReferenceError* exception.
             1. Else if the binding for _N_ in _envRec_ is a mutable binding, change its bound value to _V_.
-            1. Else this must be an attempt to change the value of an immutable binding so if _S_ is *true* throw a *TypeError* exception.
+            1. Else this must be an attempt to change the value of an immutable binding so if _S_ is *true*, throw a *TypeError* exception.
             1. Return NormalCompletion(~empty~).
           </emu-alg>
           <emu-note>
@@ -4958,11 +4958,11 @@ function f(){eval("var x; x = (delete x, 0);")}
       <!-- es6num="8.1.1.2.2" -->
       <emu-clause id="sec-object-environment-records-createmutablebinding-n-d">
         <h1>CreateMutableBinding (_N_, _D_)</h1>
-        <p>The concrete Environment Record method CreateMutableBinding for object Environment Records creates in an Environment Record's associated binding object a property whose name is the String value and initializes it to the value *undefined*. If Boolean argument _D_ is provided and has the value *true* the new property's [[Configurable]] attribute is set to *true*, otherwise it is set to *false*.</p>
+        <p>The concrete Environment Record method CreateMutableBinding for object Environment Records creates in an Environment Record's associated binding object a property whose name is the String value and initializes it to the value *undefined*. If Boolean argument _D_ is provided and has the value *true* the new property's [[Configurable]] attribute is set to *true*; otherwise it is set to *false*.</p>
         <emu-alg>
           1. Let _envRec_ be the object Environment Record for which the method was invoked.
           1. Let _bindings_ be the binding object for _envRec_.
-          1. If _D_ is *true* then let _configValue_ be *true* otherwise let _configValue_ be *false*.
+          1. If _D_ is *true*, let _configValue_ be *true*; otherwise let _configValue_ be *false*.
           1. Return DefinePropertyOrThrow(_bindings_, _N_, PropertyDescriptor{[[Value]]:*undefined*, [[Writable]]: *true*, [[Enumerable]]: *true* , [[Configurable]]: _configValue_}).
         </emu-alg>
         <emu-note>
@@ -5012,7 +5012,7 @@ function f(){eval("var x; x = (delete x, 0);")}
           1. Let _value_ be HasProperty(_bindings_, _N_).
           1. ReturnIfAbrupt(_value_).
           1. If _value_ is *false*, then
-            1. If _S_ is *false*, return the value *undefined*, otherwise throw a *ReferenceError* exception.
+            1. If _S_ is *false*, return the value *undefined*; otherwise throw a *ReferenceError* exception.
           1. Return Get(_bindings_, _N_).
         </emu-alg>
       </emu-clause>
@@ -5760,7 +5760,7 @@ function f(){eval("var x; x = (delete x, 0);")}
           1. ReturnIfAbrupt(_exists_).
           1. If _exists_ is *true*, then
             1. Return a value of type Reference whose base value is _envRec_, whose referenced name is _name_, and whose strict reference flag is _strict_.
-          1. Else
+          1. Else,
             1. Let _outer_ be the value of _lex_'s outer environment reference.
             1. Return GetIdentifierReference(_outer_, _name_, _strict_).
         </emu-alg>
@@ -6422,7 +6422,7 @@ function f(){eval("var x; x = (delete x, 0);")}
           1. Let _X_ be _O_'s own property whose key is _P_.
           1. If _X_ is a data property, then
             1. Set _D_.[[Value]] to the value of _X_'s [[Value]] attribute.
-            1. Set _D_.[[Writable]] to the value of _X_'s [[Writable]] attribute
+            1. Set _D_.[[Writable]] to the value of _X_'s [[Writable]] attribute.
           1. Else _X_ is an accessor property, so
             1. Set _D_.[[Get]] to the value of _X_'s [[Get]] attribute.
             1. Set _D_.[[Set]] to the value of _X_'s [[Set]] attribute.
@@ -6880,10 +6880,10 @@ if (!visited.has(protoName)) yield protoName;
           1. Let _calleeRealm_ be the value of _F_'s [[Realm]] internal slot.
           1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
           1. If _thisMode_ is ~strict~, let _thisValue_ be _thisArgument_.
-          1. Else
+          1. Else,
             1. If _thisArgument_ is *null* or *undefined*, then
               1. Let _thisValue_ be _calleeRealm_.[[globalThis]].
-            1. Else
+            1. Else,
               1. Let _thisValue_ be ToObject(_thisArgument_).
               1. Assert: _thisValue_ is not an abrupt completion.
               1. NOTE ToObject produces wrapper objects using _calleeRealm_.
@@ -7652,7 +7652,7 @@ if (!visited.has(protoName)) yield protoName;
           1. If IsDataDescriptor(_desc_) is *true* and _P_ is `"caller"` and _desc_.[[Value]] is a strict mode Function object, throw a *TypeError* exception.
           1. Return _desc_.
         </emu-alg>
-        <p>If an implementation does not provide a built-in `caller` property for argument exotic objects then step 8 of this algorithm is must be skipped.</p>
+        <p>If an implementation does not provide a built-in `caller` property for argument exotic objects then step 8 of this algorithm must be skipped.</p>
       </emu-clause>
 
       <!-- es6num="9.4.4.2" -->
@@ -7669,7 +7669,7 @@ if (!visited.has(protoName)) yield protoName;
           1. If the value of _isMapped_ is *true*, then
             1. If IsAccessorDescriptor(_Desc_) is *true*, then
               1. Call _map_.[[Delete]](_P_).
-            1. Else
+            1. Else,
               1. If _Desc_.[[Value]] is present, then
                 1. Let _setStatus_ be Set(_map_, _P_, _Desc_.[[Value]], *false*).
                 1. Assert: _setStatus_ is *true* because formal parameters mapped by argument objects are always writable.
@@ -10792,7 +10792,7 @@ a = b + c(d + e).print()
             1. Let _env_ be the EnvironmentRecord component of _environment_.
             1. Perform _env_.InitializeBinding(_name_, _value_).
             1. Return NormalCompletion(*undefined*).
-          1. Else
+          1. Else,
             1. Let _lhs_ be ResolveBinding(_name_).
             1. Return PutValue(_lhs_, _value_).
         </emu-alg>
@@ -13668,7 +13668,7 @@ a = b + c(d + e).print()
         1. If _lval_ is *true*, then
           1. Let _trueRef_ be the result of evaluating the first |AssignmentExpression|.
           1. Return GetValue(_trueRef_).
-        1. Else
+        1. Else,
           1. Let _falseRef_ be the result of evaluating the second |AssignmentExpression|.
           1. Return GetValue(_falseRef_).
       </emu-alg>
@@ -14018,7 +14018,7 @@ a = b + c(d + e).print()
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
             1. ReturnIfAbrupt(_next_).
             1. If _next_ is *false*, set _iteratorRecord_.[[done]] to *true*.
-            1. Else
+            1. Else,
               1. Let _value_ be IteratorValue(_next_).
               1. If _value_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
               1. ReturnIfAbrupt(_value_).
@@ -15322,7 +15322,7 @@ a = b + c(d + e).print()
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
             1. ReturnIfAbrupt(_next_).
             1. If _next_ is *false*, set _iteratorRecord_.[[done]] to *true*.
-            1. Else
+            1. Else,
               1. Let _v_ be IteratorValue(_next_).
               1. If _v_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
               1. ReturnIfAbrupt(_v_).
@@ -15340,7 +15340,7 @@ a = b + c(d + e).print()
           1. Let _A_ be ArrayCreate(0).
           1. Let _n_=0.
           1. Repeat,
-            1. If _iteratorRecord_.[[done]] is *false*,
+            1. If _iteratorRecord_.[[done]] is *false*, then
               1. Let _next_ be IteratorStep(_iteratorRecord_.[[iterator]]).
               1. If _next_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
               1. ReturnIfAbrupt(_next_).
@@ -16320,7 +16320,7 @@ a = b + c(d + e).print()
             1. If _lhsKind_ is either ~assignment~ or ~varBinding~, then
               1. If _destructuring_ is *false*, then
                 1. Let _lhsRef_ be the result of evaluating _lhs_ ( it may be evaluated repeatedly).
-            1. Else
+            1. Else,
               1. Assert: _lhsKind_ is ~lexicalBinding~.
               1. Assert: _lhs_ is a |ForDeclaration|.
               1. Let _iterationEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -17590,7 +17590,7 @@ a = b + c(d + e).print()
         1. If an implementation defined debugging facility is available and enabled, then
           1. Perform an implementation defined debugging action.
           1. Let _result_ be an implementation defined Completion value.
-        1. Else
+        1. Else,
           1. Let _result_ be NormalCompletion(~empty~).
         1. Return _result_.
       </emu-alg>
@@ -18299,8 +18299,8 @@ a = b + c(d + e).print()
           `(` Expression `,` `...` BindingIdentifier `)`
       </emu-grammar>
       <emu-alg>
-        1. If the <sub>[Yield]</sub> grammar parameter is present for |CoverParenthesizedExpressionAndArrowParameterList[Yield]| return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList[Yield]| using |ArrowFormalParameters[Yield]| as the goal symbol.
-        1. If the <sub>[Yield]</sub> grammar parameter is not present for |CoverParenthesizedExpressionAndArrowParameterList[Yield]| return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList| using |ArrowFormalParameters| as the goal symbol.
+        1. If the <sub>[Yield]</sub> grammar parameter is present for |CoverParenthesizedExpressionAndArrowParameterList[Yield]|, return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList[Yield]| using |ArrowFormalParameters[Yield]| as the goal symbol.
+        1. If the <sub>[Yield]</sub> grammar parameter is not present for |CoverParenthesizedExpressionAndArrowParameterList[Yield]|, return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList| using |ArrowFormalParameters| as the goal symbol.
       </emu-alg>
     </emu-clause>
 
@@ -18359,7 +18359,7 @@ a = b + c(d + e).print()
         1. If _next_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
         1. ReturnIfAbrupt(_next_).
         1. If _next_ is *false*, set _iteratorRecord_.[[done]] to *true*.
-        1. Else
+        1. Else,
           1. Let _v_ be IteratorValue(_next_).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[done]] to *true*.
           1. ReturnIfAbrupt(_v_).
@@ -19102,7 +19102,7 @@ a = b + c(d + e).print()
       <emu-alg>
         1. If _symbol_ is |ClassBody|, return *true*.
         1. If _symbol_ is |ClassHeritage|, then
-          1. If |ClassHeritage| is present, return *true* otherwise return *false*.
+          1. If |ClassHeritage| is present, return *true*; otherwise return *false*.
         1. Let _inHeritage_ be |ClassHeritage| Contains _symbol_.
         1. If _inHeritage_ is *true*, return *true*.
         1. Return the result of ComputedPropertyContains for |ClassBody| with argument _symbol_.
@@ -19277,7 +19277,7 @@ a = b + c(d + e).print()
         1. If |ClassHeritage_opt| is not present, then
           1. Let _protoParent_ be the intrinsic object %ObjectPrototype%.
           1. Let _constructorParent_ be the intrinsic object %FunctionPrototype%.
-        1. Else
+        1. Else,
           1. Set the running execution context's LexicalEnvironment to _classScope_.
           1. Let _superclass_ be the result of evaluating |ClassHeritage|.
           1. Set the running execution context's LexicalEnvironment to _lex_.
@@ -19286,7 +19286,7 @@ a = b + c(d + e).print()
             1. Let _protoParent_ be *null*.
             1. Let _constructorParent_ be the intrinsic object %FunctionPrototype%.
           1. Else if IsConstructor(_superclass_) is *false*, throw a *TypeError* exception.
-          1. Else
+          1. Else,
             1. If _superclass_ has a [[FunctionKind]] internal slot whose value is `"generator"`, throw a *TypeError* exception.
             1. Let _protoParent_ be Get(_superclass_, `"prototype"`).
             1. ReturnIfAbrupt(_protoParent_).
@@ -19295,7 +19295,7 @@ a = b + c(d + e).print()
         1. Let _proto_ be ObjectCreate(_protoParent_).
         1. If |ClassBody_opt| is not present, let _constructor_ be ~empty~.
         1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
-        1. If _constructor_ is ~empty~, then,
+        1. If _constructor_ is ~empty~, then
           1. If |ClassHeritage_opt| is present, then
             1. Let _constructor_ be the result of parsing the source text
               <pre>
@@ -19343,7 +19343,7 @@ a = b + c(d + e).print()
         1. ReturnIfAbrupt(_value_).
         1. Let _hasNameProperty_ be HasOwnProperty(_value_, `"name"`).
         1. ReturnIfAbrupt(_hasNameProperty_).
-        1. If _hasNameProperty_ is *false*, then perform SetFunctionName(_value_, _className_).
+        1. If _hasNameProperty_ is *false*, perform SetFunctionName(_value_, _className_).
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _status_ be InitializeBoundName(_className_, _value_, _env_).
         1. ReturnIfAbrupt(_status_).
@@ -19863,7 +19863,7 @@ a = b + c(d + e).print()
             1. If _fn_ is not an element of _declaredFunctionNames_, then
               1. Let _fnDefinable_ be _envRec_.CanDeclareGlobalFunction(_fn_).
               1. ReturnIfAbrupt(_fnDefinable_).
-              1. If _fnDefinable_ is *false*, throw *TypeError* exception.
+              1. If _fnDefinable_ is *false*, throw a *TypeError* exception.
               1. Append _fn_ to _declaredFunctionNames_.
               1. Insert _d_ as the first element of _functionsToInitialize_.
         1. Let _declaredVarNames_ be an empty List.
@@ -19873,7 +19873,7 @@ a = b + c(d + e).print()
               1. If _vn_ is not an element of _declaredFunctionNames_, then
                 1. Let _vnDefinable_ be _envRec_.CanDeclareGlobalVar(_vn_).
                 1. ReturnIfAbrupt(_vnDefinable_).
-                1. If _vnDefinable_ is *false*, throw *TypeError* exception.
+                1. If _vnDefinable_ is *false*, throw a *TypeError* exception.
                 1. If _vn_ is not an element of _declaredVarNames_, then
                   1. Append _vn_ to _declaredVarNames_.
         1. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviours that cause abnormal terminations in some of the following steps.
@@ -19995,7 +19995,7 @@ a = b + c(d + e).print()
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _hasDuplicates_ be ContainsDuplicateLabels of |ModuleItemList| with argument _labelSet_.
-          1. If _hasDuplicates_ is *true* return *true*.
+          1. If _hasDuplicates_ is *true*, return *true*.
           1. Return ContainsDuplicateLabels of |ModuleItem| with argument _labelSet_.
         </emu-alg>
         <emu-grammar>
@@ -20891,7 +20891,7 @@ a = b + c(d + e).print()
               1. If _ee_.[[ModuleRequest]] is *null*, then
                 1. If _ee_.[[LocalName]] is not an element of _importedBoundNames_, then
                   1. Append _ee_ to _localExportEntries_.
-                1. Else
+                1. Else,
                   1. Let _ie_ be the element of _importEntries_ whose [[LocalName]] is the same as _ee_.[[LocalName]].
                   1. If _ie_.[[ImportName]] is `"*"`, then
                     1. Assert: this is a re-export of an imported module namespace object.
@@ -20968,7 +20968,7 @@ a = b + c(d + e).print()
               1. Assert: A `default` export was not explicitly defined by this module.
               1. Throw a *SyntaxError* exception.
               1. NOTE A `default` export cannot be provided by an `export *`.
-            1. If _exportStarSet_ contains _module_, then return *null*.
+            1. If _exportStarSet_ contains _module_, return *null*.
             1. Append _module_ to _exportStarSet_.
             1. Let _starResolution_ be *null*.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
@@ -20979,7 +20979,7 @@ a = b + c(d + e).print()
               1. If _resolution_ is `"ambiguous"`, return `"ambiguous"`.
               1. If _resolution_ is not *null*, then
                 1. If _starResolution_ is *null*, let _starResolution_ be _resolution_.
-                1. Else
+                1. Else,
                   1. Assert: there is more than one * import that includes the requested name.
                   1. If _resolution_.[[module]] and _starResolution_.[[module]] are not the same Module Record or SameValue(_resolution_.[[bindingName]], _starResolution_.[[bindingName]]) is *false*, return `"ambiguous"`.
             1. Return _starResolution_.
@@ -21620,7 +21620,7 @@ a = b + c(d + e).print()
           1. If _module_ is *null*, then
             1. Let _localName_ be _sourceName_.
             1. Let _importName_ be *null*.
-          1. Else
+          1. Else,
             1. Let _localName_ be *null*.
             1. Let _importName_ be _sourceName_.
           1. Return a new List containing the Record {[[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _sourceName_ }.
@@ -21632,7 +21632,7 @@ a = b + c(d + e).print()
           1. If _module_ is *null*, then
             1. Let _localName_ be _sourceName_.
             1. Let _importName_ be *null*.
-          1. Else
+          1. Else,
             1. Let _localName_ be *null*.
             1. Let _importName_ be _sourceName_.
           1. Return a new List containing the Record {[[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
@@ -21997,7 +21997,7 @@ a = b + c(d + e).print()
                 1. If _varEnvRec_ is a global Environment Record, then
                   1. Let _fnDefinable_ be _varEnvRec_.CanDeclareGlobalFunction(_fn_).
                   1. ReturnIfAbrupt(_fnDefinable_).
-                  1. If _fnDefinable_ is *false*, throw *SyntaxError* exception.
+                  1. If _fnDefinable_ is *false*, throw a *SyntaxError* exception.
                 1. Append _fn_ to _declaredFunctionNames_.
                 1. Insert _d_ as the first element of _functionsToInitialize_.
           1. NOTE: Annex <emu-xref href="#sec-web-compat-evaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
@@ -22009,7 +22009,7 @@ a = b + c(d + e).print()
                   1. If _varEnvRec_ is a global Environment Record, then
                     1. Let _vnDefinable_ be _varEnvRec_.CanDeclareGlobalVar(_vn_).
                     1. ReturnIfAbrupt(_vnDefinable_).
-                    1. If _vnDefinable_ is *false*, throw *SyntaxError* exception.
+                    1. If _vnDefinable_ is *false*, throw a *SyntaxError* exception.
                   1. If _vn_ is not an element of _declaredVarNames_, then
                     1. Append _vn_ to _declaredVarNames_.
           1. NOTE: No abnormal terminations occur after this algorithm step unless _varEnvRec_ is a global Environment Record and the global object is a Proxy exotic object.
@@ -24283,7 +24283,7 @@ new Function("a,b", "c", "return a+b+c")
           1. If _e_ = 0, then
             1. Let _c_ = `"+"`.
             1. Let _d_ = `"0"`.
-          1. Else
+          1. Else,
             1. If _e_ &gt; 0, let _c_ = `"+"`.
             1. Else _e_ &le; 0,
               1. Let _c_ = `"-"`.
@@ -25000,7 +25000,7 @@ new Function("a,b", "c", "return a+b+c")
           1. Let _a_ be ToUint32(_x_).
           1. Let _b_ be ToUint32(_y_).
           1. Let _product_ be (_a_ &times; _b_) modulo 2<sup>32</sup>.
-          1. If _product_ &ge; 2<sup>31</sup>, return _product_ - 2<sup>32</sup>, otherwise return _product_.
+          1. If _product_ &ge; 2<sup>31</sup>, return _product_ - 2<sup>32</sup>; otherwise return _product_.
         </emu-alg>
       </emu-clause>
 
@@ -26486,11 +26486,11 @@ Date.parse(x.toLocaleString())
         1. Let _m_ be ToNumber(_min_).
         1. ReturnIfAbrupt(_m_).
         1. If _sec_ is not specified, let _s_ be SecFromTime(_t_).
-        1. Else
+        1. Else,
           1. Let _s_ be ToNumber(_sec_).
           1. ReturnIfAbrupt(_s_).
         1. If _ms_ is not specified, let _milli_ be msFromTime(_t_).
-        1. Else
+        1. Else,
           1. Let _milli_ be ToNumber(_ms_).
           1. ReturnIfAbrupt(_milli_).
         1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
@@ -26513,7 +26513,7 @@ Date.parse(x.toLocaleString())
         1. Let _m_ be ToNumber(_month_).
         1. ReturnIfAbrupt(_m_).
         1. If _date_ is not specified, let _dt_ be DateFromTime(_t_).
-        1. Else
+        1. Else,
           1. Let _dt_ be ToNumber(_date_).
           1. ReturnIfAbrupt(_dt_).
         1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
@@ -26536,7 +26536,7 @@ Date.parse(x.toLocaleString())
         1. Let _s_ be ToNumber(_sec_).
         1. ReturnIfAbrupt(_s_).
         1. If _ms_ is not specified, let _milli_ be msFromTime(_t_).
-        1. Else
+        1. Else,
           1. Let _milli_ be ToNumber(_ms_).
           1. ReturnIfAbrupt(_milli_).
         1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
@@ -28550,7 +28550,7 @@ Date.parse(x.toLocaleString())
         <p>The abstract operation Canonicalize takes a character parameter _ch_ and performs the following steps:</p>
         <emu-alg>
           1. If _IgnoreCase_ is *false*, return _ch_.
-          1. If _Unicode_ is *true*,
+          1. If _Unicode_ is *true*, then
             1. If the file CaseFolding.txt of the Unicode Character Database provides a simple or common case folding mapping for _ch_, return the result of applying that mapping to _ch_.
             1. Else, return _ch_.
           1. Else,
@@ -29287,7 +29287,7 @@ Date.parse(x.toLocaleString())
             1. If _BMP_ is *true*, then
               1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting each of its 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements. The goal symbol for the parse is |Pattern|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code unit elements of _P_.
-            1. Else
+            1. Else,
               1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting _P_ as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). The goal symbol for the parse is |Pattern[U]|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code points resulting from applying UTF-16 decoding to _P_'s sequence of elements.
             1. Set the value of _obj_'s [[OriginalSource]] internal slot to _P_.
@@ -29439,7 +29439,7 @@ Date.parse(x.toLocaleString())
             1. If _fullUnicode_ is *true*, then
               1. _e_ is an index into the _Input_ character list, derived from _S_, matched by _matcher_. Let _eUTF_ be the smallest index into _S_ that corresponds to the character at element _e_ of _Input_. If _e_ is greater than or equal to the length of _Input_, then _eUTF_ is the number of code units in _S_.
               1. Let _e_ be _eUTF_.
-            1. If _global_ is *true* or _sticky_ is *true*,
+            1. If _global_ is *true* or _sticky_ is *true*, then
               1. Let _setStatus_ be Set(_R_, `"lastIndex"`, _e_, *true*).
               1. ReturnIfAbrupt(_setStatus_).
             1. Let _n_ be the length of _r_'s _captures_ List. (This is the same value as <emu-xref href="#sec-notation"></emu-xref>'s _NcapturingParens_.)
@@ -29454,7 +29454,7 @@ Date.parse(x.toLocaleString())
             1. For each integer _i_ such that _i_ &gt; 0 and _i_ &le; _n_
               1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
-              1. Else if _fullUnicode_ is *true*,
+              1. Else if _fullUnicode_ is *true*, then
                 1. Assert: _captureI_ is a List of code points.
                 1. Let _capturedValue_ be a string whose code units are the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the code points of _captureI_.
               1. Else, _fullUnicode_ is *false*,
@@ -29982,7 +29982,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
-          1. Else
+          1. Else,
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
             1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
             1. Let _mapping_ be *true*.
@@ -30487,7 +30487,7 @@ Date.parse(x.toLocaleString())
           1. Let _len_ be ToLength(Get(_O_, `"length"`)).
           1. ReturnIfAbrupt(_len_).
           1. If _len_ is 0, return -1.
-          1. If argument _fromIndex_ was passed let _n_ be ToInteger(_fromIndex_); else let _n_ be 0.
+          1. If argument _fromIndex_ was passed, let _n_ be ToInteger(_fromIndex_); else let _n_ be 0.
           1. ReturnIfAbrupt(_n_).
           1. If _n_ &ge; _len_, return -1.
           1. If _n_ &ge; 0, then
@@ -30572,7 +30572,7 @@ Date.parse(x.toLocaleString())
           1. Let _len_ be ToLength(Get(_O_, `"length"`)).
           1. ReturnIfAbrupt(_len_).
           1. If _len_ is 0, return -1.
-          1. If argument _fromIndex_ was passed let _n_ be ToInteger(_fromIndex_); else let _n_ be _len_-1.
+          1. If argument _fromIndex_ was passed, let _n_ be ToInteger(_fromIndex_); else let _n_ be _len_-1.
           1. ReturnIfAbrupt(_n_).
           1. If _n_ &ge; 0, let _k_ be min(_n_, _len_ - 1).
           1. Else _n_ &lt; 0,
@@ -30647,7 +30647,7 @@ Date.parse(x.toLocaleString())
           1. ReturnIfAbrupt(_O_).
           1. Let _len_ be ToLength(Get(_O_, `"length"`)).
           1. ReturnIfAbrupt(_len_).
-          1. If _len_ is zero,
+          1. If _len_ is zero, then
             1. Let _setStatus_ be Set(_O_, `"length"`, 0, *true*).
             1. ReturnIfAbrupt(_setStatus_).
             1. Return *undefined*.
@@ -31231,7 +31231,7 @@ Date.parse(x.toLocaleString())
           1. ReturnIfAbrupt(_firstElement_).
           1. If _firstElement_ is *undefined* or *null*, then
             1. Let _R_ be the empty String.
-          1. Else
+          1. Else,
             1. Let _R_ be ToString(Invoke(_firstElement_, `"toLocaleString"`)).
             1. ReturnIfAbrupt(_R_).
           1. Let _k_ be `1`.
@@ -31241,7 +31241,7 @@ Date.parse(x.toLocaleString())
             1. ReturnIfAbrupt(_nextElement_).
             1. If _nextElement_ is *undefined* or *null*, then
               1. Let _R_ be the empty String.
-            1. Else
+            1. Else,
               1. Let _R_ be ToString(Invoke(_nextElement_, `"toLocaleString"`)).
               1. ReturnIfAbrupt(_R_).
             1. Let _R_ be a String value produced by concatenating _S_ and _R_.
@@ -31914,7 +31914,7 @@ Date.parse(x.toLocaleString())
             1. Assert: IsConstructor(_C_) is *true*.
             1. Assert: _mapfn_ is either a callable Object or *undefined*.
             1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
-            1. Else
+            1. Else,
               1. Let _T_ be _thisArg_.
               1. Let _mapping_ be *true*.
             1. Let _usingIterator_ be GetMethod(_items_, @@iterator).
@@ -32432,7 +32432,7 @@ Date.parse(x.toLocaleString())
               1. ReturnIfAbrupt(_status_).
               1. Increase _k_ by 1.
               1. Increase _n_ by 1.
-          1. Else if _count_ &gt; 0,
+          1. Else if _count_ &gt; 0, then
             1. Let _srcBuffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetBuffer_ be the value of _A_'s [[ViewedArrayBuffer]] internal slot.
@@ -33426,7 +33426,7 @@ Date.parse(x.toLocaleString())
             1. If _next_ is *false*, return _map_.
             1. Let _nextItem_ be IteratorValue(_next_).
             1. ReturnIfAbrupt(_nextItem_).
-            1. If Type(_nextItem_) is not Object,
+            1. If Type(_nextItem_) is not Object, then
               1. Let _error_ be Completion{[[type]]: ~throw~, [[value]]: a newly created *TypeError* object, [[target]]:~empty~}.
               1. Return IteratorClose(_iter_, _error_).
             1. Let _k_ be Get(_nextItem_, `"0"`).
@@ -33799,7 +33799,7 @@ Date.parse(x.toLocaleString())
             1. Return the Number value that corresponds to _value_.
           1. If the first code unit of _type_ is `"U"`, then
             1. Let _intValue_ be the byte elements of _rawValue_ concatenated and interpreted as a bit string encoding of an unsigned little-endian binary number.
-          1. Else
+          1. Else,
             1. Let _intValue_ be the byte elements of _rawValue_ concatenated and interpreted as a bit string encoding of a binary little-endian 2's complement number of bit length _elementSize_ &times; 8.
           1. Return the Number value that corresponds to _intValue_.
         </emu-alg>
@@ -34352,7 +34352,7 @@ Date.parse(x.toLocaleString())
           1. Let _status_ be CreateDataProperty(_root_, _rootName_, _unfiltered_).
           1. Assert: _status_ is *true*.
           1. Return InternalizeJSONProperty(_root_, _rootName_).
-        1. Else
+        1. Else,
           1. Return _unfiltered_.
       </emu-alg>
       <p>JSON allows Unicode code units 0x2028 (LINE SEPARATOR) and 0x2029 (PARAGRAPH SEPARATOR) to directly appear in String literals without using an escape sequence. This is enabled by using the following alternative definition of |DoubleStringCharacter| when parsing _scriptText_ in step 5:</p>
@@ -34389,12 +34389,12 @@ Date.parse(x.toLocaleString())
                 1. ReturnIfAbrupt(_newElement_).
                 1. If _newElement_ is *undefined*, then
                   1. Let _status_ be _val_.[[Delete]](ToString(_I_)).
-                1. Else
+                1. Else,
                   1. Let _status_ be CreateDataProperty(_val_, ToString(_I_), _newElement_).
                   1. NOTE This algorithm intentionally does not throw an exception if status is *false*.
                 1. ReturnIfAbrupt(_status_).
                 1. Add 1 to _I_.
-            1. Else
+            1. Else,
               1. Let _keys_ be EnumerableOwnNames(_val_).
               1. ReturnIfAbrupt(_keys_).
               1. For each String _P_ in _keys_ do,
@@ -34402,7 +34402,7 @@ Date.parse(x.toLocaleString())
                 1. ReturnIfAbrupt(_newElement_).
                 1. If _newElement_ is *undefined*, then
                   1. Let _status_ be _val_.[[Delete]](_P_).
-                1. Else
+                1. Else,
                   1. Let _status_ be CreateDataProperty(_val_, _P_, _newElement_).
                   1. NOTE This algorithm intentionally does not throw an exception if status is *false*.
                 1. ReturnIfAbrupt(_status_).
@@ -34459,7 +34459,7 @@ Date.parse(x.toLocaleString())
           1. Set _gap_ to a String containing _space_ occurrences of code unit 0x0020 (SPACE). This will be the empty String if _space_ is less than 1.
         1. Else if Type(_space_) is String, then
           1. If the number of elements in _space_ is 10 or less, set _gap_ to _space_ otherwise set _gap_ to a String consisting of the first 10 elements of _space_.
-        1. Else
+        1. Else,
           1. Set _gap_ to the empty String.
         1. Let _wrapper_ be ObjectCreate(%ObjectPrototype%).
         1. Let _status_ be CreateDataProperty(_wrapper_, the empty String, _value_).
@@ -35639,7 +35639,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
               1. If _next_ is *false*, then
                 1. Set _iteratorRecord_.[[done]] to *true*.
                 1. Set _remainingElementsCount_.[[value]] to _remainingElementsCount_.[[value]] - 1.
-                1. If _remainingElementsCount_.[[value]] is 0,
+                1. If _remainingElementsCount_.[[value]] is 0, then
                   1. Let _valuesArray_ be CreateArrayFromList(_values_).
                   1. Let _resolveResult_ be Call(_resultCapability_.[[Resolve]], *undefined*, &laquo;_valuesArray_&raquo;).
                   1. ReturnIfAbrupt(_resolveResult_).
@@ -35678,7 +35678,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
             1. Let _remainingElementsCount_ be the value of _F_'s [[RemainingElements]] internal slot.
             1. Set _values_[_index_] to _x_.
             1. Set _remainingElementsCount_.[[value]] to _remainingElementsCount_.[[value]] - 1.
-            1. If _remainingElementsCount_.[[value]] is 0,
+            1. If _remainingElementsCount_.[[value]] is 0, then
               1. Let _valuesArray_ be CreateArrayFromList(_values_).
               1. Return Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;_valuesArray_&raquo;).
             1. Return *undefined*.


### PR DESCRIPTION
- Use `Throw a TypeError exception` instead of `Throw TypeError exception`
- Add ; before otherwise
- Add , before consequent in concise if-predicate steps
- Add , after `Else`
- Add `then` in if-predicates
- Remove `then` in concise if-predicates