### PR TITLE
Restore SyntaxError description

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11370,8 +11370,7 @@ a = b + c
         <p>The abstract operation GetTemplateObject is called with a grammar production, _templateLiteral_, as an argument. It performs the following steps:</p>
         <emu-alg>
           1. Let _rawStrings_ be TemplateStrings of _templateLiteral_ with argument *true*.
-          1. Let _ctx_ be the running execution context.
-          1. Let _realm_ be _ctx_'s Realm.
+          1. Let _realm_ be the current Realm Record.
           1. Let _templateRegistry_ be _realm_.[[templateMap]].
           1. For each element _e_ of _templateRegistry_, do
             1. If _e_.[[strings]] and _rawStrings_ contain the same values in the same order, then
@@ -14624,7 +14623,7 @@ eval("1;var a;")
         <emu-alg>
           1. Let _next_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_next_).
-          1. Return NormalCompletion( ~empty~).
+          1. Return NormalCompletion(~empty~).
         </emu-alg>
         <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
@@ -18654,7 +18653,7 @@ eval("1;var a;")
         `;`
     </emu-grammar>
     <emu-note>
-      <p>A |ClassBody| is always strict code.</p>
+      <p>A class definition is always strict code.</p>
     </emu-note>
 
     <!-- es6num="14.5.1" -->
@@ -23607,7 +23606,7 @@ new Function("a,b", "c", "return a+b+c")
       <!-- es6num="19.5.5.4" -->
       <emu-clause id="sec-native-error-types-used-in-this-standard-syntaxerror">
         <h1>SyntaxError</h1>
-        <p></p>
+        <p>Indicates that a parsing error has occurred.</p>
       </emu-clause>
 
       <!-- es6num="19.5.5.5" -->
@@ -31558,7 +31557,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>%<var>TypedArray</var>Prototype%</code>, 0).
+          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>, 0).
         </emu-alg>
       </emu-clause>
 
@@ -31575,7 +31574,7 @@ Date.parse(x.toLocaleString())
           1. Let _elementLength_ be ToLength(_numberLength_).
           1. If SameValueZero(_numberLength_, _elementLength_) is *false*, throw a *RangeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>%<var>TypedArray</var>Prototype%</code>, _elementLength_).
+          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>, _elementLength_).
         </emu-alg>
 
         <!-- es6num="22.2.1.2.1" -->
@@ -31626,7 +31625,7 @@ Date.parse(x.toLocaleString())
           1. Assert: Type(_typedArray_) is Object and _typedArray_ has a [[TypedArrayName]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>%<var>TypedArray</var>Prototype%</code>).
+          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
           1. Let _srcArray_ be _typedArray_.
           1. Let _srcData_ be the value of _srcArray_'s [[ViewedArrayBuffer]] internal slot.
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
@@ -31694,7 +31693,7 @@ Date.parse(x.toLocaleString())
           1. Assert: Type(_buffer_) is Object and _buffer_ has an [[ArrayBufferData]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>%<var>TypedArray</var>Prototype%</code>).
+          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
           1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
           1. Let _elementSize_ be the Number value of the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _offset_ be ? ToInteger(_byteOffset_).


### PR DESCRIPTION
And add missing quotes around string literals.
Also amend the strict mode note for class definitions to fix https://bugs.ecmascript.org/show_bug.cgi?id=4497