### PR TITLE
Add config for `*.md` files in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Add configuration in the `.editorconfig` file to prevent the removal of trailing whitespaces from `*.md` files, as they are used¹ in Markdown.

--

¹ e.g. from https://daringfireball.net/projects/markdown/syntax#block:

 > " When you do want to insert a `<br />` break tag using Markdown, you end a line with two or more spaces, then type return. "