### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Proposals follow [this process document](https://tc39.github.io/process-document
 | | [Trailing commas in function parameter lists and calls](https://jeffmo.github.io/es-trailing-function-commas/) | Jeff Morrison | 3
 | | [function.sent metaproperty](https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md) |  Allen Wirfs-Brock |2      |
 | | [Rest/Spread Properties](https://github.com/sebmarkbage/ecmascript-rest-spread) | Sebastian Markbage | 2
-| | [Typed Objects](https://github.com/dslomov-chromium/typed-objects-es7)       |Dmitry Lomov, Niko Matsakis   |1
+| | [Typed Objects](https://github.com/dslomov/typed-objects-es7)       |Dmitry Lomov, Niko Matsakis   |1
 | | [ArrayBuffer.transfer](https://gist.github.com/lukewagner/2735af7eea411e18cf20) | Luke Wagneer & Allen Wirfs-Brock | 1
 |🚀| [Additional export-from Statements](https://github.com/leebyron/ecmascript-more-export-from)| Lee Byron | 1
 |🚀|[Class and Property Decorators](https://github.com/wycats/javascript-decorators/blob/master/README.md) | Yehuda Katz and Jonathan Turner | 1 |
 | | [`Function.prototype.toString` revision](https://github.com/michaelficarra/Function-prototype-toString-revision)| Michael Ficarra| 1
 | | [Observable](https://github.com/zenparsing/es-observable) | Kevin Smith & Jafar Husain | 1
 | | [String.prototype.{trimLeft,trimRight}](https://github.com/sebmarkbage/ecmascript-string-left-right-trim) | Sebastian Markbage | 1
-| | [Class Property Declarations](https://github.com/jeffmo/es-class-properties)| Jeff Morrison| 1
-| | [String#matchAll](https://github.com/ljharb/String.prototype.matchAll) | Jordan Harband | 1
+| | [Class Property Declarations](https://github.com/jeffmo/es-class-fields-and-static-properties)| Jeff Morrison| 1
+| | [String#matchAll](https://github.com/tc39/String.prototype.matchAll) | Jordan Harband | 1
 | | [Shared memory and atomics](https://github.com/lars-t-hansen/ecmascript_sharedmem) | Lars T Hansen | 1
 |🚀|[Callable class constructors](https://github.com/tc39/ecma262/blob/master/workingdocs/callconstructor.md) | Yehuda Katz and Allen Wirfs-Brock | 1
 | | [System.global](https://github.com/tc39/proposal-global) | Jordan Harband | 1


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/dslomov-chromium/typed-objects-es7 | https://github.com/dslomov/typed-objects-es7 
https://github.com/jeffmo/es-class-properties | https://github.com/jeffmo/es-class-fields-and-static-properties 
https://github.com/ljharb/String.prototype.matchAll | https://github.com/tc39/String.prototype.matchAll 
