### PR TITLE
Replace assertions with '!' shorthand

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7323,8 +7323,7 @@
             1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, `"length"`).
             1. Assert: _oldLenDesc_ will never be *undefined* or an accessor descriptor because Array objects are created with a length data property that cannot be deleted or reconfigured.
             1. Let _oldLen_ be _oldLenDesc_.[[Value]].
-            1. Let _index_ be ToUint32(_P_).
-            1. Assert: _index_ will never be an abrupt completion.
+            1. Let _index_ be ! ToUint32(_P_).
             1. If _index_ &ge; _oldLen_ and _oldLenDesc_.[[Writable]] is *false*, return *false*.
             1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
             1. If _succeeded_ is *false*, return *false*.
@@ -7351,8 +7350,7 @@
           1. Set the [[DefineOwnProperty]] internal method of _A_ as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set the [[Prototype]] internal slot of _A_ to _proto_.
           1. Set the [[Extensible]] internal slot of _A_ to *true*.
-          1. Perform OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor{[[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
-          1. Assert: the preceding step never produces an abrupt completion.
+          1. Perform ! OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor{[[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
           1. Return _A_.
         </emu-alg>
       </emu-clause>
@@ -15703,10 +15701,9 @@ eval("1;var a;")
           1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
           1. For each element _dn_ of _boundNames_ do
             1. If _isConst_ is *true*, then
-              1. Perform _loopEnvRec_.CreateImmutableBinding(_dn_, *true*).
+              1. Perform ! _loopEnvRec_.CreateImmutableBinding(_dn_, *true*).
             1. Else,
-              1. Perform _loopEnvRec_.CreateMutableBinding(_dn_, *false*).
-              1. Assert: The above call to CreateMutableBinding will never return an abrupt completion.
+              1. Perform ! _loopEnvRec_.CreateMutableBinding(_dn_, *false*).
           1. Set the running execution context's LexicalEnvironment to _loopEnv_.
           1. Let _forDcl_ be the result of evaluating |LexicalDeclaration|.
           1. If _forDcl_ is an abrupt completion, then
@@ -15987,10 +15984,9 @@ eval("1;var a;")
           1. Assert: _envRec_ is a declarative Environment Record.
           1. For each element _name_ of the BoundNames of |ForBinding| do
             1. If IsConstantDeclaration of |LetOrConst| is *true*, then
-              1. Perform _envRec_.CreateImmutableBinding(_name_, *true*).
+              1. Perform ! _envRec_.CreateImmutableBinding(_name_, *true*).
             1. Else,
-              1. Perform _envRec_.CreateMutableBinding(_name_).
-              1. Assert: The above call to CreateMutableBinding will never return an abrupt completion.
+              1. Perform ! _envRec_.CreateMutableBinding(_name_).
         </emu-alg>
       </emu-clause>
 
@@ -17296,8 +17292,7 @@ eval("1;var a;")
         1. Let _catchEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Let _catchEnvRec_ be _catchEnv_'s EnvironmentRecord.
         1. For each element _argName_ of the BoundNames of |CatchParameter|, do
-          1. Perform _catchEnvRec_.CreateMutableBinding(_argName_).
-          1. Assert: The above call to CreateMutableBinding will never return an abrupt completion.
+          1. Perform ! _catchEnvRec_.CreateMutableBinding(_argName_).
         1. Set the running execution context's LexicalEnvironment to _catchEnv_.
         1. Let _status_ be the result of performing BindingInitialization for |CatchParameter| passing _thrownValue_ and _catchEnv_ as arguments.
         1. If _status_ is an abrupt completion, then
@@ -26907,14 +26902,12 @@ Date.parse(x.toLocaleString())
           1. Let _R_ be ? ToString(_separator_).
           1. If _lim_ = 0, return _A_.
           1. If _separator_ is *undefined*, then
-            1. Perform CreateDataProperty(_A_, `"0"`, _S_).
-            1. Assert: The above call will never result in an abrupt completion.
+            1. Perform ! CreateDataProperty(_A_, `"0"`, _S_).
             1. Return _A_.
           1. If _s_ = 0, then
             1. Let _z_ be SplitMatch(_S_, 0, _R_).
             1. If _z_ is not *false*, return _A_.
-            1. Perform CreateDataProperty(_A_, `"0"`, _S_).
-            1. Assert: The above call will never result in an abrupt completion.
+            1. Perform ! CreateDataProperty(_A_, `"0"`, _S_).
             1. Return _A_.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &ne; _s_
@@ -26924,15 +26917,13 @@ Date.parse(x.toLocaleString())
               1. If _e_ = _p_, let _q_ be _q_+1.
               1. Else _e_ &ne; _p_,
                 1. Let _T_ be a String value equal to the substring of _S_ consisting of the code units at indices _p_ (inclusive) through _q_ (exclusive).
-                1. Perform CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
-                1. Assert: The above call will never result in an abrupt completion.
+                1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
                 1. Increment _lengthA_ by 1.
                 1. If _lengthA_ = _lim_, return _A_.
                 1. Let _p_ be _e_.
                 1. Let _q_ be _p_.
           1. Let _T_ be a String value equal to the substring of _S_ consisting of the code units at indices _p_ (inclusive) through _s_ (exclusive).
-          1. Perform CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
-          1. Assert: The above call will never result in an abrupt completion.
+          1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -28885,11 +28876,10 @@ Date.parse(x.toLocaleString())
             1. Let _A_ be ArrayCreate(_n_ + 1).
             1. Assert: The value of _A_'s `"length"` property is _n_ + 1.
             1. Let _matchIndex_ be _lastIndex_.
-            1. Assert: The following CreateDataProperty calls will not result in an abrupt completion.
-            1. Perform CreateDataProperty(_A_, `"index"`, _matchIndex_).
-            1. Perform CreateDataProperty(_A_, `"input"`, _S_).
+            1. Perform ! CreateDataProperty(_A_, `"index"`, _matchIndex_).
+            1. Perform ! CreateDataProperty(_A_, `"input"`, _S_).
             1. Let _matchedSubstr_ be the matched substring (i.e. the portion of _S_ between offset _lastIndex_ inclusive and offset _e_ exclusive).
-            1. Perform CreateDataProperty(_A_, `"0"`, _matchedSubstr_).
+            1. Perform ! CreateDataProperty(_A_, `"0"`, _matchedSubstr_).
             1. For each integer _i_ such that _i_ &gt; 0 and _i_ &le; _n_
               1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
@@ -28899,7 +28889,7 @@ Date.parse(x.toLocaleString())
               1. Else, _fullUnicode_ is *false*,
                 1. Assert: _captureI_ is a List of code units.
                 1. Let _capturedValue_ be a string consisting of the code units of _captureI_.
-              1. Perform CreateDataProperty(_A_, ! ToString(_i_), _capturedValue_).
+              1. Perform ! CreateDataProperty(_A_, ! ToString(_i_), _capturedValue_).
             1. Return _A_.
           </emu-alg>
         </emu-clause>
@@ -29160,8 +29150,7 @@ Date.parse(x.toLocaleString())
           1. If _size_ = 0, then
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is not *null*, return _A_.
-            1. Assert: The following call will never result in an abrupt completion.
-            1. Perform CreateDataProperty(_A_, `"0"`, _S_).
+            1. Perform ! CreateDataProperty(_A_, `"0"`, _S_).
             1. Return _A_.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &lt; _size_
@@ -29174,8 +29163,7 @@ Date.parse(x.toLocaleString())
               1. If _e_ = _p_, let _q_ be AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
               1. Else _e_ &ne; _p_,
                 1. Let _T_ be a String value equal to the substring of _S_ consisting of the elements at indices _p_ (inclusive) through _q_ (exclusive).
-                1. Assert: The following call will never result in an abrupt completion.
-                1. Perform CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
+                1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
                 1. Let _lengthA_ be _lengthA_ + 1.
                 1. If _lengthA_ = _lim_, return _A_.
                 1. Let _p_ be _e_.
@@ -29184,14 +29172,13 @@ Date.parse(x.toLocaleString())
                 1. Let _i_ be 1.
                 1. Repeat, while _i_ &le; _numberOfCaptures_,
                   1. Let _nextCapture_ be ? Get(_z_, ! ToString(_i_)).
-                  1. Perform CreateDataProperty(_A_, ! ToString(_lengthA_), _nextCapture_).
+                  1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _nextCapture_).
                   1. Let _i_ be _i_ + 1.
                   1. Let _lengthA_ be _lengthA_ + 1.
                   1. If _lengthA_ = _lim_, return _A_.
                 1. Let _q_ be _p_.
           1. Let _T_ be a String value equal to the substring of _S_ consisting of the elements at indices _p_ (inclusive) through _size_ (exclusive).
-          1. Assert: The following call will never result in an abrupt completion.
-          1. Perform CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
+          1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
           1. Return _A_.
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.split]"`.</p>


### PR DESCRIPTION
Found by `/^\s*\d+\.\s*Assert:.*?abrupt.*?$/`