### PR TITLE
Function length and name clean-ups

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21611,7 +21611,7 @@ eval("1;var a;")
   <p>Unless otherwise specified every built-in prototype object has the Object prototype object, which is the initial value of the expression `Object.prototype` (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>), as the value of its [[Prototype]] internal slot, except the Object prototype object itself.</p>
   <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function.</p>
   <p>Unless otherwise specified, each built-in function defined in this specification is created as if by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>).</p>
-  <p>Every built-in Function object, including constructors, has a `length` property whose value is an integer. Unless otherwise specified, this value is equal to the largest number of named arguments shown in the subclause headings for the function description, not including optional parameters (which are indicated with brackets: `[` `]`) or rest parameters (which are shown using the form «...name») are not included in the default argument count.</p>
+  <p>Every built-in Function object, including constructors, has a `length` property whose value is an integer. Unless otherwise specified, this value is equal to the largest number of named arguments shown in the subclause headings for the function description. Optional parameters (which are indicated with brackets: `[` `]`) or rest parameters (which are shown using the form «...name») are not included in the default argument count.</p>
   <emu-note>
     <p>For example, the function object that is the initial value of the `map` property of the Array prototype object is described under the subclause heading «Array.prototype.map (callbackFn [ , thisArg])» which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the `length` property of that Function object is `1`.</p>
   </emu-note>
@@ -22509,7 +22509,7 @@ eval("1;var a;")
           1. If _value_ is *null*, *undefined* or not supplied, return ObjectCreate(%ObjectPrototype%).
           1. Return ToObject(_value_).
         </emu-alg>
-        <p>The `length` property of the `Object` constructor is 1.</p>
+        <p>The `length` property of the `Object` constructor function is 1.</p>
       </emu-clause>
     </emu-clause>
 
@@ -22544,16 +22544,15 @@ eval("1;var a;")
 
       <!-- es6num="19.1.2.2" -->
       <emu-clause id="sec-object.create">
-        <h1>Object.create ( _O_ [ , _Properties_ ] )</h1>
+        <h1>Object.create ( _O_, _Properties_ )</h1>
         <p>The `create` function creates a new object with a specified prototype. When the `create` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_O_) is neither Object nor Null, throw a *TypeError* exception.
           1. Let _obj_ be ObjectCreate(_O_).
-          1. If the argument _Properties_ is present and not *undefined*, then
+          1. If _Properties_ is not *undefined*, then
             1. Return ? ObjectDefineProperties(_obj_, _Properties_).
           1. Return _obj_.
         </emu-alg>
-        <p>The `length` property of the `create` method is 2.</p>
       </emu-clause>
 
       <!-- es6num="19.1.2.3" -->
@@ -23204,7 +23203,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-properties-of-the-boolean-constructor">
       <h1>Properties of the Boolean Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the Boolean constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Boolean constructor has the following properties:</p>
+      <p>The Boolean constructor has the following properties:</p>
 
       <!-- es6num="19.3.2.1" -->
       <emu-clause id="sec-boolean.prototype">
@@ -23288,7 +23287,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-properties-of-the-symbol-constructor">
       <h1>Properties of the Symbol Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the Symbol constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Symbol constructor has the following properties:</p>
+      <p>The Symbol constructor has the following properties:</p>
 
       <!-- es6num="19.4.2.1" -->
       <emu-clause id="sec-symbol.for">
@@ -23559,7 +23558,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-properties-of-the-error-constructor">
       <h1>Properties of the Error Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the Error constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Error constructor has the following properties:</p>
+      <p>The Error constructor has the following properties:</p>
 
       <!-- es6num="19.5.2.1" -->
       <emu-clause id="sec-error.prototype">
@@ -23693,7 +23692,8 @@ new Function("a,b", "c", "return a+b+c")
       <emu-clause id="sec-properties-of-the-nativeerror-constructors">
         <h1>Properties of the _NativeError_ Constructors</h1>
         <p>The value of the [[Prototype]] internal slot of a _NativeError_ constructor is the intrinsic object %Error% (<emu-xref href="#sec-error-constructor"></emu-xref>).</p>
-        <p>Besides the `length` property, each _NativeError_ constructor has the following properties:</p>
+        <p>Each _NativeError_ constructor has a `name` property whose value is the String value `"<var>NativeError</var>"`.</p>
+        <p>Each _NativeError_ constructor has the following properties:</p>
 
         <!-- es6num="19.5.6.2.1" -->
         <emu-clause id="sec-nativeerror.prototype">
@@ -23753,7 +23753,7 @@ new Function("a,b", "c", "return a+b+c")
 
       <!-- es6num="20.1.1.1" -->
       <emu-clause id="sec-number-constructor-number-value">
-        <h1>Number ( [ _value_ ] )</h1>
+        <h1>Number ( _value_ )</h1>
         <p>When `Number` is called with argument _number_, the following steps are taken:</p>
         <emu-alg>
           1. If no arguments were passed to this function invocation, let _n_ be +0.
@@ -23763,7 +23763,6 @@ new Function("a,b", "c", "return a+b+c")
           1. Set the value of _O_'s [[NumberData]] internal slot to _n_.
           1. Return _O_.
         </emu-alg>
-        <p>The `length` property of the `Number` constructor is 1.</p>
       </emu-clause>
     </emu-clause>
 
@@ -23771,7 +23770,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-properties-of-the-number-constructor">
       <h1>Properties of the Number Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the Number constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Number constructor has the following properties:</p>
+      <p>The Number constructor has the following properties:</p>
 
       <!-- es6num="20.1.2.1" -->
       <emu-clause id="sec-number.epsilon">
@@ -25522,6 +25521,7 @@ THH:mm:ss.sss
       <p>The Date constructor is the %Date% intrinsic object and the initial value of the `Date` property of the global object. When called as a constructor it creates and initializes a new Date object. When `Date` is called as a function rather than as a constructor, it returns a String representing the current time (UTC).</p>
       <p>The `Date` constructor is a single function whose behaviour is overloaded based upon the number and types of its arguments.</p>
       <p>The `Date` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behaviour must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</p>
+      <p>The `length` property of the `Date` constructor function is 7.</p>
 
       <!-- es6num="20.3.2.1" -->
       <emu-clause id="sec-date-year-month-date-hours-minutes-seconds-ms">
@@ -25548,7 +25548,6 @@ THH:mm:ss.sss
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
             1. Return ToDateString(_now_).
         </emu-alg>
-        <p>The `length` property of the `Date` function is 7.</p>
       </emu-clause>
 
       <!-- es6num="20.3.2.2" -->
@@ -25601,7 +25600,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-properties-of-the-date-constructor">
       <h1>Properties of the Date Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the Date constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Date constructor has the following properties:</p>
+      <p>The Date constructor has the following properties:</p>
 
       <!-- es6num="20.3.3.1" -->
       <emu-clause id="sec-date.now">
@@ -26319,7 +26318,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-string-constructor">
       <h1>Properties of the String Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the String constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the String constructor has the following properties:</p>
+      <p>The String constructor has the following properties:</p>
 
       <!-- es6num="21.1.2.1" -->
       <emu-clause id="sec-string.fromcharcode">
@@ -28789,7 +28788,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-regexp-constructor">
       <h1>Properties of the RegExp Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the RegExp constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the RegExp constructor has the following properties:</p>
+      <p>The RegExp constructor has the following properties:</p>
 
       <!-- es6num="21.2.4.1" -->
       <emu-clause id="sec-regexp.prototype">
@@ -29364,7 +29363,6 @@ Date.parse(x.toLocaleString())
           1. Assert: the value of _array_'s `length` property is _numberOfArgs_.
           1. Return _array_.
         </emu-alg>
-        <p>The `length` property of the Array constructor is 1.</p>
       </emu-clause>
     </emu-clause>
 
@@ -29372,7 +29370,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-array-constructor">
       <h1>Properties of the Array Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the Array constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Array constructor has the following properties:</p>
+      <p>The Array constructor has the following properties:</p>
 
       <!-- es6num="22.1.2.1" -->
       <emu-clause id="sec-array.from">
@@ -30963,6 +30961,7 @@ Date.parse(x.toLocaleString())
           1. Let _argumentsList_ be the _argumentsList_ argument of the [[Construct]] internal method that invoked the active function.
           1. Return Construct(_super_, _argumentsList_, NewTarget).
         </emu-alg>
+        <p>The `length` property of the %TypedArray% constructor function is 3.</p>
       </emu-clause>
     </emu-clause>
 
@@ -30971,7 +30970,8 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-%typedarray%-intrinsic-object">
       <h1>Properties of the %TypedArray% Intrinsic Object</h1>
       <p>The value of the [[Prototype]] internal slot of %TypedArray% is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides a `length` property whose value is 3 and a `name` property whose value is `"TypedArray"`, %TypedArray% has the following properties:</p>
+      <p>The `name` property of the %TypedArray% constructor function is `"TypedArray"`.</p>
+      <p>The %TypedArray% constructor has the following properties:</p>
 
       <!-- es6num="22.2.2.1" -->
       <emu-clause id="sec-%typedarray%.from">
@@ -31346,7 +31346,6 @@ Date.parse(x.toLocaleString())
         <h1>%TypedArray%.prototype.set ( _overloaded_ [ , _offset_ ])</h1>
         <p>%TypedArray%`.prototype.set` is a single function whose behaviour is overloaded based upon the type of its first argument.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
-        <p>The `length` property of the `set` method is 2.</p>
 
         <!-- es6num="22.2.3.22.1" -->
         <emu-clause id="sec-%typedarray%.prototype.set-array-offset">
@@ -31526,7 +31525,7 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="22.2.3.26" -->
       <emu-clause id="sec-%typedarray%.prototype.subarray">
-        <h1>%TypedArray%.prototype.subarray( [ _begin_ [ , _end_ ] ] )</h1>
+        <h1>%TypedArray%.prototype.subarray( _begin_ , _end_ )</h1>
         <p>Returns a new _TypedArray_ object whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -31547,7 +31546,6 @@ Date.parse(x.toLocaleString())
           1. Let _argumentsList_ be &laquo;_buffer_, _beginByteOffset_, _newLength_&raquo;.
           1. Return TypedArraySpeciesCreate(_O_, _argumentsList_).
         </emu-alg>
-        <p>The `length` property of the `subarray` method is 2.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
@@ -31608,6 +31606,7 @@ Date.parse(x.toLocaleString())
       <p>The _TypedArray_ intrinsic constructor functions are single functions whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</p>
       <p>The _TypedArray_ constructors are not intended to be called as a function and will throw an exception when called in that manner.</p>
       <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray`%.prototype` built-in methods.</p>
+      <p>The `length` property of the _TypedArray_ constructor function is 3.</p>
 
       <!-- es6num="22.2.4.1" -->
       <emu-clause id="sec-typedarray">
@@ -31777,7 +31776,7 @@ Date.parse(x.toLocaleString())
       <p>The value of the [[Prototype]] internal slot of each _TypedArray_ constructor is the %TypedArray% intrinsic object (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>).</p>
       <p>Each _TypedArray_ constructor has a [[TypedArrayConstructorName]] internal slot property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-49"></emu-xref>.</p>
       <p>Each _TypedArray_ constructor has a `name` property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-49"></emu-xref>.</p>
-      <p>Besides a `length` property (whose value is 3), each _TypedArray_ constructor has the following properties:</p>
+      <p>Each _TypedArray_ constructor has the following properties:</p>
 
       <!-- es6num="22.2.5.1" -->
       <emu-clause id="sec-typedarray.bytes_per_element">
@@ -31876,7 +31875,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-map-constructor">
       <h1>Properties of the Map Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the Map constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Map constructor has the following properties:</p>
+      <p>The Map constructor has the following properties:</p>
 
       <!-- es6num="23.1.2.1" -->
       <emu-clause id="sec-map.prototype">
@@ -32239,7 +32238,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-set-constructor">
       <h1>Properties of the Set Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the Set constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Set constructor has the following properties:</p>
+      <p>The Set constructor has the following properties:</p>
 
       <!-- es6num="23.2.2.1" -->
       <emu-clause id="sec-set.prototype">
@@ -32597,7 +32596,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-weakmap-constructor">
       <h1>Properties of the WeakMap Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the WeakMap constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the WeakMap constructor has the following properties:</p>
+      <p>The WeakMap constructor has the following properties:</p>
 
       <!-- es6num="23.3.2.1" -->
       <emu-clause id="sec-weakmap.prototype">
@@ -32752,7 +32751,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-weakset-constructor">
       <h1>Properties of the WeakSet Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the WeakSet constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the WeakSet constructor has the following properties:</p>
+      <p>The WeakSet constructor has the following properties:</p>
 
       <!-- es6num="23.4.2.1" -->
       <emu-clause id="sec-weakset.prototype">
@@ -33002,7 +33001,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-arraybuffer-constructor">
       <h1>Properties of the ArrayBuffer Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the ArrayBuffer constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides its `length` property (whose value is 1), the ArrayBuffer constructor has the following properties:</p>
+      <p>The ArrayBuffer constructor has the following properties:</p>
 
       <!-- es6num="24.1.3.1" -->
       <emu-clause id="sec-arraybuffer.isview">
@@ -33169,7 +33168,7 @@ Date.parse(x.toLocaleString())
 
       <!-- es6num="24.2.2.1" -->
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
-        <h1>DataView (_buffer_ [ , _byteOffset_ [ , _byteLength_ ] ] )</h1>
+        <h1>DataView (_buffer_, _byteOffset_, _byteLength_ )</h1>
         <p>`DataView` called with arguments _buffer_, _byteOffset_, and _byteLength_ performs the following steps:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
@@ -33193,7 +33192,6 @@ Date.parse(x.toLocaleString())
           1. Set _O_'s [[ByteOffset]] internal slot to _offset_.
           1. Return _O_.
         </emu-alg>
-        <p>The `length` property of the `DataView` constructor is 3.</p>
       </emu-clause>
     </emu-clause>
 
@@ -33201,7 +33199,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-dataview-constructor">
       <h1>Properties of the DataView Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the `DataView` constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the DataView constructor has the following properties:</p>
+      <p>The DataView constructor has the following properties:</p>
 
       <!-- es6num="24.2.3.1" -->
       <emu-clause id="sec-dataview.prototype">
@@ -34720,7 +34718,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
     <emu-clause id="sec-properties-of-the-promise-constructor">
       <h1>Properties of the Promise Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the `Promise` constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
-      <p>Besides the `length` property, the Promise constructor has the following properties:</p>
+      <p>The Promise constructor has the following properties:</p>
 
       <!-- es6num="25.4.4.1" -->
       <emu-clause id="sec-promise.all">
@@ -35235,7 +35233,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       <h1>Properties of the Proxy Constructor</h1>
       <p>The value of the [[Prototype]] internal slot of the `Proxy` constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
       <p>The `Proxy` constructor does not have a `prototype` property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</p>
-      <p>Besides the `length` property, the `Proxy` constructor has the following properties:</p>
+      <p>The `Proxy` constructor has the following properties:</p>
 
       <!-- es6num="26.2.2.1" -->
       <emu-clause id="sec-proxy.revocable">


### PR DESCRIPTION
- Restore explicit length definition for constructor functions
- Change "length" of %TypedArray%.prototype.set from 2 to 1 (was 1 in ES2015)
- Add "name" property definition for NativeErrors
- Remove optional parameter notation for Object.create
- Remove optional parameter notation for Number constructor
- Remove optional parameter notation for %TypedArray%.prototype.subarray
- Remove optional parameter notation for DataView constructor