### PR TITLE
[[Construct]]: extends the check against non-undefined primitive

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6854,8 +6854,8 @@
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. If _result_.[[Type]] is ~return~, then
           1. If Type(_result_.[[Value]]) is Object, return NormalCompletion(_result_.[[Value]]).
-          1. If _kind_ is `"base"`, return NormalCompletion(_thisArgument_).
-          1. If _result_.[[Value]] is not *undefined*, throw a *TypeError* exception.
+          1. If _result_.[[Value]] is not *undefined*, then
+            1. If the value of the [[FunctionKind]] internal slot of _F_ is `"classConstructor"`, throw a *TypeError* exception.
         1. Else, ReturnIfAbrupt(_result_).
         1. Return ? _envRec_.GetThisBinding().
       </emu-alg>


### PR DESCRIPTION
When a non-undefined primitive is returned, throw a TypeError
exception, except in the legacy case when the constructor was defined
with the `function` keyword.
