### PR TITLE
Object.getOwnPropertyDescriptors is not at stage 0

### DIFF
--- a/stage0.md
+++ b/stage0.md
@@ -10,7 +10,6 @@ Stage 0 proposals have been presented to the committee and not rejected definiti
 |🚀| [`String.prototype.at`](https://github.com/mathiasbynens/String.prototype.at) | Mathias Bynens & Rick Waldron | 0     |
 | | [Structured Clone](https://github.com/dslomov-chromium/ecmascript-structured-clone)       |Dmitry Lomov   |0
 | | [WeakRefs](https://github.com/tc39/proposal-weakrefs) | Dean Tribble | 0
-|🚀| [Object.getOwnPropertyDescriptors](https://gist.github.com/WebReflection/9353781) | Rick Waldron & Andrea Giammarchi | 0
 |🚀| [Set/Map.prototype.toJSON](https://github.com/DavidBruant/Map-Set.prototype.toJSON) | David Bruant ? | 0
 | | Annex B - HTML Attribute Event Handlers| Allen Wirfs-Brock | 0
 | | [Reflect.isCallable/Reflect.isConstructor](https://github.com/caitp/TC39-Proposals/blob/master/tc39-reflect-isconstructor-iscallable.md)| Caitlin Potter| 0


### PR DESCRIPTION
I guess it wasn't removed from the stage 0 doc when bumped up