### PR TITLE
The split index is not necessarily an integer index into the string

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26891,7 +26891,7 @@ Date.parse(x.toLocaleString())
           1. Repeat, while _q_ &ne; _s_
             1. Let _e_ be SplitMatch(_S_, _q_, _R_).
             1. If _e_ is *false*, let _q_ be _q_+1.
-            1. Else _e_ is an integer index into _S_,
+            1. Else _e_ is an integer index &le; _s_,
               1. If _e_ = _p_, let _q_ be _q_+1.
               1. Else _e_ &ne; _p_,
                 1. Let _T_ be a String value equal to the substring of _S_ consisting of the code units at indices _p_ (inclusive) through _q_ (exclusive).
@@ -26907,17 +26907,8 @@ Date.parse(x.toLocaleString())
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The value of _separator_ may be an empty String, an empty regular expression, or a regular expression that can match an empty String. In this case, _separator_ does not match the empty substring at the beginning or end of the input String, nor does it match the empty substring at the end of the previous separator match. (For example, if _separator_ is the empty String, the String is split up into individual code unit elements; the length of the result array equals the length of the String, and each substring contains one code unit.) If _separator_ is a regular expression, only the first match at a given index of the *this* String is considered, even if backtracking could yield a non-empty-substring match at that index. (For example, `"ab".split(/a*?/)` evaluates to the array `["a","b"]`, while `"ab".split(/a*/)` evaluates to the array `["","b"]`.)</p>
+          <p>The value of _separator_ may be an empty String. In this case, _separator_ does not match the empty substring at the beginning or end of the input String, nor does it match the empty substring at the end of the previous separator match. If _separator_ is the empty String, the String is split up into individual code unit elements; the length of the result array equals the length of the String, and each substring contains one code unit.</p>
           <p>If the *this* object is (or converts to) the empty String, the result depends on whether _separator_ can match the empty String. If it can, the result array contains no elements. Otherwise, the result array contains one element, which is the empty String.</p>
-          <p>If _separator_ is a regular expression that contains capturing parentheses, then each time _separator_ is matched the results (including any *undefined* results) of the capturing parentheses are spliced into the output array. For example,</p>
-          <pre>
-            "A&lt;B&gt;bold&lt;/B&gt;and&lt;CODE&gt;coded&lt;/CODE&gt;".split(/&lt;(\/)?([^&lt;&gt;]+)&gt;/)
-          </pre>
-          <p>evaluates to the array:</p>
-          <pre><code class="javascript">
-["A", undefined, "B", "bold", "/", "B", "and", undefined,
-"CODE", "coded", "/", "CODE", ""]
-          </code></pre>
           <p>If _separator_ is *undefined*, then the result array contains just one String, which is the *this* value (converted to a String). If _limit_ is not *undefined*, then the output array is truncated so that it contains no more than _limit_ elements.</p>
         </emu-note>
         <emu-note>
@@ -29111,9 +29102,9 @@ Date.parse(x.toLocaleString())
         <h1>RegExp.prototype [ @@split ] ( _string_, _limit_ )</h1>
         <emu-note>
           <p>Returns an Array object into which substrings of the result of converting _string_ to a String have been stored. The substrings are determined by searching from left to right for matches of the *this* value regular expression; these occurrences are not part of any substring in the returned array, but serve to divide up the String value.</p>
-          <p>The *this* value may be an empty regular expression or a regular expression that can match an empty String. In this case, regular expression does not match the empty substring at the beginning or end of the input String, nor does it match the empty substring at the end of the previous separator match. (For example, if the regular expression matches the empty String, the String is split up into individual code unit elements; the length of the result array equals the length of the String, and each substring contains one code unit.) Only the first match at a given index of the *this* String is considered, even if backtracking could yield a non-empty-substring match at that index. (For example, `/a*?/[Symbol.split]("ab")` evaluates to the array `["a","b"]`, while `/a*/[Symbol.split]("ab")` evaluates to the array `["","b"]`.)</p>
+          <p>The *this* value may be an empty regular expression or a regular expression that can match an empty String. In this case, the regular expression does not match the empty substring at the beginning or end of the input String, nor does it match the empty substring at the end of the previous separator match. (For example, if the regular expression matches the empty String, the String is split up into individual code unit elements; the length of the result array equals the length of the String, and each substring contains one code unit.) Only the first match at a given index of the String is considered, even if backtracking could yield a non-empty-substring match at that index. (For example, `/a*?/[Symbol.split]("ab")` evaluates to the array `["a","b"]`, while `/a*/[Symbol.split]("ab")` evaluates to the array `["","b"]`.)</p>
           <p>If the _string_ is (or converts to) the empty String, the result depends on whether the regular expression can match the empty String. If it can, the result array contains no elements. Otherwise, the result array contains one element, which is the empty String.</p>
-          <p>If the regular expression that contains capturing parentheses, then each time _separator_ is matched the results (including any *undefined* results) of the capturing parentheses are spliced into the output array. For example,</p>
+          <p>If the regular expression contains capturing parentheses, then each time _separator_ is matched the results (including any *undefined* results) of the capturing parentheses are spliced into the output array. For example,</p>
           <pre><code class="javascript">/&lt;(\/)?([^&lt;&gt;]+)&gt;/[Symbol.split]("A&lt;B&gt;bold&lt;/B&gt;and&lt;CODE&gt;coded&lt;/CODE&gt;")</code></pre>
           <p>evaluates to the array</p>
           <pre><code class="javascript">["A",undefined,"B","bold","/","B","and",undefined,"CODE","coded","/","CODE",""]</code></pre>


### PR DESCRIPTION
Also removed regular expression notes from String.prototype.split and fixed typos.