### PR TITLE
Correct argument in invocation of UpdateEmpty

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14380,7 +14380,7 @@ a = b + c
         1. Let _sl_ be the result of evaluating |StatementList|.
         1. ReturnIfAbrupt(_sl_).
         1. Let _s_ be the result of evaluating |StatementListItem|.
-        1. Return Completion(UpdateEmpty(_s_, _sl_)).
+        1. Return Completion(UpdateEmpty(_s_, _sl_.[[value]])).
       </emu-alg>
       <emu-note>
         <p>The value of a |StatementList| is the value of the last value producing item in the |StatementList|. For example, the following calls to the `eval` function all return the value 1:</p>


### PR DESCRIPTION
The the second parameter of the UpdateEmpty abstract operation is a
ECMAScript language value or `empty`. Update the invocation from the
BlockStatement runtime semantics.