### PR TITLE
Fix TypedArrays.prototype.constructor reference

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31778,7 +31778,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="22.2.6.2" -->
       <emu-clause id="sec-typedarray.prototype.constructor">
         <h1>_TypedArray_.prototype.constructor</h1>
-        <p>The initial value of a <code><var>TypedArray</var>.prototype.constructor</code> is the corresponding %_TypedArray_% intrinsic object.</p>
+        <p>The initial value of a <code><var>TypedArray</var>.prototype.constructor</code> is the corresponding _TypedArray_ object.</p>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
Fix the reference so a `Float32Array.prototype.constructor` references the
corresponding `Float32Array` object, etc.

The `%TypedArray%` constructor is not called anymore and it should not be
the reference for TypedArray instances