### PR TITLE
Normative: change default function length value to not include optional arguments

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2987,7 +2987,7 @@
 
     <!-- es6num="7.1.1" -->
     <emu-clause id="sec-toprimitive" aoid="ToPrimitive">
-      <h1>ToPrimitive ( _input_ [, _PreferredType_] )</h1>
+      <h1>ToPrimitive ( _input_ [ , _PreferredType_ ] )</h1>
       <p>The abstract operation ToPrimitive takes an _input_ argument and an optional argument _PreferredType_. The abstract operation ToPrimitive converts its _input_ argument to a non-Object type. If an object is capable of converting to more than one primitive type, it may use the optional hint _PreferredType_ to favour that type. Conversion occurs according to <emu-xref href="#table-9"></emu-xref>:</p>
       <emu-table id="table-9" caption="ToPrimitive Conversions">
         <table>
@@ -4306,7 +4306,7 @@
 
     <!-- es6num="7.3.12" -->
     <emu-clause id="sec-call" aoid="Call">
-      <h1>Call(_F_, _V_, [_argumentsList_])</h1>
+      <h1>Call(_F_, _V_, [ _argumentsList_ ])</h1>
       <p>The abstract operation Call is used to call the [[Call]] internal method of a function object. The operation is called with arguments _F_, _V_ , and optionally _argumentsList_ where _F_ is the function object, _V_ is an ECMAScript language value that is the *this* value of the [[Call]], and _argumentsList_ is the value passed to the corresponding argument of the internal method. If _argumentsList_ is not present, an empty List is used as its value. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. ReturnIfAbrupt(_F_).
@@ -4318,7 +4318,7 @@
 
     <!-- es6num="7.3.13" -->
     <emu-clause id="sec-construct" aoid="Construct">
-      <h1>Construct (_F_, [_argumentsList_], [_newTarget_])</h1>
+      <h1>Construct (_F_, [ _argumentsList_, [ _newTarget_ ]])</h1>
       <p>The abstract operation Construct is used to call the [[Construct]] internal method of a function object. The operation is called with arguments _F_, and optionally _argumentsList_, and _newTarget_ where _F_ is the function object. _argumentsList_ and _newTarget_ are the values to be passed as the corresponding arguments of the internal method. If _argumentsList_ is not present, an empty List is used as its value. If _newTarget_ is not present, _F_ is used as its value. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. If _newTarget_ was not passed, let _newTarget_ be _F_.
@@ -4397,7 +4397,7 @@
 
     <!-- es6num="7.3.17" -->
     <emu-clause id="sec-createlistfromarraylike" aoid="CreateListFromArrayLike">
-      <h1>CreateListFromArrayLike (_obj_ [, _elementTypes_] )</h1>
+      <h1>CreateListFromArrayLike (_obj_ [ , _elementTypes_ ] )</h1>
       <p>The abstract operation CreateListFromArrayLike is used to create a List value whose elements are provided by the indexed properties of an array-like object, _obj_. The optional argument _elementTypes_ is a List containing the names of ECMAScript Language Types that are allowed for element values of the List that is created. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. ReturnIfAbrupt(_obj_).
@@ -4418,7 +4418,7 @@
 
     <!-- es6num="7.3.18" -->
     <emu-clause id="sec-invoke" aoid="Invoke">
-      <h1>Invoke(_O_,_P_, [_argumentsList_])</h1>
+      <h1>Invoke(_O_, _P_ [ , _argumentsList_ ])</h1>
       <p>The abstract operation Invoke is used to call a method property of an object. The operation is called with arguments _O_, _P_ , and optionally _argumentsList_ where _O_ serves as both the lookup point for the property and the *this* value of the call, _P_ is the property key, and _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, an empty List is used as its value. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -6064,7 +6064,7 @@
 
     <!-- es6num="8.3.1" -->
     <emu-clause id="sec-resolvebinding" aoid="ResolveBinding">
-      <h1>ResolveBinding ( _name_, [_env_] )</h1>
+      <h1>ResolveBinding ( _name_ [ , _env_ ] )</h1>
       <p>The ResolveBinding abstract operation is used to determine the binding of _name_ passed as a String value. The optional argument _env_ can be used to explicitly provide the Lexical Environment that is to be searched for the binding. During execution of ECMAScript code, ResolveBinding is performed using the following algorithm:</p>
       <emu-alg>
         1. If _env_ was not passed or if _env_ is *undefined*, then
@@ -21676,9 +21676,9 @@ eval("1;var a;")
   <p>Unless otherwise specified every built-in prototype object has the Object prototype object, which is the initial value of the expression `Object.prototype` (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>), as the value of its [[Prototype]] internal slot, except the Object prototype object itself.</p>
   <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function.</p>
   <p>Unless otherwise specified, each built-in function defined in this specification is created as if by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>).</p>
-  <p>Every built-in Function object, including constructors, has a `length` property whose value is an integer. Unless otherwise specified, this value is equal to the largest number of named arguments shown in the subclause headings for the function description, including optional parameters. However, rest parameters shown using the form &ldquo;...name&rdquo; are not included in the default argument count.</p>
+  <p>Every built-in Function object, including constructors, has a `length` property whose value is an integer. Unless otherwise specified, this value is equal to the largest number of named arguments shown in the subclause headings for the function description, not including optional parameters (which are indicated with brackets: `[` `]`) or rest parameters (which are shown using the form «...name») are not included in the default argument count.</p>
   <emu-note>
-    <p>For example, the function object that is the initial value of the `slice` property of the String prototype object is described under the subclause heading &ldquo;String.prototype.slice (start, end)&rdquo; which shows the two named arguments start and end; therefore the value of the `length` property of that Function object is `2`.</p>
+    <p>For example, the function object that is the initial value of the `map` property of the Array prototype object is described under the subclause heading «Array.prototype.map (callbackFn [ , thisArg])» which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the `length` property of that Function object is `1`.</p>
   </emu-note>
   <p>Unless otherwise specified, the `length` property of a built-in Function object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   <p>Every built-in Function object, including constructors, that is not identified as an anonymous function has a `name` property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. For functions that are specified as properties of objects, the name value is the property name string used to access the function. Functions that are specified as get or set accessor functions of built-in properties have `"get "` or `"set "` prepended to the property name string. The value of the `name` property is explicitly specified for each built-in functions whose property key is a Symbol value.</p>
@@ -22603,7 +22603,6 @@ eval("1;var a;")
                 1. Let _status_ be ? Set(_to_, _nextKey_, _propValue_, *true*).
           1. Return _to_.
         </emu-alg>
-        <p>The `length` property of the `assign` method is 2.</p>
       </emu-clause>
 
       <!-- es6num="19.1.2.2" -->
@@ -22617,6 +22616,7 @@ eval("1;var a;")
             1. Return ? ObjectDefineProperties(_obj_, _Properties_).
           1. Return _obj_.
         </emu-alg>
+        <p>The `length` property of the `create` method is 2.</p>
       </emu-clause>
 
       <!-- es6num="19.1.2.3" -->
@@ -22899,7 +22899,6 @@ eval("1;var a;")
           1. Return ? Invoke(_O_, `"toString"`).
         </emu-alg>
         <p>The optional parameters to this function are not used but are intended to correspond to the parameter pattern used by ECMA-402 `toLocalString` functions. Implementations that do not include ECMA-402 support must not use those parameter positions for other purposes.</p>
-        <p>The `length` property of the `toLocaleString` method is 0.</p>
         <emu-note>
           <p>This function provides a generic `toLocaleString` implementation for objects that have no locale-specific `toString` behaviour. `Array`, `Number`, `Date`, and `Typed Arrays` provide their own locale-sensitive `toLocaleString` methods.</p>
         </emu-note>
@@ -23123,7 +23122,6 @@ new Function("a,b", "c", "return a+b+c")
           1. Perform SetFunctionName(_F_, _targetName_, `"bound"`).
           1. Return _F_.
         </emu-alg>
-        <p>The `length` property of the `bind` method is 1.</p>
         <emu-note>
           <p>Function objects created using `Function.prototype.bind` are exotic objects. They also do not have a `prototype` property.</p>
         </emu-note>
@@ -23143,7 +23141,6 @@ new Function("a,b", "c", "return a+b+c")
           1. Perform PrepareForTailCall().
           1. Return ? Call(_func_, _thisArg_, _argList_).
         </emu-alg>
-        <p>The `length` property of the `call` method is 1.</p>
         <emu-note>
           <p>The thisArg value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* thisArg is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the thisArg is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
         </emu-note>
@@ -24090,7 +24087,6 @@ new Function("a,b", "c", "return a+b+c")
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Number.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
         <p>Produces a String value that represents this Number value formatted according to the conventions of the host environment's current locale. This function is implementation-dependent, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
         <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
-        <p>The `length` property of the `toLocaleString` method is 0.</p>
       </emu-clause>
 
       <!-- es6num="20.1.3.5" -->
@@ -24704,7 +24700,7 @@ new Function("a,b", "c", "return a+b+c")
 
       <!-- es6num="20.2.2.18" -->
       <emu-clause id="sec-math.hypot">
-        <h1>Math.hypot ( _value1_ , _value2_ , &hellip;_values_ )</h1>
+        <h1>Math.hypot ( _value1_ , _value2_ , ..._values_ )</h1>
         <p>`Math.hypot` returns an implementation-dependent approximation of the square root of the sum of squares of its arguments.</p>
         <ul>
           <li>
@@ -24844,7 +24840,7 @@ new Function("a,b", "c", "return a+b+c")
 
       <!-- es6num="20.2.2.24" -->
       <emu-clause id="sec-math.max">
-        <h1>Math.max ( _value1_, _value2_ , &hellip;_values_ )</h1>
+        <h1>Math.max ( _value1_, _value2_ , ..._values_ )</h1>
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the largest of the resulting values.</p>
         <ul>
           <li>
@@ -24857,12 +24853,11 @@ new Function("a,b", "c", "return a+b+c")
             The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm (<emu-xref href="#sec-abstract-relational-comparison"></emu-xref>) except that +0 is considered to be larger than -0.
           </li>
         </ul>
-        <p>The `length` property of the `max` method is 2.</p>
       </emu-clause>
 
       <!-- es6num="20.2.2.25" -->
       <emu-clause id="sec-math.min">
-        <h1>Math.min ( _value1_, _value2_ , &hellip;_values_ )</h1>
+        <h1>Math.min ( _value1_, _value2_ , ..._values_ )</h1>
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the smallest of the resulting values.</p>
         <ul>
           <li>
@@ -24875,7 +24870,6 @@ new Function("a,b", "c", "return a+b+c")
             The comparison of values to determine the smallest value is done using the Abstract Relational Comparison algorithm (<emu-xref href="#sec-abstract-relational-comparison"></emu-xref>) except that +0 is considered to be larger than -0.
           </li>
         </ul>
-        <p>The `length` property of the `min` method is 2.</p>
       </emu-clause>
 
       <!-- es6num="20.2.2.26" -->
@@ -25594,7 +25588,7 @@ THH:mm:ss.sss
 
       <!-- es6num="20.3.2.1" -->
       <emu-clause id="sec-date-year-month-date-hours-minutes-seconds-ms">
-        <h1>Date ( _year_, _month_ [, _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] )</h1>
+        <h1>Date ( _year_, _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] )</h1>
         <p>This description applies only if the Date constructor is called with at least two arguments.</p>
         <p>When the `Date` function is called the following steps are taken:</p>
         <emu-alg>
@@ -25617,6 +25611,7 @@ THH:mm:ss.sss
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
             1. Return ToDateString(_now_).
         </emu-alg>
+        <p>The `length` property of the `Date` function is 7.</p>
       </emu-clause>
 
       <!-- es6num="20.3.2.2" -->
@@ -25968,6 +25963,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
+        <p>The `length` property of the `setFullYear` method is 3.</p>
         <emu-note>
           <p>If _month_ is not specified, this method behaves as if _month_ were specified with the value `getMonth()`. If _date_ is not specified, it behaves as if _date_ were specified with the value `getDate()`.</p>
         </emu-note>
@@ -25988,6 +25984,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
+        <p>The `length` property of the `setHours` method is 4.</p>
         <emu-note>
           <p>If _min_ is not specified, this method behaves as if _min_ were specified with the value `getMinutes()`. If _sec_ is not specified, it behaves as if _sec_ were specified with the value `getSeconds()`. If _ms_ is not specified, it behaves as if _ms_ were specified with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -26021,6 +26018,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
+        <p>The `length` property of the `setMinutes` method is 3.</p>
         <emu-note>
           <p>If _sec_ is not specified, this method behaves as if _sec_ were specified with the value `getSeconds()`. If _ms_ is not specified, this behaves as if _ms_ were specified with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -26039,6 +26037,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
+        <p>The `length` property of the `setMonth` method is 2.</p>
         <emu-note>
           <p>If _date_ is not specified, this method behaves as if _date_ were specified with the value `getDate()`.</p>
         </emu-note>
@@ -26057,6 +26056,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
+        <p>The `length` property of the `setSeconds` method is 2.</p>
         <emu-note>
           <p>If _ms_ is not specified, this method behaves as if _ms_ were specified with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -26103,6 +26103,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
+        <p>The `length` property of the `setUTCFullYear` method is 3.</p>
         <emu-note>
           <p>If _month_ is not specified, this method behaves as if _month_ were specified with the value `getUTCMonth()`. If _date_ is not specified, it behaves as if _date_ were specified with the value `getUTCDate()`.</p>
         </emu-note>
@@ -26123,6 +26124,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
+        <p>The `length` property of the `setUTCHours` method is 4.</p>
         <emu-note>
           <p>If _min_ is not specified, this method behaves as if _min_ were specified with the value `getUTCMinutes()`. If _sec_ is not specified, it behaves as if _sec_ were specified with the value `getUTCSeconds()`. If _ms_ is not specified, it behaves as if _ms_ were specified with the value `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -26144,7 +26146,7 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="20.3.4.32" -->
       <emu-clause id="sec-date.prototype.setutcminutes">
-        <h1>Date.prototype.setUTCMinutes ( _min_ [ , _sec_ [, _ms_ ] ] )</h1>
+        <h1>Date.prototype.setUTCMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
@@ -26160,6 +26162,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
+        <p>The `length` property of the `setUTCMinutes` method is 3.</p>
         <emu-note>
           <p>If _sec_ is not specified, this method behaves as if _sec_ were specified with the value `getUTCSeconds()`. If _ms_ is not specified, it function behaves as if _ms_ were specified with the value return by `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -26180,6 +26183,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
+        <p>The `length` property of the `setUTCMonth` method is 2.</p>
         <emu-note>
           <p>If _date_ is not specified, this method behaves as if _date_ were specified with the value `getUTCDate()`.</p>
         </emu-note>
@@ -26200,6 +26204,7 @@ Date.parse(x.toLocaleString())
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
+        <p>The `length` property of the `setUTCSeconds` method is 2.</p>
         <emu-note>
           <p>If _ms_ is not specified, this method behaves as if _ms_ were specified with the value `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -26242,7 +26247,6 @@ Date.parse(x.toLocaleString())
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleDateString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleDateString` method is used.</p>
         <p>This function returns a String value. The contents of the String are implementation-dependent, but are intended to represent the &ldquo;date&rdquo; portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
-        <p>The `length` property of the `toLocaleDateString` method is 0.</p>
       </emu-clause>
 
       <!-- es6num="20.3.4.39" -->
@@ -26251,7 +26255,6 @@ Date.parse(x.toLocaleString())
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
         <p>This function returns a String value. The contents of the String are implementation-dependent, but are intended to represent the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
-        <p>The `length` property of the `toLocaleString` method is 0.</p>
       </emu-clause>
 
       <!-- es6num="20.3.4.40" -->
@@ -26260,7 +26263,6 @@ Date.parse(x.toLocaleString())
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleTimeString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleTimeString` method is used.</p>
         <p>This function returns a String value. The contents of the String are implementation-dependent, but are intended to represent the &ldquo;time&rdquo; portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
-        <p>The `length` property of the `toLocaleTimeString` method is 0.</p>
       </emu-clause>
 
       <!-- es6num="20.3.4.41" -->
@@ -26453,7 +26455,6 @@ Date.parse(x.toLocaleString())
             1. Append in order the code unit elements of _nextSub_ to the end of _stringElements_.
             1. Let _nextIndex_ be _nextIndex_ + 1.
         </emu-alg>
-        <p>The `length` property of the `raw` function is 1.</p>
         <emu-note>
           <p>String.raw is intended for use as a tag function of a Tagged Template (<emu-xref href="#sec-tagged-templates"></emu-xref>). When called as such, the first argument will be a well formed template object and the rest parameter will contain the substitution values.</p>
         </emu-note>
@@ -26573,7 +26574,7 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="21.1.3.6" -->
       <emu-clause id="sec-string.prototype.endswith">
-        <h1>String.prototype.endsWith ( _searchString_ [ , _endPosition_] )</h1>
+        <h1>String.prototype.endsWith ( _searchString_ [ , _endPosition_ ] )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be RequireObjectCoercible(*this* value).
@@ -26590,7 +26591,6 @@ Date.parse(x.toLocaleString())
           1. If the sequence of elements of _S_ starting at _start_ of length _searchLength_ is the same as the full element sequence of _searchStr_, return *true*.
           1. Otherwise, return *false*.
         </emu-alg>
-        <p>The `length` property of the `endsWith` method is 1.</p>
         <emu-note>
           <p>Returns *true* if the sequence of elements of _searchString_ converted to a String is the same as the corresponding elements of this object (converted to a String) starting at _endPosition_ - length(this). Otherwise returns *false*.</p>
         </emu-note>
@@ -26618,7 +26618,6 @@ Date.parse(x.toLocaleString())
           1. Let _searchLen_ be the number of elements in _searchStr_.
           1. If there exists any integer _k_ not smaller than _start_ such that _k_ + _searchLen_ is not greater than _len_, and for all nonnegative integers _j_ less than _searchLen_, the code unit at index _k_+_j_ of _S_ is the same as the code unit at index _j_ of _searchStr_, return *true*; but if there is no such integer _k_, return *false*.
         </emu-alg>
-        <p>The `length` property of the `includes` method is 1.</p>
         <emu-note>
           <p>If _searchString_ appears as a substring of the result of converting this object to a String, at one or more indices that are greater than or equal to _position_, return *true*; otherwise, returns *false*. If _position_ is *undefined*, 0 is assumed, so as to search all of the String.</p>
         </emu-note>
@@ -26647,7 +26646,6 @@ Date.parse(x.toLocaleString())
           1. Let _searchLen_ be the number of elements in _searchStr_.
           1. Return the smallest possible integer _k_ not smaller than _start_ such that _k_+ _searchLen_ is not greater than _len_, and for all nonnegative integers _j_ less than _searchLen_, the code unit at index _k_+_j_ of _S_ is the same as the code unit at index _j_ of _searchStr_; but if there is no such integer _k_, return the value `-1`.
         </emu-alg>
-        <p>The `length` property of the `indexOf` method is 1.</p>
         <emu-note>
           <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -26671,7 +26669,6 @@ Date.parse(x.toLocaleString())
           1. Let _searchLen_ be the number of elements in _searchStr_.
           1. Return the largest possible nonnegative integer _k_ not larger than _start_ such that _k_+ _searchLen_ is not greater than _len_, and for all nonnegative integers _j_ less than _searchLen_, the code unit at index _k_+_j_ of _S_ is the same as the code unit at index _j_ of _searchStr_; but if there is no such integer _k_, return the value `-1`.
         </emu-alg>
-        <p>The `length` property of the `lastIndexOf` method is 1.</p>
         <emu-note>
           <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -26679,7 +26676,7 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="21.1.3.10" -->
       <emu-clause id="sec-string.prototype.localecompare">
-        <h1>String.prototype.localeCompare ( _that_ [, _reserved1_ [ , _reserved2_ ] ] )</h1>
+        <h1>String.prototype.localeCompare ( _that_ [ , _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `localeCompare` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `localeCompare` method is used.</p>
         <p>When the `localeCompare` method is called with argument _that_, it returns a Number other than *NaN* that represents the result of a locale-sensitive String comparison of the *this* value (converted to a String) with _that_ (converted to a String). The two Strings are _S_ and _That_. The two Strings are compared in an implementation-defined fashion. The result is intended to order String values in the sort order specified by a host default locale, and will be negative, zero, or positive, depending on whether _S_ comes before _That_ in the sort order, the Strings are equal, or _S_ comes after _That_ in the sort order, respectively.</p>
         <p>Before performing the comparisons, the following steps are performed to prepare the Strings:</p>
@@ -26691,7 +26688,6 @@ Date.parse(x.toLocaleString())
         <p>The meaning of the optional second and third parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not assign any other interpretation to those parameter positions.</p>
         <p>The `localeCompare` method, if considered as a function of two arguments *this* and _that_, is a consistent comparison function (as defined in <emu-xref href="#sec-array.prototype.sort"></emu-xref>) on the set of all Strings.</p>
         <p>The actual return values are implementation-defined to permit implementers to encode additional information in the value, but the function is required to define a total ordering on all Strings. This function must treat Strings that are canonically equivalent according to the Unicode standard as identical and must return `0` when comparing Strings that are considered canonically equivalent.</p>
-        <p>The `length` property of the `localeCompare` method is 1.</p>
         <emu-note>
           <p>The `localeCompare` method itself is not directly suitable as an argument to `Array.prototype.sort` because the latter requires a function of two arguments.</p>
         </emu-note>
@@ -26735,7 +26731,6 @@ Date.parse(x.toLocaleString())
           1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="http://www.unicode.org/reports/tr15/tr15-29.html">http://www.unicode.org/reports/tr15/tr15-29.html</a>.
           1. Return _ns_.
         </emu-alg>
-        <p>The `length` property of the `normalize` method is 0.</p>
         <emu-note>
           <p>The `normalize` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -27041,7 +27036,7 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="21.1.3.18" -->
       <emu-clause id="sec-string.prototype.startswith">
-        <h1>String.prototype.startsWith ( _searchString_ [, _position_ ] )</h1>
+        <h1>String.prototype.startsWith ( _searchString_ [ , _position_ ] )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be RequireObjectCoercible(*this* value).
@@ -27057,7 +27052,6 @@ Date.parse(x.toLocaleString())
           1. If the sequence of elements of _S_ starting at _start_ of length _searchLength_ is the same as the full element sequence of _searchStr_, return *true*.
           1. Otherwise, return *false*.
         </emu-alg>
-        <p>The `length` property of the `startsWith` method is 1.</p>
         <emu-note>
           <p>This method returns *true* if the sequence of elements of _searchString_ converted to a String is the same as the corresponding elements of this object (converted to a String) starting at index _position_. Otherwise returns *false*.</p>
         </emu-note>
@@ -27099,7 +27093,6 @@ Date.parse(x.toLocaleString())
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `toLocaleLowerCase` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleLowerCase` method is used.</p>
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>This function works exactly the same as `toLowerCase` except that its result is intended to yield the correct result for the host environment's current locale, rather than a locale-independent result. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
-        <p>The `length` property of the `toLocaleLowerCase` method is 0.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <emu-note>
           <p>The `toLocaleLowerCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -27112,7 +27105,6 @@ Date.parse(x.toLocaleString())
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `toLocaleUpperCase` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleUpperCase` method is used.</p>
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>This function works exactly the same as `toUpperCase` except that its result is intended to yield the correct result for the host environment's current locale, rather than a locale-independent result. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
-        <p>The `length` property of the `toLocaleUpperCase` method is 0.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <emu-note>
           <p>The `toLocaleUpperCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -29498,7 +29490,6 @@ Date.parse(x.toLocaleString())
           1. Perform ? Set(_A_, `"length"`, _len_, *true*).
           1. Return _A_.
         </emu-alg>
-        <p>The `length` property of the `from` method is 1.</p>
         <emu-note>
           <p>The `from` function is an intentionally generic factory method; it does not require that its *this* value be the Array constructor. Therefore it can be transferred to or inherited by any other constructors that may be called with a single numeric argument.</p>
         </emu-note>
@@ -29534,7 +29525,6 @@ Date.parse(x.toLocaleString())
           1. Perform ? Set(_A_, `"length"`, _len_, *true*).
           1. Return _A_.
         </emu-alg>
-        <p>The `length` property of the `of` method is 0.</p>
         <emu-note>
           <p>The _items_ argument is assumed to be a well-formed rest argument value.</p>
         </emu-note>
@@ -29670,7 +29660,6 @@ Date.parse(x.toLocaleString())
             1. Let _count_ be _count_ - 1.
           1. Return _O_.
         </emu-alg>
-        <p>The `length` property of the `copyWithin` method is 2.</p>
         <emu-note>
           <p>The `copyWithin` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29688,7 +29677,7 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="22.1.3.5" -->
       <emu-clause id="sec-array.prototype.every">
-        <h1>Array.prototype.every ( _callbackfn_ [ , _thisArg_] )</h1>
+        <h1>Array.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `every` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *false*. If such an element is found, `every` immediately returns *false*. Otherwise, if _callbackfn_ returned *true* for all elements, `every` will return *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
@@ -29713,7 +29702,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return *true*.
         </emu-alg>
-        <p>The `length` property of the `every` method is 1.</p>
         <emu-note>
           <p>The `every` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29740,7 +29728,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return _O_.
         </emu-alg>
-        <p>The `length` property of the `fill` method is 1.</p>
         <emu-note>
           <p>The `fill` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29777,7 +29764,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return _A_.
         </emu-alg>
-        <p>The `length` property of the `filter` method is 1.</p>
         <emu-note>
           <p>The `filter` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29809,7 +29795,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return *undefined*.
         </emu-alg>
-        <p>The `length` property of the `find` method is 1.</p>
         <emu-note>
           <p>The `find` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29840,7 +29825,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return -1.
         </emu-alg>
-        <p>The `length` property of the `findIndex` method is 1.</p>
         <emu-note>
           <p>The `findIndex` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29871,7 +29855,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return *undefined*.
         </emu-alg>
-        <p>The `length` property of the `forEach` method is 1.</p>
         <emu-note>
           <p>The `forEach` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29904,8 +29887,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return *false*.
         </emu-alg>
-
-        <p>The `length` property of the `includes` method is *1*.</p>
 
         <emu-note>
            The `includes` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.
@@ -29944,7 +29925,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return -1.
         </emu-alg>
-        <p>The `length` property of the `indexOf` method is 1.</p>
         <emu-note>
           <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -30014,7 +29994,6 @@ Date.parse(x.toLocaleString())
             1. Decrease _k_ by 1.
           1. Return -1.
         </emu-alg>
-        <p>The `length` property of the `lastIndexOf` method is 1.</p>
         <emu-note>
           <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -30048,7 +30027,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return _A_.
         </emu-alg>
-        <p>The `length` property of the `map` method is 1.</p>
         <emu-note>
           <p>The `map` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -30142,7 +30120,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return _accumulator_.
         </emu-alg>
-        <p>The `length` property of the `reduce` method is 1.</p>
         <emu-note>
           <p>The `reduce` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -30184,7 +30161,6 @@ Date.parse(x.toLocaleString())
             1. Decrease _k_ by 1.
           1. Return _accumulator_.
         </emu-alg>
-        <p>The `length` property of the `reduceRight` method is 1.</p>
         <emu-note>
           <p>The `reduceRight` function is intentionally generic; it does not require that its this value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -30328,7 +30304,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return *false*.
         </emu-alg>
-        <p>The `length` property of the `some` method is 1.</p>
         <emu-note>
           <p>The `some` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -30537,7 +30512,6 @@ Date.parse(x.toLocaleString())
           1. Perform ? Set(_O_, `"length"`, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
           1. Return _A_.
         </emu-alg>
-        <p>The `length` property of the `splice` method is 2.</p>
         <emu-note>
           <p>The explicit setting of the `length` property of the result Array in step 19 was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting `length` became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
@@ -31075,7 +31049,6 @@ Date.parse(x.toLocaleString())
           1. If _thisArg_ was supplied, let _t_ be _thisArg_; else let _t_ be *undefined*.
           1. Return TypedArrayFrom(_C_, _source_, _f_, _t_).
         </emu-alg>
-        <p>The `length` property of the `from` method is 1.</p>
 
         <!-- es6num="22.2.2.1.1" -->
         <emu-clause id="sec-typedarrayfrom" aoid="TypedArrayFrom">
@@ -31148,7 +31121,6 @@ Date.parse(x.toLocaleString())
             1. Increase _k_ by 1.
           1. Return _newObj_.
         </emu-alg>
-        <p>The `length` property of the `of` method is 0.</p>
         <emu-note>
           <p>The _items_ argument is assumed to be a well-formed rest argument value.</p>
         </emu-note>
@@ -31231,11 +31203,10 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="22.2.3.5" -->
       <emu-clause id="sec-%typedarray%.prototype.copywithin">
-        <h1>%TypedArray%.prototype.copyWithin (_target_, _start_ [, _end_ ] )</h1>
+        <h1>%TypedArray%.prototype.copyWithin (_target_, _start_ [ , _end_ ] )</h1>
         <p>%TypedArray%`.prototype.copyWithin` is a distinct function that implements the same algorithm as `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"` and the actual copying of values in step 12 must be performed in a manner that preserves the bit-level encoding of the source data</p>
         <p>The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `copyWithin` method is 2.</p>
 
         <!-- es6num="22.2.3.5.1" -->
         <emu-clause id="sec-validatetypedarray" aoid="ValidateTypedArray">
@@ -31268,7 +31239,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `every` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.8" -->
@@ -31276,7 +31246,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.fill (_value_ [ , _start_ [ , _end_ ] ] )</h1>
         <p>%TypedArray%`.prototype.fill` is a distinct function that implements the same algorithm as `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `fill` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.9" -->
@@ -31309,7 +31278,6 @@ Date.parse(x.toLocaleString())
           1. Return _A_.
         </emu-alg>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
-        <p>The `length` property of the `filter` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.10" -->
@@ -31317,7 +31285,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.find (_predicate_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `find` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.11" -->
@@ -31325,7 +31292,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `findIndex` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.12" -->
@@ -31333,7 +31299,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `forEach` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.13" -->
@@ -31341,7 +31306,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.indexOf (_searchElement_ [ , _fromIndex_ ] )</h1>
         <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `indexOf` method is 1.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.includes">
@@ -31351,7 +31315,6 @@ Date.parse(x.toLocaleString())
 
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
 
-        <p>The `length` property of the `includes` method is *1*.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.14" -->
@@ -31377,7 +31340,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `lastIndexOf` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.17" -->
@@ -31419,7 +31381,6 @@ Date.parse(x.toLocaleString())
           1. Return _A_.
         </emu-alg>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
-        <p>The `length` property of the `map` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.19" -->
@@ -31427,7 +31388,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `reduce` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.20" -->
@@ -31435,7 +31395,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `reduceRight` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.21" -->
@@ -31450,7 +31409,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.set ( _overloaded_ [ , _offset_ ])</h1>
         <p>%TypedArray%`.prototype.set` is a single function whose behaviour is overloaded based upon the type of its first argument.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
-        <p>The `length` property of the `set` method is 1.</p>
 
         <!-- es6num="22.2.3.22.1" -->
         <emu-clause id="sec-%typedarray%.prototype.set-array-offset">
@@ -31486,11 +31444,12 @@ Date.parse(x.toLocaleString())
               1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
             1. Return *undefined*.
           </emu-alg>
+          <p>The `length` property of the `set` method is 2.</p>
         </emu-clause>
 
         <!-- es6num="22.2.3.22.2" -->
         <emu-clause id="sec-%typedarray%.prototype.set-typedarray-offset">
-          <h1>%TypedArray%.prototype.set(_typedArray_ [, _offset_ ] )</h1>
+          <h1>%TypedArray%.prototype.set(_typedArray_ [ , _offset_ ] )</h1>
           <p>Sets multiple values in this _TypedArray_, reading the values from the _typedArray_ argument object. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
           <emu-alg>
             1. Assert: _typedArray_ has a [[TypedArrayName]] internal slot. If it does not, the definition in <emu-xref href="#sec-%typedarray%.prototype.set-array-offset"></emu-xref> applies.
@@ -31591,7 +31550,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
-        <p>The `length` property of the `some` method is 1.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.25" -->
@@ -31652,6 +31610,7 @@ Date.parse(x.toLocaleString())
           1. Let _argumentsList_ be &laquo;_buffer_, _beginByteOffset_, _newLength_&raquo;.
           1. Return TypedArraySpeciesCreate(_O_, _argumentsList_).
         </emu-alg>
+        <p>The `length` property of the `subarray` method is 2.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
@@ -32080,7 +32039,6 @@ Date.parse(x.toLocaleString())
               1. Let _funcResult_ be ? Call(_callbackfn_, _T_, &laquo; _e_.[[value]], _e_.[[key]], _M_ &raquo;).
           1. Return *undefined*.
         </emu-alg>
-        <p>The `length` property of the `forEach` method is 1.</p>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each key/value pair present in the map object, in key insertion order. _callbackfn_ is called only for keys of the map which actually exist; it is not called for keys that have been deleted from the map.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
@@ -32460,7 +32418,6 @@ Date.parse(x.toLocaleString())
               1. Let _funcResult_ be ? Call(_callbackfn_, _T_, &laquo; _e_, _e_, _S_ &raquo;).
           1. Return *undefined*.
         </emu-alg>
-        <p>The `length` property of the `forEach` method is 1.</p>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each value present in the set object, in value insertion order. _callbackfn_ is called only for values of the Set which actually exist; it is not called for keys that have been deleted from the set.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
@@ -33004,7 +32961,7 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="24.1.1.4" -->
       <emu-clause id="sec-clonearraybuffer" aoid="CloneArrayBuffer">
-        <h1>CloneArrayBuffer( _srcBuffer_, _srcByteOffset_ [, _cloneConstructor_] )</h1>
+        <h1>CloneArrayBuffer( _srcBuffer_, _srcByteOffset_ [ , _cloneConstructor_ ] )</h1>
         <p>The abstract operation CloneArrayBuffer takes three parameters, an ArrayBuffer _srcBuffer_, an integer _srcByteOffset_ and optionally a constructor function _cloneConstructor_. It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data starting at _srcByteOffset_. This operation performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_srcBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
@@ -33276,7 +33233,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="24.2.2.1" -->
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
         <h1>DataView (_buffer_ [ , _byteOffset_ [ , _byteLength_ ] ] )</h1>
-        <p>`DataView` called with arguments _buffer_, _byteOffset_, and _length_ performs the following steps:</p>
+        <p>`DataView` called with arguments _buffer_, _byteOffset_, and _byteLength_ performs the following steps:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If Type(_buffer_) is not Object, throw a *TypeError* exception.
@@ -33299,6 +33256,7 @@ Date.parse(x.toLocaleString())
           1. Set _O_'s [[ByteOffset]] internal slot to _offset_.
           1. Return _O_.
         </emu-alg>
+        <p>The `length` property of the `DataView` function is 3.</p>
       </emu-clause>
     </emu-clause>
 
@@ -35167,7 +35125,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
 
     <!-- es6num="26.1.2" -->
     <emu-clause id="sec-reflect.construct">
-      <h1>Reflect.construct ( _target_, _argumentsList_ [, _newTarget_] )</h1>
+      <h1>Reflect.construct ( _target_, _argumentsList_ [ , _newTarget_ ] )</h1>
       <p>When the `construct` function is called with arguments _target_, _argumentsList_, and _newTarget_ the following steps are taken:</p>
       <emu-alg>
         1. If IsConstructor(_target_) is *false*, throw a *TypeError* exception.
@@ -35176,7 +35134,6 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         1. Let _args_ be ? CreateListFromArrayLike(_argumentsList_).
         1. Return ? Construct(_target_, _args_, _newTarget_).
       </emu-alg>
-      <p>The `length` property of the `construct` function is 2.</p>
     </emu-clause>
 
     <!-- es6num="26.1.3" -->
@@ -35223,7 +35180,6 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           1. Let _receiver_ be _target_.
         1. Return ? _target_.[[Get]](_key_, _receiver_).
       </emu-alg>
-      <p>The `length` property of the `get` function is 2.</p>
     </emu-clause>
 
     <!-- es6num="26.1.7" -->
@@ -35301,7 +35257,6 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           1. Let _receiver_ be _target_.
         1. Return ? _target_.[[Set]](_key_, _V_, _receiver_).
       </emu-alg>
-      <p>The `length` property of the `set` function is 3.</p>
     </emu-clause>
 
     <!-- es6num="26.1.14" -->


### PR DESCRIPTION
Fixes #264.

 - A few legacy methods that have deviating lengths are documented explicitly.
 - Any unneeded explicit lengths are removed.
 - Needed legacy explicit lengths are added.
 - Spacing inside optional argument brackets is made consistent
 - Fixed a bug with a `DataView` note having the wrong argument name
 - replaced two instances of a spreaded argument using an ellipsis with three dots

The DataView prototype get/set methods have inconsistent lengths across all browsers, so rather than select one of them as legacy, I decided to let them fall into the default category, which hopefully implementations will align with.