### PR TITLE
[Editorial] Remove unused fooStatus vars in the spec and replace with "Perform"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28696,7 +28696,7 @@ Date.parse(x.toLocaleString())
             1. Set the value of _obj_'s [[OriginalSource]] internal slot to _P_.
             1. Set the value of _obj_'s [[OriginalFlags]] internal slot to _F_.
             1. Set _obj_'s [[RegExpMatcher]] internal slot to the internal procedure that evaluates the above parse of _P_ by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
-            1. Let _setStatus_ be ? Set(_obj_, `"lastIndex"`, 0, *true*).
+            1. Perform ? Set(_obj_, `"lastIndex"`, 0, *true*).
             1. Return _obj_.
           </emu-alg>
         </emu-clause>
@@ -28817,12 +28817,12 @@ Date.parse(x.toLocaleString())
             1. Let _matchSucceeded_ be *false*.
             1. Repeat, while _matchSucceeded_ is *false*
               1. If _lastIndex_ &gt; _length_, then
-                1. Let _setStatus_ be ? Set(_R_, `"lastIndex"`, 0, *true*).
+                1. Perform ? Set(_R_, `"lastIndex"`, 0, *true*).
                 1. Return *null*.
               1. Let _r_ be _matcher_(_S_, _lastIndex_).
               1. If _r_ is ~failure~, then
                 1. If _sticky_ is *true*, then
-                  1. Let _setStatus_ be ? Set(_R_, `"lastIndex"`, 0, *true*).
+                  1. Perform ? Set(_R_, `"lastIndex"`, 0, *true*).
                   1. Return *null*.
                 1. Let _lastIndex_ be AdvanceStringIndex(_S_, _lastIndex_, _fullUnicode_).
               1. Else,
@@ -28833,7 +28833,7 @@ Date.parse(x.toLocaleString())
               1. _e_ is an index into the _Input_ character list, derived from _S_, matched by _matcher_. Let _eUTF_ be the smallest index into _S_ that corresponds to the character at element _e_ of _Input_. If _e_ is greater than or equal to the length of _Input_, then _eUTF_ is the number of code units in _S_.
               1. Let _e_ be _eUTF_.
             1. If _global_ is *true* or _sticky_ is *true*, then
-              1. Let _setStatus_ be ? Set(_R_, `"lastIndex"`, _e_, *true*).
+              1. Perform ? Set(_R_, `"lastIndex"`, _e_, *true*).
             1. Let _n_ be the length of _r_'s _captures_ List. (This is the same value as <emu-xref href="#sec-notation"></emu-xref>'s _NcapturingParens_.)
             1. Let _A_ be ArrayCreate(_n_ + 1).
             1. Assert: The value of _A_'s `"length"` property is _n_ + 1.
@@ -28940,7 +28940,7 @@ Date.parse(x.toLocaleString())
             1. Return RegExpExec(_rx_, _S_).
           1. Else _global_ is *true*,
             1. Let _fullUnicode_ be ToBoolean(? Get(_rx_, `"unicode"`)).
-            1. Let _setStatus_ be ? Set(_rx_, `"lastIndex"`, 0, *true*).
+            1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
             1. Let _A_ be ArrayCreate(0).
             1. Let _n_ be 0.
             1. Repeat,
@@ -28955,7 +28955,7 @@ Date.parse(x.toLocaleString())
                 1. If _matchStr_ is the empty String, then
                   1. Let _thisIndex_ be ? ToLength(? Get(_rx_, `"lastIndex"`)).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Let _setStatus_ be ? Set(_rx_, `"lastIndex"`, _nextIndex_, *true*).
+                  1. Perform ? Set(_rx_, `"lastIndex"`, _nextIndex_, *true*).
                 1. Increment _n_.
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.match]"`.</p>
@@ -28993,7 +28993,7 @@ Date.parse(x.toLocaleString())
           1. Let _global_ be ToBoolean(? Get(_rx_, `"global"`)).
           1. If _global_ is *true*, then
             1. Let _fullUnicode_ be ToBoolean(? Get(_rx_, `"unicode"`)).
-            1. Let _setStatus_ be ? Set(_rx_, `"lastIndex"`, 0, *true*).
+            1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
           1. Let _results_ be a new empty List.
           1. Let _done_ be *false*.
           1. Repeat, while _done_ is *false*
@@ -29007,7 +29007,7 @@ Date.parse(x.toLocaleString())
                 1. If _matchStr_ is the empty String, then
                   1. Let _thisIndex_ be ? ToLength(? Get(_rx_, `"lastIndex"`)).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Let _setStatus_ be ? Set(_rx_, `"lastIndex"`, _nextIndex_, *true*).
+                  1. Perform ? Set(_rx_, `"lastIndex"`, _nextIndex_, *true*).
           1. Let _accumulatedResult_ be the empty String value.
           1. Let _nextSourcePosition_ be 0.
           1. Repeat, for each _result_ in _results_,
@@ -29119,7 +29119,7 @@ Date.parse(x.toLocaleString())
             1. Return _A_.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &lt; _size_
-            1. Let _setStatus_ be ? Set(_splitter_, `"lastIndex"`, _q_, *true*).
+            1. Perform ? Set(_splitter_, `"lastIndex"`, _q_, *true*).
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is *null*, let _q_ be AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
             1. Else _z_ is not *null*,
@@ -29337,7 +29337,7 @@ Date.parse(x.toLocaleString())
               1. Let _Pk_ be ToString(_k_).
               1. Let _next_ be ? IteratorStep(_iterator_).
               1. If _next_ is *false*, then
-                1. Let _setStatus_ be ? Set(_A_, `"length"`, _k_, *true*).
+                1. Perform ? Set(_A_, `"length"`, _k_, *true*).
                 1. Return _A_.
               1. Let _nextValue_ be ? IteratorValue(_next_).
               1. If _mapping_ is *true*, then
@@ -29363,9 +29363,9 @@ Date.parse(x.toLocaleString())
             1. If _mapping_ is *true*, then
               1. Let _mappedValue_ be ? Call(_mapfn_, _T_, &laquo;_kValue_, _k_&raquo;).
             1. Else, let _mappedValue_ be _kValue_.
-            1. Let _defineStatus_ be ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
+            1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
             1. Increase _k_ by 1.
-          1. Let _setStatus_ be ? Set(_A_, `"length"`, _len_, *true*).
+          1. Perform ? Set(_A_, `"length"`, _len_, *true*).
           1. Return _A_.
         </emu-alg>
         <p>The `length` property of the `from` method is 1.</p>
@@ -29400,9 +29400,9 @@ Date.parse(x.toLocaleString())
           1. Repeat, while _k_ &lt; _len_
             1. Let _kValue_ be _items_[_k_].
             1. Let _Pk_ be ToString(_k_).
-            1. Let _defineStatus_ be ? CreateDataPropertyOrThrow(_A_,_Pk_, _kValue_).
+            1. Perform ? CreateDataPropertyOrThrow(_A_,_Pk_, _kValue_).
             1. Increase _k_ by 1.
-          1. Let _setStatus_ be ? Set(_A_, `"length"`, _len_, *true*).
+          1. Perform ? Set(_A_, `"length"`, _len_, *true*).
           1. Return _A_.
         </emu-alg>
         <p>The `length` property of the `of` method is 0.</p>
@@ -29473,7 +29473,7 @@ Date.parse(x.toLocaleString())
               1. If _n_&ge;2<sup>53</sup>-1, throw a *TypeError* exception.
               1. Let _status_ be ? CreateDataPropertyOrThrow(_A_, ToString(_n_), _E_).
               1. Increase _n_ by 1.
-          1. Let _setStatus_ be ? Set(_A_, `"length"`, _n_, *true*).
+          1. Perform ? Set(_A_, `"length"`, _n_, *true*).
           1. Return _A_.
         </emu-alg>
         <p>The `length` property of the `concat` method is 1.</p>
@@ -29533,9 +29533,9 @@ Date.parse(x.toLocaleString())
             1. Let _fromPresent_ be ? HasProperty(_O_, _fromKey_).
             1. If _fromPresent_ is *true*, then
               1. Let _fromVal_ be ? Get(_O_, _fromKey_).
-              1. Let _setStatus_ be ? Set(_O_, _toKey_, _fromVal_, *true*).
+              1. Perform ? Set(_O_, _toKey_, _fromVal_, *true*).
             1. Else _fromPresent_ is *false*,
-              1. Let _deleteStatus_ be ? DeletePropertyOrThrow(_O_, _toKey_).
+              1. Perform ? DeletePropertyOrThrow(_O_, _toKey_).
             1. Let _from_ be _from_ + _direction_.
             1. Let _to_ be _to_ + _direction_.
             1. Let _count_ be _count_ - 1.
@@ -29607,7 +29607,7 @@ Date.parse(x.toLocaleString())
           1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_),0); else let _final_ be min(_relativeEnd_, _len_).
           1. Repeat, while _k_ &lt; _final_
             1. Let _Pk_ be ToString(_k_).
-            1. Let _setStatus_ be ? Set(_O_, _Pk_, _value_, *true*).
+            1. Perform ? Set(_O_, _Pk_, _value_, *true*).
             1. Increase _k_ by 1.
           1. Return _O_.
         </emu-alg>
@@ -29898,14 +29898,14 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If _len_ is zero, then
-            1. Let _setStatus_ be ? Set(_O_, `"length"`, 0, *true*).
+            1. Perform ? Set(_O_, `"length"`, 0, *true*).
             1. Return *undefined*.
           1. Else _len_ &gt; 0,
             1. Let _newLen_ be _len_-1.
             1. Let _indx_ be ToString(_newLen_).
             1. Let _element_ be ? Get(_O_, _indx_).
-            1. Let _deleteStatus_ be ? DeletePropertyOrThrow(_O_, _indx_).
-            1. Let _setStatus_ be ? Set(_O_, `"length"`, _newLen_, *true*).
+            1. Perform ? DeletePropertyOrThrow(_O_, _indx_).
+            1. Perform ? Set(_O_, `"length"`, _newLen_, *true*).
             1. Return _element_.
         </emu-alg>
         <emu-note>
@@ -29928,9 +29928,9 @@ Date.parse(x.toLocaleString())
           1. If _len_ + _argCount_ &gt; 2<sup>53</sup>-1, throw a *TypeError* exception.
           1. Repeat, while _items_ is not empty
             1. Remove the first element from _items_ and let _E_ be the value of the element.
-            1. Let _setStatus_ be ? Set(_O_, ToString(_len_), _E_, *true*).
+            1. Perform ? Set(_O_, ToString(_len_), _E_, *true*).
             1. Let _len_ be _len_+1.
-          1. Let _setStatus_ be ? Set(_O_, `"length"`, _len_, *true*).
+          1. Perform ? Set(_O_, `"length"`, _len_, *true*).
           1. Return _len_.
         </emu-alg>
         <p>The `length` property of the `push` method is 1.</p>
@@ -30046,16 +30046,14 @@ Date.parse(x.toLocaleString())
             1. If _upperExists_ is *true*, then
               1. Let _upperValue_ be ? Get(_O_, _upperP_).
             1. If _lowerExists_ is *true* and _upperExists_ is *true*, then
-              1. Let _setStatus_ be ? Set(_O_, _lowerP_, _upperValue_, *true*).
-              1. Let _setStatus_ be ? Set(_O_, _upperP_, _lowerValue_, *true*).
+              1. Perform ? Set(_O_, _lowerP_, _upperValue_, *true*).
+              1. Perform ? Set(_O_, _upperP_, _lowerValue_, *true*).
             1. Else if _lowerExists_ is *false* and _upperExists_ is *true*, then
-              1. Let _setStatus_ be ? Set(_O_, _lowerP_, _upperValue_, *true*).
-              1. Let _deleteStatus_ be DeletePropertyOrThrow (_O_, _upperP_).
-              1. ReturnIfAbrupt(_deleteStatus_).
+              1. Perform ? Set(_O_, _lowerP_, _upperValue_, *true*).
+              1. Perform ? DeletePropertyOrThrow (_O_, _upperP_).
             1. Else if _lowerExists_ is *true* and _upperExists_ is *false*, then
-              1. Let _deleteStatus_ be DeletePropertyOrThrow (_O_, _lowerP_).
-              1. ReturnIfAbrupt(_deleteStatus_).
-              1. Let _setStatus_ be ? Set(_O_, _upperP_, _lowerValue_, *true*).
+              1. Perform ? DeletePropertyOrThrow (_O_, _lowerP_).
+              1. Perform ? Set(_O_, _upperP_, _lowerValue_, *true*).
             1. Else both _lowerExists_ and _upperExists_ are *false*,
               1. No action is required.
             1. Increase _lower_ by 1.
@@ -30077,7 +30075,7 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If _len_ is zero, then
-            1. Let _setStatus_ be ? Set(_O_, `"length"`, 0, *true*).
+            1. Perform ? Set(_O_, `"length"`, 0, *true*).
             1. Return *undefined*.
           1. Let _first_ be ? Get(_O_, `"0"`).
           1. Let _k_ be 1.
@@ -30087,12 +30085,12 @@ Date.parse(x.toLocaleString())
             1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
             1. If _fromPresent_ is *true*, then
               1. Let _fromVal_ be ? Get(_O_, _from_).
-              1. Let _setStatus_ be ? Set(_O_, _to_, _fromVal_, *true*).
+              1. Perform ? Set(_O_, _to_, _fromVal_, *true*).
             1. Else _fromPresent_ is *false*,
-              1. Let _deleteStatus_ be ? DeletePropertyOrThrow(_O_, _to_).
+              1. Perform ? DeletePropertyOrThrow(_O_, _to_).
             1. Increase _k_ by 1.
-          1. Let _deleteStatus_ be ? DeletePropertyOrThrow(_O_, ToString(_len_-1)).
-          1. Let _setStatus_ be ? Set(_O_, `"length"`, _len_-1, *true*).
+          1. Perform ? DeletePropertyOrThrow(_O_, ToString(_len_-1)).
+          1. Perform ? Set(_O_, `"length"`, _len_-1, *true*).
           1. Return _first_.
         </emu-alg>
         <emu-note>
@@ -30125,7 +30123,7 @@ Date.parse(x.toLocaleString())
               1. Let _status_ be ? CreateDataPropertyOrThrow(_A_, ToString(_n_), _kValue_ ).
             1. Increase _k_ by 1.
             1. Increase _n_ by 1.
-          1. Let _setStatus_ be ? Set(_A_, `"length"`, _n_, *true*).
+          1. Perform ? Set(_A_, `"length"`, _n_, *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -30333,7 +30331,7 @@ Date.parse(x.toLocaleString())
               1. Let _fromValue_ be ? Get(_O_, _from_).
               1. Let _status_ be ? CreateDataPropertyOrThrow(_A_, ToString(_k_), _fromValue_).
             1. Increment _k_ by 1.
-          1. Let _setStatus_ be ? Set(_A_, `"length"`, _actualDeleteCount_, *true*).
+          1. Perform ? Set(_A_, `"length"`, _actualDeleteCount_, *true*).
           1. Let _items_ be a List whose elements are, in left to right order, the portion of the actual argument list starting with the third argument. The list is empty if fewer than three arguments were passed.
           1. Let _itemCount_ be the number of elements in _items_.
           1. If _itemCount_ &lt; _actualDeleteCount_, then
@@ -30344,13 +30342,13 @@ Date.parse(x.toLocaleString())
               1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
               1. If _fromPresent_ is *true*, then
                 1. Let _fromValue_ be ? Get(_O_, _from_).
-                1. Let _setStatus_ be ? Set(_O_, _to_, _fromValue_, *true*).
+                1. Perform ? Set(_O_, _to_, _fromValue_, *true*).
               1. Else _fromPresent_ is *false*,
-                1. Let _deleteStatus_ be ? DeletePropertyOrThrow(_O_, _to_).
+                1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Increase _k_ by 1.
             1. Let _k_ be _len_.
             1. Repeat, while _k_ &gt; (_len_ - _actualDeleteCount_ + _itemCount_)
-              1. Let _deleteStatus_ be ? DeletePropertyOrThrow(_O_, ToString(_k_-1)).
+              1. Perform ? DeletePropertyOrThrow(_O_, ToString(_k_-1)).
               1. Decrease _k_ by 1.
           1. Else if _itemCount_ &gt; _actualDeleteCount_, then
             1. Let _k_ be (_len_ - _actualDeleteCount_).
@@ -30360,16 +30358,16 @@ Date.parse(x.toLocaleString())
               1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
               1. If _fromPresent_ is *true*, then
                 1. Let _fromValue_ be ? Get(_O_, _from_).
-                1. Let _setStatus_ be ? Set(_O_, _to_, _fromValue_, *true*).
+                1. Perform ? Set(_O_, _to_, _fromValue_, *true*).
               1. Else _fromPresent_ is *false*,
-                1. Let _deleteStatus_ be ? DeletePropertyOrThrow(_O_, _to_).
+                1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Decrease _k_ by 1.
           1. Let _k_ be _actualStart_.
           1. Repeat, while _items_ is not empty
             1. Remove the first element from _items_ and let _E_ be the value of that element.
-            1. Let _setStatus_ be ? Set(_O_, ToString(_k_), _E_, *true*).
+            1. Perform ? Set(_O_, ToString(_k_), _E_, *true*).
             1. Increase _k_ by 1.
-          1. Let _setStatus_ be ? Set(_O_, `"length"`, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
+          1. Perform ? Set(_O_, `"length"`, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
           1. Return _A_.
         </emu-alg>
         <p>The `length` property of the `splice` method is 2.</p>
@@ -30455,17 +30453,17 @@ Date.parse(x.toLocaleString())
               1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
               1. If _fromPresent_ is *true*, then
                 1. Let _fromValue_ be ? Get(_O_, _from_).
-                1. Let _setStatus_ be ? Set(_O_, _to_, _fromValue_, *true*).
+                1. Perform ? Set(_O_, _to_, _fromValue_, *true*).
               1. Else _fromPresent_ is *false*,
-                1. Let _deleteStatus_ be ? DeletePropertyOrThrow(_O_, _to_).
+                1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Decrease _k_ by 1.
             1. Let _j_ be 0.
             1. Let _items_ be a List whose elements are, in left to right order, the arguments that were passed to this function invocation.
             1. Repeat, while _items_ is not empty
               1. Remove the first element from _items_ and let _E_ be the value of that element.
-              1. Let _setStatus_ be ? Set(_O_, ToString(_j_), _E_, *true*).
+              1. Perform ? Set(_O_, ToString(_j_), _E_, *true*).
               1. Increase _j_ by 1.
-          1. Let _setStatus_ be ? Set(_O_, `"length"`, _len_+_argCount_, *true*).
+          1. Perform ? Set(_O_, `"length"`, _len_+_argCount_, *true*).
           1. Return _len_+_argCount_.
         </emu-alg>
         <p>The `length` property of the `unshift` method is 1.</p>
@@ -31077,7 +31075,7 @@ Date.parse(x.toLocaleString())
                 1. If _mapping_ is *true*, then
                   1. Let _mappedValue_ be ? Call(_mapfn_, _T_, &laquo;_kValue_, _k_&raquo;).
                 1. Else, let _mappedValue_ be _kValue_.
-                1. Let _setStatus_ be ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
+                1. Perform ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
                 1. Increase _k_ by 1.
               1. Assert: _values_ is now an empty List.
               1. Return _targetObj_.
@@ -31092,7 +31090,7 @@ Date.parse(x.toLocaleString())
               1. If _mapping_ is *true*, then
                 1. Let _mappedValue_ be ? Call(_mapfn_, _T_, &laquo;_kValue_, _k_&raquo;).
               1. Else, let _mappedValue_ be _kValue_.
-              1. Let _setStatus_ be ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
+              1. Perform ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
               1. Increase _k_ by 1.
             1. Return _targetObj_.
           </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -29029,11 +29029,10 @@ Date.parse(x.toLocaleString())
               1. Let _replacerArgs_ be &laquo;_matched_&raquo;.
               1. Append in list order the elements of _captures_ to the end of the List _replacerArgs_.
               1. Append _position_ and _S_ as the last two elements of _replacerArgs_.
-              1. Let _replValue_ be Call(_replaceValue_, *undefined*, _replacerArgs_).
-              1. Let _replacement_ be ToString(_replValue_).
+              1. Let _replValue_ be ? Call(_replaceValue_, *undefined*, _replacerArgs_).
+              1. Let _replacement_ be ? ToString(_replValue_).
             1. Else,
               1. Let _replacement_ be GetSubstitution(_matched_, _S_, _position_, _captures_, _replaceValue_).
-            1. ReturnIfAbrupt(_replacement_).
             1. If _position_ &ge; _nextSourcePosition_, then
               1. NOTE _position_ should not normally move backwards. If it does, it is an indication of an ill-behaving RegExp subclass or use of an access triggered side-effect to change the global flag or other characteristics of _rx_. In such cases, the corresponding substitution is ignored.
               1. Let _accumulatedResult_ be the String formed by concatenating the code units of the current value of _accumulatedResult_ with the substring of _S_ consisting of the code units from _nextSourcePosition_ (inclusive) up to _position_ (exclusive) and with the code units of _replacement_.


### PR DESCRIPTION
The ReturnIfAbrupt refactor seems to have left lots of unused spec variables. This PR removes them in favor of "Perform" to indicate an operation that, if it's not an abrupt completion, is purely for side effects.

I have no opinion on what the wording should be - please bikeshed all you like - but we don't need all the "setStatus" "deleteStatus" etc vars so I think they should be removed.