### PR TITLE
Move <dfn>s for %FunctionPrototype% and %TypedArrayPrototype%

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23052,7 +23052,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.2.2" -->
     <emu-clause id="sec-properties-of-the-function-constructor">
       <h1>Properties of the Function Constructor</h1>
-      <p>The `Function` constructor is itself a built-in function object. The value of the [[Prototype]] internal slot of the `Function` constructor is <dfn>%FunctionPrototype%</dfn>, the intrinsic Function prototype object (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The `Function` constructor is itself a built-in function object. The value of the [[Prototype]] internal slot of the `Function` constructor is %FunctionPrototype%, the intrinsic Function prototype object (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
       <p>The value of the [[Extensible]] internal slot of the Function constructor is *true*.</p>
       <p>The Function constructor has the following properties:</p>
 
@@ -23073,7 +23073,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.2.3" -->
     <emu-clause id="sec-properties-of-the-function-prototype-object">
       <h1>Properties of the Function Prototype Object</h1>
-      <p>The Function prototype object is the intrinsic object %FunctionPrototype%. The Function prototype object is itself a built-in function object. When invoked, it accepts any arguments and returns *undefined*. It does not have a [[Construct]] internal method so it is not a constructor.</p>
+      <p>The Function prototype object is the intrinsic object <dfn>%FunctionPrototype%</dfn>. The Function prototype object is itself a built-in function object. When invoked, it accepts any arguments and returns *undefined*. It does not have a [[Construct]] internal method so it is not a constructor.</p>
       <emu-note>
         <p>The Function prototype object is specified to be a function object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
       </emu-note>
@@ -31033,7 +31033,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="22.2.2.3" -->
       <emu-clause id="sec-%typedarray%.prototype">
         <h1>%TypedArray%.prototype</h1>
-        <p>The initial value of %TypedArray%.prototype is the <dfn>%TypedArrayPrototype%</dfn> intrinsic object (<emu-xref href="#sec-properties-of-the-%typedarrayprototype%-object"></emu-xref>).</p>
+        <p>The initial value of %TypedArray%.prototype is the %TypedArrayPrototype% intrinsic object (<emu-xref href="#sec-properties-of-the-%typedarrayprototype%-object"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -31054,7 +31054,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="22.2.3" -->
     <emu-clause id="sec-properties-of-the-%typedarrayprototype%-object">
       <h1>Properties of the %TypedArrayPrototype% Object</h1>
-      <p>The value of the [[Prototype]] internal slot of the %TypedArrayPrototype% object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The %TypedArrayPrototype% object is an ordinary object. It does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</p>
+      <p>The value of the [[Prototype]] internal slot of the <dfn>%TypedArrayPrototype%</dfn> object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The %TypedArrayPrototype% object is an ordinary object. It does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</p>
 
       <!-- es6num="22.2.3.1" -->
       <emu-clause id="sec-get-%typedarray%.prototype.buffer">


### PR DESCRIPTION
Moves the definitions of %FunctionPrototype% and %TypedArrayPrototype% to the corresponding prototype sections.