### PR TITLE
Assert required internal slots are passed to IntegerIndexedObjectCreate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7979,6 +7979,7 @@ if (!visited.has(protoName)) yield protoName;
         <h1>IntegerIndexedObjectCreate (_prototype_, _internalSlotsList_)</h1>
         <p>The abstract operation IntegerIndexedObjectCreate with arguments _prototype_ and _internalSlotsList_ is used to specify the creation of new Integer Indexed exotic objects. The argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. IntegerIndexedObjectCreate performs the following steps:</p>
         <emu-alg>
+          1. Assert: _internalSlotsList_ contains the names [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]].
           1. Let _A_ be a newly created object with an internal slot for each name in _internalSlotsList_.
           1. Set _A_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set the [[GetOwnProperty]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-getownproperty-p"></emu-xref>.


### PR DESCRIPTION
Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4471