### PR TITLE
Layering: formalize the "continent" concept

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6254,6 +6254,8 @@
         1. Add _pending_ at the back of the Job Queue named by _queueName_.
         1. Return NormalCompletion(~empty~).
       </emu-alg>
+
+      <emu-note>For host environments consisting of multiple continents, when those host environments enqueue their own jobs, they should generally specify which continent's job queues they are enqueuing on.</emu-note>
     </emu-clause>
 
     <!-- es6num="8.4.2" -->
@@ -6285,6 +6287,20 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-continents">
+    <h1>Continents</h1>
+
+    <p>A <dfn id="continent">continent</dfn> is an independent unit of ECMAScript computation, and is the largest unit that this specification deals with. Everything within this specification is assumed to occur within a single continent.</p>
+
+    <p>The host environment must create a continent prior to the execution of any Jobs or the evaluation of any ECMAScript code.</p>
+
+    <p>A continent may contain multiple realms, as defined in <emu-xref href="#sec-code-realms"></emu-xref>. Each realm belongs to exactly one continent. Depending on the host environment, code executed within a given continent's realms may or may not be able to reach objects from other realms in that continent. However, code executed in one continent must not be able to directly reference or share objects from another continent.</p>
+
+    <p>Each continent contains a set of job queues, as defined in <emu-xref href="#sec-jobs-and-job-queues"></emu-xref>.</p>
+
+    <emu-note>Typically, a continent is implemented as a single thread of execution. For example, in a web browser, each unit of related similar-origin browsing contexts consists of a single continent, as does each worker.</emu-note>
+  </emu-clause>
+
   <emu-clause id="sec-initializehostdefinedrealm" aoid="InitializeHostDefinedRealm">
     <h1>InitializeHostDefinedRealm( )</h1>
     <p>The abstract operation InitializeHostDefinedRealm performs the following steps:</p>
@@ -6308,6 +6324,10 @@
           1. Perform EnqueueJob(`"ScriptJobs"`, TopLevelModuleEvaluationJob, &laquo; _sourceText_, _hostDefined_ &raquo;).
       1. NextJob NormalCompletion(*undefined*).
     </emu-alg>
+
+    <emu-note>
+      Host environments are expected to first create a continent, and then create new host-defined realms within it using this abstract operation.
+    </emu-note>
   </emu-clause>
 </emu-clause>
 


### PR DESCRIPTION
This includes a couple fixes to help HTML and ES play well together. The second one, allowing the global this and global object to diverge, is significant. It fixes the following from HTML:

> This is a willful violation of the JavaScript specification current at the time of writing (ECMAScript edition 5, as defined in section 10.4.1.1 Initial Global Execution Context, step 3). The JavaScript specification requires that the this keyword in the global scope return the global object, but this is not compatible with the security design prevalent in implementations as specified herein.

/cc @annevk.