### PR TITLE
Remove obsolete comment about [[Construct]] on generator function.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18487,9 +18487,6 @@ eval("1;var a;")
         1. Perform GeneratorStart(_G_, |FunctionBody|).
         1. Return Completion{[[type]]: ~return~, [[value]]: _G_, [[target]]: ~empty~}.
       </emu-alg>
-      <emu-note>
-        <p>If the generator was invoked using [[Call]], the `this` binding will have already been initialized in the normal manner. If the generator was invoked using [[Construct]], the `this` bind is not initialized and any references to `this` within the |FunctionBody| will produce a *ReferenceError* exception.</p>
-      </emu-note>
     </emu-clause>
 
     <!-- es6num="14.4.12" -->


### PR DESCRIPTION
Generator functions no longer have [[Construct]].