### PR TITLE
Meta: Redirect to HTTPS

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4,6 +4,11 @@
 <link href="ecmarkup.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="ecmarkup.js"></script>
+<script>
+  if (location.hostname === 'tc39.github.io' && location.protocol !== 'https:') {
+    location.protocol = 'https:';
+  }
+</script>
 <pre class=metadata>
   title: ECMAScript® 2016 Language Specification
   shortname: ECMA-262


### PR DESCRIPTION
This “ensures” people are browsing https://tc39.github.io/ecma262/ rather than its HTTP counterpart.

Since GitHub Pages doesn’t offer HSTS or proper redirects yet, this is the best we can do.