### PR TITLE
add 64-bit integer operations entry to stage 0 proposals table

### DIFF
--- a/stage0.md
+++ b/stage0.md
@@ -20,5 +20,6 @@ Stage 0 proposals have been presented to the committee and not rejected definiti
 | | [RegExp Look-behind](http://www.akenotsuki.com/misc/srell/lookbehind_proposal.html) | Gorkem Yakin, Brian Terlson, & Nozomu Katō | 0 
 |🚀| [Encapsulated private state for objects](https://github.com/wycats/javascript-private-state) | Yehuda Katz & Allen Wirfs-Brock | 0
 | | [Error.isError](https://github.com/ljharb/proposal-is-error) | Jordan Harband | 0
+| | [64-Bit Integer Operations](https://gist.github.com/BrendanEich/4294d5c212a6d2254703) | Brendan Eich | 0
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.


### PR DESCRIPTION
Reference: https://esdiscuss.org/topic/efficient-64-bit-arithmetic#content-7

https://gist.github.com/BrendanEich/4294d5c212a6d2254703

Looks like it was never added here