### PR TITLE
Only reference Object.assign as function, not method

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22603,7 +22603,7 @@ eval("1;var a;")
                 1. Perform ? Set(_to_, _nextKey_, _propValue_, *true*).
           1. Return _to_.
         </emu-alg>
-        <p>The `length` property of the `assign` method is 2.</p>
+        <p>The `length` property of the `assign` function is 2.</p>
       </emu-clause>
 
       <!-- es6num="19.1.2.2" -->


### PR DESCRIPTION
I'd like to suggest only referring to `Object.assign()` as a function since it never uses ~~context~~ the `this` value.

If this is too nitty please let me know for future reference.