### PR TITLE
Add missing super restrictions for GeneratorDeclaration

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18594,20 +18594,10 @@ a = b + c(d + e).print()
           It is a Syntax Error if any element of the BoundNames of |StrictFormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
         </li>
       </ul>
-      <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <ul>
-        <li>
-          It is a Syntax Error if HasDirectSuper of |GeneratorDeclaration| is *true*.
-        </li>
-      </ul>
-      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <ul>
-        <li>
-          It is a Syntax Error if HasDirectSuper of |GeneratorExpression| is *true*.
-        </li>
-      </ul>
       <emu-grammar>
         GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
 
         GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
       </emu-grammar>
@@ -18629,6 +18619,12 @@ a = b + c(d + e).print()
         </li>
         <li>
           It is a Syntax Error if |GeneratorBody| Contains |SuperProperty| is *true*.
+        </li>
+        <li>
+          It is a Syntax Error if |FormalParameters| Contains |SuperCall| is *true*.
+        </li>
+        <li>
+          It is a Syntax Error if |GeneratorBody| Contains |SuperCall| is *true*.
         </li>
       </ul>
     </emu-clause>
@@ -18700,19 +18696,6 @@ a = b + c(d + e).print()
       <emu-grammar>GeneratorMethod : `*` PropertyName `(` StrictFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If |StrictFormalParameters| Contains |SuperCall| is *true*, return *true*.
-        1. Return |GeneratorBody| Contains |SuperCall|.
-      </emu-alg>
-      <emu-grammar>
-        GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. If |FormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |GeneratorBody| Contains |SuperCall|.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
HasDirectSuper for GeneratorDeclaration/Expression has been removed, SuperCall
is now handled explicitly in 14.4.1 to mirror the early error restrictions for
FunctionDeclaration/Expression.

Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4494
Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4420