### PR TITLE
Editorial: fix abstract operation call syntax

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4318,8 +4318,8 @@
       <emu-alg>
         1. If _newTarget_ was not passed, let _newTarget_ be _F_.
         1. If _argumentsList_ was not passed, let _argumentsList_ be a new empty List.
-        1. Assert: IsConstructor (_F_) is *true*.
-        1. Assert: IsConstructor (_newTarget_) is *true*.
+        1. Assert: IsConstructor(_F_) is *true*.
+        1. Assert: IsConstructor(_newTarget_) is *true*.
         1. Return _F_.[[Construct]](_argumentsList_, _newTarget_).
       </emu-alg>
       <emu-note>
@@ -6619,7 +6619,7 @@ for (let protoName of Reflect.enumerate(proto)) {
       <p>The abstract operation GetPrototypeFromConstructor determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's `prototype` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
-        1. Assert: IsCallable (_constructor_) is *true*.
+        1. Assert: IsCallable(_constructor_) is *true*.
         1. Let _proto_ be ? Get(_constructor_, `"prototype"`).
         1. If Type(_proto_) is not Object, then
           1. Let _realm_ be ? GetFunctionRealm(_constructor_).
@@ -7467,7 +7467,7 @@ for (let protoName of Reflect.enumerate(proto)) {
           <p>When the abstract operation StringGetIndexProperty is called with an exotic String object _S_ and with property key _P_, the following steps are taken:</p>
           <emu-alg>
             1. If Type(_P_) is not String, return *undefined*.
-            1. Let _index_ be CanonicalNumericIndexString (_P_).
+            1. Let _index_ be CanonicalNumericIndexString(_P_).
             1. Assert: _index_ is not an abrupt completion.
             1. If _index_ is *undefined*, return *undefined*.
             1. If IsInteger(_index_) is *false*, return *undefined*.
@@ -7817,7 +7817,7 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
           1. If Type(_P_) is String, then
-            1. Let _numericIndex_ be CanonicalNumericIndexString (_P_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. Assert: _numericIndex_ is not an abrupt completion.
             1. If _numericIndex_ is not *undefined*, then
               1. If IsInteger(_numericIndex_) is *false*, return *false*.
@@ -7832,7 +7832,7 @@ for (let protoName of Reflect.enumerate(proto)) {
               1. If _Desc_ has a [[Writable]] field and if _Desc_.[[Writable]] is *false*, return *false*.
               1. If _Desc_ has a [[Value]] field, then
                 1. Let _value_ be _Desc_.[[Value]].
-                1. Return IntegerIndexedElementSet (_O_, _intIndex_, _value_).
+                1. Return IntegerIndexedElementSet(_O_, _intIndex_, _value_).
               1. Return *true*.
           1. Return OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
         </emu-alg>
@@ -7845,7 +7845,7 @@ for (let protoName of Reflect.enumerate(proto)) {
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is String and if SameValue(_O_, _Receiver_) is *true*, then
-            1. Let _numericIndex_ be CanonicalNumericIndexString (_P_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. Assert: _numericIndex_ is not an abrupt completion.
             1. If _numericIndex_ is not *undefined*, then
               1. Return IntegerIndexedElementGet(_O_, _numericIndex_).
@@ -7860,7 +7860,7 @@ for (let protoName of Reflect.enumerate(proto)) {
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is String and if SameValue(_O_, _Receiver_) is *true*, then
-            1. Let _numericIndex_ be CanonicalNumericIndexString (_P_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. Assert: _numericIndex_ is not an abrupt completion.
             1. If _numericIndex_ is not *undefined*, then
               1. Return IntegerIndexedElementSet (_O_, _numericIndex_, _V_).
@@ -8446,7 +8446,7 @@ for (let protoName of Reflect.enumerate(proto)) {
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. Let _resultDesc_ be ? ToPropertyDescriptor(_trapResultObj_).
         1. Call CompletePropertyDescriptor(_resultDesc_).
-        1. Let _valid_ be IsCompatiblePropertyDescriptor (_extensibleTarget_, _resultDesc_, _targetDesc_).
+        1. Let _valid_ be IsCompatiblePropertyDescriptor(_extensibleTarget_, _resultDesc_, _targetDesc_).
         1. If _valid_ is *false*, throw a *TypeError* exception.
         1. If _resultDesc_.[[Configurable]] is *false*, then
           1. If _targetDesc_ is *undefined* or _targetDesc_.[[Configurable]] is *true*, then
@@ -11896,7 +11896,7 @@ a = b + c
             1. Else,
               1. Let _argList_ be ArgumentListEvaluation of _arguments_.
               1. ReturnIfAbrupt(_argList_).
-            1. If IsConstructor (_constructor_) is *false*, throw a *TypeError* exception.
+            1. If IsConstructor(_constructor_) is *false*, throw a *TypeError* exception.
             1. Return Construct(_constructor_, _argList_).
           </emu-alg>
         </emu-clause>
@@ -15544,7 +15544,7 @@ eval("1;var a;")
             1. Let _exprValue_ be ? GetValue(_exprRef_).
             1. If ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
             1. Let _stmt_ be the result of evaluating |Statement|.
-            1. If LoopContinues (_stmt_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmt_, _V_)).
+            1. If LoopContinues(_stmt_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmt_, _V_)).
             1. If _stmt_.[[value]] is not ~empty~, let _V_ be _stmt_.[[value]].
         </emu-alg>
       </emu-clause>
@@ -18629,7 +18629,7 @@ eval("1;var a;")
             1. Let _innerResult_ be ? IteratorNext(_iterator_, _received_.[[value]]).
             1. Let _done_ be ? IteratorComplete(_innerResult_).
             1. If _done_ is *true*, then
-              1. Return IteratorValue (_innerResult_).
+              1. Return IteratorValue(_innerResult_).
             1. Let _received_ be GeneratorYield(_innerResult_).
           1. Else if _received_.[[type]] is ~throw~, then
             1. Let _throw_ be ? GetMethod(_iterator_, `"throw"`).
@@ -25062,17 +25062,17 @@ new Function("a,b", "c", "return a+b+c")
         <p>Months are identified by an integer in the range 0 to 11, inclusive. The mapping MonthFromTime(_t_) from a time value _t_ to a month number is defined by:</p>
         <emu-eqn aoid="MonthFromTime">MonthFromTime(_t_)
           = 0 if 0 &le; DayWithinYear(_t_) &lt; 31
-          = 1 if 31 &le; DayWithinYear (_t_) &lt; 59+InLeapYear(_t_)
-          = 2 if 59+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 90+InLeapYear(_t_)
-          = 3 if 90+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 120+InLeapYear(_t_)
-          = 4 if 120+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 151+InLeapYear(_t_)
-          = 5 if 151+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 181+InLeapYear(_t_)
-          = 6 if 181+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 212+InLeapYear(_t_)
-          = 7 if 212+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 243+InLeapYear(_t_)
-          = 8 if 243+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 273+InLeapYear(_t_)
-          = 9 if 273+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 304+InLeapYear(_t_)
-          = 10 if 304+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 334+InLeapYear(_t_)
-          = 11 if 334+InLeapYear(_t_) &le; DayWithinYear (_t_) &lt; 365+InLeapYear(_t_)
+          = 1 if 31 &le; DayWithinYear(_t_) &lt; 59+InLeapYear(_t_)
+          = 2 if 59+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 90+InLeapYear(_t_)
+          = 3 if 90+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 120+InLeapYear(_t_)
+          = 4 if 120+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 151+InLeapYear(_t_)
+          = 5 if 151+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 181+InLeapYear(_t_)
+          = 6 if 181+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 212+InLeapYear(_t_)
+          = 7 if 212+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 243+InLeapYear(_t_)
+          = 8 if 243+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 273+InLeapYear(_t_)
+          = 9 if 273+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 304+InLeapYear(_t_)
+          = 10 if 304+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 334+InLeapYear(_t_)
+          = 11 if 334+InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 365+InLeapYear(_t_)
         </emu-eqn>
         <p>where</p>
         <emu-eqn aoid="DayWithinYear">DayWithinYear(_t_) = Day(_t_)-DayFromYear(YearFromTime(_t_))</emu-eqn>
@@ -25451,7 +25451,7 @@ THH:mm:ss.sss
             1. Return _O_.
           1. Else,
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
-            1. Return ToDateString (_now_).
+            1. Return ToDateString(_now_).
         </emu-alg>
       </emu-clause>
 
@@ -25478,7 +25478,7 @@ THH:mm:ss.sss
             1. Return _O_.
           1. Else,
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
-            1. Return ToDateString (_now_).
+            1. Return ToDateString(_now_).
         </emu-alg>
       </emu-clause>
 
@@ -25496,7 +25496,7 @@ THH:mm:ss.sss
             1. Return _O_.
           1. Else,
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
-            1. Return ToDateString (_now_).
+            1. Return ToDateString(_now_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -30082,9 +30082,9 @@ Date.parse(x.toLocaleString())
               1. Perform ? Set(_O_, _upperP_, _lowerValue_, *true*).
             1. Else if _lowerExists_ is *false* and _upperExists_ is *true*, then
               1. Perform ? Set(_O_, _lowerP_, _upperValue_, *true*).
-              1. Perform ? DeletePropertyOrThrow (_O_, _upperP_).
+              1. Perform ? DeletePropertyOrThrow(_O_, _upperP_).
             1. Else if _lowerExists_ is *true* and _upperExists_ is *false*, then
-              1. Perform ? DeletePropertyOrThrow (_O_, _lowerP_).
+              1. Perform ? DeletePropertyOrThrow(_O_, _lowerP_).
               1. Perform ? Set(_O_, _upperP_, _lowerValue_, *true*).
             1. Else both _lowerExists_ and _upperExists_ are *false*,
               1. No action is required.
@@ -30946,7 +30946,7 @@ Date.parse(x.toLocaleString())
               1. If _subclass_ has a [[TypedArrayConstructorName]] internal slot, let _constructorName_ be the value of _subclass_'s [[TypedArrayConstructorName]] internal slot.
               1. Let _subclass_ be ? _subclass_.[[GetPrototypeOf]]().
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%TypedArrayPrototype%"`).
-            1. Let _obj_ be IntegerIndexedObjectCreate (_proto_, &laquo;[[ViewedArrayBuffer]], [[TypedArrayName]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]]&raquo; ).
+            1. Let _obj_ be IntegerIndexedObjectCreate(_proto_, &laquo;[[ViewedArrayBuffer]], [[TypedArrayName]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]]&raquo; ).
             1. Assert: The [[ViewedArrayBuffer]] internal slot of _obj_ is *undefined*.
             1. Set _obj_'s [[TypedArrayName]] internal slot to _constructorName_.
             1. If _length_ was not passed, then
@@ -31529,14 +31529,14 @@ Date.parse(x.toLocaleString())
             1. If SameValue(_srcType_, _targetType_) is *false*, then
               1. Repeat, while _targetByteIndex_ &lt; _limit_
                 1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, _srcType_).
-                1. Perform SetValueInBuffer (_targetBuffer_, _targetByteIndex_, _targetType_, _value_).
+                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
             1. Else,
               1. NOTE: If _srcType_ and _targetType_ are the same the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
               1. Repeat, while _targetByteIndex_ &lt; _limit_
                 1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, `"Uint8"`).
-                1. Perform SetValueInBuffer (_targetBuffer_, _targetByteIndex_, `"Uint8"`, _value_).
+                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, `"Uint8"`, _value_).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + 1.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + 1.
             1. Return *undefined*.
@@ -31583,7 +31583,7 @@ Date.parse(x.toLocaleString())
             1. Let _srcByteIndex_ be (_k_ &times; _elementSize_) + _srcByteOffet_.
             1. Repeat, while _targetByteIndex_ &lt; _count_ &times; _elementSize_
               1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, `"Uint8"`).
-              1. Perform SetValueInBuffer (_targetBuffer_, _targetByteIndex_, `"Uint8"`, _value_).
+              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, `"Uint8"`, _value_).
               1. Increase _srcByteIndex_ by 1.
               1. Increase _targetByteIndex_ by 1.
           1. Return _A_.
@@ -31727,7 +31727,7 @@ Date.parse(x.toLocaleString())
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _here_ be the active function.
           1. Let _super_ be ? _here_.[[GetPrototypeOf]]().
-          1. If IsConstructor (_super_) is *false*, throw a *TypeError* exception.
+          1. If IsConstructor(_super_) is *false*, throw a *TypeError* exception.
           1. Let _argumentsList_ be the _argumentsList_ argument of the [[Construct]] internal method that invoked the active function.
           1. Return Construct(_super_, _argumentsList_, NewTarget).
         </emu-alg>
@@ -34483,7 +34483,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
             1. Let _thenAction_ be _then_.[[value]].
             1. If IsCallable(_thenAction_) is *false*, then
               1. Return FulfillPromise(_promise_, _resolution_).
-            1. Perform EnqueueJob (`"PromiseJobs"`, PromiseResolveThenableJob, &laquo;_promise_, _resolution_, _thenAction_&raquo;).
+            1. Perform EnqueueJob(`"PromiseJobs"`, PromiseResolveThenableJob, &laquo;_promise_, _resolution_, _thenAction_&raquo;).
             1. Return *undefined*.
           </emu-alg>
           <p>The `length` property of a promise resolve function is 1.</p>


### PR DESCRIPTION
As per [previous discussion](https://github.com/tc39/ecma262/pull/230#issuecomment-162664443).

Before anyone asks, I wrote a quick script to aid in finding these abstract operation call syntax ECMASpeak violations. I hope this may be useful for someone else as well:

```js
(() => {
  'use strict';

  const excludedTags = ['H1', 'A'];
  const reg = /[A-Z]\w+ \($/;
  const luke = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
    acceptNode(node) {
      return node.nodeValue.endsWith(' (') && !excludedTags.includes(node.parentNode.nodeName) && reg.test(node.nodeValue);
    }
  });

  luke[Symbol.iterator] = function() {
    return {
      next: () => {
        const value = this.nextNode();
        return { value, done: !value };
      }
    };
  };

  for (const node of luke) {
    console.warn(node.nodeValue);
    node.parentNode.style.outline = '2px dashed red';
    node.parentNode.scrollIntoView();

    // Pause and manually analyze whether the match is a ECMASpeak violation.
    debugger;
  }
})();
```

Open the [rendered spec.](https://tc39.github.io/ecma262/) and paste the script above in Chrome 47+'s console. Voila.

Note that the script is quite inaccurate, so each potential match has to be manually reviewed (thus the debugger part). Once you find a violation, correct the source file in a text editor. I did this part by using Sublime Text's find and replace feature—for each abstract operation, replace `([^>.]\bAbstractOperation) \(` with `$1(`.

This script and workflow can surely do with some improvement.