### PR TITLE
Editorial: remove bogus uses of emu-eqn

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -652,9 +652,9 @@
   <emu-clause id="sec-algorithm-conventions">
     <h1>Algorithm Conventions</h1>
     <p>The specification often uses a numbered list to specify steps in an algorithm. These algorithms are used to precisely specify the required semantics of ECMAScript language constructs. The algorithms are not intended to imply the use of any specific implementation technique. In practice, there may be more efficient algorithms available to implement a given feature.</p>
-    <p>Algorithms may be explicitly parameterized, in which case the names and usage of the parameters must be provided as part of the algorithm's definition. In order to facilitate their use in multiple parts of this specification, some algorithms, called <em>abstract operations</em>, are named and written in parameterized functional form so that they may be referenced by name from within other algorithms. Abstract operations are typically referenced using a functional application style such as <emu-eqn>operationName(_arg1_, _arg2_)</emu-eqn>. Some abstract operations are treated as polymorphically dispatched methods of class-like specification abstractions. Such method-like abstract operations are typically referenced using a method application style such as <emu-eqn>_someValue_.operationName(_arg1_, _arg2_)</emu-eqn>.</p>
-    <p>Calls to abstract operations return Completion Records. Abstract operations referenced using the functional application style and the method application style that are prefixed by `?` indicate that ReturnIfAbrupt should be applied to the resulting Completion Record. For example, <emu-eqn>?operationName()</emu-eqn> is equivalent to: <emu-eqn>ReturnIfAbrupt(operationName())</emu-eqn>. Similarly, <emu-eqn>? _someValue_.operationName()</emu-eqn> is equivalent to <emu-eqn>ReturnIfAbrupt(_someValue_.operationName())</emu-eqn>.</p>
-    <p>The prefix `!` is used to indicate that an abstract operation will never return an abrupt completion and that the resulting Completion Record's value field should be used in place of the return value of the operation. For example, <emu-eqn>Let _val_ be ! operationName()</emu-eqn> is equivalent to the following algorithm steps:</p>
+    <p>Algorithms may be explicitly parameterized, in which case the names and usage of the parameters must be provided as part of the algorithm's definition. In order to facilitate their use in multiple parts of this specification, some algorithms, called <em>abstract operations</em>, are named and written in parameterized functional form so that they may be referenced by name from within other algorithms. Abstract operations are typically referenced using a functional application style such as operationName(_arg1_, _arg2_). Some abstract operations are treated as polymorphically dispatched methods of class-like specification abstractions. Such method-like abstract operations are typically referenced using a method application style such as _someValue_.operationName(_arg1_, _arg2_).</p>
+    <p>Calls to abstract operations return Completion Records. Abstract operations referenced using the functional application style and the method application style that are prefixed by `?` indicate that ReturnIfAbrupt should be applied to the resulting Completion Record. For example, ? operationName() is equivalent to ReturnIfAbrupt(operationName()). Similarly, ? _someValue_.operationName() is equivalent to ReturnIfAbrupt(_someValue_.operationName()).</p>
+    <p>The prefix `!` is used to indicate that an abstract operation will never return an abrupt completion and that the resulting Completion Record's value field should be used in place of the return value of the operation. For example, &ldquo;Let _val_ be ! operationName()&rdquo; is equivalent to the following algorithm steps:</p>
     <emu-alg>
       1. Let _val_ be operationName().
       1. Assert: _val_ is never an abrupt completion.
@@ -667,7 +667,7 @@
       Block :
         `{` StatementList `}`
     </emu-grammar>
-    <p>but there is no corresponding Evaluation algorithm that is explicitly specified for that production. If in some algorithm there is a statement of the form: &ldquo;<emu-eqn>Return the result of evaluating |Block|</emu-eqn>&rdquo; it is implicit that an Evaluation algorithm exists of the form:</p>
+    <p>but there is no corresponding Evaluation algorithm that is explicitly specified for that production. If in some algorithm there is a statement of the form: &ldquo;Return the result of evaluating |Block|&rdquo; it is implicit that an Evaluation algorithm exists of the form:</p>
     <p><b>Runtime Semantics: Evaluation</b></p>
     <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
     <emu-alg>
@@ -719,7 +719,7 @@
 <emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
   <h1>ECMAScript Data Types and Values</h1>
   <p>Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further subclassified into ECMAScript language types and specification types.</p>
-  <p>Within this specification, the notation &ldquo;<emu-eqn>Type(_x_)</emu-eqn>&rdquo; is used as shorthand for &ldquo;<emu-eqn>the type of _x_</emu-eqn>&rdquo; where &ldquo;<emu-eqn>type</emu-eqn>&rdquo; refers to the ECMAScript language and specification types defined in this clause. When the term &ldquo;empty&rdquo; is used as if it was naming a value, it is equivalent to saying &ldquo;no value of any type&rdquo;.</p>
+  <p>Within this specification, the notation &ldquo;Type(_x_)&rdquo; is used as shorthand for &ldquo;the <dfn id="type">type</dfn> of _x_&rdquo; where &ldquo;type&rdquo; refers to the ECMAScript language and specification types defined in this clause. When the term &ldquo;empty&rdquo; is used as if it was naming a value, it is equivalent to saying &ldquo;no value of any type&rdquo;.</p>
 
   <!-- es6num="6.1" -->
   <emu-clause id="sec-ecmascript-language-types">
@@ -942,7 +942,7 @@
       <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>52</sup>, and _e_ is -1074.</p>
       <p>Note that all the positive and negative integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the integer 0 has two representations, `+0` and `-0`).</p>
       <p>A finite number has an <em>odd significand</em> if it is nonzero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
-      <p>In this specification, the phrase &ldquo;<emu-eqn>the Number value for _x_</emu-eqn>&rdquo; where _x_ represents an exact nonzero real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 &ldquo;round to nearest, ties to even&rdquo; mode.)</p>
+      <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact nonzero real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 &ldquo;round to nearest, ties to even&rdquo; mode.)</p>
       <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup>-1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup>-1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
     </emu-clause>
 
@@ -2630,13 +2630,13 @@
         <emu-alg>
           1. Return NormalCompletion(`"Infinity"`).
         </emu-alg>
-        <p>However, if the value expression of a &ldquo;<emu-eqn>return</emu-eqn>&rdquo; statement is a Completion Record construction literal, the resulting Completion Record is returned. If the value expression is a call to an abstract operation, the &ldquo;<emu-eqn>return</emu-eqn>&rdquo; statement simply returns the Completion Record produced by the abstract operation.</p>
-        <p>The abstract operation <emu-eqn>Completion(_completionRecord_)</emu-eqn> is used to emphasize that a previously computed Completion Record is being returned. The Completion abstract operation takes a single argument, _completionRecord_, and performs the following steps:</p>
+        <p>However, if the value expression of a &ldquo;return&rdquo; statement is a Completion Record construction literal, the resulting Completion Record is returned. If the value expression is a call to an abstract operation, the &ldquo;return&rdquo; statement simply returns the Completion Record produced by the abstract operation.</p>
+        <p>The abstract operation Completion(_completionRecord_) is used to emphasize that a previously computed Completion Record is being returned. The Completion abstract operation takes a single argument, _completionRecord_, and performs the following steps:</p>
         <emu-alg>
           1. Assert: _completionRecord_ is a Completion Record.
           1. Return _completionRecord_ as the Completion Record of this abstract operation.
         </emu-alg>
-        <p>A &ldquo;<emu-eqn>return</emu-eqn>&rdquo; statement without a value in an algorithm step means the same thing as:</p>
+        <p>A &ldquo;return&rdquo; statement without a value in an algorithm step means the same thing as:</p>
         <emu-alg>
           1. Return NormalCompletion(*undefined*).
         </emu-alg>
@@ -3057,7 +3057,7 @@
           </tbody>
         </table>
       </emu-table>
-      <p>When <emu-eqn>Type(_input_)</emu-eqn> is Object, the following steps are taken:</p>
+      <p>When Type(_input_) is Object, the following steps are taken:</p>
       <emu-alg>
         1. If _PreferredType_ was not passed, let _hint_ be `"default"`.
         1. Else if _PreferredType_ is hint String, let _hint_ be `"string"`.
@@ -3370,19 +3370,19 @@
               The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>)) times 10<sup>_e_</sup>, where _n_ is the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times <emu-eqn>10<sup>-_n_</sup></emu-eqn>)) times <emu-eqn>10<sup>_e_</sup></emu-eqn>, where _n_ is the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times <emu-eqn>10<sup>-_n_</sup></emu-eqn>, where _n_ is the number of code points in |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times <emu-eqn>10<sup>_e_-_n_</sup></emu-eqn>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
               The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times <emu-eqn>10<sup>_e_</sup></emu-eqn>, where _e_ is the MV of |ExponentPart|.
             </li>
           </ul>
           <p>Once the exact MV for a String numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is +0 unless the first non white space code point in the String numeric literal is `"-"`, in which case the rounded value is -0. Otherwise, the rounded value must be the Number value for the MV (in the sense defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal includes a |StrUnsignedDecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit and then incrementing the literal at the 20th digit position. A digit is significant if it is not part of an |ExponentPart| and</p>
@@ -3428,7 +3428,7 @@
             The ToInt32 abstract operation is idempotent: if applied to a result that it produced, the second application leaves that value unchanged.
           </li>
           <li>
-            ToInt32(ToUint32(_x_)) is equal to <emu-eqn>ToInt32(_x_)</emu-eqn> for all values of _x_. (It is to preserve this latter property that *+&infin;* and *-&infin;* are mapped to *+0*.)
+            ToInt32(ToUint32(_x_)) is equal to ToInt32(_x_) for all values of _x_. (It is to preserve this latter property that *+&infin;* and *-&infin;* are mapped to *+0*.)
           </li>
           <li>
             ToInt32 maps *-0* to *+0*.
@@ -3458,7 +3458,7 @@
             The ToUint32 abstract operation is idempotent: if applied to a result that it produced, the second application leaves that value unchanged.
           </li>
           <li>
-            <emu-eqn>ToUint32(ToInt32(_x_))</emu-eqn> is equal to <emu-eqn>ToUint32(_x_)</emu-eqn> for all values of _x_. (It is to preserve this latter property that *+&infin;* and *-&infin;* are mapped to *+0*.)
+            ToUint32(ToInt32(_x_)) is equal to ToUint32(_x_) for all values of _x_. (It is to preserve this latter property that *+&infin;* and *-&infin;* are mapped to *+0*.)
           </li>
           <li>
             ToUint32 maps *-0* to *+0*.
@@ -7299,7 +7299,7 @@ for (let protoName of Reflect.enumerate(proto)) {
       <h1>Array Exotic Objects</h1>
       <p>An <em>Array object</em> is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array object has a `length` property whose value is always a nonnegative integer less than 2<sup>32</sup>. The value of the `length` property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array object is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the `length` property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the `length` property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array object and is unaffected by `length` or array index properties that may be inherited from its prototypes.</p>
       <emu-note>
-        <p>A String property name _P_ is an <em>array index</em> if and only if <emu-eqn>ToString(ToUint32(_P_))</emu-eqn> is equal to _P_ and <emu-eqn>ToUint32(_P_)</emu-eqn> is not equal to <emu-eqn>2<sup>32</sup>-1</emu-eqn>.</p>
+        <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) is equal to _P_ and ToUint32(_P_) is not equal to <emu-eqn>2<sup>32</sup>-1</emu-eqn>.</p>
       </emu-note>
       <p>Array exotic objects always have a non-configurable property named `"length"`.</p>
       <p>Array exotic objects provide an alternative definition for the [[DefineOwnProperty]] internal method. Except for that internal method, Array exotic objects provide all of the other essential internal methods as specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</p>
@@ -7420,7 +7420,7 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>In steps 3 and 4, if <emu-eqn>_Desc_.[[Value]]</emu-eqn> is an object then its `valueOf` method is called twice. This is legacy behaviour that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
+          <p>In steps 3 and 4, if _Desc_.[[Value]] is an object then its `valueOf` method is called twice. This is legacy behaviour that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -9338,13 +9338,13 @@ a = b / hi / g.exec(c).map(d);
         <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if <emu-eqn>SV(|UnicodeEscapeSequence|)</emu-eqn> is none of `"$"`, or `"_"`, or the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of a code point matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of a code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if <emu-eqn>SV(|UnicodeEscapeSequence|)</emu-eqn> is none of `"$"`, or `"_"`, or the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
       </emu-clause>
@@ -13095,7 +13095,7 @@ a = b + c
     <!-- es6num="12.9.4" -->
     <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
       <h1>Runtime Semantics: InstanceofOperator(_O_, _C_)</h1>
-      <p>The abstract operation <emu-eqn>InstanceofOperator(_O_, _C_)</emu-eqn> implements the generic algorithm for determining if an object _O_ inherits from the inheritance path defined by constructor _C_. This abstract operation performs the following steps:</p>
+      <p>The abstract operation InstanceofOperator(_O_, _C_) implements the generic algorithm for determining if an object _O_ inherits from the inheritance path defined by constructor _C_. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. If Type(_C_) is not Object, throw a *TypeError* exception.
         1. Let _instOfHandler_ be ? GetMethod(_C_,@@hasInstance).
@@ -13527,7 +13527,7 @@ a = b + c
         1. Return _r_.
       </emu-alg>
       <emu-note>
-        <p>When an assignment occurs within strict mode code, it is an runtime error if _lref_ in step 1.f of the first algorithm or step 7 of the second algorithm it is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value <emu-eqn>{[[Writable]]:*false*}</emu-eqn>, to an accessor property with the attribute value <emu-eqn>{[[Set]]:*undefined*}</emu-eqn>, nor to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
+        <p>When an assignment occurs within strict mode code, it is an runtime error if _lref_ in step 1.f of the first algorithm or step 7 of the second algorithm it is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value {[[Writable]]:*false*}, to an accessor property with the attribute value {[[Set]]:*undefined*}, nor to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
       </emu-note>
     </emu-clause>
 
@@ -19707,10 +19707,10 @@ eval("1;var a;")
             It is a Syntax Error if any element of the ExportedBindings of |ModuleItemList| does not also occur in either the VarDeclaredNames of |ModuleItemList|, or the LexicallyDeclaredNames of |ModuleItemList|.
           </li>
           <li>
-            It is a Syntax Error if |ModuleItemList| Contains `super`.
+            It is a Syntax Error if |ModuleItemList| contains `super`.
           </li>
           <li>
-            It is a Syntax Error if <emu-eqn>|ModuleItemList| Contains |NewTarget|</emu-eqn>
+            It is a Syntax Error if |ModuleItemList| contains |NewTarget|.
           </li>
           <li>
             It is a Syntax Error if ContainsDuplicateLabels of |ModuleItemList| with argument &laquo; &raquo; is *true*.
@@ -21602,7 +21602,7 @@ eval("1;var a;")
   <p>There are certain built-in objects available whenever an ECMAScript |Script| or |Module| begins execution. One, the global object, is part of the lexical environment of the executing program. Others are accessible as initial properties of the global object or indirectly as properties of accessible built-in objects.</p>
   <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in Function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in Function object has a [[Realm]] internal slot whose value is the code Realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
-  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;`this` <emu-eqn>value</emu-eqn>&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
+  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;`this` value&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>
   <emu-note>
     <p>Implementations that add additional capabilities to the set of built-in functions are encouraged to do so by adding new functions rather than adding new parameters to existing functions.</p>
@@ -23219,7 +23219,7 @@ new Function("a,b", "c", "return a+b+c")
       <h1>Properties of the Boolean Prototype Object</h1>
       <p>The Boolean prototype object is the intrinsic object %BooleanPrototype%. The Boolean prototype object is an ordinary object. The Boolean prototype is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</p>
       <p>The value of the [[Prototype]] internal slot of the Boolean prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
-      <p>The abstract operation <emu-eqn>thisBooleanValue(_value_)</emu-eqn> performs the following steps:</p>
+      <p>The abstract operation thisBooleanValue(_value_) performs the following steps:</p>
       <emu-alg>
         1. If Type(_value_) is Boolean, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[BooleanData]] internal slot, then
@@ -23914,7 +23914,7 @@ new Function("a,b", "c", "return a+b+c")
       <p>The Number prototype object is the intrinsic object %NumberPrototype%. The Number prototype object is an ordinary object. The Number prototype is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</p>
       <p>The value of the [[Prototype]] internal slot of the Number prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
-      <p>The abstract operation <emu-eqn>thisNumberValue(_value_)</emu-eqn> performs the following steps:</p>
+      <p>The abstract operation thisNumberValue(_value_) performs the following steps:</p>
       <emu-alg>
         1. If Type(_value_) is Number, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[NumberData]] internal slot, then
@@ -25662,7 +25662,7 @@ Date.parse(x.toLocaleString())
       <p>The Date prototype object is the intrinsic object %DatePrototype%. The Date prototype object is itself an ordinary object. It is not a Date instance and does not have a [[DateValue]] internal slot.</p>
       <p>The value of the [[Prototype]] internal slot of the Date prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-date-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly defined otherwise, the methods of the Date prototype object defined below are not generic and the *this* value passed to them must be an object that has a [[DateValue]] internal slot that has been initialized to a time value.</p>
-      <p>The abstract operation <emu-eqn>thisTimeValue(_value_)</emu-eqn> performs the following steps:</p>
+      <p>The abstract operation thisTimeValue(_value_) performs the following steps:</p>
       <emu-alg aoid="thisTimeValue">
         1. If Type(_value_) is Object and _value_ has a [[DateValue]] internal slot, then
           1. Return the value of _value_'s [[DateValue]] internal slot.
@@ -26405,7 +26405,7 @@ Date.parse(x.toLocaleString())
       <p>The String prototype object is the intrinsic object %StringPrototype%. The String prototype object is an ordinary object. The String prototype is itself a String object; it has a [[StringData]] internal slot with the value *""*.</p>
       <p>The value of the [[Prototype]] internal slot of the String prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
-      <p>The abstract operation <emu-eqn>thisStringValue(_value_)</emu-eqn> performs the following steps:</p>
+      <p>The abstract operation thisStringValue(_value_) performs the following steps:</p>
       <emu-alg>
         1. If Type(_value_) is String, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[StringData]] internal slot, then
@@ -27418,7 +27418,7 @@ Date.parse(x.toLocaleString())
         <p>The descriptions below use the following variables:</p>
         <ul>
           <li>
-            _Input_ is a List consisting of all of the characters, in order, of the String being matched by the regular expression pattern. Each character is either a code unit or a code point, depending upon the kind of pattern involved. The notation <emu-eqn>_Input_[_n_]</emu-eqn> means the _n_<sup>th</sup> character of _Input_, where _n_ can range between 0 (inclusive) and _InputLength_ (exclusive).
+            _Input_ is a List consisting of all of the characters, in order, of the String being matched by the regular expression pattern. Each character is either a code unit or a code point, depending upon the kind of pattern involved. The notation _Input_[_n_] means the _n_<sup>th</sup> character of _Input_, where _n_ can range between 0 (inclusive) and _InputLength_ (exclusive).
           </li>
           <li>
             _InputLength_ is the number of characters in _Input_.
@@ -27442,7 +27442,7 @@ Date.parse(x.toLocaleString())
             A <em>CharSet</em> is a mathematical set of characters, either code units or code points depending up the state of the _Unicode_ flag. &ldquo;All characters&rdquo; means either all code unit values or all code point values also depending upon the state if _Unicode_.
           </li>
           <li>
-            A <em>State</em> is an ordered pair <emu-eqn>(_endIndex_, _captures_)</emu-eqn> where _endIndex_ is an integer and _captures_ is a List of _NcapturingParens_ values. States are used to represent partial match states in the regular expression matching algorithms. The _endIndex_ is one plus the index of the last input character matched so far by the pattern, while _captures_ holds the results of capturing parentheses. The _n_<sup>th</sup> element of _captures_ is either a List that represents the value obtained by the _n_<sup>th</sup> set of capturing parentheses or *undefined* if the _n_<sup>th</sup> set of capturing parentheses hasn't been reached yet. Due to backtracking, many States may be in use at any time during the matching process.
+            A <em>State</em> is an ordered pair (_endIndex_, _captures_) where _endIndex_ is an integer and _captures_ is a List of _NcapturingParens_ values. States are used to represent partial match states in the regular expression matching algorithms. The _endIndex_ is one plus the index of the last input character matched so far by the pattern, while _captures_ holds the results of capturing parentheses. The _n_<sup>th</sup> element of _captures_ is either a List that represents the value obtained by the _n_<sup>th</sup> set of capturing parentheses or *undefined* if the _n_<sup>th</sup> set of capturing parentheses hasn't been reached yet. Due to backtracking, many States may be in use at any time during the matching process.
           </li>
           <li>
             A <em>MatchResult</em> is either a State or the special token ~failure~ that indicates that the match failed.
@@ -27457,7 +27457,7 @@ Date.parse(x.toLocaleString())
             An <em>AssertionTester</em> procedure is an internal closure that takes a State argument and returns a Boolean result. The assertion tester tests a specific condition (specified by the closure's already-bound arguments) against the current place in _Input_ and returns *true* if the condition matched or *false* if not.
           </li>
           <li>
-            An <em>EscapeValue</em> is either a character or an integer. An EscapeValue is used to denote the interpretation of a |DecimalEscape| escape sequence: a character _ch_ means that the escape sequence is interpreted as the character _ch_, while an integer _n_ means that the escape sequence is interpreted as a backreference to the <emu-eqn>_n_<sup>th</sup></emu-eqn> set of capturing parentheses.
+            An <em>EscapeValue</em> is either a character or an integer. An EscapeValue is used to denote the interpretation of a |DecimalEscape| escape sequence: a character _ch_ means that the escape sequence is interpreted as the character _ch_, while an integer _n_ means that the escape sequence is interpreted as a backreference to the _n_<sup>th</sup> set of capturing parentheses.
           </li>
         </ul>
       </emu-clause>
@@ -28831,7 +28831,7 @@ Date.parse(x.toLocaleString())
       <emu-clause id="sec-regexp.prototype.exec">
         <h1>RegExp.prototype.exec ( _string_ )</h1>
         <p>Performs a regular expression match of _string_ against the regular expression and returns an Array object containing the results of the match, or *null* if _string_ did not match.</p>
-        <p>The String <emu-eqn>ToString(_string_)</emu-eqn> is searched for an occurrence of the regular expression pattern as follows:</p>
+        <p>The String ToString(_string_) is searched for an occurrence of the regular expression pattern as follows:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
@@ -29494,7 +29494,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="22.1.3" -->
     <emu-clause id="sec-properties-of-the-array-prototype-object">
       <h1>Properties of the Array Prototype Object</h1>
-      <p>The Array prototype object is the intrinsic object %ArrayPrototype%. The Array prototype object is an Array exotic objects and has the internal methods specified for such objects. It has a `length` property whose initial value is 0 and whose attributes are <emu-eqn>{ [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }</emu-eqn>.</p>
+      <p>The Array prototype object is the intrinsic object %ArrayPrototype%. The Array prototype object is an Array exotic objects and has the internal methods specified for such objects. It has a `length` property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       <p>The value of the [[Prototype]] internal slot of the Array prototype object is the intrinsic object %ObjectPrototype%.</p>
       <emu-note>
         <p>The Array prototype object is specified to be an Array exotic object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
@@ -30601,7 +30601,7 @@ Date.parse(x.toLocaleString())
       <emu-clause id="sec-properties-of-array-instances-length">
         <h1>length</h1>
         <p>The `length` property of an Array instance is a data property whose value is always numerically greater than the name of every configurable own property whose name is an array index.</p>
-        <p>The `length` property initially has the attributes <emu-eqn>{ [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }</emu-eqn>.</p>
+        <p>The `length` property initially has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>Reducing the value of the `length` property has the side-effect of deleting own array elements whose array index is between the old and new length values. However, non-configurable properties can not be deleted. Attempting to set the length property of an Array object to a value that is numerically less than or equal to the largest numeric own property name of an existing non-configurable array indexed property of the array will result in the length being set to a numeric value that is one greater than that non-configurable numeric own property name. See <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.</p>
         </emu-note>
@@ -33614,7 +33614,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         <p>String values are wrapped in QUOTATION MARK (`"`) code units. The code units `"` and `\\` are escaped with `\\` prefixes. Control characters code units are replaced with escape sequences `\\u`HHHH, or with the shorter forms, `\\b` (BACKSPACE), `\\f` (FORM FEED), `\\n` (LINE FEED), `\\r` (CARRIAGE RETURN), `\\t` (CHARACTER TABULATION).</p>
       </emu-note>
       <emu-note>
-        <p>Finite numbers are stringified as if by calling <emu-eqn>ToString(_number_)</emu-eqn>. *NaN* and Infinity regardless of sign are represented as the String `null`.</p>
+        <p>Finite numbers are stringified as if by calling ToString(_number_). *NaN* and Infinity regardless of sign are represented as the String `null`.</p>
       </emu-note>
       <emu-note>
         <p>Values that do not have a JSON representation (such as *undefined* and functions) do not produce a String. Instead they produce the *undefined* value. In arrays these values are represented as the String `null`. In objects an unrepresentable value causes the property to be excluded from stringification.</p>
@@ -36148,7 +36148,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       <!-- es6num="B.2.3.1" -->
       <emu-annex id="sec-string.prototype.substr">
         <h1>String.prototype.substr (_start_, _length_)</h1>
-        <p>The `substr` method takes two arguments, _start_ and _length_, and returns a substring of the result of converting the *this* object to a String, starting from index _start_ and running for _length_ code units (or through the end of the String if _length_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>(_sourceLength_+_start_)</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object. The following steps are taken:</p>
+        <p>The `substr` method takes two arguments, _start_ and _length_, and returns a substring of the result of converting the *this* object to a String, starting from index _start_ and running for _length_ code units (or through the end of the String if _length_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_sourceLength_+_start_</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object. The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).


### PR DESCRIPTION
The majority of uses of emu-eqn in this spec were bogus: around property descriptors, abstract operation calls, or in one case just part of a sentence.