### PR TITLE
Move ExponentiationExpression before MultiplicativeExpression

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12221,57 +12221,6 @@ a = b + c
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-exp-operator">
-    <h1>Exponentiation Operator</h1>
-    <h2>Syntax</h2>
-
-    <emu-grammar>
-      ExponentiationExpression[Yield] :
-        UnaryExpression[?Yield]
-        UpdateExpression[?Yield] `**` ExponentiationExpression[?Yield]
-    </emu-grammar>
-
-    <emu-clause id="sec-exp-operator-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        ExponentiationExpression :
-          UpdateExpression `**` ExponentiationExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
-        ExponentiationExpression :
-          UpdateExpression `**` ExponentiationExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-exp-operator-runtime-semantics-evaluation">
-      <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>
-        ExponentiationExpression : UpdateExpression `**` ExponentiationExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Let _left_ be the result of evaluating _UpdateExpression_.
-        1. Let _leftValue_ be ? GetValue(_left_).
-        1. Let _right_ be the result of evaluating _ExponentiationExpression_.
-        1. Let _rightValue_ be ? GetValue(_right_).
-        1. Let _base_ be ? ToNumber(_leftValue_).
-        1. Let _exponent_ be ? ToNumber(_rightValue_).
-        1. Return the result of <emu-xref href="#sec-applying-the-exp-operator" title>Applying the ** operator</emu-xref> with _base_ and _exponent_ as specified in <emu-xref href="#sec-applying-the-exp-operator"></emu-xref>.
-      </emu-alg>
-    </emu-clause>
-  </emu-clause>
-
   <!-- es6num="12.5" -->
   <emu-clause id="sec-unary-operators">
     <h1>Unary Operators</h1>
@@ -12584,6 +12533,57 @@ a = b + c
           1. Return *true*.
         </emu-alg>
       </emu-clause>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-exp-operator">
+    <h1>Exponentiation Operator</h1>
+    <h2>Syntax</h2>
+
+    <emu-grammar>
+      ExponentiationExpression[Yield] :
+        UnaryExpression[?Yield]
+        UpdateExpression[?Yield] `**` ExponentiationExpression[?Yield]
+    </emu-grammar>
+
+    <emu-clause id="sec-exp-operator-static-semantics-isfunctiondefinition">
+      <h1>Static Semantics: IsFunctionDefinition</h1>
+      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
+      <emu-grammar>
+        ExponentiationExpression :
+          UpdateExpression `**` ExponentiationExpression
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget">
+      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
+      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+      <emu-grammar>
+        ExponentiationExpression :
+          UpdateExpression `**` ExponentiationExpression
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-exp-operator-runtime-semantics-evaluation">
+      <h1>Runtime Semantics: Evaluation</h1>
+      <emu-grammar>
+        ExponentiationExpression : UpdateExpression `**` ExponentiationExpression
+      </emu-grammar>
+      <emu-alg>
+        1. Let _left_ be the result of evaluating _UpdateExpression_.
+        1. Let _leftValue_ be ? GetValue(_left_).
+        1. Let _right_ be the result of evaluating _ExponentiationExpression_.
+        1. Let _rightValue_ be ? GetValue(_right_).
+        1. Let _base_ be ? ToNumber(_leftValue_).
+        1. Let _exponent_ be ? ToNumber(_rightValue_).
+        1. Return the result of <emu-xref href="#sec-applying-the-exp-operator" title>Applying the ** operator</emu-xref> with _base_ and _exponent_ as specified in <emu-xref href="#sec-applying-the-exp-operator"></emu-xref>.
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
Move ExponentiationExpression before MultiplicativeExpression to mirror the precedence levels.