### PR TITLE
Delete extraneous emu-xrefs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1168,7 +1168,7 @@
         <p>Internal slots correspond to internal state that is associated with objects and used by various ECMAScript specification algorithms. Internal slots are not object properties and they are not inherited. Depending upon the specific internal slot specification, such state may consist of values of any ECMAScript language type or of specific ECMAScript specification type values. Unless explicitly specified otherwise, internal slots are allocated as part of the process of creating an object and may not be dynamically added to an object. Unless specified otherwise, the initial value of an internal slot is the value *undefined*. Various algorithms within this specification create objects that have internal slots. However, the ECMAScript language provides no direct way to associate internal slots with an object.</p>
         <p>Internal methods and internal slots are identified within this specification using names enclosed in double square brackets [[ ]].</p>
         <p><emu-xref href="#table-5"></emu-xref> summarizes the <em>essential internal methods</em> used by this specification that are applicable to all objects created or manipulated by ECMAScript code. Every object must have algorithms for all of the essential internal methods. However, all objects do not necessarily use the same algorithms for those methods.</p>
-        <p>The &ldquo;Signature&rdquo; column of <emu-xref href="#table-5"></emu-xref> and other similar tables describes the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names. If a parameter name is the same as an ECMAScript type name then the name describes the required type of the parameter value. If an internal method explicitly returns a value, its parameter list is followed by the symbol &ldquo;&rarr;&rdquo; and the type name of the returned value. The type names used in signatures refer to the types defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> augmented by the following additional names. &ldquo;<em>any</em>&rdquo; means the value may be any ECMAScript language type. An internal method implicitly returns a Completion Record as described in <emu-xref href="#sec-completion-record-specification-type"></emu-xref>. In addition to its parameters, an internal method always has access to the object that is the target of the method invocation.</p>
+        <p>The &ldquo;Signature&rdquo; column of <emu-xref href="#table-5"></emu-xref> and other similar tables describes the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names. If a parameter name is the same as an ECMAScript type name then the name describes the required type of the parameter value. If an internal method explicitly returns a value, its parameter list is followed by the symbol &ldquo;&rarr;&rdquo; and the type name of the returned value. The type names used in signatures refer to the types defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> augmented by the following additional names. &ldquo;<em>any</em>&rdquo; means the value may be any ECMAScript language type. An internal method implicitly returns a Completion Record. In addition to its parameters, an internal method always has access to the object that is the target of the method invocation.</p>
         <emu-table id="table-5" caption="Essential Internal Methods">
           <table>
             <tbody>
@@ -2698,7 +2698,7 @@
       <emu-note>
         <p>The Reference type is used to explain the behaviour of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a reference.</p>
       </emu-note>
-      <p>A <dfn>Reference</dfn> is a resolved name or property binding. A Reference consists of three components, the <em>base</em> value, the <em>referenced name</em> and the Boolean valued <em>strict reference</em> flag. The <em>base</em> value is either *undefined*, an Object, a Boolean, a String, a Symbol, a Number, or an Environment Record (<emu-xref href="#sec-environment-records"></emu-xref>). A _base_ value of *undefined* indicates that the Reference could not be resolved to a binding. The <em>referenced name</em> is a String or Symbol value.</p>
+      <p>A <dfn>Reference</dfn> is a resolved name or property binding. A Reference consists of three components, the <em>base</em> value, the <em>referenced name</em> and the Boolean valued <em>strict reference</em> flag. The <em>base</em> value is either *undefined*, an Object, a Boolean, a String, a Symbol, a Number, or an Environment Record. A _base_ value of *undefined* indicates that the Reference could not be resolved to a binding. The <em>referenced name</em> is a String or Symbol value.</p>
       <p>A Super Reference is a Reference that is used to represents a name binding that was expressed using the super keyword. A Super Reference has an additional _thisValue_ component and its _base_ value will never be an Environment Record.</p>
       <p>The following abstract operations are used in this specification to access the components of references:</p>
       <ul>
@@ -5103,7 +5103,7 @@
       <!-- es6num="8.1.1.4" -->
       <emu-clause id="sec-global-environment-records">
         <h1>Global Environment Records</h1>
-        <p>A global Environment Record is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm (<emu-xref href="#sec-code-realms"></emu-xref>). A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-block-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-block-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
+        <p>A global Environment Record is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm. A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-block-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-block-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
         <p>A global Environment Record is logically a single record but it is specified as a composite encapsulating an object Environment Record and a declarative Environment Record. The object Environment Record has as its base object the global object of the associated Realm Record. This global object is the value returned by the global Environment Record's GetThisBinding concrete method. The object Environment Record component of a global Environment Record contains the bindings for all built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>) and all bindings introduced by a |FunctionDeclaration|, |GeneratorDeclaration|, or |VariableStatement| contained in global code. The bindings for all other ECMAScript declarations in global code are contained in the declarative Environment Record component of the global Environment Record.</p>
         <p>Properties may be created directly on a global object. Hence, the object Environment Record component of a global Environment Record may contain both bindings created explicitly by |FunctionDeclaration|, |GeneratorDeclaration|, or |VariableDeclaration| declarations and bindings created implicitly as properties of the global object. In order to identify which bindings were explicitly created using declarations, a global Environment Record maintains a list of the names bound using its CreateGlobalVarBindings and CreateGlobalFunctionBindings concrete methods.</p>
         <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-18"></emu-xref> and the additional methods listed in <emu-xref href="#table-19"></emu-xref>.</p>
@@ -5523,7 +5523,7 @@
                 CreateImportBinding(N, M, N2)
               </td>
               <td>
-                Create an immutable indirect binding in a module Environment Record. The String value _N_ is the text of the bound name. _M_ is a Module Record (see <emu-xref href="#sec-abstract-module-records"></emu-xref>), and _N2_ is a binding that exists in M's module Environment Record.
+                Create an immutable indirect binding in a module Environment Record. The String value _N_ is the text of the bound name. _M_ is a Module Record, and _N2_ is a binding that exists in M's module Environment Record.
               </td>
             </tr>
             <tr>
@@ -5594,7 +5594,7 @@
         <!-- es6num="8.1.1.5.5" -->
         <emu-clause id="sec-createimportbinding">
           <h1>CreateImportBinding (_N_, _M_, _N2_)</h1>
-          <p>The concrete Environment Record method CreateImportBinding for module Environment Records creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _M_ is a Module Record (see <emu-xref href="#sec-abstract-module-records"></emu-xref>), and _N2_ is the name of a binding that exists in M's module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding.</p>
+          <p>The concrete Environment Record method CreateImportBinding for module Environment Records creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _M_ is a Module Record, and _N2_ is the name of a binding that exists in M's module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding.</p>
           <emu-alg>
             1. Let _envRec_ be the module Environment Record for which the method was invoked.
             1. Assert: _envRec_ does not already have a binding for _N_.
@@ -8097,7 +8097,7 @@
         <h1>ModuleNamespaceCreate (_module_, _exports_)</h1>
         <p>The abstract operation ModuleNamespaceCreate with arguments _module_, and _exports_ is used to specify the creation of new module namespace exotic objects. It performs the following steps:</p>
         <emu-alg>
-          1. Assert: _module_ is a Module Record (see <emu-xref href="#sec-abstract-module-records"></emu-xref>).
+          1. Assert: _module_ is a Module Record.
           1. Assert: _module_.[[Namespace]] is *undefined*.
           1. Assert: _exports_ is a List of String values.
           1. Let _M_ be a newly created object.
@@ -8834,7 +8834,7 @@
       <p>An ECMAScript |Script| syntactic unit may be processed using either unrestricted or strict mode syntax and semantics. Code is interpreted as <dfn>strict mode code</dfn> in the following situations:</p>
       <ul>
         <li>
-          Global code is strict mode code if it begins with a Directive Prologue that contains a Use Strict Directive (see <emu-xref href="#sec-directive-prologues-and-the-use-strict-directive"></emu-xref>).
+          Global code is strict mode code if it begins with a Directive Prologue that contains a Use Strict Directive.
         </li>
         <li>
           Module code is always strict mode code.
@@ -9363,7 +9363,7 @@ a = b / hi / g.exec(c).map(d);
         </emu-grammar>
         <p>`await` is only treated as a |FutureReservedWord| when |Module| is the goal symbol of the syntactic grammar.</p>
         <emu-note>
-          <p>Use of the following tokens within strict mode code (see <emu-xref href="#sec-strict-mode-code"></emu-xref>) is also reserved. That usage is restricted using static semantic restrictions (see <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>) rather than the lexical grammar:</p>
+          <p>Use of the following tokens within strict mode code is also reserved. That usage is restricted using static semantic restrictions (see <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>) rather than the lexical grammar:</p>
           <figure>
             <table class="lightweight-table">
               <tbody>
@@ -9521,7 +9521,7 @@ a = b / hi / g.exec(c).map(d);
       <emu-note>
         <p>For example: `3in` is an error and not the two input elements `3` and `in`.</p>
       </emu-note>
-      <p>A conforming implementation, when processing strict mode code (see <emu-xref href="#sec-strict-mode-code"></emu-xref>), must not extend, as described in <emu-xref href="#sec-additional-syntax-numeric-literals"></emu-xref>, the syntax of |NumericLiteral| to include <emu-xref href="#prod-annexB-LegacyOctalIntegerLiteral"></emu-xref>, nor extend the syntax of |DecimalIntegerLiteral| to include <emu-xref href="#prod-annexB-NonOctalDecimalIntegerLiteral"></emu-xref>.</p>
+      <p>A conforming implementation, when processing strict mode code, must not extend, as described in <emu-xref href="#sec-additional-syntax-numeric-literals"></emu-xref>, the syntax of |NumericLiteral| to include <emu-xref href="#prod-annexB-LegacyOctalIntegerLiteral"></emu-xref>, nor extend the syntax of |DecimalIntegerLiteral| to include <emu-xref href="#prod-annexB-NonOctalDecimalIntegerLiteral"></emu-xref>.</p>
 
       <!-- es6num="11.8.3.1" -->
       <emu-clause id="sec-static-semantics-mv">
@@ -9725,7 +9725,7 @@ a = b / hi / g.exec(c).map(d);
           HexEscapeSequence
           UnicodeEscapeSequence
       </emu-grammar>
-      <p>A conforming implementation, when processing strict mode code (see <emu-xref href="#sec-strict-mode-code"></emu-xref>), must not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.</p>
+      <p>A conforming implementation, when processing strict mode code, must not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.</p>
       <emu-grammar>
         CharacterEscapeSequence ::
           SingleEscapeCharacter
@@ -11985,7 +11985,7 @@ a = b + c
     <emu-clause id="sec-argument-lists">
       <h1>Argument Lists</h1>
       <emu-note>
-        <p>The evaluation of an argument list produces a List of values (see <emu-xref href="#sec-list-and-record-specification-type"></emu-xref>).</p>
+        <p>The evaluation of an argument list produces a List of values.</p>
       </emu-note>
 
       <!-- es6num="12.3.6.1" -->
@@ -18159,7 +18159,7 @@ eval("1;var a;")
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
-        1. If the function code for this |ArrowFunction| is strict mode code (<emu-xref href="#sec-strict-mode-code"></emu-xref>), let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. If the function code for this |ArrowFunction| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _parameters_ be CoveredFormalsList of |ArrowParameters|.
         1. Let _closure_ be FunctionCreate(~Arrow~, _parameters_, |ConciseBody|, _scope_, _strict_).
@@ -23018,7 +23018,7 @@ new Function("a,b", "c", "return a+b+c")
             1. Let _bodyText_ be ? ToString(_bodyText_).
             1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
             1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
-            1. If _bodyText_ is strict mode code (see <emu-xref href="#sec-strict-mode-code"></emu-xref>), then let _strict_ be *true*, else let _strict_ be *false*.
+            1. If _bodyText_ is strict mode code, then let _strict_ be *true*, else let _strict_ be *false*.
             1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar>StrictFormalParameters : FormalParameters</emu-grammar> are applied. Parsing and early error detection may be interweaved in an implementation dependent manner.
             1. If ContainsUseStrict of _body_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
             1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.

--- a/spec.html
+++ b/spec.html
@@ -23052,7 +23052,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.2.2" -->
     <emu-clause id="sec-properties-of-the-function-constructor">
       <h1>Properties of the Function Constructor</h1>
-      <p>The `Function` constructor is itself a built-in function object. The value of the [[Prototype]] internal slot of the `Function` constructor is <dfn>%FunctionPrototype%</dfn>, the intrinsic Function prototype object.</p>
+      <p>The Function constructor is itself a built-in function object. The value of the [[Prototype]] internal slot of the Function constructor is the intrinsic object <dfn>%FunctionPrototype%</dfn>.</p>
       <p>The value of the [[Extensible]] internal slot of the Function constructor is *true*.</p>
       <p>The Function constructor has the following properties:</p>
 

--- a/spec.html
+++ b/spec.html
@@ -9295,13 +9295,13 @@ a = b / hi / g.exec(c).map(d);
         <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of a code point matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
       </emu-clause>
@@ -9316,7 +9316,7 @@ a = b / hi / g.exec(c).map(d);
             IdentifierName IdentifierPart
         </emu-grammar>
         <emu-alg>
-          1. Return the String value consisting of the sequence of code units corresponding to |IdentifierName|. In determining the sequence any occurrences of `\\` |UnicodeEscapeSequence| are first replaced with the code point represented by the |UnicodeEscapeSequence| and then the code points of the entire |IdentifierName| are converted to code units by UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) each code point.
+          1. Return the String value consisting of the sequence of code units corresponding to |IdentifierName|. In determining the sequence any occurrences of `\\` |UnicodeEscapeSequence| are first replaced with the code point represented by the |UnicodeEscapeSequence| and then the code points of the entire |IdentifierName| are converted to code units by UTF16Encoding each code point.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -9813,7 +9813,7 @@ a = b / hi / g.exec(c).map(d);
             The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter| followed by all the code units in the SV of |SingleStringCharacters| in order.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>DoubleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
@@ -9822,7 +9822,7 @@ a = b / hi / g.exec(c).map(d);
             The SV of <emu-grammar>DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>SingleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
@@ -9997,7 +9997,7 @@ a = b / hi / g.exec(c).map(d);
             The SV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit value that is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
@@ -10009,7 +10009,7 @@ a = b / hi / g.exec(c).map(d);
             The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit value that is (4096 times the MV of the first |HexDigit|) plus (256 times the MV of the second |HexDigit|) plus (16 times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the MV of |HexDigits|.
+            The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the UTF16Encoding of the MV of |HexDigits|.
           </li>
         </ul>
       </emu-clause>
@@ -10176,7 +10176,7 @@ a = b / hi / g.exec(c).map(d);
             The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TV of |TemplateCharacter| followed by all the code units in the TV of |TemplateCharacters| in order.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the code point value of |SourceCharacter|.
+            The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
             The TV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
@@ -10212,7 +10212,7 @@ a = b / hi / g.exec(c).map(d);
             The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TRV of |TemplateCharacter| followed by all the code units in the TRV of |TemplateCharacters|, in order.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the code point value of |SourceCharacter|.
+            The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
             The TRV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
@@ -26350,7 +26350,7 @@ Date.parse(x.toLocaleString())
             1. Let _nextCP_ be ? ToNumber(_next_).
             1. If SameValue(_nextCP_, ToInteger(_nextCP_)) is *false*, throw a *RangeError* exception.
             1. If _nextCP_ &lt; 0 or _nextCP_ &gt; 0x10FFFF, throw a *RangeError* exception.
-            1. Append the elements of the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of _nextCP_ to the end of _elements_.
+            1. Append the elements of the UTF16Encoding of _nextCP_ to the end of _elements_.
             1. Let _nextIndex_ be _nextIndex_ + 1.
           1. Return the String value whose elements are, in order, the elements in the List _elements_. If _length_ is 0, the empty string is returned.
         </emu-alg>
@@ -27046,7 +27046,7 @@ Date.parse(x.toLocaleString())
           1. Let _cpList_ be a List containing in order the code points as defined in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref> of _S_, starting at the first element of _S_.
           1. For each code point _c_ in _cpList_, if the Unicode Character Database provides a language insensitive lower case equivalent of _c_, then replace _c_ in _cpList_ with that equivalent code point(s).
           1. Let _cuList_ be a new List.
-          1. For each code point _c_ in _cpList_, in order, append to _cuList_ the elements of the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of _c_.
+          1. For each code point _c_ in _cpList_, in order, append to _cuList_ the elements of the UTF16Encoding of _c_.
           1. Let _L_ be a String whose elements are, in order, the elements of _cuList_.
           1. Return _L_.
         </emu-alg>
@@ -27395,7 +27395,7 @@ Date.parse(x.toLocaleString())
       <p>The syntax and semantics of |Pattern| is defined as if the source code for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>
       <emu-note>
         <p>For example, consider a pattern expressed in source text as the single non-BMP character U+1D11E (MUSICAL SYMBOL G CLEF). Interpreted as a Unicode pattern, it would be a single element (character) List consisting of the single code point 0x1D11E. However, interpreted as a BMP pattern, it is first UTF-16 encoded to produce a two element List consisting of the code units 0xD834 and 0xDD1E.</p>
-        <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the string would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16Decode (see <emu-xref href="#sec-utf16decode"></emu-xref>) must be used in producing a List consisting of a single pattern character, the code point U+1D11E.</p>
+        <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the string would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16Decode must be used in producing a List consisting of a single pattern character, the code point U+1D11E.</p>
         <p>An implementation may not actually perform such translations to or from UTF-16, but the semantics of this specification requires that the result of pattern matching be as if such translations were performed.</p>
       </emu-note>
 
@@ -28895,7 +28895,7 @@ Date.parse(x.toLocaleString())
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
               1. Else if _fullUnicode_ is *true*, then
                 1. Assert: _captureI_ is a List of code points.
-                1. Let _capturedValue_ be a string whose code units are the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the code points of _captureI_.
+                1. Let _capturedValue_ be a string whose code units are the UTF16Encoding of the code points of _captureI_.
               1. Else, _fullUnicode_ is *false*,
                 1. Assert: _captureI_ is a List of code units.
                 1. Let _capturedValue_ be a string consisting of the code units of _captureI_.
@@ -33491,7 +33491,7 @@ Date.parse(x.toLocaleString())
       </emu-grammar>
       <ul>
         <li>
-          The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or U+0000 through U+001F</emu-grammar> is the UTF16Encoding (<emu-xref href="#sec-utf16encoding"></emu-xref>) of the code point value of |SourceCharacter|.
+          The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or U+0000 through U+001F</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
         </li>
       </ul>
       <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -7134,7 +7134,7 @@
     <h1>Built-in Function Objects</h1>
     <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided exotic function objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
     <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such exotic function objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
-    <p>Unless otherwise specified every built-in function object has the %FunctionPrototype% object (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>) as the initial value of its [[Prototype]] internal slot.</p>
+    <p>Unless otherwise specified every built-in function object has the %FunctionPrototype% object as the initial value of its [[Prototype]] internal slot.</p>
     <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict mode functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value `"classConstructor"`.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
     <p>Built-in functions that are not constructors do not have a `prototype` property unless otherwise specified in the description of a particular function.</p>
@@ -22801,7 +22801,7 @@ eval("1;var a;")
       <!-- es6num="19.1.2.16" -->
       <emu-clause id="sec-object.prototype">
         <h1>Object.prototype</h1>
-        <p>The initial value of `Object.prototype` is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Object.prototype` is the intrinsic object %ObjectPrototype%.</p>
         <p>This property has the attributes {[[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -23052,7 +23052,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.2.2" -->
     <emu-clause id="sec-properties-of-the-function-constructor">
       <h1>Properties of the Function Constructor</h1>
-      <p>The `Function` constructor is itself a built-in function object. The value of the [[Prototype]] internal slot of the `Function` constructor is <dfn>%FunctionPrototype%</dfn>, the intrinsic Function prototype object (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The `Function` constructor is itself a built-in function object. The value of the [[Prototype]] internal slot of the `Function` constructor is <dfn>%FunctionPrototype%</dfn>, the intrinsic Function prototype object.</p>
       <p>The value of the [[Extensible]] internal slot of the Function constructor is *true*.</p>
       <p>The Function constructor has the following properties:</p>
 
@@ -23065,7 +23065,7 @@ new Function("a,b", "c", "return a+b+c")
       <!-- es6num="19.2.2.2" -->
       <emu-clause id="sec-function.prototype">
         <h1>Function.prototype</h1>
-        <p>The value of `Function.prototype` is %FunctionPrototype%, the intrinsic Function prototype object (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+        <p>The value of `Function.prototype` is %FunctionPrototype%, the intrinsic Function prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -23077,7 +23077,7 @@ new Function("a,b", "c", "return a+b+c")
       <emu-note>
         <p>The Function prototype object is specified to be a function object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
       </emu-note>
-      <p>The value of the [[Prototype]] internal slot of the Function prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The initial value of the [[Extensible]] internal slot of the Function prototype object is *true*.</p>
+      <p>The value of the [[Prototype]] internal slot of the Function prototype object is the intrinsic object %ObjectPrototype%. The initial value of the [[Extensible]] internal slot of the Function prototype object is *true*.</p>
       <p>The Function prototype object does not have a `prototype` property.</p>
       <p>The value of the `length` property of the Function prototype object is 0.</p>
       <p>The value of the `name` property of the Function prototype object is the empty String.</p>
@@ -23270,13 +23270,13 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.3.2" -->
     <emu-clause id="sec-properties-of-the-boolean-constructor">
       <h1>Properties of the Boolean Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Boolean constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Boolean constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Boolean constructor has the following properties:</p>
 
       <!-- es6num="19.3.2.1" -->
       <emu-clause id="sec-boolean.prototype">
         <h1>Boolean.prototype</h1>
-        <p>The initial value of `Boolean.prototype` is the intrinsic object %BooleanPrototype% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Boolean.prototype` is the intrinsic object %BooleanPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -23285,7 +23285,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-properties-of-the-boolean-prototype-object">
       <h1>Properties of the Boolean Prototype Object</h1>
       <p>The Boolean prototype object is the intrinsic object <dfn>%BooleanPrototype%</dfn>. The Boolean prototype object is an ordinary object. The Boolean prototype is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</p>
-      <p>The value of the [[Prototype]] internal slot of the Boolean prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Boolean prototype object is the intrinsic object %ObjectPrototype%.</p>
       <p>The abstract operation thisBooleanValue(_value_) performs the following steps:</p>
       <emu-alg>
         1. If Type(_value_) is Boolean, return _value_.
@@ -23354,7 +23354,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.4.2" -->
     <emu-clause id="sec-properties-of-the-symbol-constructor">
       <h1>Properties of the Symbol Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Symbol constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Symbol constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Symbol constructor has the following properties:</p>
 
       <!-- es6num="19.4.2.1" -->
@@ -23456,7 +23456,7 @@ new Function("a,b", "c", "return a+b+c")
       <!-- es6num="19.4.2.7" -->
       <emu-clause id="sec-symbol.prototype">
         <h1>Symbol.prototype</h1>
-        <p>The initial value of `Symbol.prototype` is the intrinsic object %SymbolPrototype% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Symbol.prototype` is the intrinsic object %SymbolPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -23514,7 +23514,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-properties-of-the-symbol-prototype-object">
       <h1>Properties of the Symbol Prototype Object</h1>
       <p>The Symbol prototype object is the intrinsic object <dfn>%SymbolPrototype%</dfn>. The Symbol prototype object is an ordinary object. It is not a Symbol instance and does not have a [[SymbolData]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the Symbol prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Symbol prototype object is the intrinsic object %ObjectPrototype%.</p>
 
       <!-- es6num="19.4.3.1" -->
       <emu-clause id="sec-symbol.prototype.constructor">
@@ -23624,13 +23624,13 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.5.2" -->
     <emu-clause id="sec-properties-of-the-error-constructor">
       <h1>Properties of the Error Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Error constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Error constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Error constructor has the following properties:</p>
 
       <!-- es6num="19.5.2.1" -->
       <emu-clause id="sec-error.prototype">
         <h1>Error.prototype</h1>
-        <p>The initial value of `Error.prototype` is the intrinsic object %ErrorPrototype% (<emu-xref href="#sec-properties-of-the-error-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Error.prototype` is the intrinsic object %ErrorPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -23639,7 +23639,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-properties-of-the-error-prototype-object">
       <h1>Properties of the Error Prototype Object</h1>
       <p>The Error prototype object is the intrinsic object <dfn>%ErrorPrototype%</dfn>. The Error prototype object is an ordinary object. It is not an Error instance and does not have an [[ErrorData]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the Error prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Error prototype object is the intrinsic object %ObjectPrototype%.</p>
 
       <!-- es6num="19.5.3.1" -->
       <emu-clause id="sec-error.prototype.constructor">
@@ -23757,7 +23757,7 @@ new Function("a,b", "c", "return a+b+c")
       <!-- es6num="19.5.6.2" -->
       <emu-clause id="sec-properties-of-the-nativeerror-constructors">
         <h1>Properties of the _NativeError_ Constructors</h1>
-        <p>The value of the [[Prototype]] internal slot of a _NativeError_ constructor is the intrinsic object %Error% (<emu-xref href="#sec-error-constructor"></emu-xref>).</p>
+        <p>The value of the [[Prototype]] internal slot of a _NativeError_ constructor is the intrinsic object %Error%.</p>
         <p>Each _NativeError_ constructor has a `name` property whose value is the String value `"<var>NativeError</var>"`.</p>
         <p>Each _NativeError_ constructor has the following properties:</p>
 
@@ -23773,7 +23773,7 @@ new Function("a,b", "c", "return a+b+c")
       <emu-clause id="sec-properties-of-the-nativeerror-prototype-objects">
         <h1>Properties of the _NativeError_ Prototype Objects</h1>
         <p>Each _NativeError_ prototype object is an ordinary object. It is not an Error instance and does not have an [[ErrorData]] internal slot.</p>
-        <p>The value of the [[Prototype]] internal slot of each _NativeError_ prototype object is the intrinsic object %ErrorPrototype% (<emu-xref href="#sec-properties-of-the-error-prototype-object"></emu-xref>).</p>
+        <p>The value of the [[Prototype]] internal slot of each _NativeError_ prototype object is the intrinsic object %ErrorPrototype%.</p>
 
         <!-- es6num="19.5.6.3.1" -->
         <emu-clause id="sec-nativeerror.prototype.constructor">
@@ -23835,7 +23835,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="20.1.2" -->
     <emu-clause id="sec-properties-of-the-number-constructor">
       <h1>Properties of the Number Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Number constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Number constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Number constructor has the following properties:</p>
 
       <!-- es6num="20.1.2.1" -->
@@ -23968,7 +23968,7 @@ new Function("a,b", "c", "return a+b+c")
       <!-- es6num="20.1.2.15" -->
       <emu-clause id="sec-number.prototype">
         <h1>Number.prototype</h1>
-        <p>The initial value of `Number.prototype` is the intrinsic object %NumberPrototype% (<emu-xref href="#sec-properties-of-the-number-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Number.prototype` is the intrinsic object %NumberPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -23977,7 +23977,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-properties-of-the-number-prototype-object">
       <h1>Properties of the Number Prototype Object</h1>
       <p>The Number prototype object is the intrinsic object <dfn>%NumberPrototype%</dfn>. The Number prototype object is an ordinary object. The Number prototype is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</p>
-      <p>The value of the [[Prototype]] internal slot of the Number prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Number prototype object is the intrinsic object %ObjectPrototype%.</p>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
       <p>The abstract operation thisNumberValue(_value_) performs the following steps:</p>
       <emu-alg>
@@ -24175,7 +24175,7 @@ new Function("a,b", "c", "return a+b+c")
   <emu-clause id="sec-math-object">
     <h1>The Math Object</h1>
     <p>The Math object is the <dfn>%Math%</dfn> intrinsic object and the initial value of the `Math` property of the global object. The Math object is a single ordinary object.</p>
-    <p>The value of the [[Prototype]] internal slot of the Math object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+    <p>The value of the [[Prototype]] internal slot of the Math object is the intrinsic object %ObjectPrototype%.</p>
     <p>The Math object is not a function object. It does not have a [[Construct]] internal method; it is not possible to use the Math object as a constructor with the `new` operator. The Math object also does not have a [[Call]] internal method; it is not possible to invoke the Math object as a function.</p>
     <emu-note>
       <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; has a technical meaning defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>.</p>
@@ -25596,7 +25596,7 @@ THH:mm:ss.sss
     <!-- es6num="20.3.3" -->
     <emu-clause id="sec-properties-of-the-date-constructor">
       <h1>Properties of the Date Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Date constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Date constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Date constructor has the following properties:</p>
 
       <!-- es6num="20.3.3.1" -->
@@ -25626,7 +25626,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="20.3.3.3" -->
       <emu-clause id="sec-date.prototype">
         <h1>Date.prototype</h1>
-        <p>The initial value of `Date.prototype` is the intrinsic object %DatePrototype% (<emu-xref href="#sec-properties-of-the-date-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Date.prototype` is the intrinsic object %DatePrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -25656,7 +25656,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-date-prototype-object" aoid="thisTimeValue">
       <h1>Properties of the Date Prototype Object</h1>
       <p>The Date prototype object is the intrinsic object <dfn>%DatePrototype%</dfn>. The Date prototype object is itself an ordinary object. It is not a Date instance and does not have a [[DateValue]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the Date prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-date-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Date prototype object is the intrinsic object %ObjectPrototype%.</p>
       <p>Unless explicitly defined otherwise, the methods of the Date prototype object defined below are not generic and the *this* value passed to them must be an object that has a [[DateValue]] internal slot that has been initialized to a time value.</p>
       <p>The abstract operation thisTimeValue(_value_) performs the following steps:</p>
       <emu-alg>
@@ -26314,7 +26314,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="21.1.2" -->
     <emu-clause id="sec-properties-of-the-string-constructor">
       <h1>Properties of the String Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the String constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the String constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The String constructor has the following properties:</p>
 
       <!-- es6num="21.1.2.1" -->
@@ -26360,7 +26360,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="21.1.2.3" -->
       <emu-clause id="sec-string.prototype">
         <h1>String.prototype</h1>
-        <p>The initial value of `String.prototype` is the intrinsic object %StringPrototype% (<emu-xref href="#sec-properties-of-the-string-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `String.prototype` is the intrinsic object %StringPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26399,7 +26399,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-string-prototype-object">
       <h1>Properties of the String Prototype Object</h1>
       <p>The String prototype object is the intrinsic object <dfn>%StringPrototype%</dfn>. The String prototype object is an ordinary object. The String prototype is itself a String object; it has a [[StringData]] internal slot with the value *""*.</p>
-      <p>The value of the [[Prototype]] internal slot of the String prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the String prototype object is the intrinsic object %ObjectPrototype%.</p>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
       <p>The abstract operation thisStringValue(_value_) performs the following steps:</p>
       <emu-alg>
@@ -27154,7 +27154,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="21.1.5.2" -->
       <emu-clause id="sec-%stringiteratorprototype%-object">
         <h1>The %StringIteratorPrototype% Object</h1>
-        <p>All String Iterator Objects inherit properties from the <dfn>%StringIteratorPrototype%</dfn> intrinsic object. The %StringIteratorPrototype% object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object (<emu-xref href="#sec-%iteratorprototype%-object"></emu-xref>). In addition, %StringIteratorPrototype% has the following properties:</p>
+        <p>All String Iterator Objects inherit properties from the <dfn>%StringIteratorPrototype%</dfn> intrinsic object. The %StringIteratorPrototype% object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object. In addition, %StringIteratorPrototype% has the following properties:</p>
 
         <!-- es6num="21.1.5.2.1" -->
         <emu-clause id="sec-%stringiteratorprototype%.next">
@@ -28774,13 +28774,13 @@ Date.parse(x.toLocaleString())
     <!-- es6num="21.2.4" -->
     <emu-clause id="sec-properties-of-the-regexp-constructor">
       <h1>Properties of the RegExp Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the RegExp constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the RegExp constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The RegExp constructor has the following properties:</p>
 
       <!-- es6num="21.2.4.1" -->
       <emu-clause id="sec-regexp.prototype">
         <h1>RegExp.prototype</h1>
-        <p>The initial value of `RegExp.prototype` is the intrinsic object %RegExpPrototype% (<emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `RegExp.prototype` is the intrinsic object %RegExpPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -28802,7 +28802,7 @@ Date.parse(x.toLocaleString())
     <emu-clause id="sec-properties-of-the-regexp-prototype-object">
       <h1>Properties of the RegExp Prototype Object</h1>
       <p>The RegExp prototype object is the intrinsic object <dfn>%RegExpPrototype%</dfn>. The RegExp prototype object is an ordinary object. It is not a RegExp instance and does not have a [[RegExpMatcher]] internal slot or any of the other internal slots of RegExp instance objects.</p>
-      <p>The value of the [[Prototype]] internal slot of the RegExp prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the RegExp prototype object is the intrinsic object %ObjectPrototype%.</p>
       <emu-note>
         <p>The RegExp prototype object does not have a `valueOf` property of its own; however, it inherits the `valueOf` property from the Object prototype object.</p>
       </emu-note>
@@ -29355,7 +29355,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="22.1.2" -->
     <emu-clause id="sec-properties-of-the-array-constructor">
       <h1>Properties of the Array Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Array constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Array constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Array constructor has the following properties:</p>
 
       <!-- es6num="22.1.2.1" -->
@@ -29460,7 +29460,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="22.1.2.4" -->
       <emu-clause id="sec-array.prototype">
         <h1>Array.prototype</h1>
-        <p>The value of `Array.prototype` is %ArrayPrototype%, the intrinsic Array prototype object (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>).</p>
+        <p>The value of `Array.prototype` is %ArrayPrototype%, the intrinsic Array prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -30493,7 +30493,7 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _func_ be ? Get(_array_, `"join"`).
-          1. If IsCallable(_func_) is *false*, let _func_ be the intrinsic function %ObjProto_toString% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>).
+          1. If IsCallable(_func_) is *false*, let _func_ be the intrinsic function %ObjProto_toString%.
           1. Return ? Call(_func_, _array_).
         </emu-alg>
         <emu-note>
@@ -30620,7 +30620,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="22.1.5.2" -->
       <emu-clause id="sec-%arrayiteratorprototype%-object">
         <h1>The %ArrayIteratorPrototype% Object</h1>
-        <p>All Array Iterator Objects inherit properties from the %ArrayIteratorPrototype% intrinsic object. The <dfn>%ArrayIteratorPrototype%</dfn> object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object (<emu-xref href="#sec-%iteratorprototype%-object"></emu-xref>). In addition, %ArrayIteratorPrototype% has the following properties:</p>
+        <p>All Array Iterator Objects inherit properties from the %ArrayIteratorPrototype% intrinsic object. The <dfn>%ArrayIteratorPrototype%</dfn> object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object. In addition, %ArrayIteratorPrototype% has the following properties:</p>
 
         <!-- es6num="22.1.5.2.1" -->
         <emu-clause id="sec-%arrayiteratorprototype%.next">
@@ -30955,7 +30955,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="22.2.2" -->
     <emu-clause id="sec-properties-of-the-%typedarray%-intrinsic-object">
       <h1>Properties of the %TypedArray% Intrinsic Object</h1>
-      <p>The value of the [[Prototype]] internal slot of %TypedArray% is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of %TypedArray% is the intrinsic object %FunctionPrototype%.</p>
       <p>The `name` property of the %TypedArray% constructor function is `"TypedArray"`.</p>
       <p>The %TypedArray% constructor has the following properties:</p>
 
@@ -31033,7 +31033,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="22.2.2.3" -->
       <emu-clause id="sec-%typedarray%.prototype">
         <h1>%TypedArray%.prototype</h1>
-        <p>The initial value of %TypedArray%.prototype is the <dfn>%TypedArrayPrototype%</dfn> intrinsic object (<emu-xref href="#sec-properties-of-the-%typedarrayprototype%-object"></emu-xref>).</p>
+        <p>The initial value of %TypedArray%.prototype is the <dfn>%TypedArrayPrototype%</dfn> intrinsic object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -31054,7 +31054,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="22.2.3" -->
     <emu-clause id="sec-properties-of-the-%typedarrayprototype%-object">
       <h1>Properties of the %TypedArrayPrototype% Object</h1>
-      <p>The value of the [[Prototype]] internal slot of the %TypedArrayPrototype% object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The %TypedArrayPrototype% object is an ordinary object. It does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</p>
+      <p>The value of the [[Prototype]] internal slot of the %TypedArrayPrototype% object is the intrinsic object %ObjectPrototype%. The %TypedArrayPrototype% object is an ordinary object. It does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</p>
 
       <!-- es6num="22.2.3.1" -->
       <emu-clause id="sec-get-%typedarray%.prototype.buffer">
@@ -31770,7 +31770,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="22.2.5" -->
     <emu-clause id="sec-properties-of-the-typedarray-constructors">
       <h1>Properties of the _TypedArray_ Constructors</h1>
-      <p>The value of the [[Prototype]] internal slot of each _TypedArray_ constructor is the %TypedArray% intrinsic object (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of each _TypedArray_ constructor is the %TypedArray% intrinsic object.</p>
       <p>Each _TypedArray_ constructor has a `name` property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-49"></emu-xref>.</p>
       <p>Each _TypedArray_ constructor has the following properties:</p>
 
@@ -31792,7 +31792,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="22.2.6" -->
     <emu-clause id="sec-properties-of-typedarray-prototype-objects">
       <h1>Properties of _TypedArray_ Prototype Objects</h1>
-      <p>The value of the [[Prototype]] internal slot of a _TypedArray_ prototype object is the intrinsic object %TypedArrayPrototype% (<emu-xref href="#sec-properties-of-the-%typedarrayprototype%-object"></emu-xref>). A _TypedArray_ prototype object is an ordinary object. It does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</p>
+      <p>The value of the [[Prototype]] internal slot of a _TypedArray_ prototype object is the intrinsic object %TypedArrayPrototype%. A _TypedArray_ prototype object is an ordinary object. It does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</p>
 
       <!-- es6num="22.2.6.1" -->
       <emu-clause id="sec-typedarray.prototype.bytes_per_element">
@@ -31870,13 +31870,13 @@ Date.parse(x.toLocaleString())
     <!-- es6num="23.1.2" -->
     <emu-clause id="sec-properties-of-the-map-constructor">
       <h1>Properties of the Map Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Map constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Map constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Map constructor has the following properties:</p>
 
       <!-- es6num="23.1.2.1" -->
       <emu-clause id="sec-map.prototype">
         <h1>Map.prototype</h1>
-        <p>The initial value of `Map.prototype` is the intrinsic object %MapPrototype% (<emu-xref href="#sec-properties-of-the-map-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Map.prototype` is the intrinsic object %MapPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -31897,7 +31897,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="23.1.3" -->
     <emu-clause id="sec-properties-of-the-map-prototype-object">
       <h1>Properties of the Map Prototype Object</h1>
-      <p>The Map prototype object is the intrinsic object <dfn>%MapPrototype%</dfn>. The value of the [[Prototype]] internal slot of the Map prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The Map prototype object is an ordinary object. It does not have a [[MapData]] internal slot.</p>
+      <p>The Map prototype object is the intrinsic object <dfn>%MapPrototype%</dfn>. The value of the [[Prototype]] internal slot of the Map prototype object is the intrinsic object %ObjectPrototype%. The Map prototype object is an ordinary object. It does not have a [[MapData]] internal slot.</p>
 
       <!-- es6num="23.1.3.1" -->
       <emu-clause id="sec-map.prototype.clear">
@@ -32108,7 +32108,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="23.1.5.2" -->
       <emu-clause id="sec-%mapiteratorprototype%-object">
         <h1>The %MapIteratorPrototype% Object</h1>
-        <p>All Map Iterator Objects inherit properties from the <dfn>%MapIteratorPrototype%</dfn> intrinsic object. The %MapIteratorPrototype% intrinsic object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object (<emu-xref href="#sec-%iteratorprototype%-object"></emu-xref>). In addition, %MapIteratorPrototype% has the following properties:</p>
+        <p>All Map Iterator Objects inherit properties from the <dfn>%MapIteratorPrototype%</dfn> intrinsic object. The %MapIteratorPrototype% intrinsic object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object. In addition, %MapIteratorPrototype% has the following properties:</p>
 
         <!-- es6num="23.1.5.2.1" -->
         <emu-clause id="sec-%mapiteratorprototype%.next">
@@ -32233,13 +32233,13 @@ Date.parse(x.toLocaleString())
     <!-- es6num="23.2.2" -->
     <emu-clause id="sec-properties-of-the-set-constructor">
       <h1>Properties of the Set Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Set constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the Set constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Set constructor has the following properties:</p>
 
       <!-- es6num="23.2.2.1" -->
       <emu-clause id="sec-set.prototype">
         <h1>Set.prototype</h1>
-        <p>The initial value of `Set.prototype` is the intrinsic %SetPrototype% object (<emu-xref href="#sec-properties-of-the-set-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Set.prototype` is the intrinsic %SetPrototype% object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -32260,7 +32260,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="23.2.3" -->
     <emu-clause id="sec-properties-of-the-set-prototype-object">
       <h1>Properties of the Set Prototype Object</h1>
-      <p>The Set prototype object is the intrinsic object <dfn>%SetPrototype%</dfn>. The value of the [[Prototype]] internal slot of the Set prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The Set prototype object is an ordinary object. It does not have a [[SetData]] internal slot.</p>
+      <p>The Set prototype object is the intrinsic object <dfn>%SetPrototype%</dfn>. The value of the [[Prototype]] internal slot of the Set prototype object is the intrinsic object %ObjectPrototype%. The Set prototype object is an ordinary object. It does not have a [[SetData]] internal slot.</p>
 
       <!-- es6num="23.2.3.1" -->
       <emu-clause id="sec-set.prototype.add">
@@ -32456,7 +32456,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="23.2.5.2" -->
       <emu-clause id="sec-%setiteratorprototype%-object">
         <h1>The %SetIteratorPrototype% Object</h1>
-        <p>All Set Iterator Objects inherit properties from the <dfn>%SetIteratorPrototype%</dfn> intrinsic object. The %SetIteratorPrototype% intrinsic object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object (<emu-xref href="#sec-%iteratorprototype%-object"></emu-xref>). In addition, %SetIteratorPrototype% has the following properties:</p>
+        <p>All Set Iterator Objects inherit properties from the <dfn>%SetIteratorPrototype%</dfn> intrinsic object. The %SetIteratorPrototype% intrinsic object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object. In addition, %SetIteratorPrototype% has the following properties:</p>
 
         <!-- es6num="23.2.5.2.1" -->
         <emu-clause id="sec-%setiteratorprototype%.next">
@@ -32594,13 +32594,13 @@ Date.parse(x.toLocaleString())
     <!-- es6num="23.3.2" -->
     <emu-clause id="sec-properties-of-the-weakmap-constructor">
       <h1>Properties of the WeakMap Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the WeakMap constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the WeakMap constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The WeakMap constructor has the following properties:</p>
 
       <!-- es6num="23.3.2.1" -->
       <emu-clause id="sec-weakmap.prototype">
         <h1>WeakMap.prototype</h1>
-        <p>The initial value of `WeakMap.prototype` is the intrinsic object %WeakMapPrototype% (<emu-xref href="#sec-properties-of-the-weakmap-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `WeakMap.prototype` is the intrinsic object %WeakMapPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -32608,7 +32608,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="23.3.3" -->
     <emu-clause id="sec-properties-of-the-weakmap-prototype-object">
       <h1>Properties of the WeakMap Prototype Object</h1>
-      <p>The WeakMap prototype object is the intrinsic object <dfn>%WeakMapPrototype%</dfn>. The value of the [[Prototype]] internal slot of the WeakMap prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The WeakMap prototype object is an ordinary object. It does not have a [[WeakMapData]] internal slot.</p>
+      <p>The WeakMap prototype object is the intrinsic object <dfn>%WeakMapPrototype%</dfn>. The value of the [[Prototype]] internal slot of the WeakMap prototype object is the intrinsic object %ObjectPrototype%. The WeakMap prototype object is an ordinary object. It does not have a [[WeakMapData]] internal slot.</p>
 
       <!-- es6num="23.3.3.1" -->
       <emu-clause id="sec-weakmap.prototype.constructor">
@@ -32749,13 +32749,13 @@ Date.parse(x.toLocaleString())
     <!-- es6num="23.4.2" -->
     <emu-clause id="sec-properties-of-the-weakset-constructor">
       <h1>Properties of the WeakSet Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the WeakSet constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the WeakSet constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The WeakSet constructor has the following properties:</p>
 
       <!-- es6num="23.4.2.1" -->
       <emu-clause id="sec-weakset.prototype">
         <h1>WeakSet.prototype</h1>
-        <p>The initial value of `WeakSet.prototype` is the intrinsic %WeakSetPrototype% object (<emu-xref href="#sec-properties-of-the-weakset-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `WeakSet.prototype` is the intrinsic %WeakSetPrototype% object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -32763,7 +32763,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="23.4.3" -->
     <emu-clause id="sec-properties-of-the-weakset-prototype-object">
       <h1>Properties of the WeakSet Prototype Object</h1>
-      <p>The WeakSet prototype object is the intrinsic object <dfn>%WeakSetPrototype%</dfn>. The value of the [[Prototype]] internal slot of the WeakSet prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The WeakSet prototype object is an ordinary object. It does not have a [[WeakSetData]] internal slot.</p>
+      <p>The WeakSet prototype object is the intrinsic object <dfn>%WeakSetPrototype%</dfn>. The value of the [[Prototype]] internal slot of the WeakSet prototype object is the intrinsic object %ObjectPrototype%. The WeakSet prototype object is an ordinary object. It does not have a [[WeakSetData]] internal slot.</p>
 
       <!-- es6num="23.4.3.1" -->
       <emu-clause id="sec-weakset.prototype.add">
@@ -32999,7 +32999,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="24.1.3" -->
     <emu-clause id="sec-properties-of-the-arraybuffer-constructor">
       <h1>Properties of the ArrayBuffer Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the ArrayBuffer constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the ArrayBuffer constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The ArrayBuffer constructor has the following properties:</p>
 
       <!-- es6num="24.1.3.1" -->
@@ -33016,7 +33016,7 @@ Date.parse(x.toLocaleString())
       <!-- es6num="24.1.3.2" -->
       <emu-clause id="sec-arraybuffer.prototype">
         <h1>ArrayBuffer.prototype</h1>
-        <p>The initial value of ArrayBuffer.prototype is the intrinsic object %ArrayBufferPrototype% (<emu-xref href="#sec-properties-of-the-arraybuffer-prototype-object"></emu-xref>).</p>
+        <p>The initial value of ArrayBuffer.prototype is the intrinsic object %ArrayBufferPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -33037,7 +33037,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="24.1.4" -->
     <emu-clause id="sec-properties-of-the-arraybuffer-prototype-object">
       <h1>Properties of the ArrayBuffer Prototype Object</h1>
-      <p>The ArrayBuffer prototype object is the intrinsic object <dfn>%ArrayBufferPrototype%</dfn>. The value of the [[Prototype]] internal slot of the ArrayBuffer prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The ArrayBuffer prototype object is an ordinary object. It does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</p>
+      <p>The ArrayBuffer prototype object is the intrinsic object <dfn>%ArrayBufferPrototype%</dfn>. The value of the [[Prototype]] internal slot of the ArrayBuffer prototype object is the intrinsic object %ObjectPrototype%. The ArrayBuffer prototype object is an ordinary object. It does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</p>
 
       <!-- es6num="24.1.4.1" -->
       <emu-clause id="sec-get-arraybuffer.prototype.bytelength">
@@ -33197,13 +33197,13 @@ Date.parse(x.toLocaleString())
     <!-- es6num="24.2.3" -->
     <emu-clause id="sec-properties-of-the-dataview-constructor">
       <h1>Properties of the DataView Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the `DataView` constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the `DataView` constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The DataView constructor has the following properties:</p>
 
       <!-- es6num="24.2.3.1" -->
       <emu-clause id="sec-dataview.prototype">
         <h1>DataView.prototype</h1>
-        <p>The initial value of `DataView.prototype` is the intrinsic object %DataViewPrototype% (<emu-xref href="#sec-properties-of-the-dataview-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `DataView.prototype` is the intrinsic object %DataViewPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -33211,7 +33211,7 @@ Date.parse(x.toLocaleString())
     <!-- es6num="24.2.4" -->
     <emu-clause id="sec-properties-of-the-dataview-prototype-object">
       <h1>Properties of the DataView Prototype Object</h1>
-      <p>The DataView prototype object is the intrinsic object <dfn>%DataViewPrototype%</dfn>. The value of the [[Prototype]] internal slot of the DataView prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The DataView prototype object is an ordinary object. It does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</p>
+      <p>The DataView prototype object is the intrinsic object <dfn>%DataViewPrototype%</dfn>. The value of the [[Prototype]] internal slot of the DataView prototype object is the intrinsic object %ObjectPrototype%. The DataView prototype object is an ordinary object. It does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</p>
 
       <!-- es6num="24.2.4.1" -->
       <emu-clause id="sec-get-dataview.prototype.buffer">
@@ -33457,7 +33457,7 @@ Date.parse(x.toLocaleString())
     <h1>The JSON Object</h1>
     <p>The JSON object is the <dfn>%JSON%</dfn> intrinsic object and the initial value of the `JSON` property of the global object. The JSON object is a single ordinary object that contains two functions, `parse` and `stringify`, that are used to parse and construct JSON texts. The JSON Data Interchange Format is defined in ECMA-404. The JSON interchange format used in this specification is exactly that described by ECMA-404.</p>
     <p>Conforming implementations of `JSON.parse` and `JSON.stringify` must support the exact interchange format described in the ECMA-404 specification without any deletions or extensions to the format.</p>
-    <p>The value of the [[Prototype]] internal slot of the JSON object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The value of the [[Extensible]] internal slot of the JSON object is set to *true*.</p>
+    <p>The value of the [[Prototype]] internal slot of the JSON object is the intrinsic object %ObjectPrototype%. The value of the [[Extensible]] internal slot of the JSON object is set to *true*.</p>
     <p>The JSON object does not have a [[Construct]] internal method; it is not possible to use the JSON object as a constructor with the `new` operator.</p>
     <p>The JSON object does not have a [[Call]] internal method; it is not possible to invoke the JSON object as a function.</p>
 
@@ -33985,7 +33985,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
     <!-- es6num="25.1.2" -->
     <emu-clause id="sec-%iteratorprototype%-object">
       <h1>The %IteratorPrototype% Object</h1>
-      <p>The value of the [[Prototype]] internal slot of the <dfn>%IteratorPrototype%</dfn> object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The %IteratorPrototype% object is an ordinary object. The initial value of the [[Extensible]] internal slot of the %IteratorPrototype% object is *true*.</p>
+      <p>The value of the [[Prototype]] internal slot of the <dfn>%IteratorPrototype%</dfn> object is the intrinsic object %ObjectPrototype%. The %IteratorPrototype% object is an ordinary object. The initial value of the [[Extensible]] internal slot of the %IteratorPrototype% object is *true*.</p>
       <emu-note>
         <p>All objects defined in this specification that implement the Iterator interface also inherit from %IteratorPrototype%. ECMAScript code may also define objects that inherit from %IteratorPrototype%.The %IteratorPrototype% object provides a place where additional methods that are applicable to all iterator objects may be added.</p>
         <p>The following expression is one way that ECMAScript code can access the %IteratorPrototype% object:</p>
@@ -34126,7 +34126,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       <h1>Properties of Generator Prototype</h1>
       <p>The Generator prototype object is the <dfn>%GeneratorPrototype%</dfn> intrinsic. It is also the initial value of the `prototype` property of the %Generator% intrinsic (the GeneratorFunction.prototype).</p>
       <p>The Generator prototype is an ordinary object. It is not a Generator instance and does not have a [[GeneratorState]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the Generator prototype object is the intrinsic object %IteratorPrototype% (<emu-xref href="#sec-%iteratorprototype%-object"></emu-xref>). The initial value of the [[Extensible]] internal slot of the Generator prototype object is *true*.</p>
+      <p>The value of the [[Prototype]] internal slot of the Generator prototype object is the intrinsic object %IteratorPrototype%. The initial value of the [[Extensible]] internal slot of the Generator prototype object is *true*.</p>
       <p>All Generator instances indirectly inherit properties of the Generator prototype object.</p>
 
       <!-- es6num="25.3.1.1" -->
@@ -34715,7 +34715,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
     <!-- es6num="25.4.4" -->
     <emu-clause id="sec-properties-of-the-promise-constructor">
       <h1>Properties of the Promise Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the `Promise` constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the `Promise` constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The Promise constructor has the following properties:</p>
 
       <!-- es6num="25.4.4.1" -->
@@ -34804,7 +34804,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       <!-- es6num="25.4.4.2" -->
       <emu-clause id="sec-promise.prototype">
         <h1>Promise.prototype</h1>
-        <p>The initial value of `Promise.prototype` is the intrinsic object %PromisePrototype% (<emu-xref href="#sec-properties-of-the-promise-prototype-object"></emu-xref>).</p>
+        <p>The initial value of `Promise.prototype` is the intrinsic object %PromisePrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -34905,7 +34905,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
     <!-- es6num="25.4.5" -->
     <emu-clause id="sec-properties-of-the-promise-prototype-object">
       <h1>Properties of the Promise Prototype Object</h1>
-      <p>The Promise prototype object is the intrinsic object <dfn>%PromisePrototype%</dfn>. The value of the [[Prototype]] internal slot of the Promise prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>). The Promise prototype object is an ordinary object. It does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</p>
+      <p>The Promise prototype object is the intrinsic object <dfn>%PromisePrototype%</dfn>. The value of the [[Prototype]] internal slot of the Promise prototype object is the intrinsic object %ObjectPrototype%. The Promise prototype object is an ordinary object. It does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</p>
 
       <!-- es6num="25.4.5.1" -->
       <emu-clause id="sec-promise.prototype.catch">
@@ -35043,7 +35043,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
   <emu-clause id="sec-reflect-object">
     <h1>The Reflect Object</h1>
     <p>The Reflect object is the <dfn>%Reflect%</dfn> intrinsic object and the initial value of the `Reflect` property of the global object.The Reflect object is an ordinary object.</p>
-    <p>The value of the [[Prototype]] internal slot of the Reflect object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
+    <p>The value of the [[Prototype]] internal slot of the Reflect object is the intrinsic object %ObjectPrototype%.</p>
     <p>The Reflect object is not a function object. It does not have a [[Construct]] internal method; it is not possible to use the Reflect object as a constructor with the `new` operator. The Reflect object also does not have a [[Call]] internal method; it is not possible to invoke the Reflect object as a function.</p>
 
     <!-- es6num="26.1.1" -->
@@ -35219,7 +35219,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
     <!-- es6num="26.2.2" -->
     <emu-clause id="sec-properties-of-the-proxy-constructor">
       <h1>Properties of the Proxy Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the `Proxy` constructor is the intrinsic object %FunctionPrototype% (<emu-xref href="#sec-properties-of-the-function-prototype-object"></emu-xref>).</p>
+      <p>The value of the [[Prototype]] internal slot of the `Proxy` constructor is the intrinsic object %FunctionPrototype%.</p>
       <p>The `Proxy` constructor does not have a `prototype` property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</p>
       <p>The `Proxy` constructor has the following properties:</p>
 

--- a/spec.html
+++ b/spec.html
@@ -1368,7 +1368,7 @@
             A <em>non-existent</em> property is a property that does not exist as an own property on a non-extensible target.
           </li>
           <li>
-            All references to <em>SameValue</em> are according to the definition of SameValue algorithm specified in <emu-xref href="#sec-samevalue"></emu-xref>.
+            All references to <em>SameValue</em> are according to the definition of the SameValue algorithm.
           </li>
         </ul>
         <h2>[[GetPrototypeOf]] ( )</h2>
@@ -3950,7 +3950,7 @@
         1. Return SameValueNonNumber(_x_, _y_).
       </emu-alg>
       <emu-note>
-        <p>This algorithm differs from the Strict Equality Comparison Algorithm (<emu-xref href="#sec-strict-equality-comparison"></emu-xref>) in its treatment of signed zeroes and NaNs.</p>
+        <p>This algorithm differs from the Strict Equality Comparison Algorithm in its treatment of signed zeroes and NaNs.</p>
       </emu-note>
     </emu-clause>
 
@@ -4066,7 +4066,7 @@
         1. Return SameValueNonNumber(_x_, _y_).
       </emu-alg>
       <emu-note>
-        <p>This algorithm differs from the SameValue Algorithm (<emu-xref href="#sec-samevalue"></emu-xref>) in its treatment of signed zeroes and NaNs.</p>
+        <p>This algorithm differs from the SameValue Algorithm in its treatment of signed zeroes and NaNs.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -4300,7 +4300,7 @@
       <p>The abstract operation CreateArrayFromList is used to create an Array object whose elements are provided by a List. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: _elements_ is a List whose elements are all ECMAScript language values.
-        1. Let _array_ be ArrayCreate(0) (see <emu-xref href="#sec-arraycreate"></emu-xref>).
+        1. Let _array_ be ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each element _e_ of _elements_
           1. Let _status_ be CreateDataProperty(_array_, ! ToString(_n_), _e_).
@@ -4351,7 +4351,7 @@
         1. If IsCallable(_C_) is *false*, return *false*.
         1. If _C_ has a [[BoundTargetFunction]] internal slot, then
           1. Let _BC_ be the value of _C_'s [[BoundTargetFunction]] internal slot.
-          1. Return ? InstanceofOperator(_O_, _BC_) (see <emu-xref href="#sec-instanceofoperator"></emu-xref>).
+          1. Return ? InstanceofOperator(_O_, _BC_).
         1. If Type(_O_) is not Object, return *false*.
         1. Let _P_ be ? Get(_C_, `"prototype"`).
         1. If Type(_P_) is not Object, throw a *TypeError* exception.
@@ -11870,7 +11870,7 @@ a = b + c
           1. Else Type(_ref_) is not Reference,
             1. Let _thisValue_ be *undefined*.
           1. Let _thisCall_ be this |CallExpression|.
-          1. Let _tailCall_ be IsInTailPosition(_thisCall_). (See <emu-xref href="#sec-isintailposition"></emu-xref>)
+          1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateDirectCall(_func_, _thisValue_, |Arguments|, _tailCall_).
         </emu-alg>
         <p>A |CallExpression| evaluation that executes step 3.a.vi is a <em>direct eval</em>.</p>
@@ -11878,7 +11878,7 @@ a = b + c
         <emu-alg>
           1. Let _ref_ be the result of evaluating |CallExpression|.
           1. Let _thisCall_ be this |CallExpression|.
-          1. Let _tailCall_ be IsInTailPosition(_thisCall_). (See <emu-xref href="#sec-isintailposition"></emu-xref>)
+          1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_ref_, |Arguments|, _tailCall_).
         </emu-alg>
       </emu-clause>
@@ -12051,14 +12051,14 @@ a = b + c
         <emu-alg>
           1. Let _tagRef_ be the result of evaluating |MemberExpression|.
           1. Let _thisCall_ be this |MemberExpression|.
-          1. Let _tailCall_ be IsInTailPosition(_thisCall_). (See <emu-xref href="#sec-isintailposition"></emu-xref>)
+          1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_tagRef_, |TemplateLiteral|, _tailCall_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression TemplateLiteral</emu-grammar>
         <emu-alg>
           1. Let _tagRef_ be the result of evaluating |CallExpression|.
           1. Let _thisCall_ be this |CallExpression|.
-          1. Let _tailCall_ be IsInTailPosition(_thisCall_). (See <emu-xref href="#sec-isintailposition"></emu-xref>)
+          1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_tagRef_, |TemplateLiteral|, _tailCall_).
         </emu-alg>
       </emu-clause>
@@ -12834,7 +12834,7 @@ a = b + c
           <p>No hint is provided in the calls to ToPrimitive in steps 5 and 6. All standard objects except Date objects handle the absence of a hint as if the hint Number were given; Date objects handle the absence of a hint as if the hint String were given. Exotic objects may handle the absence of a hint in some other manner.</p>
         </emu-note>
         <emu-note>
-          <p>Step 7 differs from step 5 of the Abstract Relational Comparison algorithm (<emu-xref href="#sec-abstract-relational-comparison"></emu-xref>), by using the logical-or operation instead of the logical-and operation.</p>
+          <p>Step 7 differs from step 5 of the Abstract Relational Comparison algorithm, by using the logical-or operation instead of the logical-and operation.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -13078,7 +13078,7 @@ a = b + c
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be the result of performing Abstract Relational Comparison _lval_ &lt; _rval_ (see <emu-xref href="#sec-abstract-relational-comparison"></emu-xref>).
+        1. Let _r_ be the result of performing Abstract Relational Comparison _lval_ &lt; _rval_.
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
@@ -21636,7 +21636,7 @@ eval("1;var a;")
     <p>An implementation must not extend this specification in the following ways:</p>
     <ul>
       <li>
-        Other than as defined in this specification, ECMAScript Function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"` other than those that are created by applying the AddRestrictedFunctionProperties abstract operation (<emu-xref href="#sec-addrestrictedfunctionproperties"></emu-xref>) to the function. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |ClassDeclaration|, or |ClassExpression| regardless of whether the definition is contained in strict mode code. Built-in functions, strict mode functions created using the `Function` constructor, generator functions created using the `Generator` constructor, and functions created using the `bind` method also must not be created with such own properties.
+        Other than as defined in this specification, ECMAScript Function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"` other than those that are created by applying the AddRestrictedFunctionProperties abstract operation to the function. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |ClassDeclaration|, or |ClassExpression| regardless of whether the definition is contained in strict mode code. Built-in functions, strict mode functions created using the `Function` constructor, generator functions created using the `Generator` constructor, and functions created using the `bind` method also must not be created with such own properties.
       </li>
       <li>
         If an implementation extends non-strict or built-in function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
@@ -24095,7 +24095,7 @@ new Function("a,b", "c", "return a+b+c")
       <!-- es6num="20.1.3.5" -->
       <emu-clause id="sec-number.prototype.toprecision">
         <h1>Number.prototype.toPrecision ( _precision_ )</h1>
-        <p>Return a String containing this Number value represented either in decimal exponential notation with one digit before the significand's decimal point and <emu-eqn>_precision_-1</emu-eqn> digits after the significand's decimal point or in decimal fixed notation with _precision_ significant digits. If _precision_ is *undefined*, call ToString (<emu-xref href="#sec-tostring"></emu-xref>) instead. Specifically, perform the following steps:</p>
+        <p>Return a String containing this Number value represented either in decimal exponential notation with one digit before the significand's decimal point and <emu-eqn>_precision_-1</emu-eqn> digits after the significand's decimal point or in decimal fixed notation with _precision_ significant digits. If _precision_ is *undefined*, call ToString instead. Specifically, perform the following steps:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. If _precision_ is *undefined*, return ! ToString(_x_).
@@ -24852,7 +24852,7 @@ new Function("a,b", "c", "return a+b+c")
             If any value is NaN, the result is NaN.
           </li>
           <li>
-            The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm (<emu-xref href="#sec-abstract-relational-comparison"></emu-xref>) except that +0 is considered to be larger than -0.
+            The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that +0 is considered to be larger than -0.
           </li>
         </ul>
       </emu-clause>
@@ -24869,7 +24869,7 @@ new Function("a,b", "c", "return a+b+c")
             If any value is NaN, the result is NaN.
           </li>
           <li>
-            The comparison of values to determine the smallest value is done using the Abstract Relational Comparison algorithm (<emu-xref href="#sec-abstract-relational-comparison"></emu-xref>) except that +0 is considered to be larger than -0.
+            The comparison of values to determine the smallest value is done using the Abstract Relational Comparison algorithm except that +0 is considered to be larger than -0.
           </li>
         </ul>
       </emu-clause>
@@ -26644,7 +26644,7 @@ Date.parse(x.toLocaleString())
             1. If _matcher_ is not *undefined*, then
               1. Return ? Call(_matcher_, _regexp_, &laquo; _O_ &raquo;).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _rx_ be ? RegExpCreate(_regexp_, *undefined*) (see <emu-xref href="#sec-regexpcreate"></emu-xref>).
+          1. Let _rx_ be ? RegExpCreate(_regexp_, *undefined*).
           1. Return ? Invoke(_rx_, @@match, &laquo; _S_ &raquo;).
         </emu-alg>
         <emu-note>
@@ -26859,7 +26859,7 @@ Date.parse(x.toLocaleString())
             1. If _searcher_ is not *undefined*, then
               1. Return ? Call(_searcher_, _regexp_, &laquo; _O_ &raquo;).
           1. Let _string_ be ? ToString(_O_).
-          1. Let _rx_ be ? RegExpCreate(_regexp_, *undefined*) (see <emu-xref href="#sec-regexpcreate"></emu-xref>).
+          1. Let _rx_ be ? RegExpCreate(_regexp_, *undefined*).
           1. Return ? Invoke(_rx_, @@search, &laquo; _string_ &raquo;).
         </emu-alg>
         <emu-note>
@@ -29825,7 +29825,7 @@ Date.parse(x.toLocaleString())
       <emu-clause id="sec-array.prototype.indexof">
         <h1>Array.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
-          <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the Strict Equality Comparison algorithm (<emu-xref href="#sec-strict-equality-comparison"></emu-xref>), and if found at one or more indices, returns the smallest such index; otherwise, -1 is returned.</p>
+          <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the smallest such index; otherwise, -1 is returned.</p>
           <p>The optional second argument _fromIndex_ defaults to 0 (i.e. the whole array is searched). If it is greater than or equal to the length of the array, -1 is returned, i.e. the array will not be searched. If it is negative, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than 0, the whole array will be searched.</p>
         </emu-note>
         <p>When the `indexOf` method is called with one or two arguments, the following steps are taken:</p>
@@ -29897,7 +29897,7 @@ Date.parse(x.toLocaleString())
       <emu-clause id="sec-array.prototype.lastindexof">
         <h1>Array.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
-          <p>`lastIndexOf` compares _searchElement_ to the elements of the array in descending order using the Strict Equality Comparison algorithm (<emu-xref href="#sec-strict-equality-comparison"></emu-xref>), and if found at one or more indices, returns the largest such index; otherwise, -1 is returned.</p>
+          <p>`lastIndexOf` compares _searchElement_ to the elements of the array in descending order using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the largest such index; otherwise, -1 is returned.</p>
           <p>The optional second argument _fromIndex_ defaults to the array's length minus one (i.e. the whole array is searched). If it is greater than or equal to the length of the array, the whole array will be searched. If it is negative, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than 0, -1 is returned.</p>
         </emu-note>
         <p>When the `lastIndexOf` method is called with one or two arguments, the following steps are taken:</p>
@@ -30251,7 +30251,7 @@ Date.parse(x.toLocaleString())
           1. Return *false*.
         </emu-alg>
         <p>The <em>sort order</em> is the ordering, after completion of this function, of the integer indexed property values of _obj_ whose integer indexes are less than _len_. The result of the `sort` function is then determined as follows:</p>
-        <p>If _comparefn_ is not *undefined* and is not a consistent comparison function for the elements of this array (see below), the sort order is implementation-defined. The sort order is also implementation-defined if _comparefn_ is *undefined* and SortCompare (<emu-xref href="#sec-sortcompare"></emu-xref>) does not act as a consistent comparison function.</p>
+        <p>If _comparefn_ is not *undefined* and is not a consistent comparison function for the elements of this array (see below), the sort order is implementation-defined. The sort order is also implementation-defined if _comparefn_ is *undefined* and SortCompare does not act as a consistent comparison function.</p>
         <p>Let _proto_ be _obj_.[[GetPrototypeOf]](). If _proto_ is not *null* and there exists an integer _j_ such that all of the conditions below are satisfied then the sort order is implementation-defined:</p>
         <ul>
           <li>
@@ -36565,7 +36565,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatibility semantics are applied and introduce observable differences from non-compatibility semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
       <emu-annex id="sec-web-compat-functiondeclarationinstantiation">
         <h1>Changes to FunctionDeclarationInstantiation</h1>
-        <p>During FunctionDeclarationInstantiation (<emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>) the following steps are performed in place of step 29:</p>
+        <p>During FunctionDeclarationInstantiation the following steps are performed in place of step 29:</p>
         <emu-alg>
           1. If _strict_ is *false*, then
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|,
@@ -36588,7 +36588,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       </emu-annex>
       <emu-annex id="sec-web-compat-globaldeclarationinstantiation">
         <h1>Changes to GlobalDeclarationInstantiation</h1>
-        <p>During GlobalDeclarationInstantiation (<emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref>) the following steps are performed in place of step 14:</p>
+        <p>During GlobalDeclarationInstantiation the following steps are performed in place of step 14:</p>
         <emu-alg>
           1. Let _declaredFunctionOrVarNames_ be an empty List.
           1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
@@ -36615,7 +36615,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
       </emu-annex>
       <emu-annex id="sec-web-compat-evaldeclarationinstantiation">
         <h1>Changes to EvalDeclarationInstantiation</h1>
-        <p>During EvalDeclarationInstantiation (<emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref>) the following steps are performed in place of step 9:</p>
+        <p>During EvalDeclarationInstantiation the following steps are performed in place of step 9:</p>
         <emu-alg>
           1. If _strict_ is *false*, then
             1. Let _declaredFunctionOrVarNames_ be an empty List.

--- a/spec.html
+++ b/spec.html
@@ -3283,7 +3283,7 @@
         </emu-grammar>
         <p>All grammar symbols not explicitly defined above have the definitions used in the Lexical Grammar for numeric literals (<emu-xref href="#sec-literals-numeric-literals"></emu-xref>)</p>
         <emu-note>
-          <p>Some differences should be noted between the syntax of a |StringNumericLiteral| and a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>):</p>
+          <p>Some differences should be noted between the syntax of a |StringNumericLiteral| and a |NumericLiteral|:</p>
           <ul>
             <li>
               A |StringNumericLiteral| may include leading and/or trailing white space and/or line terminators.
@@ -8919,7 +8919,7 @@ a = b / hi / g.exec(c).map(d);
     <h1>Unicode Format-Control Characters</h1>
     <p>The Unicode format-control characters (i.e., the characters in category &ldquo;Cf&rdquo; in the Unicode Character Database such as LEFT-TO-RIGHT MARK or RIGHT-TO-LEFT MARK) are control codes used to control the formatting of a range of text in the absence of higher-level protocols for this (such as mark-up languages).</p>
     <p>It is useful to allow format-control characters in source text to facilitate editing and display. All format control characters may be used within comments, and within string literals, template literals, and regular expression literals.</p>
-    <p>U+200C (ZERO WIDTH NON-JOINER) and U+200D (ZERO WIDTH JOINER) are format-control characters that are used to make necessary distinctions when forming words or phrases in certain languages. In ECMAScript source text these code points may also be used in an |IdentifierName| (see <emu-xref href="#sec-identifier-names"></emu-xref>) after the first character.</p>
+    <p>U+200C (ZERO WIDTH NON-JOINER) and U+200D (ZERO WIDTH JOINER) are format-control characters that are used to make necessary distinctions when forming words or phrases in certain languages. In ECMAScript source text these code points may also be used in an |IdentifierName| after the first character.</p>
     <p>U+FEFF (ZERO WIDTH NO-BREAK SPACE) is a format-control character used primarily at the start of a text to mark it as Unicode and to allow detection of the text's encoding and byte order. &lt;ZWNBSP&gt; characters intended for this purpose can sometimes also appear after the start of a text, for example as a result of concatenating files. In ECMAScript source text &lt;ZWNBSP&gt; code points are treated as white space characters (see <emu-xref href="#sec-white-space"></emu-xref>).</p>
     <p>The special treatment of certain format-control characters outside of comments, string literals, and regular expression literals is summarized in <emu-xref href="#table-31"></emu-xref>.</p>
     <emu-table id="table-31" caption="Format-Control Code Point Usage">
@@ -9106,7 +9106,7 @@ a = b / hi / g.exec(c).map(d);
   <emu-clause id="sec-line-terminators">
     <h1>Line Terminators</h1>
     <p>Like white space code points, line terminator code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other. However, unlike white space code points, line terminators have some influence over the behaviour of the syntactic grammar. In general, line terminators may occur between any two tokens, but there are a few places where they are forbidden by the syntactic grammar. Line terminators also affect the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A line terminator cannot occur within any token except a |StringLiteral|, |Template|, or |TemplateSubstitutionTail|. Line terminators may only occur within a |StringLiteral| token as part of a |LineContinuation|.</p>
-    <p>A line terminator can occur within a |MultiLineComment| (<emu-xref href="#sec-comments"></emu-xref>) but cannot occur within a |SingleLineComment|.</p>
+    <p>A line terminator can occur within a |MultiLineComment| but cannot occur within a |SingleLineComment|.</p>
     <p>Line terminators are included in the set of white space code points that are matched by the `\\s` class in regular expressions.</p>
     <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-33"></emu-xref>.</p>
     <emu-table id="table-33" caption="Line Terminator Code Points">
@@ -9248,7 +9248,7 @@ a = b / hi / g.exec(c).map(d);
   <!-- es6num="11.6" -->
   <emu-clause id="sec-names-and-keywords">
     <h1>Names and Keywords</h1>
-    <p>|IdentifierName| and |ReservedWord| are tokens that are interpreted according to the Default Identifier Syntax given in Unicode Standard Annex #31, Identifier and Pattern Syntax, with some small modifications. |ReservedWord| is an enumerated subset of |IdentifierName|. The syntactic grammar defines |Identifier| as an |IdentifierName| that is not a |ReservedWord| (see <emu-xref href="#sec-reserved-words"></emu-xref>). The Unicode identifier grammar is based on character properties specified by the Unicode Standard. The Unicode code points in the specified categories in version 5.1.0 of the Unicode standard must be treated as in those categories by all conforming ECMAScript implementations. ECMAScript implementations may recognize identifier code points defined in later editions of the Unicode Standard.</p>
+    <p>|IdentifierName| and |ReservedWord| are tokens that are interpreted according to the Default Identifier Syntax given in Unicode Standard Annex #31, Identifier and Pattern Syntax, with some small modifications. |ReservedWord| is an enumerated subset of |IdentifierName|. The syntactic grammar defines |Identifier| as an |IdentifierName| that is not a |ReservedWord|. The Unicode identifier grammar is based on character properties specified by the Unicode Standard. The Unicode code points in the specified categories in version 5.1.0 of the Unicode standard must be treated as in those categories by all conforming ECMAScript implementations. ECMAScript implementations may recognize identifier code points defined in later editions of the Unicode Standard.</p>
     <emu-note>
       <p>This standard specifies specific code point additions: U+0024 (DOLLAR SIGN) and U+005F (LOW LINE) are permitted anywhere in an |IdentifierName|, and the code points U+200C (ZERO WIDTH NON-JOINER) and U+200D (ZERO WIDTH JOINER) are permitted anywhere after the first code point of an |IdentifierName|.</p>
     </emu-note>
@@ -11001,7 +11001,7 @@ a = b + c
             It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
           </li>
         </ul>
-        <p>In addition to describing an actual object initializer the |ObjectLiteral| productions are also used as a cover grammar for |ObjectAssignmentPattern| (<emu-xref href="#sec-destructuring-assignment"></emu-xref>). and may be recognized as part of a |CoverParenthesizedExpressionAndArrowParameterList|. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the following Early Error rules are <b>not</b> applied. In addition, they are not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList|.</p>
+        <p>In addition to describing an actual object initializer the |ObjectLiteral| productions are also used as a cover grammar for |ObjectAssignmentPattern|. and may be recognized as part of a |CoverParenthesizedExpressionAndArrowParameterList|. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the following Early Error rules are <b>not</b> applied. In addition, they are not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList|.</p>
         <emu-grammar>PropertyDefinition : CoverInitializedName</emu-grammar>
         <ul>
           <li>
@@ -11009,7 +11009,7 @@ a = b + c
           </li>
         </ul>
         <emu-note>
-          <p>This production exists so that |ObjectLiteral| can serve as a cover grammar for |ObjectAssignmentPattern| (<emu-xref href="#sec-destructuring-assignment"></emu-xref>). It cannot occur in an actual object initializer.</p>
+          <p>This production exists so that |ObjectLiteral| can serve as a cover grammar for |ObjectAssignmentPattern|. It cannot occur in an actual object initializer.</p>
         </emu-note>
       </emu-clause>
 
@@ -21654,7 +21654,7 @@ eval("1;var a;")
         When processing strict mode code, the syntax of |NumericLiteral| must not be extended to include <emu-xref href="#prod-annexB-LegacyOctalIntegerLiteral"></emu-xref> and the syntax of |DecimalIntegerLiteral| must not be extended to include <emu-xref href="#prod-annexB-NonOctalDecimalIntegerLiteral"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-numeric-literals"></emu-xref>.
       </li>
       <li>
-        |TemplateCharacter| (<emu-xref href="#sec-template-literal-lexical-components"></emu-xref>) must not be extended to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as defined in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.
+        |TemplateCharacter| must not be extended to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as defined in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.
       </li>
       <li>
         When processing strict mode code, the extensions defined in <emu-xref href="#sec-labelled-function-declarations"></emu-xref>, <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>, and <emu-xref href="#sec-functiondeclarations-in-ifstatement-statement-clauses"></emu-xref> must not be supported.
@@ -28297,7 +28297,7 @@ Date.parse(x.toLocaleString())
         <h1>CharacterClassEscape</h1>
         <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates by returning the ten-element set of characters containing the characters `0` through `9` inclusive.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> .</p>
-        <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates by returning the set of characters containing the characters that are on the right-hand side of the |WhiteSpace| (<emu-xref href="#sec-white-space"></emu-xref>) or |LineTerminator| (<emu-xref href="#sec-line-terminators"></emu-xref>) productions.</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates by returning the set of characters containing the characters that are on the right-hand side of the |WhiteSpace| or |LineTerminator| productions.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> .</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> evaluates by returning the set of characters containing the sixty-three characters:</p>
         <figure>
@@ -35261,7 +35261,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
   <!-- es6num="26.3" -->
   <emu-clause id="sec-module-namespace-objects">
     <h1>Module Namespace Objects</h1>
-    <p>A Module Namespace Object is a module namespace exotic object that provides runtime property-based access to a module's exported bindings. There is no constructor function for Module Namespace Objects. Instead, such an object is created for each module that is imported by an |ImportDeclaration| that includes a |NameSpaceImport| (See <emu-xref href="#sec-imports"></emu-xref>).</p>
+    <p>A Module Namespace Object is a module namespace exotic object that provides runtime property-based access to a module's exported bindings. There is no constructor function for Module Namespace Objects. Instead, such an object is created for each module that is imported by an |ImportDeclaration| that includes a |NameSpaceImport|.</p>
     <p>In addition to the properties specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref> each Module Namespace Object has the following own properties:</p>
 
     <!-- es6num="26.3.1" -->
@@ -35744,7 +35744,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         FourToSeven :: one of
           `4` `5` `6` `7`
       </emu-grammar>
-      <p>This definition of |EscapeSequence| is not used in strict mode or when parsing |TemplateCharacter| (<emu-xref href="#sec-template-literal-lexical-components"></emu-xref>).</p>
+      <p>This definition of |EscapeSequence| is not used in strict mode or when parsing |TemplateCharacter|.</p>
 
       <!-- es6num="B.1.2.1" -->
       <emu-annex id="sec-additional-syntax-string-literals-static-semantics">


### PR DESCRIPTION
Some \<emu-xref\> are no longer needed now that abstract operations and \<dfn\> automatically create links. 
