### PR TITLE
Remove unnecessary step on %ArrayIteratorPrototype%.next

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30638,10 +30638,7 @@ Date.parse(x.toLocaleString())
             1. If _a_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
             1. Let _index_ be the value of the [[ArrayIteratorNextIndex]] internal slot of _O_.
             1. Let _itemKind_ be the value of the [[ArrayIterationKind]] internal slot of _O_.
-            1. If _a_ has a [[TypedArrayName]] internal slot, then
-              1. Let _len_ be the value of _a_'s [[ArrayLength]] internal slot.
-            1. Else,
-              1. Let _len_ be ? ToLength(? Get(_a_, `"length"`)).
+            1. Let _len_ be ? ToLength(? Get(_a_, `"length"`)).
             1. If _index_ &ge; _len_, then
               1. Set the value of the [[IteratedObject]] internal slot of _O_ to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).


### PR DESCRIPTION
It is not necessary to account for TypedArrays but making this special case.

This change enables runtime optimization on the method call. The api is
already secured for any further property access on a TypedArray instance if
a custom length is defined.