### PR TITLE
Add zones proposal to stage 0

### DIFF
--- a/stage0.md
+++ b/stage0.md
@@ -22,5 +22,6 @@ Stage 0 proposals have been presented to the committee and not rejected definiti
 | | [64-Bit Integer Operations](https://gist.github.com/BrendanEich/4294d5c212a6d2254703) | Brendan Eich | 0
 | | [Method Parameter Decorators](https://goo.gl/r1XT9b) | Igor Minar | 0
 | | [Function Expression Decorators](https://goo.gl/8MmCMG) | Igor Minar | 0
+| | [Zones](https://gist.github.com/mhevery/63fdcdf7c65886051d55) [(presentation)](https://docs.google.com/presentation/d/1H3E2ToJ8VHgZS8eS6bRv-vg5OksObj5wv6gyzJJwOK0/edit) | Misko Hevery | 0
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.


### PR DESCRIPTION
https://github.com/rwaldron/tc39-notes/blob/master/es7/2016-01/2016-01-26.md#conclusionresolution-1

rwalron's meeting notes say it's ready for stage 0.

I wasn't sure if I should add the proposal gist or the presentation to the list, so I added both. Hopefully, they can be replaced once an official proposal doc is created.

Also, am I correct that mhevery is the champion?