### PR TITLE
Early draft proposal: Alternative sloppy-mode block-scoped function hoisting semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7130,7 +7130,10 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. Assert: _status_ is never an abrupt completion.
         1. For each parsed grammar phrase _f_ in _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
-          1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
+          1. If _f_ is directly contained in a |Block|, |CaseClause| or |DefaultClause| and this function is not executing in strict mode,
+            1. Let _fo_ be *undefined*.
+          1. Otherwise,
+            1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
           1. Let _status_ be _varEnvRec_.SetMutableBinding(_fn_, _fo_, *false*).
           1. Assert: _status_ is never an abrupt completion.
         1. Return NormalCompletion(~empty~).
@@ -14225,7 +14228,9 @@ a = b + c
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. Return the BoundNames of |Declaration|.
+        1. If this production occurs in strict mode code, or if the |Declaration| is not a |FunctionDeclaration|,
+          1. Return the BoundNames of |Declaration|.
+        1. Otherwise, return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -14246,7 +14251,9 @@ a = b + c
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. Return a new List containing DeclarationPart of |Declaration|.
+        1. If this production occurs in strict mode code, or if the |Declaration| is not a |FunctionDeclaration|,
+          1. Return a new List containing DeclarationPart of |Declaration|.
+        1. Otherwise, return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -14399,6 +14406,30 @@ a = b + c
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-block-static-semantics-sloppymodeblockscopedfunctiondeclarations">
+      <h1>Static Semantics: SloppyModeBlockScopedFunctionDeclarations</h1>
+      <emu-see-also-para op="SloppyModeBlockScopedFunctionDeclarations"></emu-see-also-para>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be SloppyModeBlockScopedFunctionDeclarations of |StatementList|.
+        1. Append to _declarations_ the elements of the SloppyModeBlockScopedFunctionDeclarations of |StatementListItem|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. If |Declaration| is a |FunctionDeclaration|, and this production does not occur in strict mode code, return a new List containing the |FunctionDeclaration|.
+        1. Otherwise, return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+    </emu-clause>
+
     <!-- es6num="13.2.13" -->
     <emu-clause id="sec-block-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
@@ -14456,6 +14487,13 @@ eval("1;var a;")
             1. Let _fn_ be the sole element of the BoundNames of _d_.
             1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
             1. Perform _env_.InitializeBinding(_fn_, _fo_).
+        1. Let _sloppyModeBlockScopedFunctionDeclarations_ be the SloppyModeBlockScopedFunctionDeclarations of _code_.
+        1. For each element _d_ in _sloppyModeBlockScopedFunctionDeclarations_ do
+          1. Assert: _d_ is a |FunctionDeclaration| production.
+          1. Let _fn_ be the sole element of the BoundNames of _d_.
+          1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
+          1. Let _venv_ be the running execution context's VariableEnvironment.
+          1. Perform _venv_.SetMutableBinding(_fn_, _fo_, *false*).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -19560,7 +19598,10 @@ eval("1;var a;")
             1. ReturnIfAbrupt(_status_).
         1. For each production _f_ in _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
-          1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _env_.
+          1. If _f_ is directly contained in a |Block|, |CaseClause| or |DefaultClause| and this is not executing in strict mode,
+            1. Let _fo_ be *undefined*.
+          1. Otherwise,
+            1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
           1. Let _status_ be ? _envRec_.CreateGlobalFunctionBinding(_fn_, _fo_, *false*).
         1. For each String _vn_ in _declaredVarNames_, in list order do
           1. Let _status_ be ? _envRec_.CreateGlobalVarBinding(_vn_, *false*).
@@ -21676,7 +21717,10 @@ eval("1;var a;")
               1. ReturnIfAbrupt(_status_).
           1. For each production _f_ in _functionsToInitialize_, do
             1. Let _fn_ be the sole element of the BoundNames of _f_.
-            1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
+            1. If _f_ is directly contained in a |Block|, |CaseClause| or |DefaultClause| and this is not executing in strict mode,
+              1. Let _fo_ be *undefined*.
+            1. Otherwise,
+              1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
             1. If _varEnvRec_ is a global Environment Record, then
               1. Let _status_ be ? _varEnvRec_.CreateGlobalFunctionBinding(_fn_, _fo_, *true*).
             1. Else,
@@ -36058,166 +36102,6 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           It is a Syntax Error if any strict mode source code matches this rule.
         </li>
       </ul>
-    </emu-annex>
-
-    <!-- es6num="B.3.3" -->
-    <emu-annex id="sec-block-level-function-declarations-web-legacy-compatibility-semantics">
-      <h1>Block-Level Function Declarations Web Legacy Compatibility Semantics</h1>
-      <p>Prior to ECMAScript 2015, the ECMAScript specification did not define the occurrence of a |FunctionDeclaration| as an element of a |Block| statement's |StatementList|. However, support for that form of |FunctionDeclaration| was an allowable extension and most browser-hosted ECMAScript implementations permitted them. Unfortunately, the semantics of such declarations differ among those implementations. Because of these semantic differences, existing web ECMAScript code that uses |Block| level function declarations is only portable among browser implementation if the usage only depends upon the semantic intersection of all of the browser implementations for such declarations. The following are the use cases that fall within that intersection semantics:</p>
-      <ol>
-        <li>
-          A function is declared and only referenced within a single block
-          <ul>
-            <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
-            </li>
-            <li>
-              No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
-            </li>
-            <li>
-              All occurrences of _f_ as an |IdentifierReference| are within the |StatementList| of the |Block| containing the declaration of _f_.
-            </li>
-          </ul>
-        </li>
-        <li>
-          A function is declared and possibly used within a single |Block| but also referenced by an inner function definition that is not contained within that same |Block|.
-          <ul>
-            <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
-            </li>
-            <li>
-              No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
-            </li>
-            <li>
-              There may be occurrences of _f_ as an |IdentifierReference| within the |StatementList| of the |Block| containing the declaration of _f_.
-            </li>
-            <li>
-              There is at least one occurrence of _f_ as an |IdentifierReference| within another function _h_ that is nested within _g_ and no other declaration of _f_ shadows the references to _f_ from within _h_.
-            </li>
-            <li>
-              All invocations of _h_ occur after the declaration of _f_ has been evaluated.
-            </li>
-          </ul>
-        </li>
-        <li>
-          A function is declared and possibly used within a single block but also referenced within subsequent blocks.
-          <ul>
-            <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
-            </li>
-            <li>
-              No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
-            </li>
-            <li>
-              There may be occurrences of _f_ as an |IdentifierReference| within the |StatementList| of the |Block| containing the declaration of _f_.
-            </li>
-            <li>
-              There is at least one occurrence of _f_ as an |IdentifierReference| within the function code of _g_ that lexically follows the |Block| containing the declaration of _f_.
-            </li>
-          </ul>
-        </li>
-      </ol>
-      <p>The first use case is interoperable with the semantics of |Block| level function declarations provided by ECMAScript 2015. Any pre-existing ECMAScript code that employs that use case will operate using the Block level function declarations semantics defined by clauses 9, 13, and 14 of this specification.</p>
-      <p>ECMAScript 2015 interoperability for the second and third use cases requires the following extensions to the clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, clause <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>, clause <emu-xref href="#sec-eval-x"></emu-xref> and clause <emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref> semantics.</p>
-      <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatability semantics are applied and introduce observable differences from non-compatability semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
-      <emu-annex id="sec-web-compat-functiondeclarationinstantiation">
-        <h1>Changes to FunctionDeclarationInstantiation</h1>
-        <p>During FunctionDeclarationInstantiation (<emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>) the following steps are performed in place of step 29:</p>
-        <emu-alg>
-          1. If _strict_ is *false*, then
-            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|,
-              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-              1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of BoundNames of _argumentsList_, then
-                1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
-                1. If _instantiatedVarNames_ does not contain _F_, then
-                  1. Let _status_ be _varEnvRec_.CreateMutableBinding(_F_).
-                  1. Assert: _status_ is never an abrupt completion.
-                  1. Perform _varEnvRec_.InitializeBinding(_F_, *undefined*).
-                  1. Append _F_ to _instantiatedVarNames_.
-                1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                  1. Let _fenv_ be the running execution context's VariableEnvironment.
-                  1. Let _benv_ be the running execution context's LexicalEnvironment.
-                  1. Let _fobj_ be _benv_.GetBindingValue(_F_, *false*).
-                  1. Assert: _fobj_ is never an abrupt completion.
-                  1. Let _status_ be _fenv_.SetMutableBinding(_F_, _fobj_, *false*).
-                  1. Assert: _status_ is never an abrupt completion.
-                  1. Return NormalCompletion(~empty~).
-        </emu-alg>
-      </emu-annex>
-      <emu-annex id="sec-web-compat-globaldeclarationinstantiation">
-        <h1>Changes to GlobalDeclarationInstantiation</h1>
-        <p>During GlobalDeclarationInstatiation (<emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref>) the following steps are performed in place of step 14:</p>
-        <emu-alg>
-          1. Let _declaredFunctionOrVarNames_ be an empty List.
-          1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
-          1. Append to _declaredFunctionOrVarNames_ the elements of _declaredVarNames_.
-          1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within script,
-            1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-            2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for script, then
-              1. If _envRec_.HasLexicalDeclaration(_F_) is *false*, then
-                1. Let _fnDefinable_ be ? _envRec_.CanDeclareGlobalFunction(_F_).
-                3. If _fnDefinable_ is *true*, then
-                  1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
-                  2. If _declaredFunctionOrVarNames_ does not contain _F_, then
-                    1. Let _status_ be ? _envRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *false*).
-                    1. Append _F_ to _declaredFunctionOrVarNames_.
-                  3. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _genv_ be the running execution context’s VariableEnvironment.
-                    2. Let _benv_ be the running execution context’s LexicalEnvironment.
-                    3. Let _fobj_ be _benv_.GetBindingValue(_F_, *false*).
-                    4. Assert: _fobj_ is never an abrupt completion.
-                    5. Let _status_ be ? _genv_.SetMutableBinding(_F_, _fobj_, *false*).
-                    7. Return NormalCompletion(~empty~).
-        </emu-alg>
-      </emu-annex>
-      <emu-annex id="sec-web-compat-evaldeclarationinstantiation">
-        <h1>Changes to EvalDeclarationInstantiation</h1>
-        <p>During EvalDeclarationInstantiation (<emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref>) the following steps are performed in place of step 9:</p>
-        <emu-alg>
-          1. If _strict_ is *false*, then
-            1. Let _declaredFunctionOrVarNames_ be an empty List.
-            1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
-            1. Append to _declaredFunctionOrVarNames_ the elements of _declaredVarNames_.
-            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _body_,
-              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-              2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _body_, then
-                1. Let _bindingExists_ be *false*.
-                3. Let _thisLex_ be _lexEnv_.
-                4. Assert: the following loop will terminate.
-                5. Repeat while _thisLex_ is not the same as _varEnv_,
-                  1. Let _thisEnvRec_ be _thisLex_'s EnvironmentRecord.
-                  2. If _thisEnvRec_ is not an object Environment Record, then
-                    1. If _thisEnvRec_.HasBinding(_F_) is *true*, then
-                      1. Let _bindingExists_ be *true*.
-                  1. Let _thisLex_ be _thisLex_'s outer environment reference.
-                6. If _bindingExists_ is *false* and _varEnvRec_ is a global Environment Record, then
-                  1. If _varEnvRec_.HasLexicalDeclaration(_F_) is *false*, then
-                    1. Let _fnDefinable_ be ? _varEnvRec_.CanDeclareGlobalFunction(_F_).
-                  1. Else,
-                    1. Let _fnDefinable_ be *false*.
-                1. Else,
-                  1. Let _fnDefinable_ be *true*.
-                7. If _bindingExists_ is *false* and _fnDefinable_ is *true*, then
-                  1. If _declaredFunctionOrVarNames_ does not contain _F_, then
-                    1. If _varEnvRec_ is a global Environment Record, then
-                      1. Let _status_ be ? _varEnvRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *true*).
-                    1. Else,
-                      1. Let _bindingExists_ be _varEnvRec_.HasBinding(_F_).
-                      1. If _bindingExists_ is *false*, then
-                        1. Let _status_ be _varEnvRec_.CreateMutableBinding(_F_, *true*).
-                        1. Assert: _status_ is not an abrupt completion.
-                        1. Let _status_ be _varEnvRec_.InitializeBinding(_F_, *undefined*).
-                        1. Assert: _status_ is not an abrupt completion.
-                    1. Append _F_ to _declaredFunctionOrVarNames_.
-                  2. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _genv_ be the running execution context’s VariableEnvironment.
-                    2. Let _benv_ be the running execution context’s LexicalEnvironment.
-                    3. Let _fobj_ be _benv_.GetBindingValue(_F_, *false*).
-                    4. Assert: _fobj_ is never an abrupt completion.
-                    5. Let _status_ be ? _genv_.SetMutableBinding(_F_, _fobj_, *false*).
-                    7. Return NormalCompletion(~empty~).
-        </emu-alg>
-      </emu-annex>
     </emu-annex>
 
     <!-- es6num="B.3.4" -->


### PR DESCRIPTION
This patch offers an alternative mechanism for sloppy-mode block-scoped
function hoisting, removing the lexical binding for such functions and
making a single, var-scoped binding. Motivation:
https://gist.github.com/littledan/09f08c9bf473a800f5b3
https://github.com/tc39/ecma262/issues/162