### PR TITLE
Layering: add an explicit [[HostDefined]] field to Realm Records

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5775,11 +5775,19 @@
           <td>
             Template objects are canonicalized separately for each realm using its Realm Record's [[TemplateMap]]. Each [[Strings]] value is a List containing, in source text order, the raw String values of a |TemplateLiteral| that has been evaluated. The associated [[Array]] value is the corresponding template object that is passed to a tag function.
           </td>
+          <td>
+            [[HostDefined]]
+          </td>
+          <td>
+            Any, default value is *undefined*.
+          </td>
+          <td>
+            Field reserved for use by host environments that need to associate additional information with a Realm Record.
+          </td>
         </tr>
         </tbody>
       </table>
     </emu-table>
-    <p>An implementation may define other, implementation specific fields.</p>
 
     <!-- es6num="8.2.1" -->
     <emu-clause id="sec-createrealm" aoid="CreateRealm">


### PR DESCRIPTION
Previously the spec said "An implementation may define other,
implementation specific fields." This gives us a single
implementation-specific field to allow hosts to increase precision, and
to consistify with other Records in the spec which use [[HostDefined]]
for this purpose.

This is not a big deal but would clean up some stuff in HTML.