### PR TITLE
Change grammar for positive integer assertions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2956,7 +2956,7 @@
         <p>When the abstract operation CopyDataBlockBytes is called, the following steps are taken:</p>
         <emu-alg>
           1. Assert: _fromBlock_ and _toBlock_ are distinct Data Block values.
-          1. Assert: _fromIndex_, _toIndex_, and _count_ are positive integer values.
+          1. Assert: _fromIndex_, _toIndex_, and _count_ are integer values &ge; 0.
           1. Let _fromSize_ be the number of bytes in _fromBlock_.
           1. Assert: _fromIndex_+_count_ &le; _fromSize_.
           1. Let _toSize_ be the number of bytes in _toBlock_.
@@ -7338,7 +7338,7 @@
       <!-- es6num="9.4.2.2" -->
       <emu-clause id="sec-arraycreate" aoid="ArrayCreate">
         <h1>ArrayCreate (_length_ [ , _proto_ ])</h1>
-        <p>The abstract operation ArrayCreate with argument _length_ (a positive integer) and optional argument _proto_ is used to specify the creation of new Array exotic objects. It performs the following steps:</p>
+        <p>The abstract operation ArrayCreate with argument _length_ (either 0 or a positive integer) and optional argument _proto_ is used to specify the creation of new Array exotic objects. It performs the following steps:</p>
         <emu-alg>
           1. Assert: _length_ is an integer Number &ge; 0.
           1. If _length_ is -0, let _length_ be +0.
@@ -32865,7 +32865,7 @@ Date.parse(x.toLocaleString())
         <p>The abstract operation AllocateArrayBuffer with arguments _constructor_ and _byteLength_ is used to create an ArrayBuffer object. It performs the following steps:</p>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, `"%ArrayBufferPrototype%"`, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo; ).
-          1. Assert: _byteLength_ is a positive integer.
+          1. Assert: _byteLength_ is an integer value &ge; 0.
           1. Let _block_ be ? CreateByteDataBlock(_byteLength_).
           1. Set _obj_'s [[ArrayBufferData]] internal slot to _block_.
           1. Set _obj_'s [[ArrayBufferByteLength]] internal slot to _byteLength_.
@@ -32928,7 +32928,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: _byteIndex_ is a positive integer.
+          1. Assert: _byteIndex_ is an integer value &ge; 0.
           1. Let _block_ be _arrayBuffer_'s [[ArrayBufferData]] internal slot.
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. Let _rawValue_ be a List of _elementSize_ containing, in order, the _elementSize_ sequence of bytes starting with _block_[_byteIndex_].
@@ -32957,7 +32957,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: _byteIndex_ is a positive integer.
+          1. Assert: _byteIndex_ is an integer value &ge; 0.
           1. Assert: Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_'s [[ArrayBufferData]] internal slot.
           1. Assert: _block_ is not *undefined*.


### PR DESCRIPTION
The current grammar for __positive integer__ is confusing when it also accounts for positive zero. Maybe the phrase could be changed to something like `_item_ is an integer &ge; 0.` 

The current spec says:

```
6.1.6 The Number Type

...
The other 18437736874454810624 (that is, 264-253) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.

Note that there is both a positive zero and a negative zero. For brevity, these values are also referred to for expository purposes by the symbols +0 and -0, respectively. (Note that these two different zero Number values are produced by the program expressions +0 (or simply 0) and -0.)

...
Note that all the positive and negative integers whose magnitude is no greater than 253 are representable in the Number type (indeed, the integer 0 has two representations, +0 and -0).
...

6.1.7 The Object Type

...
An integer index is a String-valued property key that is a canonical numeric String (see 7.1.16) and whose numeric value is either +0 or a positive integer ≤ 253-1. An array index is an integer index whose numeric value i is in the range +0 ≤ i < 232-1.
...
```

Some parts of the spec seems to assert 0 as a positive integer, like:

```
24.1.1.1 AllocateArrayBuffer ( constructor, byteLength )

...
2. Assert: byteLength is a positive integer.
...
``` 

[SetValueInBuffer](https://tc39.github.io/ecma262/#sec-setvalueinbuffer), [GetValueInBuffer](https://tc39.github.io/ecma262/#sec-getvalueinbuffer), and [CopyDataBlockBytes](https://tc39.github.io/ecma262/#sec-copydatablockbytes) contains a similar spec.

The [ArrayCreate](https://tc39.github.io/ecma262/#sec-arraycreate) operation mentions a positive integer (and it may be 0), but it does not use it on the api steps, asserting only the value is an integer Number ≥ 0.
