### PR TITLE
Layering: fix unhandled rejection tracking in PerformPromiseThen

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34954,7 +34954,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
               1. Let _reason_ be the value of _promise_'s [[PromiseResult]] internal slot.
               1. If the value of _promise_'s [[PromiseIsHandled]] internal slot is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _rejectReaction_, _reason_ &raquo;).
-              1. Set _promise_'s [[PromiseIsHandled]] internal slot to *true*.
+            1. Set _promise_'s [[PromiseIsHandled]] internal slot to *true*.
             1. Return _resultCapability_.[[Promise]].
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
Fixes #383. then-ing a promise should always mark it as handled, not
just when the promise is already rejected.