### PR TITLE
Meta: Use Travis CI's container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ language: node_js
 
 node_js:
   - "5"
+
+sudo: false


### PR DESCRIPTION
Add `sudo: false` to the `.travis.yml` file in order to use Travis CI's container-based infrastructure, thus, making the builds start and run faster.

--

It seems this repository was recognize by Travis CI before 2015-01-01, so builds where sent to the standard infrastructure:

 * https://docs.travis-ci.com/user/migrating-from-legacy/
 * https://docs.travis-ci.com/user/workers/container-based-infrastructure/