### PR TITLE
Fix TypedArray constructor name definition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31670,7 +31670,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Assert: Type(_object_) is Object and _object_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _O_ be ? AllocateTypedArray(_TypedArray_.[[TypedArrayConstructorName]], NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
+          1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
+          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
           1. Let _arrayLike_ be ? IterableToArrayLike(_object_).
           1. Let _len_ be ? ToLength(? Get(_arrayLike_, `"length"`)).
           1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).


### PR DESCRIPTION
Remove remaining `[[TypedArrayConstructorName]]`

Ref #274 
