### PR TITLE
Editorial: clarify realm vs. Realm Record

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -776,7 +776,7 @@
       <!-- es6num="6.1.5.1" -->
       <emu-clause id="sec-well-known-symbols">
         <h1>Well-Known Symbols</h1>
-        <p>Well-known symbols are built-in Symbol values that are explicitly referenced by algorithms of this specification. They are typically used as the keys of properties whose values serve as extension points of a specification algorithm. Unless otherwise specified, well-known symbols values are shared by all Code Realms (<emu-xref href="#sec-code-realms"></emu-xref>).</p>
+        <p>Well-known symbols are built-in Symbol values that are explicitly referenced by algorithms of this specification. They are typically used as the keys of properties whose values serve as extension points of a specification algorithm. Unless otherwise specified, well-known symbols values are shared by all realms (<emu-xref href="#sec-code-realms"></emu-xref>).</p>
         <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where &ldquo;name&rdquo; is one of the values listed in <emu-xref href="#table-1"></emu-xref>.</p>
         <emu-table id="table-1" caption="Well-known Symbols">
           <table>
@@ -1531,8 +1531,8 @@
       <!-- es6num="6.1.7.4" -->
       <emu-clause id="sec-well-known-intrinsic-objects">
         <h1>Well-Known Intrinsic Objects</h1>
-        <p>Well-known intrinsics are built-in objects that are explicitly referenced by the algorithms of this specification and which usually have Realm specific identities. Unless otherwise specified each intrinsic object actually corresponds to a set of similar objects, one per Realm.</p>
-        <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current Realm, corresponding to the name. Determination of the current Realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-7"></emu-xref>.</p>
+        <p>Well-known intrinsics are built-in objects that are explicitly referenced by the algorithms of this specification and which usually have realm-specific identities. Unless otherwise specified each intrinsic object actually corresponds to a set of similar objects, one per realm.</p>
+        <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-7"></emu-xref>.</p>
         <emu-table id="table-7" caption="Well-known Intrinsic Objects">
           <table>
             <tbody>
@@ -4434,7 +4434,7 @@
           1. If the value of the [[ProxyHandler]] internal slot of _obj_ is *null*, throw a *TypeError* exception.
           1. Let _proxyTarget_ be the value of _obj_'s [[ProxyTarget]] internal slot.
           1. Return ? GetFunctionRealm(_proxyTarget_).
-        1. Return the running execution context's Realm.
+        1. Return the current Realm Record.
       </emu-alg>
       <emu-note>
         <p>Step 5 will only be reached if _target_ is a non-standard exotic function object that does not have a [[Realm]] internal slot.</p>
@@ -5126,8 +5126,8 @@
       <!-- es6num="8.1.1.4" -->
       <emu-clause id="sec-global-environment-records">
         <h1>Global Environment Records</h1>
-        <p>A global Environment Record is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common Realm (<emu-xref href="#sec-code-realms"></emu-xref>). A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-block-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-block-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
-        <p>A global Environment Record is logically a single record but it is specified as a composite encapsulating an object Environment Record and a declarative Environment Record. The object Environment Record has as its base object the global object of the associated Realm. This global object is the value returned by the global Environment Record's GetThisBinding concrete method. The object Environment Record component of a global Environment Record contains the bindings for all built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>) and all bindings introduced by a |FunctionDeclaration|, |GeneratorDeclaration|, or |VariableStatement| contained in global code. The bindings for all other ECMAScript declarations in global code are contained in the declarative Environment Record component of the global Environment Record.</p>
+        <p>A global Environment Record is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm (<emu-xref href="#sec-code-realms"></emu-xref>). A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-block-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-block-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
+        <p>A global Environment Record is logically a single record but it is specified as a composite encapsulating an object Environment Record and a declarative Environment Record. The object Environment Record has as its base object the global object of the associated Realm Record. This global object is the value returned by the global Environment Record's GetThisBinding concrete method. The object Environment Record component of a global Environment Record contains the bindings for all built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>) and all bindings introduced by a |FunctionDeclaration|, |GeneratorDeclaration|, or |VariableStatement| contained in global code. The bindings for all other ECMAScript declarations in global code are contained in the declarative Environment Record component of the global Environment Record.</p>
         <p>Properties may be created directly on a global object. Hence, the object Environment Record component of a global Environment Record may contain both bindings created explicitly by |FunctionDeclaration|, |GeneratorDeclaration|, or |VariableDeclaration| declarations and bindings created implicitly as properties of the global object. In order to identify which bindings were explicitly created using declarations, a global Environment Record maintains a list of the names bound using its CreateGlobalVarBindings and CreateGlobalFunctionBindings concrete methods.</p>
         <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-18"></emu-xref> and the additional methods listed in <emu-xref href="#table-19"></emu-xref>.</p>
         <emu-table id="table-18" caption="Additional Fields of Global Environment Records">
@@ -5152,7 +5152,7 @@
                 Object Environment Record
               </td>
               <td>
-                Binding object is the global object. It contains global built-in bindings as well as |FunctionDeclaration|, |GeneratorDeclaration|, and |VariableDeclaration| bindings in global code for the associated Realm.
+                Binding object is the global object. It contains global built-in bindings as well as |FunctionDeclaration|, |GeneratorDeclaration|, and |VariableDeclaration| bindings in global code for the associated realm.
               </td>
             </tr>
             <tr>
@@ -5174,7 +5174,7 @@
                 Declarative Environment Record
               </td>
               <td>
-                Contains bindings for all declarations in global code for the associated Realm code except for |FunctionDeclaration|, |GeneratorDeclaration|, and |VariableDeclaration| _bindings_.
+                Contains bindings for all declarations in global code for the associated realm code except for |FunctionDeclaration|, |GeneratorDeclaration|, and |VariableDeclaration| _bindings_.
               </td>
             </tr>
             <tr>
@@ -5185,7 +5185,7 @@
                 List of String
               </td>
               <td>
-                The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, and |VariableDeclaration| declarations in global code for the associated Realm.
+                The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, and |VariableDeclaration| declarations in global code for the associated realm.
               </td>
             </tr>
             </tbody>
@@ -5735,9 +5735,9 @@
 
   <!-- es6num="8.2" -->
   <emu-clause id="sec-code-realms">
-    <h1>Code Realms</h1>
-    <p>Before it is evaluated, all ECMAScript code must be associated with a <dfn id="realm">Realm</dfn>. Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript global environment, all of the ECMAScript code that is loaded within the scope of that global environment, and other associated state and resources.</p>
-    <p>A Realm is specified as a Record with the fields specified in <emu-xref href="#table-21"></emu-xref>:</p>
+    <h1>Realms</h1>
+    <p>Before it is evaluated, all ECMAScript code must be associated with a <dfn id="realm">realm</dfn>. Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript global environment, all of the ECMAScript code that is loaded within the scope of that global environment, and other associated state and resources.</p>
+    <p>A realm is represented in this specification as a <dfn id="realm-record">Realm Record</dfn> with the fields specified in <emu-xref href="#table-21"></emu-xref>:</p>
     <emu-table id="table-21" caption="Realm Record Fields">
       <table>
         <tbody>
@@ -5760,7 +5760,7 @@
             Record whose field names are intrinsic keys and whose values are objects
           </td>
           <td>
-            These are the intrinsic values used by code associated with this Realm
+            The intrinsic values used by code associated with this realm
           </td>
         </tr>
         <tr>
@@ -5771,7 +5771,7 @@
             Object
           </td>
           <td>
-            The global object for this Realm
+            The global object for this realm
           </td>
         </tr>
         <tr>
@@ -5782,7 +5782,7 @@
             Lexical Environment
           </td>
           <td>
-            The global environment for this Realm
+            The global environment for this realm
           </td>
         </tr>
         <tr>
@@ -5793,7 +5793,7 @@
             A List of Record { [[strings]]: List, [[array]]: Object}.
           </td>
           <td>
-            Template objects are canonicalized separately for each Realm using its [[templateMap]]. Each [[strings]] value is a List containing, in source text order, the raw String values of a |TemplateLiteral| that has been evaluated. The associated [[array]] value is the corresponding template object that is passed to a tag function.
+            Template objects are canonicalized separately for each realm using its Realm Record's [[templateMap]]. Each [[strings]] value is a List containing, in source text order, the raw String values of a |TemplateLiteral| that has been evaluated. The associated [[array]] value is the corresponding template object that is passed to a tag function.
           </td>
         </tr>
         </tbody>
@@ -5806,7 +5806,7 @@
       <h1>CreateRealm ( )</h1>
       <p>The abstract operation CreateRealm with no arguments performs the following steps:</p>
       <emu-alg>
-        1. Let _realmRec_ be a new Record.
+        1. Let _realmRec_ be a new Realm Record.
         1. Perform CreateIntrinsics(_realmRec_).
         1. Set _realmRec_.[[globalObject]] to *undefined*.
         1. Set _realmRec_.[[globalEnv]] to *undefined*.
@@ -5907,7 +5907,7 @@
             Realm
           </td>
           <td>
-            The Realm from which associated code accesses ECMAScript resources.
+            The Realm Record from which associated code accesses ECMAScript resources.
           </td>
         </tr>
         <tr>
@@ -5922,7 +5922,7 @@
       </table>
     </emu-table>
     <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
-    <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
+    <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
     <p>Execution contexts for ECMAScript code have the additional state components listed in <emu-xref href="#table-23"></emu-xref>.</p>
     <emu-table id="table-23" caption="Additional State Components for ECMAScript Code Execution Contexts">
       <table>
@@ -6111,7 +6111,7 @@
             A Realm Record
           </td>
           <td>
-            The Realm for the initial execution context when this PendingJob is initiated.
+            The Realm Record for the initial execution context when this PendingJob is initiated.
           </td>
         </tr>
         <tr>
@@ -6600,7 +6600,7 @@ for (let protoName of Reflect.enumerate(proto)) {
         1. Return _proto_.
       </emu-alg>
       <emu-note>
-        <p>If _constructor_ does not supply a [[Prototype]] value, the default value that is used is obtained from the Code Realm of the _constructor_ function rather than from the running execution context.</p>
+        <p>If _constructor_ does not supply a [[Prototype]] value, the default value that is used is obtained from the realm of the _constructor_ function rather than from the running execution context.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -6687,7 +6687,7 @@ for (let protoName of Reflect.enumerate(proto)) {
             Realm Record
           </td>
           <td>
-            The Code Realm in which the function was created and which provides any intrinsic objects that are accessed when evaluating the function.
+            The realm in which the function was created and which provides any intrinsic objects that are accessed when evaluating the function.
           </td>
         </tr>
         <tr>
@@ -6864,7 +6864,7 @@ for (let protoName of Reflect.enumerate(proto)) {
         1. Set the [[FunctionKind]] internal slot of _F_ to _functionKind_.
         1. Set the [[Prototype]] internal slot of _F_ to _functionPrototype_.
         1. Set the [[Extensible]] internal slot of _F_ to *true*.
-        1. Set the [[Realm]] internal slot of _F_ to the running execution context's Realm.
+        1. Set the [[Realm]] internal slot of _F_ to the current Realm Record.
         1. Return _F_.
       </emu-alg>
     </emu-clause>
@@ -6928,7 +6928,7 @@ for (let protoName of Reflect.enumerate(proto)) {
       <!-- es6num="9.2.7.1" -->
       <emu-clause id="sec-%throwtypeerror%">
         <h1>%ThrowTypeError% ( )</h1>
-        <p>The <dfn>%ThrowTypeError%</dfn> intrinsic is an anonymous built-in function object that is defined once for each Realm. When %ThrowTypeError% is called it performs the following steps:</p>
+        <p>The <dfn>%ThrowTypeError%</dfn> intrinsic is an anonymous built-in function object that is defined once for each realm. When %ThrowTypeError% is called it performs the following steps:</p>
         <emu-alg>
           1. Throw a *TypeError* exception.
         </emu-alg>
@@ -7355,7 +7355,7 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. If _isArray_ is *true*, then
             1. Let _C_ be ? Get(_originalArray_, `"constructor"`).
             1. If IsConstructor(_C_) is *true*, then
-              1. Let _thisRealm_ be the running execution context's Realm.
+              1. Let _thisRealm_ be the current Realm Record.
               1. Let _realmC_ be ? GetFunctionRealm(_C_).
               1. If _thisRealm_ and _realmC_ are not the same Realm Record, then
                 1. If SameValue(_C_, _realmC_.[[intrinsics]].[[%Array%]]) is *true*, let _C_ be *undefined*.
@@ -7367,7 +7367,7 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. Return ? Construct(_C_, &laquo; _length_ &raquo;).
         </emu-alg>
         <emu-note>
-          <p>If _originalArray_ was created using the standard built-in Array constructor for a Realm that is not the Realm of the running execution context, then a new Array is created using the Realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behaviour for the Array.prototype methods that now are defined using ArraySpeciesCreate.</p>
+          <p>If _originalArray_ was created using the standard built-in Array constructor for a realm that is not the realm of the running execution context, then a new Array is created using the realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behaviour for the Array.prototype methods that now are defined using ArraySpeciesCreate.</p>
         </emu-note>
       </emu-clause>
 
@@ -7681,7 +7681,7 @@ for (let protoName of Reflect.enumerate(proto)) {
           <h1>MakeArgGetter ( _name_, _env_)</h1>
           <p>The abstract operation MakeArgGetter called with String _name_ and Environment Record _env_ creates a built-in function object that when executed returns the value bound for _name_ in _env_. It performs the following steps:</p>
           <emu-alg>
-            1. Let _realm_ be the current Realm.
+            1. Let _realm_ be the current Realm Record.
             1. Let _steps_ be the steps of an ArgGetter function as specified below.
             1. Let _getter_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[name]], [[env]] &raquo; ).
             1. Set _getter_'s [[name]] internal slot to _name_.
@@ -7704,7 +7704,7 @@ for (let protoName of Reflect.enumerate(proto)) {
           <h1>MakeArgSetter ( _name_, _env_)</h1>
           <p>The abstract operation MakeArgSetter called with String _name_ and Environment Record _env_ creates a built-in function object that when executed sets the value bound for _name_ in _env_. It performs the following steps:</p>
           <emu-alg>
-            1. Let _realm_ be the current Realm.
+            1. Let _realm_ be the current Realm record.
             1. Let _steps_ be the steps of an ArgSetter function as specified below.
             1. Let _setter_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[name]], [[env]] &raquo; ).
             1. Set _setter_'s [[name]] internal slot to _name_.
@@ -11371,7 +11371,7 @@ a = b + c
         <emu-alg>
           1. Let _rawStrings_ be TemplateStrings of _templateLiteral_ with argument *true*.
           1. Let _ctx_ be the running execution context.
-          1. Let _realm_ be the _ctx_'s Realm.
+          1. Let _realm_ be _ctx_'s Realm.
           1. Let _templateRegistry_ be _realm_.[[templateMap]].
           1. For each element _e_ of _templateRegistry_, do
             1. If _e_.[[strings]] and _rawStrings_ contain the same values in the same order, then
@@ -11398,7 +11398,7 @@ a = b + c
           <p>The creation of a template object cannot result in an abrupt completion.</p>
         </emu-note>
         <emu-note>
-          <p>Each |TemplateLiteral| in the program code of a Realm is associated with a unique template object that is used in the evaluation of tagged Templates (<emu-xref href="#sec-template-literals-runtime-semantics-evaluation"></emu-xref>). The template objects are frozen and the same template object is used each time a specific tagged Template is evaluated. Whether template objects are created lazily upon first evaluation of the |TemplateLiteral| or eagerly prior to first evaluation is an implementation choice that is not observable to ECMAScript code.</p>
+          <p>Each |TemplateLiteral| in the program code of a realm is associated with a unique template object that is used in the evaluation of tagged Templates (<emu-xref href="#sec-template-literals-runtime-semantics-evaluation"></emu-xref>). The template objects are frozen and the same template object is used each time a specific tagged Template is evaluated. Whether template objects are created lazily upon first evaluation of the |TemplateLiteral| or eagerly prior to first evaluation is an implementation choice that is not observable to ECMAScript code.</p>
         </emu-note>
         <emu-note>
           <p>Future editions of this specification may define additional non-enumerable properties of template objects.</p>
@@ -11880,7 +11880,7 @@ a = b + c
               1. If _argList_ has no elements, return *undefined*.
               1. Let _evalText_ be the first element of _argList_.
               1. If the source code matching this |CallExpression| is strict code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
-              1. Let _evalRealm_ be the running execution context's Realm.
+              1. Let _evalRealm_ be the current Realm Record.
               1. Return ? PerformEval(_evalText_, _evalRealm_, _strictCaller_, *true*).
           1. If Type(_ref_) is Reference, then
             1. If IsPropertyReference(_ref_) is *true*, then
@@ -19474,7 +19474,7 @@ eval("1;var a;")
               Realm Record | *undefined*
             </td>
             <td>
-              The Realm within which this script was created. *undefined* if not yet assigned.
+              The realm within which this script was created. *undefined* if not yet assigned.
             </td>
           </tr>
           <tr>
@@ -19628,7 +19628,7 @@ eval("1;var a;")
       <p>The job ScriptEvaluationJob with parameters _sourceText_ and _hostDefined_ parses, validates, and evaluates _sourceText_ as a |Script|.</p>
       <emu-alg>
         1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
-        1. Let _realm_ be the running execution context's Realm.
+        1. Let _realm_ be the current Realm Record.
         1. Let _s_ be ParseScript(_sourceText_, _realm_, _hostDefined_).
         1. If _s_ is a List of errors, then
           1. Perform HostReportErrors(_s_).
@@ -20839,7 +20839,7 @@ eval("1;var a;")
         <p>A TopLevelModuleEvaluationJob with parameters _sourceText_ and _hostDefined_ is a job that parses, validates, and evaluates _sourceText_ as a |Module|.</p>
         <emu-alg>
           1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
-          1. Let _realm_ be the running execution context's Realm.
+          1. Let _realm_ be the current Realm Record.
           1. Let _m_ be ParseModule(_sourceText_, _realm_, _hostDefined_).
           1. If _m_ is a List of errors, then
             1. Perform HostReportErrors(_m_).
@@ -21572,7 +21572,7 @@ eval("1;var a;")
 <emu-clause id="sec-ecmascript-standard-built-in-objects">
   <h1>ECMAScript Standard Built-in Objects</h1>
   <p>There are certain built-in objects available whenever an ECMAScript |Script| or |Module| begins execution. One, the global object, is part of the lexical environment of the executing program. Others are accessible as initial properties of the global object or indirectly as properties of accessible built-in objects.</p>
-  <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in Function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in Function object has a [[Realm]] internal slot whose value is the code Realm for which the object was initially created.</p>
+  <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in Function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in Function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;`this` value&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>
@@ -23271,7 +23271,7 @@ new Function("a,b", "c", "return a+b+c")
           1. Append the record { [[key]]: _stringKey_, [[symbol]]: _newSymbol_ } to the GlobalSymbolRegistry List.
           1. Return _newSymbol_.
         </emu-alg>
-        <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all Code Realms. Prior to the evaluation of any ECMAScript code it is initialized as an empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-44"></emu-xref>.</p>
+        <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code it is initialized as an empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-44"></emu-xref>.</p>
         <emu-table id="table-44" caption="GlobalSymbolRegistry Record Fields">
           <table>
             <tbody>
@@ -23305,7 +23305,7 @@ new Function("a,b", "c", "return a+b+c")
                 A Symbol
               </td>
               <td>
-                A symbol that can be retrieved from any Realm.
+                A symbol that can be retrieved from any realm.
               </td>
             </tr>
             </tbody>
@@ -24860,7 +24860,7 @@ new Function("a,b", "c", "return a+b+c")
       <emu-clause id="sec-math.random">
         <h1>Math.random ( )</h1>
         <p>Returns a Number value with positive sign, greater than or equal to 0 but less than 1, chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an implementation-dependent algorithm or strategy. This function takes no arguments.</p>
-        <p>Each `Math.random` function created for distinct code Realms must produce a distinct sequence of values from successive calls.</p>
+        <p>Each `Math.random` function created for distinct realms must produce a distinct sequence of values from successive calls.</p>
       </emu-clause>
 
       <!-- es6num="20.2.2.28" -->


### PR DESCRIPTION
Fixes #252. As discussed therein, a lowercase "realm" is an abstract concept, and a "Realm Record" is a specific type of record representing that realm throughout the algorithms and data structures of the spec.

This also removes uses of the term "code realm" in favor of simply "realm", and replaces "the running execution context's Realm" with "the current Realm Record" in a few places since the latter was specifically defined to mean the former.