### PR TITLE
Truncate lastIndex to string length in RegExp.prototype[@@split]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29735,6 +29735,7 @@ Date.parse(x.toLocaleString())
             1. Else _z_ is not *null*,
               1. Let _e_ be ToLength(Get(_splitter_, `"lastIndex"`)).
               1. ReturnIfAbrupt(_e_).
+              1. Let _e_ be min(_e_, _size_).
               1. If _e_ = _p_, let _q_ be AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
               1. Else _e_ &ne; _p_,
                 1. Let _T_ be a String value equal to the substring of _S_ consisting of the elements at indices _p_ (inclusive) through _q_ (exclusive).


### PR DESCRIPTION
Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4434