### PR TITLE
Editorial: Fully Specify ModuleRequests

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21161,6 +21161,11 @@ eval("1;var a;")
         <emu-alg>
           1. Return ModuleRequests of |FromClause|.
         </emu-alg>
+        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+        <emu-grammar>FromClause : `from` ModuleSpecifier</emu-grammar>
+        <emu-alg>
+          1. Return ModuleRequests of |ModuleSpecifier|
+        </emu-alg>
         <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |StringLiteral|.


### PR DESCRIPTION
Add Static Semantics algorithms for two productions.

FromClause requires an explicit algorithm is necessary to join the
algorithms for the following productions:

    ImportDeclaration : `import` ImportClause FromClause `;`
    ModuleSpecifier : StringLiteral

ImportDeclaration (without an ImportClause) requires an explicit
algorithm to join the algorithms for the following productions:

    ModuleItem : ImportDeclaration
    ModuleSpecifier : StringLiteral