### PR TITLE
Clarify that 11.9 ASI statement list is informative

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10322,7 +10322,7 @@ a = b / hi / g.exec(c).map(d);
   <!-- es6num="11.9" -->
   <emu-clause id="sec-automatic-semicolon-insertion">
     <h1>Automatic Semicolon Insertion</h1>
-    <p>Certain ECMAScript statements (empty statement, `let`, `const`, `import` declarations, some forms of `export` declarations, variable statement, expression statement, `debugger` statement, `continue` statement, `break` statement, `return` statement, and `throw` statement) must be terminated with semicolons. Such semicolons may always appear explicitly in the source text. For convenience, however, such semicolons may be omitted from the source text in certain situations. These situations are described by saying that semicolons are automatically inserted into the source code token stream in those situations.</p>
+    <p>Certain ECMAScript statements (empty statement, `let`, `const`, `import` declarations, some forms of `export` declarations, variable statement, expression statement, `debugger` statement, `continue` statement, `break` statement, `return` statement, and `throw` statement) must be terminated with semicolons. (The preceding list is informative. If it were omitted, the remaining prose and grammar productions would fully describe the semantics.) Such semicolons may always appear explicitly in the source text. For convenience, however, such semicolons may be omitted from the source text in certain situations. These situations are described by saying that semicolons are automatically inserted into the source code token stream in those situations.</p>
 
     <!-- es6num="11.9.1" -->
     <emu-clause id="sec-rules-of-automatic-semicolon-insertion">


### PR DESCRIPTION
ASI is pretty confusing. In just the past few weeks I've seen quite a bit of uncertainty about it, including on the part of [the author of a stage 1 proposal]( https://github.com/jeffmo/es-class-fields-and-static-properties/issues/25#issuecomment-166457276); [myself](https://github.com/jeffmo/es-class-fields-and-static-properties/issues/25#issuecomment-170081700); and [a well known figure in ES world](https://github.com/babel/babel/pull/3262#issuecomment-171309580). The latter 2 cases specifically involved the list of statements in 11.9 and whether they are normative or just examples (and led to #284 & #285 here). In my case I was interpreting the ASI semantics in the context of a proposal whose grammar productions aren't in the spec yet, and therefore of course not in the list.

How would you feel about adding this language that clarifies that the list is just a hint?

> (The preceding list is informative. If it were omitted, the remaining prose and grammar productions would fully describe the semantics.)

Is it intended to keep that list updated so that it's exhaustive (assuming it is currently)?

