### PR TITLE
Check for duplicate own keys in for-in example code

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16135,7 +16135,7 @@ eval("1;var a;")
     for (let key of Reflect.ownKeys(obj)) {
       if (typeof key === "string") {
         let desc = Reflect.getOwnPropertyDescriptor(obj, key);
-        if (desc) {
+        if (desc && !visited.has(key)) {
           visited.add(key);
           if (desc.enumerable) yield key;
         }


### PR DESCRIPTION
Duplicate keys are possible when `obj` is a proxy object.