### PR TITLE
Editorial: Fix typo ( Replace HYPEN → HYPHEN )

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28661,7 +28661,7 @@ Date.parse(x.toLocaleString())
         </emu-alg>
         <p>The production <emu-grammar>ClassEscape :: `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the CharSet containing the single character - U+002D (HYPEN-MINUS).
+          1. Return the CharSet containing the single character - U+002D (HYPHEN-MINUS).
         </emu-alg>
         <p>The production <emu-grammar>ClassEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
@@ -36059,7 +36059,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <p>The abstract operation CharacterRangeOrUnion takes two CharSet parameters _A_ and _B_ and performs the following steps:</p>
           <emu-alg>
             1. If _A_ does not contain exactly one character or _B_ does not contain exactly one character, then
-              1. Let _C_ be the CharSet containing the single character - U+002D (HYPEN-MINUS).
+              1. Let _C_ be the CharSet containing the single character - U+002D (HYPHEN-MINUS).
               1. Return the union of CharSets _A_, _B_ and _C_.
             1. Return CharacterRange(_A_, _B_).
           </emu-alg>


### PR DESCRIPTION
Replacing `HYPEN` → `HYPHEN` (2 instances)