### PR TITLE
Improve TypedArray constructor/Proxy interaction

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30901,159 +30901,24 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-%typedarray%-intrinsic-object">
       <h1>The %TypedArray% Intrinsic Object</h1>
       <p>The %TypedArray% intrinsic object is a constructor function object that all of the _TypedArray_ constructor object inherit from. %TypedArray% and its corresponding prototype object provide common properties that are inherited by all _TypedArray_ constructors and their instances. The %TypedArray% intrinsic does not have a global name or appear as a property of the global object.</p>
-      <p>The %TypedArray% intrinsic function object is designed to act as the superclass of the various _TypedArray_ constructors. Those constructors use %TypedArray% to initialize their instances by invoking %TypedArray% as if by making a `super` call. The %TypedArray% intrinsic function is not designed to be directly called in any other way. If %TypedArray% is directly called or called as part of a `new` expression an exception is thrown.</p>
-      <p>The %TypedArray% intrinsic constructor function is a single function whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a `super` call of %TypedArray% depends upon the number and kind of arguments that are passed to it.</p>
+      <p>The %TypedArray% intrinsic function object is designed to act as the superclass of the various _TypedArray_ constructors.</p>
 
-      <!-- es6num="22.2.1.1" -->
-      <emu-clause id="sec-%typedarray%-intrinsic-object-%typedarray%">
-        <h1>%TypedArray% ( )</h1>
-        <p>This description applies only if the %TypedArray% function is called with no arguments.</p>
+      <!-- es6num="22.2.4.1" -->
+      <emu-clause id="sec-typedarray">
+        <h1>%TypedArray%()</h1>
+        <p>The %TypedArray% constructor performs the following steps:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Return AllocateTypedArray(NewTarget, 0).
-        </emu-alg>
-      </emu-clause>
-
-      <!-- es6num="22.2.1.2" -->
-      <emu-clause id="sec-%typedarray%-length">
-        <h1>%TypedArray% ( _length_ )</h1>
-        <p>This description applies only if the %TypedArray% function is called with at least one argument and the Type of the first argument is not Object.</p>
-        <p>%TypedArray% called with argument _length_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_length_) is not Object.
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If _length_ is *undefined*, throw a *TypeError* exception.
-          1. Let _numberLength_ be ToNumber(_length_).
-          1. Let _elementLength_ be ? ToLength(_numberLength_).
-          1. If SameValueZero(_numberLength_, _elementLength_) is *false*, throw a *RangeError* exception.
-          1. Return AllocateTypedArray(NewTarget, _elementLength_).
-        </emu-alg>
-
-        <!-- es6num="22.2.1.2.1" -->
-        <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
-          <h1>Runtime Semantics: AllocateTypedArray (_newTarget_, _length_ )</h1>
-          <p>The abstract operation AllocateTypedArray with argument _newTarget_ and optional argument _length_ is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the %TypeArray% overloads and other methods. AllocateTypedArray performs the following steps:</p>
-          <emu-alg>
-            1. Assert: IsConstructor(_newTarget_) is *true*.
-            1. If SameValue(%TypedArray%, _newTarget_) is *true*, throw a *TypeError* exception.
-            1. NOTE %TypedArray% throws an exception when invoked via either a function call or the `new` operator. It can only be successfully invoked by a |SuperCall|.
-            1. Let _constructorName_ be *undefined*.
-            1. Let _subclass_ be _newTarget_.
-            1. Repeat while _constructorName_ is *undefined*
-              1. If _subclass_ is *null*, throw a *TypeError* exception.
-              1. If SameValue(%TypedArray%, _subclass_) is *true*, throw a *TypeError* exception.
-              1. If _subclass_ has a [[TypedArrayConstructorName]] internal slot, let _constructorName_ be the value of _subclass_'s [[TypedArrayConstructorName]] internal slot.
-              1. Let _subclass_ be ? _subclass_.[[GetPrototypeOf]]().
-            1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%TypedArrayPrototype%"`).
-            1. Let _obj_ be IntegerIndexedObjectCreate(_proto_, &laquo; [[ViewedArrayBuffer]], [[TypedArrayName]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo; ).
-            1. Assert: The [[ViewedArrayBuffer]] internal slot of _obj_ is *undefined*.
-            1. Set _obj_'s [[TypedArrayName]] internal slot to _constructorName_.
-            1. If _length_ was not passed, then
-              1. Set _obj_'s [[ByteLength]] internal slot to 0.
-              1. Set _obj_'s [[ByteOffset]] internal slot to 0.
-              1. Set _obj_'s [[ArrayLength]] internal slot to 0.
-            1. Else,
-              1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-              1. Let _byteLength_ be _elementSize_ &times; _length_.
-              1. Let _data_ be ? AllocateArrayBuffer(%ArrayBuffer%, _byteLength_).
-              1. Set _obj_'s [[ViewedArrayBuffer]] internal slot to _data_.
-              1. Set _obj_'s [[ByteLength]] internal slot to _byteLength_.
-              1. Set _obj_'s [[ByteOffset]] internal slot to 0.
-              1. Set _obj_'s [[ArrayLength]] internal slot to _length_.
-            1. Return _obj_.
-          </emu-alg>
-        </emu-clause>
-      </emu-clause>
-
-      <!-- es6num="22.2.1.3" -->
-      <emu-clause id="sec-%typedarray%-typedarray">
-        <h1>%TypedArray% ( _typedArray_ )</h1>
-        <p>This description applies only if the %TypedArray% function is called with at least one argument and the Type of the first argument is Object and that object has a [[TypedArrayName]] internal slot.</p>
-        <p>%TypedArray% called with argument _typedArray_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_typedArray_) is Object and _typedArray_ has a [[TypedArrayName]] internal slot.
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _O_ be ? AllocateTypedArray(NewTarget).
-          1. Let _srcArray_ be _typedArray_.
-          1. Let _srcData_ be the value of _srcArray_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-          1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
-          1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-          1. Let _elementLength_ be the value of _srcArray_'s [[ArrayLength]] internal slot.
-          1. Let _srcName_ be the String value of _srcArray_'s [[TypedArrayName]] internal slot.
-          1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
-          1. Let _srcElementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
-          1. Let _srcByteOffset_ be the value of _srcArray_'s [[ByteOffset]] internal slot.
-          1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-          1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
-          1. If SameValue(_elementType_,_srcType_) is *true*, then
-            1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_).
-          1. Else,
-            1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
-            1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
-            1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-            1. Let _srcByteIndex_ be _srcByteOffset_.
-            1. Let _targetByteIndex_ be 0.
-            1. Let _count_ be _elementLength_.
-            1. Repeat, while _count_ &gt;0
-              1. Let _value_ be GetValueFromBuffer(_srcData_, _srcByteIndex_, _srcType_).
-              1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_).
-              1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
-              1. Set _targetByteIndex_ to _targetByteIndex_ + _elementSize_.
-              1. Decrement _count_ by 1.
-          1. Set _O_'s [[ViewedArrayBuffer]] internal slot to _data_.
-          1. Set _O_'s [[ByteLength]] internal slot to _byteLength_.
-          1. Set _O_'s [[ByteOffset]] internal slot to 0.
-          1. Set _O_'s [[ArrayLength]] internal slot to _elementLength_.
-          1. Return _O_.
-        </emu-alg>
-      </emu-clause>
-
-      <!-- es6num="22.2.1.4" -->
-      <emu-clause id="sec-%typedarray%-object">
-        <h1>%TypedArray% ( _object_ )</h1>
-        <p>This description applies only if the %TypedArray% function is called with at least one argument and the Type of the first argument is Object and that object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.</p>
-        <p>%TypedArray% called with argument _object_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_object_) is Object and _object_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Return TypedArrayFrom(NewTarget, _object_, *undefined*, *undefined*).
-        </emu-alg>
-      </emu-clause>
-
-      <!-- es6num="22.2.1.5" -->
-      <emu-clause id="sec-%typedarray%-buffer-byteoffset-length">
-        <h1>%TypedArray% ( _buffer_ [ , _byteOffset_ [ , _length_ ] ] )</h1>
-        <p>This description applies only if the %TypedArray% function is called with at least one argument and the Type of the first argument is Object and that object has an [[ArrayBufferData]] internal slot.</p>
-        <p>%TypedArray% called with arguments _buffer_, _byteOffset_, and _length_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_buffer_) is Object and _buffer_ has an [[ArrayBufferData]] internal slot.
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _O_ be ? AllocateTypedArray(NewTarget).
-          1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
-          1. Let _elementSize_ be the Number value of the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-          1. Let _offset_ be ? ToInteger(_byteOffset_).
-          1. If _offset_ &lt; 0, throw a *RangeError* exception.
-          1. If _offset_ is -0, let _offset_ be +0.
-          1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _bufferByteLength_ be the value of _buffer_'s [[ArrayBufferByteLength]] internal slot.
-          1. If _length_ is *undefined*, then
-            1. If _bufferByteLength_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
-            1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
-            1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
-          1. Else,
-            1. Let _newLength_ be ? ToLength(_length_).
-            1. Let _newByteLength_ be _newLength_ &times; _elementSize_.
-            1. If _offset_+_newByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
-          1. Set _O_'s [[ViewedArrayBuffer]] internal slot to _buffer_.
-          1. Set _O_'s [[ByteLength]] internal slot to _newByteLength_.
-          1. Set _O_'s [[ByteOffset]] internal slot to _offset_.
-          1. Set _O_'s [[ArrayLength]] internal slot to _newByteLength_ / _elementSize_ .
-          1. Return _O_.
+          1. Let _here_ be the active function object.
+          1. If SameValue(NewTarget, _here_) is *true*, throw a *TypeError* exception.
+          1. Let _super_ be ? _here_.[[GetPrototypeOf]]().
+          1. If IsConstructor (_super_) is *false*, throw a *TypeError* exception.
+          1. Let _argumentsList_ be the _argumentsList_ argument of the [[Construct]] internal method that invoked the active function.
+          1. Return Construct(_super_, _argumentsList_, NewTarget).
         </emu-alg>
       </emu-clause>
     </emu-clause>
+
 
     <!-- es6num="22.2.2" -->
     <emu-clause id="sec-properties-of-the-%typedarray%-intrinsic-object">
@@ -31099,7 +30964,7 @@ Date.parse(x.toLocaleString())
                   1. Let _nextValue_ be ? IteratorValue(_next_).
                   1. Append _nextValue_ to the end of the List _values_.
               1. Let _len_ be the number of elements in _values_.
-              1. Let _targetObj_ be ? AllocateTypedArray(_C_, _len_).
+              1. Let _targetObj_ be ? TypedArrayCreate(_C_, &laquo;_len_&raquo;).
               1. Let _k_ be 0.
               1. Repeat, while _k_ &lt; _len_
                 1. Let _Pk_ be ToString(_k_).
@@ -31114,7 +30979,7 @@ Date.parse(x.toLocaleString())
             1. Assert: _items_ is not an Iterable so assume it is an array-like object.
             1. Let _arrayLike_ be ? ToObject(_items_).
             1. Let _len_ be ? ToLength(? Get(_arrayLike_, `"length"`)).
-            1. Let _targetObj_ be ? AllocateTypedArray(_C_, _len_).
+            1. Let _targetObj_ be ? TypedArrayCreate(_C_, &laquo;_len_&raquo;).
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _len_
               1. Let _Pk_ be ToString(_k_).
@@ -31138,7 +31003,7 @@ Date.parse(x.toLocaleString())
           1. Let _items_ be the List of arguments passed to this function.
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
-          1. Let _newObj_ be ? AllocateTypedArray(_C_, _len_).
+          1. Let _newObj_ be ? TypedArrayCreate(_C_, &laquo;_len_&raquo;).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _kValue_ be _items_[_k_].
@@ -31289,8 +31154,6 @@ Date.parse(x.toLocaleString())
           1. Let _len_ be the value of _O_'s [[ArrayLength]] internal slot.
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
-          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for the value of _O_'s [[TypedArrayName]] internal slot.
-          1. Let _C_ be ? SpeciesConstructor(_O_, _defaultConstructor_).
           1. Let _kept_ be a new empty List.
           1. Let _k_ be 0.
           1. Let _captured_ be 0.
@@ -31302,10 +31165,11 @@ Date.parse(x.toLocaleString())
               1. Append _kValue_ to the end of _kept_.
               1. Increase _captured_ by 1.
             1. Increase _k_ by 1.
-          1. Let _A_ be ? AllocateTypedArray(_C_, _captured_).
+          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo;_captured_&raquo;).
           1. Let _n_ be 0.
           1. For each element _e_ of _kept_
-            1. Let _status_ be ? Set(_A_, ToString(_n_), _e_, *true* ).
+            1. Let _status_ be Set(_A_, ToString(_n_), _e_, *true* ).
+            1. Assert: _status_ is not an abrupt completion.
             1. Increment _n_ by 1.
           1. Return _A_.
         </emu-alg>
@@ -31409,9 +31273,7 @@ Date.parse(x.toLocaleString())
           1. Let _len_ be the value of _O_'s [[ArrayLength]] internal slot.
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
-          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for the value of _O_'s [[TypedArrayName]] internal slot.
-          1. Let _C_ be ? SpeciesConstructor(_O_, _defaultConstructor_).
-          1. Let _A_ be ? AllocateTypedArray(_C_, _len_).
+          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo;_len_&raquo;).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ToString(_k_).
@@ -31556,9 +31418,7 @@ Date.parse(x.toLocaleString())
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
           1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_),0); else let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be max(_final_ - _k_, 0).
-          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for the value of _O_'s [[TypedArrayName]] internal slot.
-          1. Let _C_ be ? SpeciesConstructor(_O_, _defaultConstructor_).
-          1. Let _A_ be ? AllocateTypedArray(_C_, _count_).
+          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo;_count_&raquo;).
           1. Let _srcName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
           1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
           1. Let _targetName_ be the String value of _A_'s [[TypedArrayName]] internal slot.
@@ -31578,9 +31438,10 @@ Date.parse(x.toLocaleString())
             1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcType_.
             1. NOTE: If _srcType_ and _targetType_ are the same the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
             1. Let _srcByteOffet_ be the value of _O_'s [[ByteOffset]] internal slot.
-            1. Let _targetByteIndex_ be 0.
+            1. Let _targetByteIndex_ be _A_'s [[ByteOffset]] internal slot.
             1. Let _srcByteIndex_ be (_k_ &times; _elementSize_) + _srcByteOffet_.
-            1. Repeat, while _targetByteIndex_ &lt; _count_ &times; _elementSize_
+            1. Let _limit_ be _targetByteIndex_ + _count_ &times; _elementSize_.
+            1. Repeat, while _targetByteIndex_ < _limit_
               1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, `"Uint8"`).
               1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, `"Uint8"`, _value_).
               1. Increase _srcByteIndex_ by 1.
@@ -31653,10 +31514,8 @@ Date.parse(x.toLocaleString())
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _srcByteOffset_ be the value of _O_'s [[ByteOffset]] internal slot.
           1. Let _beginByteOffset_ be _srcByteOffset_ + _beginIndex_ &times; _elementSize_.
-          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-          1. Let _constructor_ be ? SpeciesConstructor(_O_, _defaultConstructor_).
-          1. Let _argumentsList_ be &laquo; _buffer_, _beginByteOffset_, _newLength_ &raquo;.
-          1. Return Construct(_constructor_, _argumentsList_).
+          1. Let _argumentsList_ be &laquo;_buffer_, _beginByteOffset_, _newLength_&raquo;.
+          1. Return TypedArraySpeciesCreate(_constructor_, _argumentsList_).
         </emu-alg>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
@@ -31715,20 +31574,169 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-typedarray-constructors">
       <h1>The _TypedArray_ Constructors</h1>
       <p>Each of the _TypedArray_ constructor objects is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-49"></emu-xref>.</p>
+      <p>The _TypedArray_ intrinsic constructor functions are single functions whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</p>
       <p>The _TypedArray_ constructors are not intended to be called as a function and will throw an exception when called in that manner.</p>
       <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray`%.prototype` built-in methods.</p>
 
       <!-- es6num="22.2.4.1" -->
       <emu-clause id="sec-typedarray">
-        <h1>_TypedArray_( ... _argumentsList_)</h1>
-        <p>A _TypedArray_ constructor with a list of arguments _argumentsList_ performs the following steps:</p>
+        <h1>_TypedArray_ ( )</h1>
+        <p>This description applies only if the _TypedArray_ function is called with no arguments.</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _here_ be the active function.
-          1. Let _super_ be ? _here_.[[GetPrototypeOf]]().
-          1. If IsConstructor(_super_) is *false*, throw a *TypeError* exception.
-          1. Let _argumentsList_ be the _argumentsList_ argument of the [[Construct]] internal method that invoked the active function.
-          1. Return Construct(_super_, _argumentsList_, NewTarget).
+          1. Return AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, 0).
+        </emu-alg>
+      </emu-clause>
+
+      <!-- es6num="22.2.1.2" -->
+      <emu-clause id="sec-typedarray-length">
+        <h1>_TypedArray_ ( _length_ )</h1>
+        <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is not Object.</p>
+        <p>_TypedArray_ called with argument _length_ performs the following steps:</p>
+        <emu-alg>
+          1. Assert: Type(_length_) is not Object.
+          1. If NewTarget is *undefined*, throw a *TypeError* exception.
+          1. If _length_ is *undefined*, throw a *TypeError* exception.
+          1. Let _numberLength_ be ToNumber(_length_).
+          1. Let _elementLength_ be ? ToLength(_numberLength_).
+          1. If SameValueZero(_numberLength_, _elementLength_) is *false*, throw a *RangeError* exception.
+          1. Return AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, _elementLength_).
+        </emu-alg>
+
+        <!-- es6num="22.2.1.2.1" -->
+        <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
+          <h1>Runtime Semantics: AllocateTypedArray (_constructorName_, _newTarget_, _length_ )</h1>
+          <p>The abstract operation AllocateTypedArray with arguments _constructorName_ and _newTarget_ and optional argument _length_ is used to validate and create an instance of a TypedArray constructor. _constructorName_ is required to be the name of a TypedArray in <emu-xref href="#table-49"></emu-xref>. If the _length_ argument is passed an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypeArray_ overloads and other methods. AllocateTypedArray performs the following steps:</p>
+          <emu-alg>
+            1. Let _proto_ be GetPrototypeFromConstructor(_newTarget_, %TypedArrayPrototype%);
+            1. Let _obj_ be IntegerIndexedObjectCreate (_proto_, &laquo;[[ViewedArrayBuffer]], [[TypedArrayName]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]]&raquo; ).
+            1. Assert: The [[ViewedArrayBuffer]] internal slot of _obj_ is *undefined*.
+            1. Set _obj_'s [[TypedArrayName]] internal slot to _constructorName_.
+            1. If _length_ was not passed, then
+              1. Set _obj_'s [[ByteLength]] internal slot to 0.
+              1. Set _obj_'s [[ByteOffset]] internal slot to 0.
+              1. Set _obj_'s [[ArrayLength]] internal slot to 0.
+            1. Else,
+              1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
+              1. Let _byteLength_ be _elementSize_ &times; _length_.
+              1. Let _data_ be ? AllocateArrayBuffer(%ArrayBuffer%, _byteLength_).
+              1. Set _obj_'s [[ViewedArrayBuffer]] internal slot to _data_.
+              1. Set _obj_'s [[ByteLength]] internal slot to _byteLength_.
+              1. Set _obj_'s [[ByteOffset]] internal slot to 0.
+              1. Set _obj_'s [[ArrayLength]] internal slot to _length_.
+            1. Return _obj_.
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+
+      <!-- es6num="22.2.1.3" -->
+      <emu-clause id="sec-typedarray-typedarray">
+        <h1>_TypedArray_ ( _typedArray_ )</h1>
+        <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object has a [[TypedArrayName]] internal slot.</p>
+        <p>_TypedArray_ called with argument _typedArray_ performs the following steps:</p>
+        <emu-alg>
+          1. Assert: Type(_typedArray_) is Object and _typedArray_ has a [[TypedArrayName]] internal slot.
+          1. If NewTarget is *undefined*, throw a *TypeError* exception.
+          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget).
+          1. Let _srcArray_ be _typedArray_.
+          1. Let _srcData_ be the value of _srcArray_'s [[ViewedArrayBuffer]] internal slot.
+          1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
+          1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
+          1. Let _elementLength_ be the value of _srcArray_'s [[ArrayLength]] internal slot.
+          1. Let _srcName_ be the String value of _srcArray_'s [[TypedArrayName]] internal slot.
+          1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
+          1. Let _srcElementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
+          1. Let _srcByteOffset_ be the value of _srcArray_'s [[ByteOffset]] internal slot.
+          1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
+          1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
+          1. If SameValue(_elementType_,_srcType_) is *true*, then
+            1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_).
+          1. Else,
+            1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
+            1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
+            1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
+            1. Let _srcByteIndex_ be _srcByteOffset_.
+            1. Let _targetByteIndex_ be 0.
+            1. Let _count_ be _elementLength_.
+            1. Repeat, while _count_ &gt;0
+              1. Let _value_ be GetValueFromBuffer(_srcData_, _srcByteIndex_, _srcType_).
+              1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_).
+              1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
+              1. Set _targetByteIndex_ to _targetByteIndex_ + _elementSize_.
+              1. Decrement _count_ by 1.
+          1. Set _O_'s [[ViewedArrayBuffer]] internal slot to _data_.
+          1. Set _O_'s [[ByteLength]] internal slot to _byteLength_.
+          1. Set _O_'s [[ByteOffset]] internal slot to 0.
+          1. Set _O_'s [[ArrayLength]] internal slot to _elementLength_.
+          1. Return _O_.
+        </emu-alg>
+      </emu-clause>
+
+      <!-- es6num="22.2.1.4" -->
+      <emu-clause id="sec-typedarray-object">
+        <h1>_TypedArray_ ( _object_ )</h1>
+        <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.</p>
+        <p>_TypedArray_ called with argument _object_ performs the following steps:</p>
+        <emu-alg>
+          1. Assert: Type(_object_) is Object and _object_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
+          1. If NewTarget is *undefined*, throw a *TypeError* exception.
+          1. Return TypedArrayFrom(NewTarget, _object_, *undefined*, *undefined*).
+        </emu-alg>
+      </emu-clause>
+
+      <!-- es6num="22.2.1.5" -->
+      <emu-clause id="sec-typedarray-buffer-byteoffset-length">
+        <h1>_TypedArray_ ( _buffer_ [ , _byteOffset_ [ , _length_ ] ] )</h1>
+        <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object has an [[ArrayBufferData]] internal slot.</p>
+        <p>_TypedArray_ called with arguments _buffer_, _byteOffset_, and _length_ performs the following steps:</p>
+        <emu-alg>
+          1. Assert: Type(_buffer_) is Object and _buffer_ has an [[ArrayBufferData]] internal slot.
+          1. If NewTarget is *undefined*, throw a *TypeError* exception.
+          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget).
+          1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _elementSize_ be the Number value of the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
+          1. Let _offset_ be ? ToInteger(_byteOffset_).
+          1. If _offset_ &lt; 0, throw a *RangeError* exception.
+          1. If _offset_ is -0, let _offset_ be +0.
+          1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
+          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+          1. Let _bufferByteLength_ be the value of _buffer_'s [[ArrayBufferByteLength]] internal slot.
+          1. If _length_ is *undefined*, then
+            1. If _bufferByteLength_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
+            1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
+            1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
+          1. Else,
+            1. Let _newLength_ be ? ToLength(_length_).
+            1. Let _newByteLength_ be _newLength_ &times; _elementSize_.
+            1. If _offset_+_newByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
+          1. Set _O_'s [[ViewedArrayBuffer]] internal slot to _buffer_.
+          1. Set _O_'s [[ByteLength]] internal slot to _newByteLength_.
+          1. Set _O_'s [[ByteOffset]] internal slot to _offset_.
+          1. Set _O_'s [[ArrayLength]] internal slot to _newByteLength_ / _elementSize_ .
+          1. Return _O_.
+>>>>>>> Improve TypedArray constructor/Proxy interaction
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="typedarray-create">
+        <h1>TypedArrayCreate( _constructor_, _argumentList_ )</h1>
+        <emu-alg>
+          1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
+          1. Perform ? ValidateTypedArray(_newTypedArray_).
+          1. If _argumentList_ is a List of a single Number,
+            1. If the value of _newTypedArray_'s [[ArrayLength]] internal slot < _argumentList_[0], throw a *TypeError* exception.
+          1. Return _newTypedArray_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="typedarray-species-create">
+        <h1>TypedArraySpeciesCreate( _exemplar_, _argumentList_ )</h1>
+        <emu-alg>
+          1. Assert: _exemplar_ has a [[TypedArrayName]] internal slot.
+          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for the value of _exemplar_'s [[TypedArrayName]] internal slot.
+          1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
+          1. Return ? TypedArrayCreate(_constructor_, _argumentList_).
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -31637,7 +31637,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Assert: Type(_typedArray_) is Object and _typedArray_ has a [[TypedArrayName]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, %<var>TypedArray</var>Protoype%).
+          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, %<var>TypedArray</var>Prototype%).
           1. Let _srcArray_ be _typedArray_.
           1. Let _srcData_ be the value of _srcArray_'s [[ViewedArrayBuffer]] internal slot.
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
@@ -31693,7 +31693,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Assert: Type(_buffer_) is Object and _buffer_ has an [[ArrayBufferData]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, %<var>TypedArray</var>Protoype%).
+          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, %<var>TypedArray</var>Prototype%).
           1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
           1. Let _elementSize_ be the Number value of the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _offset_ be ? ToInteger(_byteOffset_).

--- a/spec.html
+++ b/spec.html
@@ -31515,7 +31515,7 @@ Date.parse(x.toLocaleString())
           1. Let _srcByteOffset_ be the value of _O_'s [[ByteOffset]] internal slot.
           1. Let _beginByteOffset_ be _srcByteOffset_ + _beginIndex_ &times; _elementSize_.
           1. Let _argumentsList_ be &laquo;_buffer_, _beginByteOffset_, _newLength_&raquo;.
-          1. Return TypedArraySpeciesCreate(_constructor_, _argumentsList_).
+          1. Return TypedArraySpeciesCreate(_O_, _argumentsList_).
         </emu-alg>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
@@ -31584,7 +31584,7 @@ Date.parse(x.toLocaleString())
         <p>This description applies only if the _TypedArray_ function is called with no arguments.</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Return AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, 0).
+          1. Return AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, %<var>TypedArray</var>Prototype%, 0).
         </emu-alg>
       </emu-clause>
 
@@ -31600,15 +31600,15 @@ Date.parse(x.toLocaleString())
           1. Let _numberLength_ be ToNumber(_length_).
           1. Let _elementLength_ be ? ToLength(_numberLength_).
           1. If SameValueZero(_numberLength_, _elementLength_) is *false*, throw a *RangeError* exception.
-          1. Return AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, _elementLength_).
+          1. Return AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, %<var>TypedArray</var>Prototype%, _elementLength_).
         </emu-alg>
 
         <!-- es6num="22.2.1.2.1" -->
         <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
-          <h1>Runtime Semantics: AllocateTypedArray (_constructorName_, _newTarget_, _length_ )</h1>
-          <p>The abstract operation AllocateTypedArray with arguments _constructorName_ and _newTarget_ and optional argument _length_ is used to validate and create an instance of a TypedArray constructor. _constructorName_ is required to be the name of a TypedArray in <emu-xref href="#table-49"></emu-xref>. If the _length_ argument is passed an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypeArray_ overloads and other methods. AllocateTypedArray performs the following steps:</p>
+          <h1>Runtime Semantics: AllocateTypedArray (_constructorName_, _newTarget_, _defaultProto_, _length_ )</h1>
+          <p>The abstract operation AllocateTypedArray with arguments _constructorName_, _newTarget_, _defaultProto_ and optional argument _length_ is used to validate and create an instance of a TypedArray constructor. _constructorName_ is required to be the name of a TypedArray in <emu-xref href="#table-49"></emu-xref>. If the _length_ argument is passed an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypeArray_ overloads and other methods. AllocateTypedArray performs the following steps:</p>
           <emu-alg>
-            1. Let _proto_ be GetPrototypeFromConstructor(_newTarget_, %TypedArrayPrototype%);
+            1. Let _proto_ be GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
             1. Let _obj_ be IntegerIndexedObjectCreate (_proto_, &laquo;[[ViewedArrayBuffer]], [[TypedArrayName]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]]&raquo; ).
             1. Assert: The [[ViewedArrayBuffer]] internal slot of _obj_ is *undefined*.
             1. Set _obj_'s [[TypedArrayName]] internal slot to _constructorName_.
@@ -31637,7 +31637,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Assert: Type(_typedArray_) is Object and _typedArray_ has a [[TypedArrayName]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget).
+          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, %<var>TypedArray</var>Protoype%).
           1. Let _srcArray_ be _typedArray_.
           1. Let _srcData_ be the value of _srcArray_'s [[ViewedArrayBuffer]] internal slot.
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
@@ -31693,7 +31693,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Assert: Type(_buffer_) is Object and _buffer_ has an [[ArrayBufferData]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget).
+          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, %<var>TypedArray</var>Protoype%).
           1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
           1. Let _elementSize_ be the Number value of the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _offset_ be ? ToInteger(_byteOffset_).

--- a/spec.html
+++ b/spec.html
@@ -31715,7 +31715,6 @@ Date.parse(x.toLocaleString())
           1. Set _O_'s [[ByteOffset]] internal slot to _offset_.
           1. Set _O_'s [[ArrayLength]] internal slot to _newByteLength_ / _elementSize_ .
           1. Return _O_.
->>>>>>> Improve TypedArray constructor/Proxy interaction
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
This patch changes the specification text for constructing TypedArrays
to skip traversing the prototype chain to find the TypedArray-related
internal slots, and instead implement the behavior in the individual
_TypedArray_() constructors. Additionally, methods which used to
allocate TypedArrays as outputs directly will now call the species
constructor, since the previous direct construction also depended on
the prototype chain walk. This addresses the GitHub issue
https://github.com/tc39/ecma262/issues/163

The patch has severa changes based on review:
- After calling a TypedArray species constructor, check that the
  result is indeed a TypedArray instance.
- Check that the %TypedArray% constructor isn't called directly.
- Some refactoring to reduce duplication.
- ValidateTypedArray as part of TypedArrayCreate (allow implementations
  to hoist/remove later checks in functions which return TypedArrays).
- TypedArrayCreate also checks that the length was set appropriately,
  and an assertion is added to %TypedArray%.prototype.filter to take
  advantage of this.
- %TypedArray%.prototype.slice deals with the case where the constructed
  TypedArray doesn't start at 0 in its ArrayBuffer.
- "active function OBJECT"
- Centralize length checking
- Replace one last usage of Construct with TypedArrayCreate
- Ensure that the NewTarget is set properly