### PR TITLE
Make Object.prototype an Immutable Prototype Exotic Object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8113,6 +8113,20 @@ for (let protoName of Reflect.enumerate(proto)) {
         </emu-alg>
       </emu-clause>
     </emu-clause>
+
+    <emu-clause id="sec-immutable-prototype-exotic-objects">
+      <h1>Immutable Prototype Exotic Objects</h1>
+      <p>An <dfn>immutable prototype exotic object</dfn> is an exotic object that disallows mutation of its prototype.</p>
+
+      <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v">
+        <h1>[[SetPrototypeOf]] (_V_)</h1>
+        <p>When the [[SetPrototypeOf]] internal method of a immutable prototype exotic object _O_ is called with argument _V_ the following steps are taken:</p>
+        <emu-alg>
+          1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
 
   <!-- es6num="9.5" -->
@@ -22734,7 +22748,7 @@ eval("1;var a;")
     <!-- es6num="19.1.3" -->
     <emu-clause id="sec-properties-of-the-object-prototype-object">
       <h1>Properties of the Object Prototype Object</h1>
-      <p>The Object prototype object is the intrinsic object %ObjectPrototype%. The Object prototype object is an ordinary object.</p>
+      <p>The Object prototype object is the intrinsic object %ObjectPrototype%. The Object prototype object is an <a href="#sec-immutable-prototype-exotic-objects">immutable prototype exotic object</a>.</p>
       <p>The value of the [[Prototype]] internal slot of the Object prototype object is *null* and the initial value of the [[Extensible]] internal slot is *true*.</p>
 
       <!-- es6num="19.1.3.1" -->


### PR DESCRIPTION
This patch builds a mechanism to fix the Proxy security issue documented
in bug #272 by locking down the prototype chain of the global object, as
Firefox has experimented with. Although the global object is provided by
the embedding environment, many embedding environments will include Object
in the prototype chain; preventing modification of Object.prototype
addresses the issue by making it impossible to insert a Proxy in that part
of the prototype chain of the global object. Embedding environments that
want to prohibit a Proxy from being in the proto chain of their global
object can make their global object and associated proto chain Immutable
Prototype exotic objects.