### PR TITLE
Remove detached buffer

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32822,32 +32822,6 @@ Date.parse(x.toLocaleString())
       </emu-clause>
 
       <!-- es6num="24.1.1.2" -->
-      <emu-clause id="sec-isdetachedbuffer" aoid="IsDetachedBuffer">
-        <h1>IsDetachedBuffer ( _arrayBuffer_ )</h1>
-        <p>The abstract operation IsDetachedBuffer with argument _arrayBuffer_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_arrayBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
-          1. If _arrayBuffer_'s [[ArrayBufferData]] internal slot is *null*, return *true*.
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
-      <!-- es6num="24.1.1.3" -->
-      <emu-clause id="sec-detacharraybuffer" aoid="DetachArrayBuffer">
-        <h1>DetachArrayBuffer ( _arrayBuffer_ )</h1>
-        <p>The abstract operation DetachArrayBuffer with argument _arrayBuffer_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_arrayBuffer_) is Object and it has [[ArrayBufferData]] and [[ArrayBufferByteLength]] internal slots.
-          1. Set _arrayBuffer_'s [[ArrayBufferData]] internal slot to *null*.
-          1. Set _arrayBuffer_'s [[ArrayBufferByteLength]] internal slot to 0.
-          1. Return NormalCompletion(*null*).
-        </emu-alg>
-        <emu-note>
-          <p>Detaching an ArrayBuffer instance disassociates the Data Block used as its backing store from the instance and sets the byte length of the buffer to 0. No operations defined by this specification use the DetachArrayBuffer abstract operation. However, an ECMAScript implementation or host environment may define such operations.</p>
-        </emu-note>
-      </emu-clause>
-
-      <!-- es6num="24.1.1.4" -->
       <emu-clause id="sec-clonearraybuffer" aoid="CloneArrayBuffer">
         <h1>CloneArrayBuffer ( _srcBuffer_, _srcByteOffset_ [ , _cloneConstructor_ ] )</h1>
         <p>The abstract operation CloneArrayBuffer takes three parameters, an ArrayBuffer _srcBuffer_, an integer _srcByteOffset_ and optionally a constructor function _cloneConstructor_. It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data starting at _srcByteOffset_. This operation performs the following steps:</p>
@@ -32866,7 +32840,7 @@ Date.parse(x.toLocaleString())
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.1.5" -->
+      <!-- es6num="24.1.1.3" -->
       <emu-clause id="sec-getvaluefrombuffer" aoid="GetValueFromBuffer">
         <h1>GetValueFromBuffer ( _arrayBuffer_, _byteIndex_, _type_ [ , _isLittleEndian_ ] )</h1>
         <p>The abstract operation GetValueFromBuffer takes four parameters, an ArrayBuffer _arrayBuffer_, an integer _byteIndex_, a String _type_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
@@ -32894,7 +32868,7 @@ Date.parse(x.toLocaleString())
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.1.6" -->
+      <!-- es6num="24.1.1.4" -->
       <emu-clause id="sec-setvalueinbuffer" aoid="SetValueInBuffer">
         <h1>SetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_ [ , _isLittleEndian_ ] )</h1>
         <p>The abstract operation SetValueInBuffer takes five parameters, an ArrayBuffer _arrayBuffer_, an integer _byteIndex_, a String _type_, a Number _value_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>

--- a/spec.html
+++ b/spec.html
@@ -7763,8 +7763,6 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. If Type(_P_) is String, then
             1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-              1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
               1. If IsInteger(_numericIndex_) is *false*, return *false*.
               1. If _numericIndex_ = -0, return *false*.
               1. If _numericIndex_ &lt; 0, return *false*.
@@ -7876,7 +7874,6 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. Assert: Type(_index_) is Number.
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
           1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If IsInteger(_index_) is *false*, return *undefined*.
           1. If _index_ = -0, return *undefined*.
           1. Let _length_ be the value of _O_'s [[ArrayLength]] internal slot.
@@ -7899,7 +7896,6 @@ for (let protoName of Reflect.enumerate(proto)) {
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
           1. Let _numValue_ be ? ToNumber(_value_).
           1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If IsInteger(_index_) is *false*, return *false*.
           1. If _index_ = -0, return *false*.
           1. Let _length_ be the value of _O_'s [[ArrayLength]] internal slot.
@@ -14889,7 +14885,7 @@ eval("1;var a;")
         </emu-note>
         <emu-grammar>BindingPattern : ObjectBindingPattern</emu-grammar>
         <emu-alg>
-          1. Let _valid_ be ? RequireObjectCoercible(_value_).
+          1. Perform ? RequireObjectCoercible(_value_).
           1. Return the result of performing BindingInitialization for |ObjectBindingPattern| using _value_ and _environment_ as arguments.
         </emu-alg>
         <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
@@ -31051,8 +31047,6 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
           1. Let _size_ be the value of _O_'s [[ByteLength]] internal slot.
           1. Return _size_.
         </emu-alg>
@@ -31066,8 +31060,6 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
           1. Let _offset_ be the value of _O_'s [[ByteOffset]] internal slot.
           1. Return _offset_.
         </emu-alg>
@@ -31094,9 +31086,7 @@ Date.parse(x.toLocaleString())
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
             1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
-            1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-            1. Return _buffer_.
+            1. Return true.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -31228,9 +31218,7 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
-          1. Assert: _O_ has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
+          1. Assert: _O_ has [[ArrayLength]] internal slot.
           1. Let _length_ be the value of _O_'s [[ArrayLength]] internal slot.
           1. Return _length_.
         </emu-alg>
@@ -31301,7 +31289,6 @@ Date.parse(x.toLocaleString())
             1. Let _targetOffset_ be ? ToInteger(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
             1. Let _targetBuffer_ be the value of _target_'s [[ViewedArrayBuffer]] internal slot.
-            1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetLength_ be the value of _target_'s [[ArrayLength]] internal slot.
             1. Let _targetName_ be the String value of _target_'s [[TypedArrayName]] internal slot.
             1. Let _targetElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
@@ -31316,7 +31303,6 @@ Date.parse(x.toLocaleString())
             1. Repeat, while _targetByteIndex_ &lt; _limit_
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _kNumber_ be ? ToNumber(? Get(_src_, _Pk_)).
-              1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
               1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _kNumber_).
               1. Set _k_ to _k_ + 1.
               1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
@@ -31337,10 +31323,8 @@ Date.parse(x.toLocaleString())
             1. Let _targetOffset_ be ? ToInteger(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
             1. Let _targetBuffer_ be the value of _target_'s [[ViewedArrayBuffer]] internal slot.
-            1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetLength_ be the value of _target_'s [[ArrayLength]] internal slot.
             1. Let _srcBuffer_ be the value of _typedArray_'s [[ViewedArrayBuffer]] internal slot.
-            1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetName_ be the String value of _target_'s [[TypedArrayName]] internal slot.
             1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
@@ -31404,7 +31388,6 @@ Date.parse(x.toLocaleString())
               1. Increase _n_ by 1.
           1. Else if _count_ &gt; 0, then
             1. Let _srcBuffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-            1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetBuffer_ be the value of _A_'s [[ViewedArrayBuffer]] internal slot.
             1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcType_.
             1. NOTE: If _srcType_ and _targetType_ are the same the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
@@ -31447,7 +31430,6 @@ Date.parse(x.toLocaleString())
           1. Assert: Both Type(_x_) and Type(_y_) is Number.
           1. If the argument _comparefn_ is not *undefined*, then
             1. Let _v_ be ? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;).
-            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. If _v_ is *NaN*, return +0.
             1. Return _v_.
           1. If _x_ and _y_ are both *NaN*, return +0.
@@ -31627,7 +31609,6 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
           1. Let _srcArray_ be _typedArray_.
           1. Let _srcData_ be the value of _srcArray_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _elementLength_ be the value of _srcArray_'s [[ArrayLength]] internal slot.
@@ -31642,7 +31623,6 @@ Date.parse(x.toLocaleString())
           1. Else,
             1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
             1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
-            1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
             1. Let _srcByteIndex_ be _srcByteOffset_.
             1. Let _targetByteIndex_ be 0.
             1. Let _count_ be _elementLength_.
@@ -31699,7 +31679,6 @@ Date.parse(x.toLocaleString())
           1. If _offset_ &lt; 0, throw a *RangeError* exception.
           1. If _offset_ is -0, let _offset_ be +0.
           1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be the value of _buffer_'s [[ArrayBufferByteLength]] internal slot.
           1. If _length_ is *undefined*, then
             1. If _bufferByteLength_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
@@ -32874,16 +32853,13 @@ Date.parse(x.toLocaleString())
         <p>The abstract operation CloneArrayBuffer takes three parameters, an ArrayBuffer _srcBuffer_, an integer _srcByteOffset_ and optionally a constructor function _cloneConstructor_. It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data starting at _srcByteOffset_. This operation performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_srcBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
-          1. If _cloneConstructor_ is not present, then
-            1. Let _cloneConstructor_ be ? SpeciesConstructor(_srcBuffer_, %ArrayBuffer%).
-            1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
+          1. If _cloneConstructor_ is not present, let _cloneConstructor_ be ? SpeciesConstructor(_srcBuffer_, %ArrayBuffer%).
           1. Else, Assert: IsConstructor(_cloneConstructor_) is *true*.
           1. Let _srcLength_ be the value of _srcBuffer_'s [[ArrayBufferByteLength]] internal slot.
           1. Assert: _srcByteOffset_ &le; _srcLength_.
           1. Let _cloneLength_ be _srcLength_ - _srcByteOffset_.
           1. Let _srcBlock_ be the value of _srcBuffer_'s [[ArrayBufferData]] internal slot.
           1. Let _targetBuffer_ be ? AllocateArrayBuffer(_cloneConstructor_, _cloneLength_).
-          1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
           1. Let _targetBlock_ be the value of _targetBuffer_'s [[ArrayBufferData]] internal slot.
           1. Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _cloneLength_).
           1. Return _targetBuffer_.
@@ -32895,7 +32871,6 @@ Date.parse(x.toLocaleString())
         <h1>GetValueFromBuffer ( _arrayBuffer_, _byteIndex_, _type_ [ , _isLittleEndian_ ] )</h1>
         <p>The abstract operation GetValueFromBuffer takes four parameters, an ArrayBuffer _arrayBuffer_, an integer _byteIndex_, a String _type_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
-          1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
           1. Assert: _byteIndex_ is a positive integer.
           1. Let _block_ be _arrayBuffer_'s [[ArrayBufferData]] internal slot.
@@ -32924,7 +32899,6 @@ Date.parse(x.toLocaleString())
         <h1>SetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_ [ , _isLittleEndian_ ] )</h1>
         <p>The abstract operation SetValueInBuffer takes five parameters, an ArrayBuffer _arrayBuffer_, an integer _byteIndex_, a String _type_, a Number _value_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
-          1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
           1. Assert: _byteIndex_ is a positive integer.
           1. Assert: Type(_value_) is Number.
@@ -33021,7 +32995,6 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
-          1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _length_ be the value of _O_'s [[ArrayBufferByteLength]] internal slot.
           1. Return _length_.
         </emu-alg>
@@ -33041,7 +33014,6 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
-          1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _len_ be the value of _O_'s [[ArrayBufferByteLength]] internal slot.
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _first_ be max((_len_ + _relativeStart_), 0); else let _first_ be min(_relativeStart_, _len_).
@@ -33051,11 +33023,8 @@ Date.parse(x.toLocaleString())
           1. Let _ctor_ be ? SpeciesConstructor(_O_, %ArrayBuffer%).
           1. Let _new_ be ? Construct(_ctor_, &laquo; _newLen_ &raquo;).
           1. If _new_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
-          1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If SameValue(_new_, _O_) is *true*, throw a *TypeError* exception.
           1. If the value of _new_'s [[ArrayBufferByteLength]] internal slot &lt; _newLen_, throw a *TypeError* exception.
-          1. NOTE: Side-effects of the above steps may have detached _O_.
-          1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _fromBuf_ be the value of _O_'s [[ArrayBufferData]] internal slot.
           1. Let _toBuf_ be the value of _new_'s [[ArrayBufferData]] internal slot.
           1. Perform CopyDataBlockBytes(_toBuf_, 0, _fromBuf_, _first_, _newLen_).
@@ -33099,7 +33068,6 @@ Date.parse(x.toLocaleString())
           1. If _numberIndex_ &ne; _getIndex_ or _getIndex_ &lt; 0, throw a *RangeError* exception.
           1. Let _isLittleEndian_ be ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be the value of _view_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _viewOffset_ be the value of _view_'s [[ByteOffset]] internal slot.
           1. Let _viewSize_ be the value of _view_'s [[ByteLength]] internal slot.
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
@@ -33122,7 +33090,6 @@ Date.parse(x.toLocaleString())
           1. Let _numberValue_ be ? ToNumber(_value_).
           1. Let _isLittleEndian_ be ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be the value of _view_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _viewOffset_ be the value of _view_'s [[ByteOffset]] internal slot.
           1. Let _viewSize_ be the value of _view_'s [[ByteLength]] internal slot.
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
@@ -33150,7 +33117,6 @@ Date.parse(x.toLocaleString())
           1. Let _numberOffset_ be ? ToNumber(_byteOffset_).
           1. Let _offset_ be ToInteger(_numberOffset_).
           1. If _numberOffset_ &ne; _offset_ or _offset_ &lt; 0, throw a *RangeError* exception.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be the value of _buffer_'s [[ArrayBufferByteLength]] internal slot.
           1. If _offset_ &gt; _bufferByteLength_, throw a *RangeError* exception.
           1. If _byteLength_ is *undefined*, then
@@ -33208,8 +33174,6 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _size_ be the value of _O_'s [[ByteLength]] internal slot.
           1. Return _size_.
         </emu-alg>
@@ -33223,8 +33187,6 @@ Date.parse(x.toLocaleString())
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _offset_ be the value of _O_'s [[ByteOffset]] internal slot.
           1. Return _offset_.
         </emu-alg>


### PR DESCRIPTION
As the similar issue on #299, the current spec does not proceed any detachment operations on ArrayBuffer, in other words, no operation sets the `[[ArrayBufferData]]` to `null`.

This might be closed if TC39 has plans to use Detached Buffers soon, removing the `IsDetachedBuffer` checks makes the steps cleaner and easier to test. 