### PR TITLE
Editorial: fix incorrect pluralization of List and Record types

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2539,7 +2539,7 @@
 
     <!-- es6num="6.2.1" -->
     <emu-clause id="sec-list-and-record-specification-type">
-      <h1>The List and Record Specification Type</h1>
+      <h1>The List and Record Specification Types</h1>
       <p>The <dfn>List</dfn> type is used to explain the evaluation of argument lists (see <emu-xref href="#sec-argument-lists"></emu-xref>) in `new` expressions, in function calls, and in other algorithms where a simple ordered list of values is needed. Values of the List type are simply ordered sequences of list elements containing the individual values. These sequences may be of any length. The elements of a list may be randomly accessed using 0-origin indices. For notational convenience an array-like syntax can be used to access List elements. For example, _arguments_[2] is shorthand for saying the 3<sup>rd</sup> element of the List _arguments_.</p>
       <p>For notational convenience within this specification, a literal syntax can be used to express a new List value. For example, &laquo; 1, 2 &raquo; defines a List value that has two elements each of which is initialized to a specific value. A new empty List can be expressed as &laquo; &raquo;.</p>
       <p>The <dfn>Record</dfn> type is used to describe data aggregations within the algorithms of this specification. A Record type value consists of one or more named fields. The value of each field is either an ECMAScript value or an abstract value represented by a name associated with the Record type. Field names are always enclosed in double brackets, for example [[Value]].</p>


### PR DESCRIPTION
Right now it looks like you are defining a single spec type, "List and Record".