### PR TITLE
Normative: remove the [[ErrorData]] internal slot

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22924,7 +22924,6 @@ eval("1;var a;")
           1. Else, if _O_ is an exotic String object, let _builtinTag_ be `"String"`.
           1. Else, if _O_ has an [[ParameterMap]] internal slot, let _builtinTag_ be `"Arguments"`.
           1. Else, if _O_ has a [[Call]] internal method, let _builtinTag_ be `"Function"`.
-          1. Else, if _O_ has an [[ErrorData]] internal slot, let _builtinTag_ be `"Error"`.
           1. Else, if _O_ has a [[BooleanData]] internal slot, let _builtinTag_ be `"Boolean"`.
           1. Else, if _O_ has a [[NumberData]] internal slot, let _builtinTag_ be `"Number"`.
           1. Else, if _O_ has a [[DateValue]] internal slot, let _builtinTag_ be `"Date"`.
@@ -23603,7 +23602,7 @@ new Function("a,b", "c", "return a+b+c")
     <emu-clause id="sec-error-constructor">
       <h1>The Error Constructor</h1>
       <p>The Error constructor is the <dfn>%Error%</dfn> intrinsic object and the initial value of the `Error` property of the global object. When `Error` is called as a function rather than as a constructor, it creates and initializes a new Error object. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</p>
-      <p>The `Error` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
+      <p>The `Error` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour should include a `super` call to the `Error` constructor to create and initialize subclass instances.</p>
 
       <!-- es6num="19.5.1.1" -->
       <emu-clause id="sec-error-message">
@@ -23611,7 +23610,7 @@ new Function("a,b", "c", "return a+b+c")
         <p>When the `Error` function is called with argument _message_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%ErrorPrototype%"`, &laquo; [[ErrorData]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%ErrorPrototype%"`).
           1. If _message_ is not *undefined*, then
             1. Let _msg_ be ? ToString(_message_).
             1. Let _msgDesc_ be the PropertyDescriptor{[[Value]]: _msg_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true*}.
@@ -23638,7 +23637,7 @@ new Function("a,b", "c", "return a+b+c")
     <!-- es6num="19.5.3" -->
     <emu-clause id="sec-properties-of-the-error-prototype-object">
       <h1>Properties of the Error Prototype Object</h1>
-      <p>The Error prototype object is the intrinsic object <dfn>%ErrorPrototype%</dfn>. The Error prototype object is an ordinary object. It is not an Error instance and does not have an [[ErrorData]] internal slot.</p>
+      <p>The Error prototype object is the intrinsic object <dfn>%ErrorPrototype%</dfn>. The Error prototype object is an ordinary object. It is not an Error instance.</p>
       <p>The value of the [[Prototype]] internal slot of the Error prototype object is the intrinsic object %ObjectPrototype% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>).</p>
 
       <!-- es6num="19.5.3.1" -->
@@ -23675,12 +23674,18 @@ new Function("a,b", "c", "return a+b+c")
           1. Return the result of concatenating _name_, the code unit 0x003A (COLON), the code unit 0x0020 (SPACE), and _msg_.
         </emu-alg>
       </emu-clause>
+
+      <emu-clause id="sec-error.prototype-@@tostringtag">
+        <h1>Error.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value `"Error"`.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
     </emu-clause>
 
     <!-- es6num="19.5.4" -->
     <emu-clause id="sec-properties-of-error-instances">
       <h1>Properties of Error Instances</h1>
-      <p>Error instances are ordinary objects that inherit properties from the Error prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified uses of [[ErrorData]] is to identify Error and _NativeError_ instances as Error objects within `Object.prototype.toString`.</p>
+      <p>Error instances are ordinary objects that inherit properties from the Error prototype object.</p>
     </emu-clause>
 
     <!-- es6num="19.5.5" -->
@@ -23735,7 +23740,7 @@ new Function("a,b", "c", "return a+b+c")
       <emu-clause id="sec-nativeerror-constructors">
         <h1>_NativeError_ Constructors</h1>
         <p>When a _NativeError_ constructor is called as a function rather than as a constructor, it creates and initializes a new _NativeError_ object. A call of the object as a function is equivalent to calling it as a constructor with the same arguments. Thus the function call <code><var>NativeError</var>(&hellip;)</code> is equivalent to the object creation expression <code>new <var>NativeError</var>(&hellip;)</code> with the same arguments.</p>
-        <p>Each _NativeError_ constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
+        <p>Each _NativeError_ constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour should include a `super` call to the _NativeError_ constructor to create and initialize subclass instances.</p>
 
         <!-- es6num="19.5.6.1.1" -->
         <emu-clause id="sec-nativeerror">
@@ -23743,7 +23748,7 @@ new Function("a,b", "c", "return a+b+c")
           <p>When a _NativeError_ function is called with argument _message_, the following steps are taken:</p>
           <emu-alg>
             1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>Prototype%"</code>, &laquo; [[ErrorData]] &raquo; ).
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>Prototype%"</code> ).
             1. If _message_ is not *undefined*, then
               1. Let _msg_ be ? ToString(_message_).
               1. Let _msgDesc_ be the PropertyDescriptor{[[Value]]: _msg_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true*}.
@@ -23772,7 +23777,7 @@ new Function("a,b", "c", "return a+b+c")
       <!-- es6num="19.5.6.3" -->
       <emu-clause id="sec-properties-of-the-nativeerror-prototype-objects">
         <h1>Properties of the _NativeError_ Prototype Objects</h1>
-        <p>Each _NativeError_ prototype object is an ordinary object. It is not an Error instance and does not have an [[ErrorData]] internal slot.</p>
+        <p>Each _NativeError_ prototype object is an ordinary object. It is not an Error instance.</p>
         <p>The value of the [[Prototype]] internal slot of each _NativeError_ prototype object is the intrinsic object %ErrorPrototype% (<emu-xref href="#sec-properties-of-the-error-prototype-object"></emu-xref>).</p>
 
         <!-- es6num="19.5.6.3.1" -->
@@ -23797,7 +23802,7 @@ new Function("a,b", "c", "return a+b+c")
       <!-- es6num="19.5.6.4" -->
       <emu-clause id="sec-properties-of-nativeerror-instances">
         <h1>Properties of _NativeError_ Instances</h1>
-        <p>_NativeError_ instances are ordinary objects that inherit properties from their _NativeError_ prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified use of [[ErrorData]] is by `Object.prototype.toString` (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>) to identify Error or _NativeError_ instances.</p>
+        <p>_NativeError_ instances are ordinary objects that inherit properties from their _NativeError_ prototype object.</p>
       </emu-clause>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This replaces the [[ErrorData]] internal slot, which is only used for
brand-checking in Object.prototype.toString, with @@toStringTag. This
lets errors be simple objects with no extra private data, just as if
they were implemented in JavaScript code.

This observably changes the behavior of Error instances with
@@toStringTag modified or shadowed.

---

Presumably this needs consensus. We can bring it up at the next meeting.