### PR TITLE
Normative: Date.parse treats date-only no offset as UTC

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25720,7 +25720,7 @@ THH:mm
 THH:mm:ss
 THH:mm:ss.sss
 </pre>
-<p>All numbers must be base 10. If the `MM` or `DD` fields are absent `"01"` is used as the value. If the `HH`, `mm`, or `ss` fields are absent `"00"` is used as the value and the value of an absent `sss` field is `"000"`. If the time zone offset is absent, the date-time is interpreted as a local time.</p>
+<p>All numbers must be base 10. If the `MM` or `DD` fields are absent `"01"` is used as the value. If the `HH`, `mm`, or `ss` fields are absent `"00"` is used as the value and the value of an absent `sss` field is `"000"`. When the time zone offset is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time.</p>
 <p>Illegal values (out-of-bounds as well as syntax errors) in a format string means that the format string is not a valid instance of this format.</p>
 <emu-note>
 <p>As every day both starts and ends with midnight, the two notations `00:00` and `24:00` are available to distinguish the two midnights that can be associated with one date. This means that the following two notations refer to exactly the same point in time: `1995-02-04T24:00` and `1995-02-05T00:00`</p>


### PR DESCRIPTION
This is a potential fix for #87. Previously, date-time forms without offsets were specified as local time and date-only forms were unspecified. This clarifies the web-reality semantics of interpreting date-only forms without offsets as UTC time.