### PR TITLE
remove unused static semantic function StaticPropertyNameList

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18977,25 +18977,6 @@ eval("1;var a;")
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.13" -->
-    <emu-clause id="sec-static-semantics-staticpropertynamelist">
-      <h1>Static Semantics: StaticPropertyNameList</h1>
-      <emu-grammar>ClassElementList : ClassElement</emu-grammar>
-      <emu-alg>
-        1. If PropName of |ClassElement| is ~empty~, return a new empty List.
-        1. If IsStatic of |ClassElement| is *false*, return a new empty List.
-        1. Return a List containing PropName of |ClassElement|.
-      </emu-alg>
-      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
-      <emu-alg>
-        1. Let _list_ be StaticPropertyNameList of |ClassElementList|.
-        1. If PropName of |ClassElement| is ~empty~, return _list_.
-        1. If IsStatic of |ClassElement| is *false*, return _list_.
-        1. Append PropName of |ClassElement| to the end of _list_.
-        1. Return _list_.
-      </emu-alg>
-    </emu-clause>
-
     <!-- es6num="14.5.14" -->
     <emu-clause id="sec-runtime-semantics-classdefinitionevaluation">
       <h1>Runtime Semantics: ClassDefinitionEvaluation</h1>


### PR DESCRIPTION
I couldn't find any references to it, so I figured it could be removed.