### PR TITLE
Normative: Allow duplicate FunctionDeclarations in a block

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36561,7 +36561,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <p>A function is declared and only referenced within a single block</p>
           <ul>
             <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
+              One or more |FunctionDeclaration|s whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
             </li>
             <li>
               No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
@@ -36575,7 +36575,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <p>A function is declared and possibly used within a single |Block| but also referenced by an inner function definition that is not contained within that same |Block|.</p>
           <ul>
             <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
+              One or more |FunctionDeclaration|s whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
             </li>
             <li>
               No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
@@ -36595,7 +36595,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           <p>A function is declared and possibly used within a single block but also referenced within subsequent blocks.</p>
           <ul>
             <li>
-              A |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occurs exactly once within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
+            One or more |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
             </li>
             <li>
               No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
@@ -36707,6 +36707,27 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
                     1. Let _fobj_ be ! _benvRec_.GetBindingValue(_F_, *false*).
                     1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
                     1. Return NormalCompletion(~empty~).
+        </emu-alg>
+      </emu-annex>
+      <emu-annex id="sec-block-duplicates-allowed-static-semantics">
+        <h1>Changes to Block Static Semantics: Early Errors</h1>
+        <p>For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
+        <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries, <ins>unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.</ins>
+          </li>
+        </ul>
+      </emu-annex>
+      <emu-annex id="sec-web-compat-blockdeclarationinstantiation">
+        <h1>Changes to BlockDeclarationInstantiation</h1>
+        <p>During BlockDeclarationInstantiation the following steps are performed in place of step 4.b.iii:</p>
+        <emu-alg>
+            1. If _envRec_.HasBinding(_fn_) is *true*, then
+              1. Assert: _d_ is a |FunctionDeclaration|.
+              1. _envRec_.SetMutableBinding(_fn_, _fo_, *false*).
+            1. Else,
+              1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
         </emu-alg>
       </emu-annex>
     </emu-annex>


### PR DESCRIPTION
A previously overlooked aspect of intersection semantics for
 #sec-block-level-function-declarations-web-legacy-compatibility-semantics
is the ability to have multiple function declarations with the same name
in the same block. This patch relaxes that constraint in sloppy mode.
Because it relaxes a static semantics rule, and replaces rather than
simply adds behavior, it is in the main spec text rather than Annex B.
The patch also puts the non-normative text in Annex B in an emu-note.

Fixes #320.