### PR TITLE
Add early error for functions with non-simple parameter list and use-strict

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17363,6 +17363,9 @@ eval("1;var a;")
           If the source code matching this production is strict code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.
         </li>
         <li>
+          It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
+        </li>
+        <li>
           It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
         </li>
         <li>
@@ -17489,6 +17492,15 @@ eval("1;var a;")
       <emu-alg>
         1. If ContainsExpression of |FormalsList| is *true*, return *true*.
         1. Return ContainsExpression of |FormalParameter|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-function-definitions-static-semantics-containsusestrict">
+      <h1>Static Semantics: ContainsUseStrict</h1>
+      <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
+      <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
+      <emu-alg>
+        1. If the DirectivePrologue of |FunctionStatementList| contains a Use Strict Directive, return *true*; otherwise, return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -17835,6 +17847,9 @@ eval("1;var a;")
           It is a Syntax Error if |ArrowParameters| Contains |YieldExpression| is *true*.
         </li>
         <li>
+          It is a Syntax Error if ContainsUseStrict of |ConciseBody| is *true* and IsSimpleParameterList of |ArrowParameters| is *false*.
+        </li>
+        <li>
           It is a Syntax Error if any element of the BoundNames of |ArrowParameters| also occurs in the LexicallyDeclaredNames of |ConciseBody|.
         </li>
       </ul>
@@ -17894,6 +17909,15 @@ eval("1;var a;")
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-arrow-function-definitions-static-semantics-containsusestrict">
+      <h1>Static Semantics: ContainsUseStrict</h1>
+      <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
+      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <!-- es6num="14.2.5" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
@@ -17921,6 +17945,11 @@ eval("1;var a;")
       <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return *true*.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return IsSimpleParameterList of _formals_.
       </emu-alg>
     </emu-clause>
 
@@ -18059,6 +18088,9 @@ eval("1;var a;")
       <emu-grammar>MethodDefinition : PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <ul>
         <li>
+          It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |StrictFormalParameters| is *false*.
+        </li>
+        <li>
           It is a Syntax Error if any element of the BoundNames of |StrictFormalParameters| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
         </li>
       </ul>
@@ -18066,6 +18098,9 @@ eval("1;var a;")
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |PropertySetParameterList| contains any duplicate elements.
+        </li>
+        <li>
+          It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |PropertySetParameterList| is *false*.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |PropertySetParameterList| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
@@ -18273,6 +18308,9 @@ eval("1;var a;")
           It is a Syntax Error if |StrictFormalParameters| Contains |YieldExpression| is *true*.
         </li>
         <li>
+          It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |StrictFormalParameters| is *false*.
+        </li>
+        <li>
           It is a Syntax Error if any element of the BoundNames of |StrictFormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
         </li>
       </ul>
@@ -18289,6 +18327,9 @@ eval("1;var a;")
         </li>
         <li>
           If the source code matching this production is strict code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.
+        </li>
+        <li>
+          It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
@@ -22767,6 +22808,7 @@ new Function("a,b", "c", "return a+b+c")
             1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails or if any static semantics errors are detected.
             1. If _bodyText_ is strict mode code (see <emu-xref href="#sec-strict-mode-code"></emu-xref>) then let _strict_ be *true*, else let _strict_ be *false*.
             1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails or if any static semantics errors are detected. If _strict_ is *true*, the Early Error rules for <emu-grammar>StrictFormalParameters : FormalParameters</emu-grammar> are applied.
+            1. If ContainsUseStrict of _body_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
             1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.
             1. If _body_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
             1. If _parameters_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.


### PR DESCRIPTION
Add early error restriction if a function with a non-simple parameter list contains a "use strict" directive.

Per resolution from July 29 2015:
- https://github.com/tc39/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists
- https://github.com/tc39/tc39-notes/blob/master/es7/2015-07/july-29.md#revisit-611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists