### PR TITLE
Revert 1 case of "a new empty List" back to "an empty List"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16037,7 +16037,7 @@ eval("1;var a;")
         <p>The abstract operation ForIn/OfHeadEvaluation is called with arguments _TDZnames_, _expr_, and _iterationKind_. The value of _iterationKind_ is either ~enumerate~ or ~iterate~.</p>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
-          1. If _TDZnames_ is not a new empty List, then
+          1. If _TDZnames_ is not an empty List, then
             1. Assert: _TDZnames_ has no duplicate entries.
             1. Let _TDZ_ be NewDeclarativeEnvironment(_oldEnv_).
             1. Let _TDZEnvRec_ be _TDZ_'s EnvironmentRecord.


### PR DESCRIPTION
because in:
```
    If _TDZnames_ is not an empty List
```
we don't care if it's a *new* empty List.