### PR TITLE
Edit B.3.4: fix typos & terminology, simplify language

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36714,7 +36714,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
     <!-- es6num="B.3.4" -->
     <emu-annex id="sec-functiondeclarations-in-ifstatement-statement-clauses">
       <h1>FunctionDeclarations in IfStatement Statement Clauses</h1>
-      <p>The following rules for |IfStatement| augment those in <emu-xref href="#sec-if-statement"></emu-xref>:</p>
+      <p>The following augments the |IfStatement| production in <emu-xref href="#sec-if-statement"></emu-xref>:</p>
       <emu-grammar>
         IfStatement[Yield, Return] :
           `if` `(` Expression[In, ?Yield] `)` FunctionDeclaration[?Yield] `else` Statement[?Yield, ?Return]
@@ -36722,7 +36722,7 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
           `if` `(` Expression[In, ?Yield] `)` FunctionDeclaration[?Yield] `else` FunctionDeclaration[?Yield]
           `if` `(` Expression[In, ?Yield] `)` FunctionDeclaration[?Yield]
       </emu-grammar>
-      <p>The above rules are only applied when parsing code that is not strict mode code. If any such code is match by one of these rules subsequent processing of that code takes places as if each matching occurrence of |FunctionDeclaration[?Yield]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
+      <p>This production only applies when parsing non-strict code. Code matching this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
     </emu-annex>
 
     <!-- es6num="B.3.5" -->


### PR DESCRIPTION
https://tc39.github.io/ecma262/#sec-functiondeclarations-in-ifstatement-statement-clauses

To begin with I was just going to fix typos, then I thought the language could be simplified, and noticed some terminology issues.

Is there anything meaningful about the "subsequent" here (emphasis mine)?:

> *subsequent* processing of that code

I figured it's redundant and trimmed it.

Typos:
  * "is match"
  * "takes places"

Terminology:
  * "rule" => "production"
  * "not strict mode code" => "non-strict code"