### PR TITLE
[editorial] Document invariant more consistently

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5545,8 +5545,9 @@
         <!-- es6num="8.1.1.5.1" -->
         <emu-clause id="sec-module-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue (_N_, _S_)</h1>
-          <p>The concrete Environment Record method GetBindingValue for module Environment Records returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.</p>
+          <p>The concrete Environment Record method GetBindingValue for module Environment Records returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown.</p>
           <emu-alg>
+            1. Assert: _S_ is *true*.
             1. Let _envRec_ be the module Environment Record for which the method was invoked.
             1. Assert: _envRec_ has a binding for _N_.
             1. If the binding for _N_ is an indirect binding, then
@@ -5554,13 +5555,10 @@
               1. Let _targetEnv_ be _M_.[[Environment]].
               1. If _targetEnv_ is *undefined*, throw a *ReferenceError* exception.
               1. Let _targetER_ be _targetEnv_'s EnvironmentRecord.
-              1. Return ? _targetER_.GetBindingValue(_N2_, _S_).
+              1. Return ? _targetER_.GetBindingValue(_N2_, *true*).
             1. If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.
             1. Return the value currently bound to _N_ in _envRec_.
           </emu-alg>
-          <emu-note>
-            <p>Because a |Module| is always strict mode code, calls to GetBindingValue should always pass *true* as the value of _S_.</p>
-          </emu-note>
         </emu-clause>
 
         <!-- es6num="8.1.1.5.2" -->

--- a/spec.html
+++ b/spec.html
@@ -5559,6 +5559,9 @@
             1. If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.
             1. Return the value currently bound to _N_ in _envRec_.
           </emu-alg>
+          <emu-note>
+            <p>_S_ will always be *true* because a |Module| is always strict mode code.</p>
+          </emu-note>
         </emu-clause>
 
         <!-- es6num="8.1.1.5.2" -->


### PR DESCRIPTION
As noted in the non-normative text, the second argument to
GetBindingValue for module Environment Records will always be true.
However, two other aspects of the text suggest that this is *not* an
invariant:

> [...] a *ReferenceError* is thrown regardless of the value of S.

And:

> 1. Return ? _targetER_.GetBindingValue(_N2_, _S_).

In this latter case, the reference to the variable instead of the
literal value *true* suggests that some other value may be specified.

Replace the non-normative text with a formal assertion as the first step
of the algorithm, and remove the details that tend to contradict the
invariant.