### PR TITLE
Editorial: be explicit about parsing realms

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19541,15 +19541,14 @@ eval("1;var a;")
     </emu-clause>
 
     <emu-clause id="sec-parse-script" aoid="ParseScript">
-      <h1>ParseScript ( _sourceText_, _hostDefined_ )</h1>
+      <h1>ParseScript ( _sourceText_, _realm_, _hostDefined_ )</h1>
 
-      <p>The abstract operation ParseScript with arguments _sourceText_ and _hostDefined_ creates a Script Record based upon the result of parsing _sourceText_ as a |Script|. ParseScript performs the following steps:</p>
+      <p>The abstract operation ParseScript with arguments _sourceText_, _realm_, and _hostDefined_ creates a Script Record based upon the result of parsing _sourceText_ as a |Script|. ParseScript performs the following steps:</p>
 
       <emu-alg>
         1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
         1. Parse _sourceText_ using |Script| as the goal symbol and analyze the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* or *ReferenceError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation dependent, but at least one must be present.
         1. If _body_ is a List of errors, then return _body_.
-        1. Let _realm_ be the running execution context's Realm.
         1. Return Script Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[ECMAScriptCode]]: _body_, [[HostDefined]]: _hostDefined_}.
       </emu-alg>
       <emu-note>
@@ -19654,7 +19653,8 @@ eval("1;var a;")
       <p>The job ScriptEvaluationJob with parameters _sourceText_ and _hostDefined_ parses, validates, and evaluates _sourceText_ as a |Script|.</p>
       <emu-alg>
         1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
-        1. Let _s_ be ParseScript(_sourceText_, _hostDefined_).
+        1. Let _realm_ be the running execution context's Realm.
+        1. Let _s_ be ParseScript(_sourceText_, _realm_, _hostDefined_).
         1. If _s_ is a List of errors, then
           1. Perform HostReportErrors(_s_).
           1. NextJob NormalCompletion(*undefined*).
@@ -20626,8 +20626,8 @@ eval("1;var a;")
 
         <!-- es6num="15.2.1.16.1" -->
         <emu-clause id="sec-parsemodule" aoid="ParseModule">
-          <h1>ParseModule ( _sourceText_, _hostDefined_ )</h1>
-          <p>The abstract operation ParseModule with arguments _sourceText_ and _hostDefined_ creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. ParseModule performs the following steps:</p>
+          <h1>ParseModule ( _sourceText_, _realm_, _hostDefined_ )</h1>
+          <p>The abstract operation ParseModule with arguments _sourceText_, _realm_, and _hostDefined_ creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. ParseModule performs the following steps:</p>
           <emu-alg>
             1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
             1. Parse _sourceText_ using |Module| as the goal symbol and analyze the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* or *ReferenceError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation dependent, but at least one must be present.
@@ -20654,7 +20654,6 @@ eval("1;var a;")
                 1. Append _ee_ to _starExportEntries_.
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
-            1. Let _realm_ be the running execution context's Realm.
             1. Return Source Text Module Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[HostDefined]]: _hostDefined_, [[Namespace]]: *undefined*, [[Evaluated]]: *false*, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_}.
           </emu-alg>
           <emu-note>
@@ -20868,7 +20867,8 @@ eval("1;var a;")
         <p>A TopLevelModuleEvaluationJob with parameters _sourceText_ and _hostDefined_ is a job that parses, validates, and evaluates _sourceText_ as a |Module|.</p>
         <emu-alg>
           1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
-          1. Let _m_ be ParseModule(_sourceText_, _hostDefined_).
+          1. Let _realm_ be the running execution context's Realm.
+          1. Let _m_ be ParseModule(_sourceText_, _realm_, _hostDefined_).
           1. If _m_ is a List of errors, then
             1. Perform HostReportErrors(_m_).
             1. NextJob NormalCompletion(*undefined*).


### PR DESCRIPTION
When creating script and module records via ParseScript/ParseModule, currently we always use the running execution context's Realm. This pushes the dependency on the current execution context out a level, to the top-level jobs, ensuring that the parsing operations do not depend on implicit global state and can be used without a running execution context.

--

This is not a big deal, but as explained above it seems like an improvement. Incidentally (not primarily), it allows HTML to avoid the awkward dance of:

1. Look up _realm execution context_, an execution context corresponding to the desired Realm _realm_.
1. Push _realm execution context_ onto the execution context stack.
1. Let _s_ be ParseScript(_sourceText_, _hostDefined_).
1. Remove _realm execution context_ from the execution context stack

in favor of the simpler

1. Let _s_ be ParseScript(_sourceText_, _realm_, _hostDefined_).

I labeled this as "editorial" instead of "layering" since IMO it's a solid editorial change independent of incidental layering benefits. "Layering" seems more for changes that are necessary for layering work.

---

An alternate design would be to not pass _realm_ to ParseScript/ParseModule at all and instead have their callers (whether the callers be HTML or ScriptEvaluationJob/TopLevelModuleEvaluationJob) set _returnedScript_.[[Realm]]. The same goes for _hostDefined_ actually. But it seems kind of nicer to have ParseScript/ParseModule return fully-formed records.