### PR TITLE
Remove initial ReturnIfAbrupt from abstract operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2866,7 +2866,6 @@
         <h1>ToPropertyDescriptor ( _Obj_ )</h1>
         <p>When the abstract operation ToPropertyDescriptor is called with object _Obj_, the following steps are taken:</p>
         <emu-alg>
-          1. ReturnIfAbrupt(_Obj_).
           1. If Type(_Obj_) is not Object, throw a *TypeError* exception.
           1. Let _desc_ be a new Property Descriptor that initially has no fields.
           1. Let _hasEnumerable_ be ? HasProperty(_Obj_, `"enumerable"`).
@@ -2906,7 +2905,6 @@
         <h1>CompletePropertyDescriptor ( _Desc_ )</h1>
         <p>When the abstract operation CompletePropertyDescriptor is called with Property Descriptor _Desc_ the following steps are taken:</p>
         <emu-alg>
-          1. ReturnIfAbrupt(_Desc_).
           1. Assert: _Desc_ is a Property Descriptor.
           1. Let _like_ be Record{[[Value]]: *undefined*, [[Writable]]: *false*, [[Get]]: *undefined*, [[Set]]: *undefined*, [[Enumerable]]: *false*, [[Configurable]]: *false*}.
           1. If either IsGenericDescriptor(_Desc_) or IsDataDescriptor(_Desc_) is *true*, then
@@ -2977,7 +2975,7 @@
   <!-- es6num="7.1" -->
   <emu-clause id="sec-type-conversion">
     <h1>Type Conversion</h1>
-    <p>The ECMAScript language implicitly performs automatic type conversion as needed. To clarify the semantics of certain constructs it is useful to define a set of conversion abstract operations. The conversion abstract operations are polymorphic; they can accept a value of any ECMAScript language type or of a Completion Record value. But no other specification types are used with these operations.</p>
+    <p>The ECMAScript language implicitly performs automatic type conversion as needed. To clarify the semantics of certain constructs it is useful to define a set of conversion abstract operations. The conversion abstract operations are polymorphic; they can accept a value of any ECMAScript language type. But no other specification types are used with these operations.</p>
 
     <!-- es6num="7.1.1" -->
     <emu-clause id="sec-toprimitive" aoid="ToPrimitive">
@@ -2993,14 +2991,6 @@
             <th>
               Result
             </th>
-          </tr>
-          <tr>
-            <td>
-              Completion Record
-            </td>
-            <td>
-              If _input_ is an abrupt completion, return _input_. Otherwise return ? ToPrimitive(_input_.[[value]]) also passing the optional hint _PreferredType_.
-            </td>
           </tr>
           <tr>
             <td>
@@ -3111,14 +3101,6 @@
           </tr>
           <tr>
             <td>
-              Completion Record
-            </td>
-            <td>
-              If _argument_ is an abrupt completion, return _argument_. Otherwise return ToBoolean(_argument_.[[value]]).
-            </td>
-          </tr>
-          <tr>
-            <td>
               Undefined
             </td>
             <td>
@@ -3195,14 +3177,6 @@
           </tr>
           <tr>
             <td>
-              Completion Record
-            </td>
-            <td>
-              If _argument_ is an abrupt completion, return _argument_. Otherwise return ? ToNumber(_argument_.[[value]]).
-            </td>
-          </tr>
-          <tr>
-            <td>
               Undefined
             </td>
             <td>
@@ -3256,7 +3230,7 @@
             <td>
               <p>Apply the following steps:</p>
               <emu-alg>
-                1. Let _primValue_ be ToPrimitive(_argument_, hint Number).
+                1. Let _primValue_ be ? ToPrimitive(_argument_, hint Number).
                 1. Return ? ToNumber(_primValue_).
               </emu-alg>
             </td>
@@ -3587,14 +3561,6 @@
           </tr>
           <tr>
             <td>
-              Completion Record
-            </td>
-            <td>
-              If _argument_ is an abrupt completion, return _argument_. Otherwise return ? ToString(_argument_.[[value]]).
-            </td>
-          </tr>
-          <tr>
-            <td>
               Undefined
             </td>
             <td>
@@ -3649,7 +3615,7 @@
             <td>
               <p>Apply the following steps:</p>
               <emu-alg>
-                1. Let _primValue_ be ToPrimitive(_argument_, hint String).
+                1. Let _primValue_ be ? ToPrimitive(_argument_, hint String).
                 1. Return ? ToString(_primValue_).
               </emu-alg>
             </td>
@@ -3718,14 +3684,6 @@
             <th>
               Result
             </th>
-          </tr>
-          <tr>
-            <td>
-              Completion Record
-            </td>
-            <td>
-              If _argument_ is an abrupt completion, return _argument_. Otherwise return ? ToObject(_argument_.[[value]]).
-            </td>
           </tr>
           <tr>
             <td>
@@ -3805,7 +3763,6 @@
       <h1>ToLength ( _argument_ )</h1>
       <p>The abstract operation ToLength converts _argument_ to an integer suitable for use as the length of an array-like object. It performs the following steps:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_argument_).
         1. Let _len_ be ? ToInteger(_argument_).
         1. If _len_ &le; +0, return +0.
         1. If _len_ is *+&infin;*, return 2<sup>53</sup>-1.
@@ -3846,14 +3803,6 @@
             <th>
               Result
             </th>
-          </tr>
-          <tr>
-            <td>
-              Completion Record
-            </td>
-            <td>
-              If _argument_ is an abrupt completion, return _argument_. Otherwise return ? RequireObjectCoercible(_argument_.[[value]]).
-            </td>
           </tr>
           <tr>
             <td>
@@ -3934,9 +3883,8 @@
     <!-- es6num="7.2.3" -->
     <emu-clause id="sec-iscallable" aoid="IsCallable">
       <h1>IsCallable ( _argument_ )</h1>
-      <p>The abstract operation IsCallable determines if _argument_, which must be an ECMAScript language value or a Completion Record, is a callable function with a [[Call]] internal method.</p>
+      <p>The abstract operation IsCallable determines if _argument_, which must be an ECMAScript language value, is a callable function with a [[Call]] internal method.</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_argument_).
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ has a [[Call]] internal method, return *true*.
         1. Return *false*.
@@ -3946,9 +3894,8 @@
     <!-- es6num="7.2.4" -->
     <emu-clause id="sec-isconstructor" aoid="IsConstructor">
       <h1>IsConstructor ( _argument_ )</h1>
-      <p>The abstract operation IsConstructor determines if _argument_, which must be an ECMAScript language value or a Completion Record, is a function object with a [[Construct]] internal method.</p>
+      <p>The abstract operation IsConstructor determines if _argument_, which must be an ECMAScript language value, is a function object with a [[Construct]] internal method.</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_argument_).
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ has a [[Construct]] internal method, return *true*.
         1. Return *false*.
@@ -3970,7 +3917,6 @@
       <h1>IsInteger ( _argument_ )</h1>
       <p>The abstract operation IsInteger determines if _argument_ is a finite integer numeric value.</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_argument_).
         1. If Type(_argument_) is not Number, return *false*.
         1. If _argument_ is *NaN*, *+&infin;*, or *-&infin;*, return *false*.
         1. If floor(abs(_argument_)) &ne; abs(_argument_), return *false*.
@@ -3981,9 +3927,8 @@
     <!-- es6num="7.2.7" -->
     <emu-clause id="sec-ispropertykey" aoid="IsPropertyKey">
       <h1>IsPropertyKey ( _argument_ )</h1>
-      <p>The abstract operation IsPropertyKey determines if _argument_, which must be an ECMAScript language value or a Completion Record, is a value that may be used as a property key.</p>
+      <p>The abstract operation IsPropertyKey determines if _argument_, which must be an ECMAScript language value, is a value that may be used as a property key.</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_argument_).
         1. If Type(_argument_) is String, return *true*.
         1. If Type(_argument_) is Symbol, return *true*.
         1. Return *false*.
@@ -4008,8 +3953,6 @@
       <h1>SameValue(_x_, _y_)</h1>
       <p>The internal comparison abstract operation SameValue(_x_, _y_), where _x_ and _y_ are ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_x_).
-        1. ReturnIfAbrupt(_y_).
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number, then
           1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
@@ -4029,8 +3972,6 @@
       <h1>SameValueZero(_x_, _y_)</h1>
       <p>The internal comparison abstract operation SameValueZero(_x_, _y_), where _x_ and _y_ are ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_x_).
-        1. ReturnIfAbrupt(_y_).
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number, then
           1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
@@ -4049,8 +3990,6 @@
       <h1>SameValueNonNumber(_x_, _y_)</h1>
       <p>The internal comparison abstract operation SameValueNonNumber(_x_, _y_), where neither _x_ nor _y_ are Number values, produces *true* or *false*. Such a comparison is performed as follows:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_x_).
-        1. ReturnIfAbrupt(_y_).
         1. Assert: Type(_x_) is not Number.
         1. Assert: Type(_x_) is the same as Type(_y_).
         1. If Type(_x_) is Undefined, return *true*.
@@ -4070,8 +4009,6 @@
       <h1>Abstract Relational Comparison</h1>
       <p>The comparison _x_ &lt; _y_, where _x_ and _y_ are values, produces *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). In addition to _x_ and _y_ the algorithm takes a Boolean flag named _LeftFirst_ as a parameter. The flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. The default value of _LeftFirst_ is *true* and indicates that the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_. Such a comparison is performed as follows:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_x_).
-        1. ReturnIfAbrupt(_y_).
         1. If the _LeftFirst_ flag is *true*, then
           1. Let _px_ be ? ToPrimitive(_x_, hint Number).
           1. Let _py_ be ? ToPrimitive(_y_, hint Number).
@@ -4100,7 +4037,7 @@
           1. If the mathematical value of _nx_ is less than the mathematical value of _ny_ &mdash;note that these mathematical values are both finite and not both zero&mdash;return *true*. Otherwise, return *false*.
       </emu-alg>
       <emu-note>
-        <p>Step 5 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) in using &ldquo;and&rdquo; instead of &ldquo;or&rdquo;.</p>
+        <p>Step 3 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) in using &ldquo;and&rdquo; instead of &ldquo;or&rdquo;.</p>
       </emu-note>
       <emu-note>
         <p>The comparison of Strings uses a simple lexicographic ordering on sequences of code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or string equality and collating order defined in the Unicode specification. Therefore String values that are canonically equal according to the Unicode standard could test as unequal. In effect this algorithm assumes that both Strings are already in normalized form. Also, note that for strings containing supplementary characters, lexicographic ordering on sequences of UTF-16 code unit values differs from that on sequences of code point values.</p>
@@ -4112,8 +4049,6 @@
       <h1>Abstract Equality Comparison</h1>
       <p>The comparison _x_ == _y_, where _x_ and _y_ are values, produces *true* or *false*. Such a comparison is performed as follows:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_x_).
-        1. ReturnIfAbrupt(_y_).
         1. If Type(_x_) is the same as Type(_y_), then
           1. Return the result of performing Strict Equality Comparison _x_ === _y_.
         1. If _x_ is *null* and _y_ is *undefined*, return *true*.
@@ -4263,11 +4198,11 @@
 
     <!-- es6num="7.3.9" -->
     <emu-clause id="sec-getmethod" aoid="GetMethod">
-      <h1>GetMethod (_O_, _P_)</h1>
-      <p>The abstract operation GetMethod is used to get the value of a specific property of an object when the value of the property is expected to be a function. The operation is called with arguments _O_ and _P_ where _O_ is the object, _P_ is the property key. This abstract operation performs the following steps:</p>
+      <h1>GetMethod (_V_, _P_)</h1>
+      <p>The abstract operation GetMethod is used to get the value of a specific property of an ECMAScript language value when the value of the property is expected to be a function. The operation is called with arguments _V_ and _P_ where _V_ is the ECMAScript language value, _P_ is the property key. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _func_ be ? GetV(_O_, _P_).
+        1. Let _func_ be ? GetV(_V_, _P_).
         1. If _func_ is either *undefined* or *null*, return *undefined*.
         1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
         1. Return _func_.
@@ -4303,7 +4238,6 @@
       <h1>Call(_F_, _V_, [_argumentsList_])</h1>
       <p>The abstract operation Call is used to call the [[Call]] internal method of a function object. The operation is called with arguments _F_, _V_ , and optionally _argumentsList_ where _F_ is the function object, _V_ is an ECMAScript language value that is the *this* value of the [[Call]], and _argumentsList_ is the value passed to the corresponding argument of the internal method. If _argumentsList_ is not present, an empty List is used as its value. This abstract operation performs the following steps:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_F_).
         1. If _argumentsList_ was not passed, let _argumentsList_ be a new empty List.
         1. If IsCallable(_F_) is *false*, throw a *TypeError* exception.
         1. Return ? _F_.[[Call]](_V_, _argumentsList_).
@@ -4394,7 +4328,6 @@
       <h1>CreateListFromArrayLike (_obj_ [, _elementTypes_] )</h1>
       <p>The abstract operation CreateListFromArrayLike is used to create a List value whose elements are provided by the indexed properties of an array-like object, _obj_. The optional argument _elementTypes_ is a List containing the names of ECMAScript Language Types that are allowed for element values of the List that is created. This abstract operation performs the following steps:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_obj_).
         1. If _elementTypes_ was not passed, let _elementTypes_ be (Undefined, Null, Boolean, String, Symbol, Number, Object).
         1. If Type(_obj_) is not Object, throw a *TypeError* exception.
         1. Let _len_ be ? ToLength(? Get(_obj_, `"length"`)).
@@ -4412,13 +4345,13 @@
 
     <!-- es6num="7.3.18" -->
     <emu-clause id="sec-invoke" aoid="Invoke">
-      <h1>Invoke(_O_,_P_, [_argumentsList_])</h1>
-      <p>The abstract operation Invoke is used to call a method property of an object. The operation is called with arguments _O_, _P_ , and optionally _argumentsList_ where _O_ serves as both the lookup point for the property and the *this* value of the call, _P_ is the property key, and _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, an empty List is used as its value. This abstract operation performs the following steps:</p>
+      <h1>Invoke(_V_, _P_, [_argumentsList_])</h1>
+      <p>The abstract operation Invoke is used to call a method property of an ECMAScript language value. The operation is called with arguments _V_, _P_ , and optionally _argumentsList_ where _V_ serves as both the lookup point for the property and the *this* value of the call, _P_ is the property key, and _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, an empty List is used as its value. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. If _argumentsList_ was not passed, let _argumentsList_ be a new empty List.
-        1. Let _func_ be GetV(_O_, _P_).
-        1. Return ? Call(_func_, _O_, _argumentsList_).
+        1. Let _func_ be ? GetV(_V_, _P_).
+        1. Return ? Call(_func_, _V_, _argumentsList_).
       </emu-alg>
     </emu-clause>
 
@@ -4512,9 +4445,8 @@
       <h1>GetIterator ( _obj_, _method_ )</h1>
       <p>The abstract operation GetIterator with argument _obj_ and optional argument _method_ performs the following steps:</p>
       <emu-alg>
-        1. ReturnIfAbrupt(_obj_).
         1. If _method_ was not passed, then
-          1. Let _method_ be GetMethod(_obj_, @@iterator).
+          1. Let _method_ be ? GetMethod(_obj_, @@iterator).
         1. Let _iterator_ be ? Call(_method_,_obj_).
         1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
         1. Return _iterator_.
@@ -7489,7 +7421,7 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>In steps 3 and 5, if <emu-eqn>_Desc_.[[Value]]</emu-eqn> is an object then its `valueOf` method is called twice. This is legacy behaviour that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
+          <p>In steps 3 and 4, if <emu-eqn>_Desc_.[[Value]]</emu-eqn> is an object then its `valueOf` method is called twice. This is legacy behaviour that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -7568,7 +7500,6 @@ for (let protoName of Reflect.enumerate(proto)) {
         <h1>StringCreate( _value_, _prototype_)</h1>
         <p>The abstract operation StringCreate with arguments _value_ and _prototype_ is used to specify the creation of new exotic String objects. It performs the following steps:</p>
         <emu-alg>
-          1. ReturnIfAbrupt(_prototype_).
           1. Assert: Type(_value_) is String.
           1. Let _S_ be a newly created String exotic object.
           1. Set the [[StringData]] internal slot of _S_ to _value_.
@@ -8757,7 +8688,7 @@ for (let protoName of Reflect.enumerate(proto)) {
         1. Let _trap_ be ? GetMethod(_handler_, `"ownKeys"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[OwnPropertyKeys]]().
-        1. Let _trapResultArray_ be Call(_trap_, _handler_, &laquo; _target_ &raquo;).
+        1. Let _trapResultArray_ be ? Call(_trap_, _handler_, &laquo; _target_ &raquo;).
         1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, &laquo; String, Symbol &raquo;).
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. Let _targetKeys_ be ? _target_.[[OwnPropertyKeys]]().
@@ -11010,7 +10941,7 @@ a = b + c
         <emu-grammar>SpreadElement : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
-          1. Let _spreadObj_ be GetValue(_spreadRef_).
+          1. Let _spreadObj_ be ? GetValue(_spreadRef_).
           1. Let _iterator_ be ? GetIterator(_spreadObj_).
           1. Repeat
             1. Let _next_ be ? IteratorStep(_iterator_).
@@ -11538,6 +11469,7 @@ a = b + c
         <emu-alg>
           1. Let _head_ be the TV of |TemplateHead| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Let _sub_ be the result of evaluating |Expression|.
+          1. ReturnIfAbrupt(_sub_).
           1. Let _middle_ be ? ToString(_sub_).
           1. Let _tail_ be the result of evaluating |TemplateSpans| .
           1. ReturnIfAbrupt(_tail_).
@@ -11562,6 +11494,7 @@ a = b + c
         <emu-alg>
           1. Let _head_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Let _sub_ be the result of evaluating |Expression|.
+          1. ReturnIfAbrupt(_sub_).
           1. Let _middle_ be ? ToString(_sub_).
           1. Return the sequence of code units consisting of the code units of _head_ followed by the elements of _middle_.
         </emu-alg>
@@ -11574,6 +11507,7 @@ a = b + c
           1. ReturnIfAbrupt(_rest_).
           1. Let _middle_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Let _sub_ be the result of evaluating |Expression|.
+          1. ReturnIfAbrupt(_sub_).
           1. Let _last_ be ? ToString(_sub_).
           1. Return the sequence of code units consisting of the elements of _rest_ followed by the code units of _middle_ followed by the elements of _last_.
         </emu-alg>
@@ -12086,7 +12020,7 @@ a = b + c
           1. Let _env_ be GetThisEnvironment( ).
           1. If _env_.HasSuperBinding() is *false*, throw a *ReferenceError* exception.
           1. Let _actualThis_ be ? _env_.GetThisBinding().
-          1. Let _baseValue_ be _env_.GetSuperBase().
+          1. Let _baseValue_ be ? _env_.GetSuperBase().
           1. Let _bv_ be ? RequireObjectCoercible(_baseValue_).
           1. Return a value of type Reference that is a Super Reference whose base value is _bv_, whose referenced name is _propertyKey_, whose thisValue is _actualThis_, and whose strict reference flag is _strict_.
         </emu-alg>
@@ -12118,7 +12052,7 @@ a = b + c
         <emu-alg>
           1. Let _list_ be an empty List.
           1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
-          1. Let _spreadObj_ be GetValue(_spreadRef_).
+          1. Let _spreadObj_ be ? GetValue(_spreadRef_).
           1. Let _iterator_ be ? GetIterator(_spreadObj_).
           1. Repeat
             1. Let _next_ be ? IteratorStep(_iterator_).
@@ -12593,7 +12527,7 @@ a = b + c
         <emu-grammar>UnaryExpression : `+` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
-          1. Return ? ToNumber(GetValue(_expr_)).
+          1. Return ? ToNumber(? GetValue(_expr_)).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -13106,7 +13040,7 @@ a = b + c
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
-        1. Let _rval_ be GetValue(_rref_).
+        1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be the result of performing Abstract Relational Comparison _lval_ &lt; _rval_. (see <emu-xref href="#sec-abstract-relational-comparison"></emu-xref>)
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
@@ -13116,7 +13050,7 @@ a = b + c
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
-        1. Let _rval_ be GetValue(_rref_).
+        1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be the result of performing Abstract Relational Comparison _rval_ &lt; _lval_ with _LeftFirst_ equal to *false*.
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
@@ -13126,7 +13060,7 @@ a = b + c
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
-        1. Let _rval_ be GetValue(_rref_).
+        1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be the result of performing Abstract Relational Comparison _rval_ &lt; _lval_ with _LeftFirst_ equal to *false*.
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
@@ -13136,7 +13070,7 @@ a = b + c
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
-        1. Let _rval_ be GetValue(_rref_).
+        1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be the result of performing Abstract Relational Comparison _lval_ &lt; _rval_.
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
@@ -18681,7 +18615,7 @@ eval("1;var a;")
       <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
-        1. Let _value_ be GetValue(_exprRef_).
+        1. Let _value_ be ? GetValue(_exprRef_).
         1. Let _iterator_ be ? GetIterator(_value_).
         1. Let _received_ be NormalCompletion(*undefined*).
         1. Repeat
@@ -24165,8 +24099,7 @@ new Function("a,b", "c", "return a+b+c")
       <emu-clause id="sec-number.prototype.valueof">
         <h1>Number.prototype.valueOf ( )</h1>
         <emu-alg>
-          1. Let _x_ be thisNumberValue(*this* value).
-          1. Return _x_.
+          1. Return ? thisNumberValue(*this* value).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -26229,7 +26162,7 @@ Date.parse(x.toLocaleString())
         <p>This function provides a String representation of a Date object for use by `JSON.stringify` (<emu-xref href="#sec-json.stringify"></emu-xref>).</p>
         <p>When the `toJSON` method is called with argument _key_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be ToObject(*this* value).
+          1. Let _O_ be ? ToObject(*this* value).
           1. Let _tv_ be ? ToPrimitive(_O_, hint Number).
           1. If Type(_tv_) is Number and _tv_ is not finite, return *null*.
           1. Return ? Invoke(_O_, `"toISOString"`).
@@ -26376,7 +26309,7 @@ Date.parse(x.toLocaleString())
             1. If NewTarget is *undefined* and Type(_value_) is Symbol, return SymbolDescriptiveString(_value_).
             1. Let _s_ be ? ToString(_value_).
           1. If NewTarget is *undefined*, return _s_.
-          1. Return ? StringCreate(_s_, GetPrototypeFromConstructor(NewTarget, `"%StringPrototype%"`)).
+          1. Return ? StringCreate(_s_, ? GetPrototypeFromConstructor(NewTarget, `"%StringPrototype%"`)).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -26491,7 +26424,7 @@ Date.parse(x.toLocaleString())
         </emu-note>
         <p>When the `charAt` method is called with one argument _pos_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _position_ be ? ToInteger(_pos_).
           1. Let _size_ be the number of elements in _S_.
@@ -26511,7 +26444,7 @@ Date.parse(x.toLocaleString())
         </emu-note>
         <p>When the `charCodeAt` method is called with one argument _pos_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _position_ be ? ToInteger(_pos_).
           1. Let _size_ be the number of elements in _S_.
@@ -26531,7 +26464,7 @@ Date.parse(x.toLocaleString())
         </emu-note>
         <p>When the `codePointAt` method is called with one argument _pos_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _position_ be ? ToInteger(_pos_).
           1. Let _size_ be the number of elements in _S_.
@@ -26555,7 +26488,7 @@ Date.parse(x.toLocaleString())
         </emu-note>
         <p>When the `concat` method is called with zero or more arguments the following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _args_ be a List whose elements are the arguments passed to this function.
           1. Let _R_ be _S_.
@@ -26582,7 +26515,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.endsWith ( _searchString_ [ , _endPosition_] )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _isRegExp_ be ? IsRegExp(_searchString_).
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
@@ -26613,7 +26546,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.includes ( _searchString_ [ , _position_ ] )</h1>
         <p>The `includes` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _isRegExp_ be ? IsRegExp(_searchString_).
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
@@ -26644,7 +26577,7 @@ Date.parse(x.toLocaleString())
         </emu-note>
         <p>The `indexOf` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _pos_ be ? ToInteger(_position_). (If _position_ is *undefined*, this step produces the value 0.)
@@ -26667,7 +26600,7 @@ Date.parse(x.toLocaleString())
         </emu-note>
         <p>The `lastIndexOf` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _numPos_ be ? ToNumber(_position_). (If _position_ is *undefined*, this step produces the value *NaN*.)
@@ -26690,7 +26623,7 @@ Date.parse(x.toLocaleString())
         <p>When the `localeCompare` method is called with argument _that_, it returns a Number other than *NaN* that represents the result of a locale-sensitive String comparison of the *this* value (converted to a String) with _that_ (converted to a String). The two Strings are _S_ and _That_. The two Strings are compared in an implementation-defined fashion. The result is intended to order String values in the sort order specified by a host default locale, and will be negative, zero, or positive, depending on whether _S_ comes before _That_ in the sort order, the Strings are equal, or _S_ comes after _That_ in the sort order, respectively.</p>
         <p>Before performing the comparisons, the following steps are performed to prepare the Strings:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _That_ be ? ToString(_that_).
         </emu-alg>
@@ -26733,7 +26666,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.normalize ( [ _form_ ] )</h1>
         <p>When the `normalize` method is called with one argument _form_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. If _form_ is not provided or _form_ is *undefined*, let _form_ be `"NFC"`.
           1. Let _f_ be ? ToString(_form_).
@@ -26752,7 +26685,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.repeat ( _count_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _n_ be ? ToInteger(_count_).
           1. If _n_ &lt; 0, throw a *RangeError* exception.
@@ -26785,7 +26718,7 @@ Date.parse(x.toLocaleString())
             1. Let _replaceValue_ be ? ToString(_replaceValue_).
           1. Search _string_ for the first occurrence of _searchString_ and let _pos_ be the index within _string_ of the first code unit of the matched substring and let _matched_ be _searchString_. If no occurrences of _searchString_ were found, return _string_.
           1. If _functionalReplace_ is *true*, then
-            1. Let _replValue_ be Call(_replaceValue_, *undefined*,&laquo; _matched_, _pos_, and _string_ &raquo;).
+            1. Let _replValue_ be ? Call(_replaceValue_, *undefined*,&laquo; _matched_, _pos_, and _string_ &raquo;).
             1. Let _replStr_ be ? ToString(_replValue_).
           1. Else,
             1. Let _captures_ be an empty List.
@@ -26949,7 +26882,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.slice ( _start_, _end_ )</h1>
         <p>The `slice` method takes two arguments, _start_ and _end_, and returns a substring of the result of converting this object to a String, starting from index _start_ and running to, but not including, index _end_ (or through the end of the String if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_sourceLength_+_start_</emu-eqn> where _sourceLength_ is the length of the String. If _end_ is negative, it is treated as <emu-eqn>_sourceLength_+_end_</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object. The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the number of elements in _S_.
           1. Let _intStart_ be ? ToInteger(_start_).
@@ -27050,7 +26983,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.startsWith ( _searchString_ [, _position_ ] )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _isRegExp_ be ? IsRegExp(_searchString_).
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
@@ -27083,7 +27016,7 @@ Date.parse(x.toLocaleString())
         <p>If _start_ is larger than _end_, they are swapped.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the number of elements in _S_.
           1. Let _intStart_ be ? ToInteger(_start_).
@@ -27130,7 +27063,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.toLowerCase ( )</h1>
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _cpList_ be a List containing in order the code points as defined in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref> of _S_, starting at the first element of _S_.
           1. For each code point _c_ in _cpList_, if the Unicode Character Database provides a language insensitive lower case equivalent of _c_ then replace _c_ in _cpList_ with that equivalent code point(s).
@@ -27153,8 +27086,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.toString ( )</h1>
         <p>When the `toString` method is called, the following steps are taken:</p>
         <emu-alg>
-          1. Let _s_ be thisStringValue(*this* value).
-          1. Return _s_.
+          1. Return ? thisStringValue(*this* value).
         </emu-alg>
         <emu-note>
           <p>For a String object, the `toString` method happens to return the same thing as the `valueOf` method.</p>
@@ -27177,7 +27109,7 @@ Date.parse(x.toLocaleString())
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _T_ be a String value that is a copy of _S_ with both leading and trailing white space removed. The definition of white space is the union of |WhiteSpace| and |LineTerminator|. When determining whether a Unicode code point is in Unicode general category &ldquo;Zs&rdquo;, code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.
           1. Return _T_.
@@ -27192,8 +27124,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype.valueOf ( )</h1>
         <p>When the `valueOf` method is called, the following steps are taken:</p>
         <emu-alg>
-          1. Let _s_ be thisStringValue(*this* value).
-          1. Return _s_.
+          1. Return ? thisStringValue(*this* value).
         </emu-alg>
       </emu-clause>
 
@@ -27202,7 +27133,7 @@ Date.parse(x.toLocaleString())
         <h1>String.prototype [ @@iterator ]( )</h1>
         <p>When the @@iterator method is called it returns an Iterator object (<emu-xref href="#sec-iterator-interface"></emu-xref>) that iterates over the code points of a String value, returning each code point as a String value. The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Return CreateStringIterator(_S_).
         </emu-alg>
@@ -29261,7 +29192,7 @@ Date.parse(x.toLocaleString())
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is *null*, let _q_ be AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
             1. Else _z_ is not *null*,
-              1. Let _e_ be ? ToLength(Get(_splitter_, `"lastIndex"`)).
+              1. Let _e_ be ? ToLength(? Get(_splitter_, `"lastIndex"`)).
               1. Let _e_ be min(_e_, _size_).
               1. If _e_ = _p_, let _q_ be AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
               1. Else _e_ &ne; _p_,
@@ -30346,7 +30277,7 @@ Date.parse(x.toLocaleString())
         <p>The elements of this array are sorted. The sort is not necessarily stable (that is, elements that compare equal do not necessarily remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative value if _x_ &lt; _y_, zero if _x_ = _y_, or a positive value if _x_ &gt; _y_.</p>
         <p>Upon entry, the following steps are performed to initialize evaluation of the `sort` function:</p>
         <emu-alg>
-          1. Let _obj_ be ToObject(*this* value).
+          1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_obj_, `"length"`)).
         </emu-alg>
         <p>Within this specification of the `sort` method, an object, _obj_, is said to be <em>sparse</em> if the following algorithm returns *true*:</p>
@@ -31065,8 +30996,8 @@ Date.parse(x.toLocaleString())
           1. Assert: Type(_length_) is not Object.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If _length_ is *undefined*, throw a *TypeError* exception.
-          1. Let _numberLength_ be ToNumber(_length_).
-          1. Let _elementLength_ be ? ToLength(_numberLength_).
+          1. Let _numberLength_ be ? ToNumber(_length_).
+          1. Let _elementLength_ be ToLength(_numberLength_).
           1. If SameValueZero(_numberLength_, _elementLength_) is *false*, throw a *RangeError* exception.
           1. Return AllocateTypedArray(NewTarget, _elementLength_).
         </emu-alg>
@@ -32395,7 +32326,7 @@ Date.parse(x.toLocaleString())
         <h1>Set.prototype.clear ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be *this* value.
+          1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
           1. Let _entries_ be the List that is the value of _S_'s [[SetData]] internal slot.
@@ -33096,8 +33027,8 @@ Date.parse(x.toLocaleString())
         <p>ArrayBuffer called with argument _length_ performs the following steps:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _numberLength_ be ToNumber(_length_).
-          1. Let _byteLength_ be ? ToLength(_numberLength_).
+          1. Let _numberLength_ be ? ToNumber(_length_).
+          1. Let _byteLength_ be ToLength(_numberLength_).
           1. If SameValueZero(_numberLength_, _byteLength_) is *false*, throw a *RangeError* exception.
           1. Return ? AllocateArrayBuffer(NewTarget, _byteLength_).
         </emu-alg>
@@ -33228,8 +33159,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. If Type(_view_) is not Object, throw a *TypeError* exception.
           1. If _view_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
-          1. Let _numberIndex_ be ToNumber(_requestIndex_).
-          1. Let _getIndex_ be ? ToInteger(_numberIndex_).
+          1. Let _numberIndex_ be ? ToNumber(_requestIndex_).
+          1. Let _getIndex_ be ToInteger(_numberIndex_).
           1. If _numberIndex_ &ne; _getIndex_ or _getIndex_ &lt; 0, throw a *RangeError* exception.
           1. Let _isLittleEndian_ be ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be the value of _view_'s [[ViewedArrayBuffer]] internal slot.
@@ -33250,8 +33181,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. If Type(_view_) is not Object, throw a *TypeError* exception.
           1. If _view_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
-          1. Let _numberIndex_ be ToNumber(_requestIndex_).
-          1. Let _getIndex_ be ? ToInteger(_numberIndex_).
+          1. Let _numberIndex_ be ? ToNumber(_requestIndex_).
+          1. Let _getIndex_ be ToInteger(_numberIndex_).
           1. If _numberIndex_ &ne; _getIndex_ or _getIndex_ &lt; 0, throw a *RangeError* exception.
           1. Let _numberValue_ be ? ToNumber(_value_).
           1. Let _isLittleEndian_ be ToBoolean(_isLittleEndian_).
@@ -33281,8 +33212,8 @@ Date.parse(x.toLocaleString())
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If Type(_buffer_) is not Object, throw a *TypeError* exception.
           1. If _buffer_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
-          1. Let _numberOffset_ be ToNumber(_byteOffset_).
-          1. Let _offset_ be ? ToInteger(_numberOffset_).
+          1. Let _numberOffset_ be ? ToNumber(_byteOffset_).
+          1. Let _offset_ be ToInteger(_numberOffset_).
           1. If _numberOffset_ &ne; _offset_ or _offset_ &lt; 0, throw a *RangeError* exception.
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be the value of _buffer_'s [[ArrayBufferByteLength]] internal slot.
@@ -36256,7 +36187,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         <h1>String.prototype.substr (_start_, _length_)</h1>
         <p>The `substr` method takes two arguments, _start_ and _length_, and returns a substring of the result of converting the *this* object to a String, starting from index _start_ and running for _length_ code units (or through the end of the String if _length_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>(_sourceLength_+_start_)</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object. The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be RequireObjectCoercible(*this* value).
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _intStart_ be ? ToInteger(_start_).
           1. If _length_ is *undefined*, let _end_ be *+&infin;*; otherwise let _end_ be ? ToInteger(_length_).
@@ -36285,7 +36216,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <h1>Runtime Semantics: CreateHTML ( _string_, _tag_, _attribute_, _value_ )</h1>
           <p>The abstract operation CreateHTML is called with arguments _string_, _tag_, _attribute_, and _value_. The arguments _tag_ and _attribute_ must be String values. The following steps are taken:</p>
           <emu-alg>
-            1. Let _str_ be RequireObjectCoercible(_string_).
+            1. Let _str_ be ? RequireObjectCoercible(_string_).
             1. Let _S_ be ? ToString(_str_).
             1. Let _p1_ be the String value that is the concatenation of `"&lt;"` and _tag_.
             1. If _attribute_ is not the empty String, then


### PR DESCRIPTION
Removes the initial ReturnIfAbrupt step(s) from the following abstract operations:
- 6.2.4: ToPropertyDescriptor, CompletePropertyDescriptor
- 7.1: ToPrimitive, ToBoolean, ToNumber, ToString, ToObject, ToLength
- 7.2: RequireObjectCoercible, IsCallable, IsConstructor, IsInteger, IsPropertyKey, SameValue, SameValueZero, SameValueNonNumber, Abstract Relational Comparison, Abstract Equality Comparison
- 7.3: Call, CreateListFromArrayLike
- 7.4: GetIterator
- 9.4.3: StringCreate