### PR TITLE
[normative] Limit application of Annex B extension

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36583,7 +36583,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         <h1>Changes to GlobalDeclarationInstantiation</h1>
         <p>During GlobalDeclarationInstantiation the following steps are performed in place of step 14:</p>
         <emu-alg>
-          1. Let _strict_ by IsStrict of _script_
+          1. Let _strict_ be IsStrict of _script_
           1. If _strict_ is *false*, then
             1. Let _declaredFunctionOrVarNames_ be a new empty List.
             1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.

--- a/spec.html
+++ b/spec.html
@@ -36583,27 +36583,29 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         <h1>Changes to GlobalDeclarationInstantiation</h1>
         <p>During GlobalDeclarationInstantiation the following steps are performed in place of step 14:</p>
         <emu-alg>
-          1. Let _declaredFunctionOrVarNames_ be a new empty List.
-          1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
-          1. Append to _declaredFunctionOrVarNames_ the elements of _declaredVarNames_.
-          1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_,
-            1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-            2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
-              1. If _envRec_.HasLexicalDeclaration(_F_) is *false*, then
-                1. Let _fnDefinable_ be ? _envRec_.CanDeclareGlobalFunction(_F_).
-                3. If _fnDefinable_ is *true*, then
-                  1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
-                  2. If _declaredFunctionOrVarNames_ does not contain _F_, then
-                    1. Perform ? _envRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *false*).
-                    1. Append _F_ to _declaredFunctionOrVarNames_.
-                  3. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _genv_ be the running execution context's VariableEnvironment.
-                    1. Let _genvRec_ be _genv_'s EnvironmentRecord.
-                    1. Let _benv_ be the running execution context's LexicalEnvironment.
-                    1. Let _benvRec_ be _benv_'s EnvironmentRecord.
-                    1. Let _fobj_ be ! _benvRec_.GetBindingValue(_F_, *false*).
-                    1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
-                    1. Return NormalCompletion(~empty~).
+          1. Let _strict_ by IsStrict of _script_
+          1. If _strict_ is *false*, then
+            1. Let _declaredFunctionOrVarNames_ be a new empty List.
+            1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
+            1. Append to _declaredFunctionOrVarNames_ the elements of _declaredVarNames_.
+            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_,
+              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
+              2. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
+                1. If _envRec_.HasLexicalDeclaration(_F_) is *false*, then
+                  1. Let _fnDefinable_ be ? _envRec_.CanDeclareGlobalFunction(_F_).
+                  3. If _fnDefinable_ is *true*, then
+                    1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
+                    2. If _declaredFunctionOrVarNames_ does not contain _F_, then
+                      1. Perform ? _envRec_.CreateGlobalFunctionBinding(_F_, *undefined*, *false*).
+                      1. Append _F_ to _declaredFunctionOrVarNames_.
+                    3. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
+                      1. Let _genv_ be the running execution context's VariableEnvironment.
+                      1. Let _genvRec_ be _genv_'s EnvironmentRecord.
+                      1. Let _benv_ be the running execution context's LexicalEnvironment.
+                      1. Let _benvRec_ be _benv_'s EnvironmentRecord.
+                      1. Let _fobj_ be ! _benvRec_.GetBindingValue(_F_, *false*).
+                      1. Perform ? _genvRec_.SetMutableBinding(_F_, _fobj_, *false*).
+                      1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
       <emu-annex id="sec-web-compat-evaldeclarationinstantiation">


### PR DESCRIPTION
Ensure that legacy extensions to GlobalDeclarationInstantiation are only
observed when the script source is not strict mode code.