### PR TITLE
Change string length check to assertion

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27910,18 +27910,17 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
           1. Return an internal closure that takes two arguments, a String _str_ and an integer _index_, and performs the following steps:
+            1. Assert: _index_ &le; the number of elements in _str_.
             1. If _Unicode_ is *true*, let _Input_ be a List consisting of the sequence of code points of _str_ interpreted as a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) Unicode string. Otherwise, let _Input_ be a List consisting of the sequence of code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
             1. Let _InputLength_ be the number of characters contained in _Input_. This variable will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.
-            1. Let _size_ be the number of elements in _str_.
-            1. If _index_ is less than _size_, let _listIndex_ be the index into _Input_ of the character that was obtained from element _index_ of _str_.
-            1. Else, let _listIndex_ be the value of _InputLength_.
+            1. Let _listIndex_ be the index into _Input_ of the character that was obtained from element _index_ of _str_.
             1. Let _c_ be a Continuation that always returns its State argument as a successful MatchResult.
             1. Let _cap_ be a List of _NcapturingParens_ *undefined* values, indexed 1 through _NcapturingParens_.
             1. Let _x_ be the State (_listIndex_, _cap_).
             1. Call _m_(_x_, _c_) and return its result.
         </emu-alg>
         <emu-note>
-          <p>A Pattern evaluates (&ldquo;compiles&rdquo;) to an internal procedure value. `RegExp.prototype.exec` and other methods can then apply this procedure to a String and an offset within the String to determine whether the pattern would match starting at exactly that offset within the String, and, if it does match, what the values of the capturing parentheses would be. The algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref> are designed so that compiling a pattern may throw a *SyntaxError* exception; on the other hand, once the pattern is successfully compiled, applying the resulting internal procedure to find a match in a String cannot throw an exception (except for any host-defined exceptions that can occur anywhere such as out-of-memory).</p>
+          <p>A Pattern evaluates (&ldquo;compiles&rdquo;) to an internal procedure value. RegExpBuiltinExec can then apply this procedure to a String and an offset within the String to determine whether the pattern would match starting at exactly that offset within the String, and, if it does match, what the values of the capturing parentheses would be. The algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref> are designed so that compiling a pattern may throw a *SyntaxError* exception; on the other hand, once the pattern is successfully compiled, applying the resulting internal procedure to find a match in a String cannot throw an exception (except for any host-defined exceptions that can occur anywhere such as out-of-memory).</p>
         </emu-note>
       </emu-clause>
 


### PR DESCRIPTION
Invalid string indices need to be handled in the caller, cf. RegExpBuiltinExec.

And changed the reference from RegExp.prototype.exec to RegExpBuiltinExec, because that's the only caller for the matcher.