### PR TITLE
Remove duplicate productions.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3286,24 +3286,6 @@
             DecimalDigits `.` DecimalDigits? ExponentPart?
             `.` DecimalDigits ExponentPart?
             DecimalDigits ExponentPart?
-
-          DecimalDigits :::
-            DecimalDigit
-            DecimalDigits DecimalDigit
-
-          DecimalDigit ::: one of
-            `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
-
-          ExponentPart :::
-            ExponentIndicator SignedInteger
-
-          ExponentIndicator ::: one of
-            `e` `E`
-
-          SignedInteger :::
-            DecimalDigits
-            `+` DecimalDigits
-            `-` DecimalDigits
         </emu-grammar>
         <p>All grammar symbols not explicitly defined above have the definitions used in the Lexical Grammar for numeric literals (<emu-xref href="#sec-literals-numeric-literals"></emu-xref>)</p>
         <emu-note>


### PR DESCRIPTION
Specifically, in 7.1.3.1 "ToNumber Applied to the String Type",
remove the productions for:
    DecimalDigits
    DecimalDigit
    ExponentPart
    ExponentIndicator
    SignedInteger
which duplicate productions (modulo the number of colons)
in 11.8.3 "Numeric Literals".

(Note that 7.1.3.1's Syntax already uses nonterminals defined
in 11.8.3 (e.g. BinaryIntegerLiteral), and already has a
sentence referring readers there for the definitions thereof.)

With this change, each nonterminal should have a single defining
production within the body of the spec (i.e., ignoring Annex B),
which should reduce link-target suprises in the rendered spec.