### PR TITLE
Updating README to point to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,8 @@ Proposals follow [this process document](https://tc39.github.io/process-document
 See also the [stage 0 proposals](stage0.md).
 
 ### Contributing New Proposals
-If you are a TC39 member representative, just submit a pull request for your proposal, probably to the `stage0.md` document.
 
-Ecma TC39 accepts Strawman Proposals from non-member individuals who have accepted the TC39 copyright and patent policies. Currently all ECMAScript related technical work is done by the TC39 RF TG (Royalty Free Task Group), for which the following IPR Policies apply:
-
-  * [Ecma International RF Patent Policy](http://www.ecma-international.org/memento/Policies/Ecma_Royalty-Free_Patent_Policy_Extension_Option.htm)
-  * [Ecma International Software Copyright Policy](http://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.htm) ([PDF](http://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.pdf))
-
-If you wish to submit a proposal and are not a representative of a TC39 member, here are the steps you need to take:
-
-  1. Read the  [TC39 process document](https://tc39.github.io/process-document/).
-  2. [Register as a TC39 contributor](http://www.ecma-international.org/memento/register_TC39_Royalty_Free_Task_Group.php) (it is not necessary to submit the contribution as attachment to the form)
-  3. Submit a pull request here for your strawman proposal.
+Please see [Contributing to ECMAScript](/CONTRIBUTING.md) for the most up-to-date information on contributing proposals to this standard.
 
 ## Developing the Specification
 


### PR DESCRIPTION
Since the "Contributing New Proposals" section is currently out of date compared to what's in CONTRIBUTING.md, updating to just point to that file.