### PR TITLE
Remove unnecessary step on Integer Indexed's [[DefineOwnProperty]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7788,18 +7788,17 @@
             1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
               1. If IsInteger(_numericIndex_) is *false*, return *false*.
-              1. Let _intIndex_ be _numericIndex_.
-              1. If _intIndex_ = *-0*, return *false*.
-              1. If _intIndex_ &lt; 0, return *false*.
+              1. If _numericIndex_ = *-0*, return *false*.
+              1. If _numericIndex_ &lt; 0, return *false*.
               1. Let _length_ be the value of _O_'s [[ArrayLength]] internal slot.
-              1. If _intIndex_ &ge; _length_, return *false*.
+              1. If _numericIndex_ &ge; _length_, return *false*.
               1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
               1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *true*, return *false*.
               1. If _Desc_ has an [[Enumerable]] field and if _Desc_.[[Enumerable]] is *false*, return *false*.
               1. If _Desc_ has a [[Writable]] field and if _Desc_.[[Writable]] is *false*, return *false*.
               1. If _Desc_ has a [[Value]] field, then
                 1. Let _value_ be _Desc_.[[Value]].
-                1. Return ? IntegerIndexedElementSet(_O_, _intIndex_, _value_).
+                1. Return ? IntegerIndexedElementSet(_O_, _numericIndex_, _value_).
               1. Return *true*.
           1. Return OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
         </emu-alg>


### PR DESCRIPTION
`intIndex` has the same value as `numericIndex` and the latter can
be reused on the following steps.