### PR TITLE
Specify which early error rules are updated for duplicate __proto__ properties

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36380,7 +36380,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
     <!-- es6num="B.3.1" -->
     <emu-annex id="sec-__proto__-property-names-in-object-initializers">
       <h1>__proto__ Property Names in Object Initializers</h1>
-      <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>:</p>
+      <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the Early Error rule is <b>not</b> applied. In addition, it is not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList|.</p>
       <emu-grammar>
         ObjectLiteral : `{` PropertyDefinitionList `}`
 


### PR DESCRIPTION
There's is an obvious downside with the proposed patch: Duplicate `__proto__` checks (resp. error reporting) will need to be deferred until it's clear if the *ObjectLiteral* is an actual object initializer. That means it needs to be handled similar to *CoverInitializedName*. 

But, on the plus side, it ensures consistent behaviour when compared to destructuring binding patterns. 

Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4539