### PR TITLE
Normative: account for possible abrupt completion

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20747,7 +20747,7 @@ eval("1;var a;")
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
               1. Let _requestedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _starNames_ be _requestedModule_.GetExportedNames(_exportStarSet_).
+              1. Let _starNames_ be ? _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
                 1. If SameValue(_n_, `"default"`) is *false*, then
                   1. If _n_ is not an element of _exportedNames_, then


### PR DESCRIPTION
The GetExportedNames method returns an abrupt completion when the host
cannot resolve the requested module. This possibility must be accounted
for when the method invokes itself.