### PR TITLE
Return undefined from RegExp.prototype flags accessors on type mismatch

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29045,7 +29045,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *undefined*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"g"`, return *true*.
           1. Return *false*.
@@ -29059,7 +29059,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *undefined*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"i"`, return *true*.
           1. Return *false*.
@@ -29110,7 +29110,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *undefined*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"m"`, return *true*.
           1. Return *false*.
@@ -29299,7 +29299,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *undefined*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"y"`, return *true*.
           1. Return *false*.
@@ -29341,7 +29341,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *undefined*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"u"`, return *true*.
           1. Return *false*.

--- a/spec.html
+++ b/spec.html
@@ -29045,7 +29045,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"g"`, return *true*.
           1. Return *false*.
@@ -29059,7 +29059,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"i"`, return *true*.
           1. Return *false*.
@@ -29110,7 +29110,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"m"`, return *true*.
           1. Return *false*.
@@ -29299,7 +29299,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"y"`, return *true*.
           1. Return *false*.
@@ -29341,7 +29341,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot, return *false*.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"u"`, return *true*.
           1. Return *false*.


### PR DESCRIPTION
This addresses #262, a web compatibility concern from the addition
of 'sticky'. Websites apparently used RegExp.prototype.sticky to
feature-test for that RegExp feature. This patch makes all flag
accessors simply return *false* if the receiver does not have an
[[OriginalFlags]] internal slot.