### PR TITLE
[normative] Prevent module binding "rescuing"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20782,7 +20782,7 @@ eval("1;var a;")
                 1. Assert: _module_ imports a specific binding for this export.
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. Let _indirectResolution_ be ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_, _exportStarSet_).
-                1. If _indirectResolution_ is not *null*, return _indirectResolution_.
+                1. Return _indirectResolution_.
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
               1. Throw a *SyntaxError* exception.


### PR DESCRIPTION
Currently, when an indirect export binding cannot be resolved,
ResolveExport continues to search for a binding of the same name as
provided by a "star export." If found, the algorithm exits normally and
that binding is used.

This means that "star exports" can effectively "rescue" faulty indirect
exports, as in the following example:

```js
// file: rescued.js
export { x } from './empty.js';
export * from './has-x.js';
```

```js
// file: empty.js
;
```

```js
// file: has-x.js
export var x;
```

`rescued.js` is ostensibly providing an `x` binding from `empty.js`, but
the binding actually originates in `has-x.js`. The author of this code
likely expects the binding to be provided by `empty.js`, and the fact
that the code executes without error may hide bugs resulting from a
misunderstanding of the actual state of the dependency graph.

Ensure that an error is reported when indirect exports cannot be
resolved, regardless of any "star exports" present in the module.