### PR TITLE
Replace completion value checks with UpdateEmpty

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2682,8 +2682,7 @@
         <h1>UpdateEmpty ( _completionRecord_, _value_)</h1>
         <p>The abstract operation UpdateEmpty with arguments _completionRecord_ and _value_ performs the following steps:</p>
         <emu-alg>
-          1. Assert: if _completionRecord_.[[type]] is ~throw~ then _completionRecord_.[[value]] is not ~empty~.
-          1. If _completionRecord_.[[type]] is ~throw~, return Completion(_completionRecord_).
+          1. Assert: If _completionRecord_.[[type]] is either ~return~ or ~throw~ then _completionRecord_.[[value]] is not ~empty~.
           1. If _completionRecord_.[[value]] is not ~empty~, return Completion(_completionRecord_).
           1. Return Completion{[[type]]: _completionRecord_.[[type]], [[value]]: _value_, [[target]]: _completionRecord_.[[target]] }.
         </emu-alg>
@@ -16635,9 +16634,7 @@ eval("1;var a;")
         1. Repeat for each |CaseClause| _C_ in _A_,
           1. If _found_ is *false*, then
             1. Let _clauseSelector_ be the result of CaseSelectorEvaluation of _C_.
-            1. If _clauseSelector_ is an abrupt completion, then
-              1. If _clauseSelector_.[[value]] is ~empty~, return Completion{[[type]]: _clauseSelector_.[[type]], [[value]]: *undefined*, [[target]]: _clauseSelector_.[[target]]}.
-              1. Else, return Completion(_clauseSelector_).
+            1. ReturnIfAbrupt(_clauseSelector_).
             1. Let _found_ be the result of performing Strict Equality Comparison _input_ === _clauseSelector_.[[value]].
           1. If _found_ is *true*, then
             1. Let _R_ be the result of evaluating _C_.
@@ -16653,9 +16650,7 @@ eval("1;var a;")
         1. Repeat for each |CaseClause| _C_ in _A_
           1. If _found_ is *false*, then
             1. Let _clauseSelector_ be the result of CaseSelectorEvaluation of _C_.
-            1. If _clauseSelector_ is an abrupt completion, then
-              1. If _clauseSelector_.[[value]] is ~empty~, return Completion{[[type]]: _clauseSelector_.[[type]], [[value]]: *undefined*, [[target]]: _clauseSelector_.[[target]]}.
-              1. Else, return Completion(_clauseSelector_).
+            1. ReturnIfAbrupt(_clauseSelector_).
             1. Let _found_ be the result of performing Strict Equality Comparison _input_ === _clauseSelector_.[[value]].
           1. If _found_ is *true*, then
             1. Let _R_ be the result of evaluating _C_.
@@ -16667,9 +16662,7 @@ eval("1;var a;")
           1. Repeat for each |CaseClause| _C_ in _B_
             1. If _foundInB_ is *false*, then
               1. Let _clauseSelector_ be the result of CaseSelectorEvaluation of _C_.
-              1. If _clauseSelector_ is an abrupt completion, then
-                1. If _clauseSelector_.[[value]] is ~empty~, return Completion{[[type]]: _clauseSelector_.[[type]], [[value]]: *undefined*, [[target]]: _clauseSelector_.[[target]]}.
-                1. Else, return Completion(_clauseSelector_).
+              1. ReturnIfAbrupt(_clauseSelector_).
               1. Let _foundInB_ be the result of performing Strict Equality Comparison _input_ === _clauseSelector_.[[value]].
             1. If _foundInB_ is *true*, then
               1. Let _R_ be the result of evaluating |CaseClause| _C_.
@@ -17243,18 +17236,14 @@ eval("1;var a;")
           1. Let _C_ be CatchClauseEvaluation of |Catch| with parameter _B_.[[value]].
         1. Else _B_.[[type]] is not ~throw~,
           1. Let _C_ be _B_.
-        1. If _C_.[[type]] is ~return~, or _C_.[[type]] is ~throw~, return Completion(_C_).
-        1. If _C_.[[value]] is not ~empty~, return Completion(_C_).
-        1. Return Completion{[[type]]: _C_.[[type]], [[value]]: *undefined*, [[target]]: _C_.[[target]]}.
+        1. Return Completion(UpdateEmpty(_C_, *undefined*)).
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
         1. Let _F_ be the result of evaluating |Finally|.
         1. If _F_.[[type]] is ~normal~, let _F_ be _B_.
-        1. If _F_.[[type]] is ~return~, or _F_.[[type]] is ~throw~, return Completion(_F_).
-        1. If _F_.[[value]] is not ~empty~, return Completion(_F_).
-        1. Return Completion{[[type]]: _F_.[[type]], [[value]]: *undefined*, [[target]]: _F_.[[target]]}.
+        1. Return Completion(UpdateEmpty(_F_, *undefined*)).
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
@@ -17264,9 +17253,7 @@ eval("1;var a;")
         1. Else _B_.[[type]] is not ~throw~, let _C_ be _B_.
         1. Let _F_ be the result of evaluating |Finally|.
         1. If _F_.[[type]] is ~normal~, let _F_ be _C_.
-        1. If _F_.[[type]] is ~return~, or _F_.[[type]] is ~throw~, return Completion(_F_).
-        1. If _F_.[[value]] is not ~empty~, return NormalCompletion(_F_.[[value]]).
-        1. Return Completion{[[type]]: _F_.[[type]], [[value]]: *undefined*, [[target]]: _F_.[[target]]}.
+        1. Return Completion(UpdateEmpty(_F_, *undefined*)).
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
- Add assertion that return-completions have a non-empty value
- Remove unnecessary empty completion value checks in CaseBlockEvaluation
- Simplify empty completion handling in TryStatement evaluation
- Fix typo in TryStatement evaluation