### PR TITLE
[editorial] Assert normal completion value

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20828,7 +20828,8 @@ eval("1;var a;")
             1. Assert: all named exports from _module_ are resolvable.
             1. Let _envRec_ be _env_'s EnvironmentRecord.
             1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
-              1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
+              1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
+              1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
               1. If _in_.[[ImportName]] is `"*"`, then
                 1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
                 1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
@@ -20870,7 +20871,8 @@ eval("1;var a;")
             1. If _module_.[[Evaluated]] is *true*, return *undefined*.
             1. Set _module_.[[Evaluated]] to *true*.
             1. For each String _required_ that is an element of _module_.[[RequestedModules]] do,
-              1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
+              1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
+              1. NOTE: ModuleDeclarationInstantiation must be completed prior to invoking this method, so every requested module is guaranteed to resolve successfully.
               1. Perform ? _requiredModule_.ModuleEvaluation().
             1. Let _moduleCxt_ be a new ECMAScript code execution context.
             1. Set the Function of _moduleCxt_ to *null*.


### PR DESCRIPTION
The Source Text Module Record's ModuleDeclarationInstantiation method
begins by recursively resolving all requested modules of all
dependencies.

The definition of HostResolveImportedModule includes the following
invariant:

> - This operation must be idempotent if it completes normally. Each
>   time it is called with a specific referencingModule, specifier pair
>   as arguments it must return the same Module Record instance.

This means that any invocation of HostResolveImportedModule that follows
the initial traversal cannot result in an abrupt completion.

Update the specification text to document this expectation.