### PR TITLE
Normative: Fix Annex B FiB to only assign function Objects out of blocks and allow redeclarations.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36546,7 +36546,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <p>A function is declared and possibly used within a single block but also referenced within subsequent blocks.</p>
           <ul>
             <li>
-              One or more |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occur exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
+              One or more |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
             </li>
             <li>
               No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
@@ -36565,7 +36565,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatibility semantics are applied and introduce observable differences from non-compatibility semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
       <emu-annex id="sec-web-compat-block-environment-records">
         <h1>Block Environment Records</h1>
-        <p>A <dfn>block Environment Record</dfn> is a declarative Environment Record that is used to represent block scopes. Functions declared inside the block are stored in a separate Environment Record in the [[FunctionsInBlock]] internal slot in addition to in the block environment record. This helps ensure that only function Objects are assigned to outer environments for web legacy compatibility.</p>
+        <p>A <dfn>block Environment Record</dfn> is a declarative Environment Record that is used to represent block scopes. Functions declared inside the block are stored in a separate Environment Record in the [[FunctionsInBlock]] internal slot in addition to in the block environment record. This helps ensure that only function objects are assigned to outer environments for web legacy compatibility.</p>
         <p>Block Environment Records have the additional state field listed in <emu-xref href="#table-block-environment-record-additional-fields"></emu-xref>.</p>
         <emu-table id="table-block-environment-record-additional-fields" caption="Additional Fields of Block Environment Records">
           <table>
@@ -36615,7 +36615,16 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         <p>In Static Semantics: Early Errors of <emu-grammar>Block : `{` StatementList `}`</emu-grammar> (<emu-xref href="#sec-block-static-semantics-early-errors"></emu-xref>) the following replaces the first list item:</p>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of StatementList contains any duplicate entries, unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.
+            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries, unless the source code matching this production is not strict mode code and the duplicate entries are only bound by |FunctionDeclaration|s.
+          </li>
+        </ul>
+      </emu-annex>
+      <emu-annex id="sec-web-compat-switch-statement-static-semantics-early-errors">
+        <h1>Changes to Switch Statement Early Errors</h1>
+        <p>In Static Semantics: Early Errors of <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar> (<emu-xref href="#sec-switch-statement-static-semantics-early-errors"></emu-xref>) the following replaces the first list item:</p>
+        <ul>
+          <li>
+            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries, unless the source code matching this production is not strict mode code and the duplicate entries are only bound by |FunctionDeclaration|s.
           </li>
         </ul>
       </emu-annex>
@@ -36638,28 +36647,30 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         </emu-alg>
         <p>The following steps are performed in place of step 4:</p>
         <emu-alg>
+          1. For each element _d_ in _declarations_ do
+            1. If _d_ is not a |FunctionDeclaration|, then
+              1. For each element _dn_ of the BoundNames of _d_ do
+                1. If IsConstantDeclaration of _d_ is *true*, then
+                  1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
+                1. Else,
+                  1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+              1. If _d_ is a |GeneratorDeclaration|, then
+                1. Let _fn_ be the sole element of the BoundNames of _d_.
+                1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
+                1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
           1. Let _functionNames_ be an empty List.
-          1. Let _functionsToInitialize_ be an empty List.
-          1. For each _d_ in _declarations_, in reverse list order do
-            1. For each element _dn_ of the BoundNames of _d_ do
-              1. If IsConstantDeclaration of _d_ is *true*, then
-                1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
-              1. Else,
-                1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
-            1. If _d_ is a |GeneratorDeclaration| production or a |FunctionDeclaration| production, then
+          1. Let _fibRec_ be the value of _envRec_.[[FunctionsInBlock]].
+          1. For each element _d_ in _declarations_, in reverse list order do
+            1. If _d_ is a |FunctionDeclaration|, then
               1. Let _fn_ be the sole element of the BoundNames of _d_.
               1. If _fn_ is not an element of _functionNames_, then
                 1. NOTE If there are multiple |FunctionDeclaration|s for the same name, the last declaration is used. There are only multiple declarations if _code_ is not contained in strict mode code.
-                1. Insert _fn_ as the first element of _functionNames_.
-                1. Insert _d_ as the first element of _functionsToInitialize_.
-          1. For each element _d_ in _functionsToInitialize_ do
-            1. Let _fn_ be the sole element of the BoundNames of _d_.
-            1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
-            1. If _d_ is a |FunctionDeclaration| production, then
-              1. Let _fibRec_ be the value of _envRec_.[[FunctionsInBlock]].
-              1. Perform ! _fibRec_.CreateMutableBinding(_fn_, *false*).
-              1. Perform _fibRec_.InitializeBinding(_fn_, _fo_).
-            1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
+                1. Append _fn_ to _functionNames_.
+                1. Perform ! _envRec_.CreateMutableBinding(_fn_, *false*).
+                1. Perform ! _fibRec_.CreateMutableBinding(_fn_, *false*).
+                1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
+                1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
+                1. Perform _fibRec_.InitializeBinding(_fn_, _fo_).
         </emu-alg>
       </emu-annex>
       <emu-annex id="sec-web-compat-functiondeclarationinstantiation">
@@ -36677,22 +36688,22 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
                   1. Insert _fn_ as the first element of _functionNamesInBlock_.
                   1. Insert _f_ as the first element of _functionsInBlock_.
               1. For each element _f_ in _functionsInBlock_ do
-                1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-                1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of BoundNames of _argumentsList_, then
-                  1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
-                  1. If _instantiatedVarNames_ does not contain _F_, then
-                    1. Perform ! _varEnvRec_.CreateMutableBinding(_F_).
-                    1. Perform _varEnvRec_.InitializeBinding(_F_, *undefined*).
-                    1. Append _F_ to _instantiatedVarNames_.
+                1. Let _fn_ be the sole element of the BoundNames of _f_.
+                1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _fn_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _fn_ is not an element of BoundNames of _argumentsList_, then
+                  1. NOTE A var binding for _fn_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
+                  1. If _instantiatedVarNames_ does not contain _fn_, then
+                    1. Perform ! _varEnvRec_.CreateMutableBinding(_fn_).
+                    1. Perform _varEnvRec_.InitializeBinding(_fn_, *undefined*).
+                    1. Append _fn_ to _instantiatedVarNames_.
                   1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
                     1. Let _fenv_ be the running execution context's VariableEnvironment.
                     1. Let _fenvRec_ be _fenv_'s EnvironmentRecord.
                     1. Let _benv_ be the running execution context's LexicalEnvironment.
                     1. Let _benvRec_ be _benv_'s EnvironmentRecord.
                     1. Let _fibRec_ be the value of _benvRec_.[[FunctionsInBlock]].
-                    1. Let _fobj_ be ! _fibRec_.GetBindingValue(_F_, *false*).
-                    1. Assert: _fobj_ is a function Object.
-                    1. Perform ! _fenvRec_.SetMutableBinding(_F_, _fobj_, *false*).
+                    1. Let _fobj_ be ! _fibRec_.GetBindingValue(_fn_, *false*).
+                    1. Assert: _fobj_ is a function object.
+                    1. Perform ! _fenvRec_.SetMutableBinding(_fn_, _fobj_, *false*).
                     1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
@@ -36713,24 +36724,24 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
                 1. Insert _fn_ as the first element of _functionNamesInBlock_.
                 1. Insert _f_ as the first element of _functionsInBlock_.
             1. For each element _f_ in _functionsInBlock_ do
-              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-              2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
-                1. If _envRec_.HasLexicalDeclaration(_F_) is *false*, then
-                  1. Let _fnDefinable_ be ? _envRec_.CanDeclareGlobalFunction(_F_).
+              1. Let _fn_ be the sole element of the BoundNames of _f_.
+              2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _fn_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
+                1. If _envRec_.HasLexicalDeclaration(_fn_) is *false*, then
+                  1. Let _fnDefinable_ be ? _envRec_.CanDeclareGlobalFunction(_fn_).
                   3. If _fnDefinable_ is *true*, then
-                    1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
-                    2. If _declaredFunctionOrVarNames_ does not contain _F_, then
-                      1. Perform ? _envRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *false*).
-                      1. Append _F_ to _declaredFunctionOrVarNames_.
+                    1. NOTE A var binding for _fn_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
+                    2. If _declaredFunctionOrVarNames_ does not contain _fn_, then
+                      1. Perform ? _envRec_.CreateGlobalFunctionBinding(_fn_, *undefined*, *false*).
+                      1. Append _fn_ to _declaredFunctionOrVarNames_.
                     3. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
                       1. Let _genv_ be the running execution context's VariableEnvironment.
                       1. Let _genvRec_ be _genv_'s EnvironmentRecord.
                       1. Let _benv_ be the running execution context's LexicalEnvironment.
                       1. Let _benvRec_ be _benv_'s EnvironmentRecord.
                       1. Let _fibRec_ be the value of _benvRec_.[[FunctionsInBlock]].
-                      1. Let _fobj_ be ! _fibRec_.GetBindingValue(_F_, *false*).
-                      1. Assert: _fobj_ is a function Object.
-                      1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
+                      1. Let _fobj_ be ! _fibRec_.GetBindingValue(_fn_, *false*).
+                      1. Assert: _fobj_ is a function object.
+                      1. Perform ? _genvRec_.SetMutableBinding(_fn_, _fobj_, *false*).
                       1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
@@ -36752,43 +36763,43 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
                   1. Insert _fn_ as the first element of _functionNamesInBlock_.
                   1. Insert _f_ as the first element of _functionsInBlock_.
               1. For each element _f_ in _functionsInBlock_ do
-                1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-                2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _body_, then
+                1. Let _fn_ be the sole element of the BoundNames of _f_.
+                2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _fn_ as a |BindingIdentifier| would not produce any Early Errors for _body_, then
                   1. Let _bindingExists_ be *false*.
                   3. Let _thisLex_ be _lexEnv_.
                   4. Assert: the following loop will terminate.
                   5. Repeat while _thisLex_ is not the same as _varEnv_,
                     1. Let _thisEnvRec_ be _thisLex_'s EnvironmentRecord.
                     2. If _thisEnvRec_ is not an object Environment Record, then
-                      1. If _thisEnvRec_.HasBinding(_F_) is *true*, then
+                      1. If _thisEnvRec_.HasBinding(_fn_) is *true*, then
                         1. Let _bindingExists_ be *true*.
                     1. Let _thisLex_ be _thisLex_'s outer environment reference.
                   6. If _bindingExists_ is *false* and _varEnvRec_ is a global Environment Record, then
-                    1. If _varEnvRec_.HasLexicalDeclaration(_F_) is *false*, then
-                      1. Let _fnDefinable_ be ? _varEnvRec_.CanDeclareGlobalFunction(_F_).
+                    1. If _varEnvRec_.HasLexicalDeclaration(_fn_) is *false*, then
+                      1. Let _fnDefinable_ be ? _varEnvRec_.CanDeclareGlobalFunction(_fn_).
                     1. Else,
                       1. Let _fnDefinable_ be *false*.
                   1. Else,
                     1. Let _fnDefinable_ be *true*.
                   7. If _bindingExists_ is *false* and _fnDefinable_ is *true*, then
-                    1. If _declaredFunctionOrVarNames_ does not contain _F_, then
+                    1. If _declaredFunctionOrVarNames_ does not contain _fn_, then
                       1. If _varEnvRec_ is a global Environment Record, then
-                        1. Perform ? _varEnvRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *true*).
+                        1. Perform ? _varEnvRec_.CreateGlobalFunctionBinding(_fn_, *undefined*, *true*).
                       1. Else,
-                        1. Let _bindingExists_ be _varEnvRec_.HasBinding(_F_).
+                        1. Let _bindingExists_ be _varEnvRec_.HasBinding(_fn_).
                         1. If _bindingExists_ is *false*, then
-                          1. Perform ! _varEnvRec_.CreateMutableBinding(_F_, *true*).
-                          1. Perform ! _varEnvRec_.InitializeBinding(_F_, *undefined*).
-                      1. Append _F_ to _declaredFunctionOrVarNames_.
+                          1. Perform ! _varEnvRec_.CreateMutableBinding(_fn_, *true*).
+                          1. Perform ! _varEnvRec_.InitializeBinding(_fn_, *undefined*).
+                      1. Append _fn_ to _declaredFunctionOrVarNames_.
                     2. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
                       1. Let _genv_ be the running execution context's VariableEnvironment.
                       1. Let _genvRec_ be _genv_'s EnvironmentRecord.
                       1. Let _benv_ be the running execution context's LexicalEnvironment.
                       1. Let _benvRec_ be _benv_'s EnvironmentRecord.
                       1. Let _fibRec_ be the value of _benvRec_.[[FunctionsInBlock]].
-                      1. Let _fobj_ be ! _fibRec_.GetBindingValue(_F_, *false*).
-                      1. Assert: _fobj_ is a function Object.
-                      1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
+                      1. Let _fobj_ be ! _fibRec_.GetBindingValue(_fn_, *false*).
+                      1. Assert: _fobj_ is a function object.
+                      1. Perform ? _genvRec_.SetMutableBinding(_fn_, _fobj_, *false*).
                       1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>

--- a/spec.html
+++ b/spec.html
@@ -36512,7 +36512,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <p>A function is declared and only referenced within a single block</p>
           <ul>
             <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
+              One or more |FunctionDeclaration|s whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
             </li>
             <li>
               No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
@@ -36526,7 +36526,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <p>A function is declared and possibly used within a single |Block| but also referenced by an inner function definition that is not contained within that same |Block|.</p>
           <ul>
             <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
+              One or more |FunctionDeclaration|s whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
             </li>
             <li>
               No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
@@ -36546,7 +36546,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <p>A function is declared and possibly used within a single block but also referenced within subsequent blocks.</p>
           <ul>
             <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
+              One or more |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occur exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
             </li>
             <li>
               No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
@@ -36563,27 +36563,137 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       <p>The first use case is interoperable with the semantics of |Block| level function declarations provided by ECMAScript 2015. Any pre-existing ECMAScript code that employs that use case will operate using the Block level function declarations semantics defined by clauses 9, 13, and 14 of this specification.</p>
       <p>ECMAScript 2015 interoperability for the second and third use cases requires the following extensions to the clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, clause <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>, clause <emu-xref href="#sec-eval-x"></emu-xref> and clause <emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref> semantics.</p>
       <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatibility semantics are applied and introduce observable differences from non-compatibility semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
+      <emu-annex id="sec-web-compat-block-environment-records">
+        <h1>Block Environment Records</h1>
+        <p>A <dfn>block Environment Record</dfn> is a declarative Environment Record that is used to represent block scopes. Functions declared inside the block are stored in a separate Environment Record in the [[FunctionsInBlock]] internal slot in addition to in the block environment record. This helps ensure that only function Objects are assigned to outer environments for web legacy compatibility.</p>
+        <p>Block Environment Records have the additional state field listed in <emu-xref href="#table-block-environment-record-additional-fields"></emu-xref>.</p>
+        <emu-table id="table-block-environment-record-additional-fields" caption="Additional Fields of Block Environment Records">
+          <table>
+            <tbody>
+              <tr>
+                <th>
+                  Field Name
+                </th>
+                <th>
+                  Value
+                </th>
+                <th>
+                  Meaning
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  [[FunctionsInBlock]]
+                </td>
+                <td>
+                  Declarative Environment Record
+                </td>
+                <td>
+                  Functions declared inside the block.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </emu-table>
+        <p>Block Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and have no additional methods.</p>
+      </emu-annex>
+      <emu-annex id="sec-web-compat-newblockenvironment">
+        <h1>NewBlockEnvironment (_E_)</h1>
+        <p>When the abstract operation NewBlockEnvironment is called with a Lexical Environment as argument _E_ the following steps are performed:</p>
+        <emu-alg>
+          1. Let _env_ be a new Lexical Environment.
+          1. Let _envRec_ be a new block Environment Record containing no bindings.
+          1. Let _fibRec_ be a new declarative Environment Record containing no bindings.
+          1. Set _envRec_.[[FunctionsInBlock]] to _fibRec_.
+          1. Set _env_'s EnvironmentRecord to be _envRec_.
+          1. Set the outer lexical environment reference of _env_ to _E_.
+          1. Return _env_.
+        </emu-alg>
+      </emu-annex>
+      <emu-annex id="sec-web-compat-block-static-semantics-early-errors">
+        <h1>Changes to Block Early Errors</h1>
+        <p>In Static Semantics: Early Errors of <emu-grammar>Block : `{` StatementList `}`</emu-grammar> (<emu-xref href="#sec-block-static-semantics-early-errors"></emu-xref>) the following replaces the first list item:</p>
+        <ul>
+          <li>
+            It is a Syntax Error if the LexicallyDeclaredNames of StatementList contains any duplicate entries, unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.
+          </li>
+        </ul>
+      </emu-annex>
+      <emu-annex id="sec-web-compat-block-runtime-semantics-evaluation">
+        <h1>Changes to Block Runtime Evaluation</h1>
+        <p>During runtime evaluation of <emu-grammar>Block : `{` StatementList `}`</emu-grammar> (<emu-xref href="#sec-block-runtime-semantics-evaluation"></emu-xref>) the following step is performed in place of step 2:</p>
+        <emu-alg>
+          1. Let _blockEnv_ be NewBlockEnvironment(_oldEnv_).
+        </emu-alg>
+        <p>During runtime evaluation of <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar> (<emu-xref href="#sec-switch-statement-runtime-semantics-evaluation"></emu-xref>) the following step is performed in place of step 4:</p>
+        <emu-alg>
+          1. Let _blockEnv_ be NewBlockEnvironment(_oldEnv_).
+        </emu-alg>
+      </emu-annex>
+      <emu-annex id="sec-web-compat-blockdeclarationinstantiation">
+        <h1>Changes to BlockDeclarationInstantiation</h1>
+        <p>During BlockDeclarationInstantiation (<emu-xref href="#sec-blockdeclarationinstantiation"></emu-xref>) the following step is performed in place of step 2:</p>
+        <emu-alg>
+          1. Assert: _envRec_ is a block Environment Record.
+        </emu-alg>
+        <p>The following steps are performed in place of step 4:</p>
+        <emu-alg>
+          1. Let _functionNames_ be an empty List.
+          1. Let _functionsToInitialize_ be an empty List.
+          1. For each _d_ in _declarations_, in reverse list order do
+            1. For each element _dn_ of the BoundNames of _d_ do
+              1. If IsConstantDeclaration of _d_ is *true*, then
+                1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
+              1. Else,
+                1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+            1. If _d_ is a |GeneratorDeclaration| production or a |FunctionDeclaration| production, then
+              1. Let _fn_ be the sole element of the BoundNames of _d_.
+              1. If _fn_ is not an element of _functionNames_, then
+                1. NOTE If there are multiple |FunctionDeclaration|s for the same name, the last declaration is used. There are only multiple declarations if _code_ is not contained in strict mode code.
+                1. Insert _fn_ as the first element of _functionNames_.
+                1. Insert _d_ as the first element of _functionsToInitialize_.
+          1. For each element _d_ in _functionsToInitialize_ do
+            1. Let _fn_ be the sole element of the BoundNames of _d_.
+            1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
+            1. If _d_ is a |FunctionDeclaration| production, then
+              1. Let _fibRec_ be the value of _envRec_.[[FunctionsInBlock]].
+              1. Perform ! _fibRec_.CreateMutableBinding(_fn_, *false*).
+              1. Perform _fibRec_.InitializeBinding(_fn_, _fo_).
+            1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
+        </emu-alg>
+      </emu-annex>
       <emu-annex id="sec-web-compat-functiondeclarationinstantiation">
         <h1>Changes to FunctionDeclarationInstantiation</h1>
         <p>During FunctionDeclarationInstantiation (<emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>) the following steps are performed in place of step 29:</p>
         <emu-alg>
           1. If _strict_ is *false*, then
-            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|,
-              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-              1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of BoundNames of _argumentsList_, then
-                1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
-                1. If _instantiatedVarNames_ does not contain _F_, then
-                  1. Perform ! _varEnvRec_.CreateMutableBinding(_F_).
-                  1. Perform _varEnvRec_.InitializeBinding(_F_, *undefined*).
-                  1. Append _F_ to _instantiatedVarNames_.
-                1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                  1. Let _fenv_ be the running execution context's VariableEnvironment.
-                  1. Let _fenvRec_ be _fenv_'s EnvironmentRecord.
-                  1. Let _benv_ be the running execution context's LexicalEnvironment.
-                  1. Let _benvRec_ be _benv_'s EnvironmentRecord.
-                  1. Let _fobj_ be ! _benvRec_.GetBindingValue(_F_, *false*).
-                  1. Perform ! _fenvRec_.SetMutableBinding(_F_, _fobj_, *false*).
-                  1. Return NormalCompletion(~empty~).
+            1. For each |Block| or |CaseBlock| _block_ contained within _code_ do,
+              1. Let _functionNamesInBlock_ be an empty List.
+              1. Let _functionsInBlock_ be an empty List.
+              1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of _block_, or of a |CaseClause| or |DefaultClause| directly contained in _block_, in reverse order do
+                1. Let _fn_ be the sole element of the BoundNames of _f_.
+                1. If _fn_ is not an element of _functionNamesInBlock_, then
+                  1. NOTE If there are multiple |FunctionDeclaration|s for the same name, the last declaration is used.
+                  1. Insert _fn_ as the first element of _functionNamesInBlock_.
+                  1. Insert _f_ as the first element of _functionsInBlock_.
+              1. For each element _f_ in _functionsInBlock_ do
+                1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
+                1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of BoundNames of _argumentsList_, then
+                  1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
+                  1. If _instantiatedVarNames_ does not contain _F_, then
+                    1. Perform ! _varEnvRec_.CreateMutableBinding(_F_).
+                    1. Perform _varEnvRec_.InitializeBinding(_F_, *undefined*).
+                    1. Append _F_ to _instantiatedVarNames_.
+                  1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
+                    1. Let _fenv_ be the running execution context's VariableEnvironment.
+                    1. Let _fenvRec_ be _fenv_'s EnvironmentRecord.
+                    1. Let _benv_ be the running execution context's LexicalEnvironment.
+                    1. Let _benvRec_ be _benv_'s EnvironmentRecord.
+                    1. Let _fibRec_ be the value of _benvRec_.[[FunctionsInBlock]].
+                    1. Let _fobj_ be ! _fibRec_.GetBindingValue(_F_, *false*).
+                    1. Assert: _fobj_ is a function Object.
+                    1. Perform ! _fenvRec_.SetMutableBinding(_F_, _fobj_, *false*).
+                    1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
       <emu-annex id="sec-web-compat-globaldeclarationinstantiation">
@@ -36593,24 +36703,35 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           1. Let _declaredFunctionOrVarNames_ be an empty List.
           1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
           1. Append to _declaredFunctionOrVarNames_ the elements of _declaredVarNames_.
-          1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_,
-            1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-            2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
-              1. If _envRec_.HasLexicalDeclaration(_F_) is *false*, then
-                1. Let _fnDefinable_ be ? _envRec_.CanDeclareGlobalFunction(_F_).
-                3. If _fnDefinable_ is *true*, then
-                  1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
-                  2. If _declaredFunctionOrVarNames_ does not contain _F_, then
-                    1. Perform ? _envRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *false*).
-                    1. Append _F_ to _declaredFunctionOrVarNames_.
-                  3. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _genv_ be the running execution context's VariableEnvironment.
-                    1. Let _genvRec_ be _genv_'s EnvironmentRecord.
-                    1. Let _benv_ be the running execution context's LexicalEnvironment.
-                    1. Let _benvRec_ be _benv_'s EnvironmentRecord.
-                    1. Let _fobj_ be ! _benvRec_.GetBindingValue(_F_, *false*).
-                    1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
-                    1. Return NormalCompletion(~empty~).
+          1. For each |Block| or |CaseBlock| _block_ contained within _script_ do
+            1. Let _functionNamesInBlock_ be an empty List.
+            1. Let _functionsInBlock_ be an empty List.
+            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of _block_, or of a |CaseClause| or |DefaultClause| directly contained in _block_, in reverse order do
+              1. Let _fn_ be the sole element of the BoundNames of _f_.
+              1. If _fn_ is not an element of _functionNamesInBlock_, then
+                1. NOTE If there are multiple |FunctionDeclaration|s for the same name, the last declaration is used.
+                1. Insert _fn_ as the first element of _functionNamesInBlock_.
+                1. Insert _f_ as the first element of _functionsInBlock_.
+            1. For each element _f_ in _functionsInBlock_ do
+              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
+              2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
+                1. If _envRec_.HasLexicalDeclaration(_F_) is *false*, then
+                  1. Let _fnDefinable_ be ? _envRec_.CanDeclareGlobalFunction(_F_).
+                  3. If _fnDefinable_ is *true*, then
+                    1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
+                    2. If _declaredFunctionOrVarNames_ does not contain _F_, then
+                      1. Perform ? _envRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *false*).
+                      1. Append _F_ to _declaredFunctionOrVarNames_.
+                    3. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
+                      1. Let _genv_ be the running execution context's VariableEnvironment.
+                      1. Let _genvRec_ be _genv_'s EnvironmentRecord.
+                      1. Let _benv_ be the running execution context's LexicalEnvironment.
+                      1. Let _benvRec_ be _benv_'s EnvironmentRecord.
+                      1. Let _fibRec_ be the value of _benvRec_.[[FunctionsInBlock]].
+                      1. Let _fobj_ be ! _fibRec_.GetBindingValue(_F_, *false*).
+                      1. Assert: _fobj_ is a function Object.
+                      1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
+                      1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
       <emu-annex id="sec-web-compat-evaldeclarationinstantiation">
@@ -36621,43 +36742,54 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
             1. Let _declaredFunctionOrVarNames_ be an empty List.
             1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
             1. Append to _declaredFunctionOrVarNames_ the elements of _declaredVarNames_.
-            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _body_,
-              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-              2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _body_, then
-                1. Let _bindingExists_ be *false*.
-                3. Let _thisLex_ be _lexEnv_.
-                4. Assert: the following loop will terminate.
-                5. Repeat while _thisLex_ is not the same as _varEnv_,
-                  1. Let _thisEnvRec_ be _thisLex_'s EnvironmentRecord.
-                  2. If _thisEnvRec_ is not an object Environment Record, then
-                    1. If _thisEnvRec_.HasBinding(_F_) is *true*, then
-                      1. Let _bindingExists_ be *true*.
-                  1. Let _thisLex_ be _thisLex_'s outer environment reference.
-                6. If _bindingExists_ is *false* and _varEnvRec_ is a global Environment Record, then
-                  1. If _varEnvRec_.HasLexicalDeclaration(_F_) is *false*, then
-                    1. Let _fnDefinable_ be ? _varEnvRec_.CanDeclareGlobalFunction(_F_).
-                  1. Else,
-                    1. Let _fnDefinable_ be *false*.
-                1. Else,
-                  1. Let _fnDefinable_ be *true*.
-                7. If _bindingExists_ is *false* and _fnDefinable_ is *true*, then
-                  1. If _declaredFunctionOrVarNames_ does not contain _F_, then
-                    1. If _varEnvRec_ is a global Environment Record, then
-                      1. Perform ? _varEnvRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *true*).
+            1. For each |Block| or |CaseBlock| _block_ contained within _body_ do,
+              1. Let _functionNamesInBlock_ be an empty List.
+              1. Let _functionsInBlock_ be an empty List.
+              1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of _block_, or of a |CaseClause| or |DefaultClause| directly contained in _block_, in reverse order do
+                1. Let _fn_ be the sole element of the BoundNames of _f_.
+                1. If _fn_ is not an element of _functionNamesInBlock_, then
+                  1. NOTE If there are multiple |FunctionDeclaration|s for the same name, the last declaration is used.
+                  1. Insert _fn_ as the first element of _functionNamesInBlock_.
+                  1. Insert _f_ as the first element of _functionsInBlock_.
+              1. For each element _f_ in _functionsInBlock_ do
+                1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
+                2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _body_, then
+                  1. Let _bindingExists_ be *false*.
+                  3. Let _thisLex_ be _lexEnv_.
+                  4. Assert: the following loop will terminate.
+                  5. Repeat while _thisLex_ is not the same as _varEnv_,
+                    1. Let _thisEnvRec_ be _thisLex_'s EnvironmentRecord.
+                    2. If _thisEnvRec_ is not an object Environment Record, then
+                      1. If _thisEnvRec_.HasBinding(_F_) is *true*, then
+                        1. Let _bindingExists_ be *true*.
+                    1. Let _thisLex_ be _thisLex_'s outer environment reference.
+                  6. If _bindingExists_ is *false* and _varEnvRec_ is a global Environment Record, then
+                    1. If _varEnvRec_.HasLexicalDeclaration(_F_) is *false*, then
+                      1. Let _fnDefinable_ be ? _varEnvRec_.CanDeclareGlobalFunction(_F_).
                     1. Else,
-                      1. Let _bindingExists_ be _varEnvRec_.HasBinding(_F_).
-                      1. If _bindingExists_ is *false*, then
-                        1. Perform ! _varEnvRec_.CreateMutableBinding(_F_, *true*).
-                        1. Perform ! _varEnvRec_.InitializeBinding(_F_, *undefined*).
-                    1. Append _F_ to _declaredFunctionOrVarNames_.
-                  2. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _genv_ be the running execution context's VariableEnvironment.
-                    1. Let _genvRec_ be _genv_'s EnvironmentRecord.
-                    1. Let _benv_ be the running execution context's LexicalEnvironment.
-                    1. Let _benvRec_ be _benv_'s EnvironmentRecord.
-                    1. Let _fobj_ be ! _benvRec_.GetBindingValue(_F_, *false*).
-                    1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
-                    1. Return NormalCompletion(~empty~).
+                      1. Let _fnDefinable_ be *false*.
+                  1. Else,
+                    1. Let _fnDefinable_ be *true*.
+                  7. If _bindingExists_ is *false* and _fnDefinable_ is *true*, then
+                    1. If _declaredFunctionOrVarNames_ does not contain _F_, then
+                      1. If _varEnvRec_ is a global Environment Record, then
+                        1. Perform ? _varEnvRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *true*).
+                      1. Else,
+                        1. Let _bindingExists_ be _varEnvRec_.HasBinding(_F_).
+                        1. If _bindingExists_ is *false*, then
+                          1. Perform ! _varEnvRec_.CreateMutableBinding(_F_, *true*).
+                          1. Perform ! _varEnvRec_.InitializeBinding(_F_, *undefined*).
+                      1. Append _F_ to _declaredFunctionOrVarNames_.
+                    2. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
+                      1. Let _genv_ be the running execution context's VariableEnvironment.
+                      1. Let _genvRec_ be _genv_'s EnvironmentRecord.
+                      1. Let _benv_ be the running execution context's LexicalEnvironment.
+                      1. Let _benvRec_ be _benv_'s EnvironmentRecord.
+                      1. Let _fibRec_ be the value of _benvRec_.[[FunctionsInBlock]].
+                      1. Let _fobj_ be ! _fibRec_.GetBindingValue(_F_, *false*).
+                      1. Assert: _fobj_ is a function Object.
+                      1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
+                      1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
     </emu-annex>


### PR DESCRIPTION
For #348 

This was more change than I'd intended. Let me know if I got the language wrong anywhere.