### PR TITLE
Remove interoperability between TypedArrays and DataView instances

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31068,7 +31068,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+          1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
           1. Return _buffer_.
         </emu-alg>
@@ -31081,7 +31082,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+          1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
           1. Let _size_ be the value of _O_'s [[ByteLength]] internal slot.
@@ -31096,7 +31098,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+          1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
           1. Let _offset_ be the value of _O_'s [[ByteOffset]] internal slot.
@@ -31124,7 +31127,7 @@ Date.parse(x.toLocaleString())
           <emu-alg>
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
-            1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+            1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
             1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. Return _buffer_.
@@ -33125,6 +33128,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. If Type(_view_) is not Object, throw a *TypeError* exception.
           1. If _view_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _numberIndex_ be ? ToNumber(_requestIndex_).
           1. Let _getIndex_ be ToInteger(_numberIndex_).
           1. If _numberIndex_ &ne; _getIndex_ or _getIndex_ &lt; 0, throw a *RangeError* exception.
@@ -33147,6 +33151,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. If Type(_view_) is not Object, throw a *TypeError* exception.
           1. If _view_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _numberIndex_ be ? ToNumber(_requestIndex_).
           1. Let _getIndex_ be ToInteger(_numberIndex_).
           1. If _numberIndex_ &ne; _getIndex_ or _getIndex_ &lt; 0, throw a *RangeError* exception.
@@ -33225,7 +33230,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+          1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
           1. Return _buffer_.
         </emu-alg>
@@ -33238,7 +33244,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+          1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _size_ be the value of _O_'s [[ByteLength]] internal slot.
@@ -33253,7 +33260,8 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+          1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _offset_ be the value of _O_'s [[ByteOffset]] internal slot.


### PR DESCRIPTION
Apply this change to prevent this - probably unwanted - interoperability.

This change help optimizing implementations.