### PR TITLE
[editorial] Remove unreachable method

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5509,7 +5509,7 @@
       <emu-clause id="sec-module-environment-records">
         <h1>Module Environment Records</h1>
         <p>A module Environment Record is a declarative Environment Record that is used to represent the outer scope of an ECMAScript |Module|. In additional to normal mutable and immutable bindings, module Environment Records also provide immutable import bindings which are bindings that provide indirect access to a target binding that exists in another Environment Record.</p>
-        <p>Module Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and share the same specifications for all of those methods except for GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding. In addition, module Environment Records support the methods listed in <emu-xref href="#table-20"></emu-xref>:</p>
+        <p>Module Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and share the same specifications for all of those methods except for GetBindingValue, HasThisBinding and GetThisBinding. In addition, module Environment Records support the methods listed in <emu-xref href="#table-20"></emu-xref>:</p>
         <emu-table id="table-20" caption="Additional Methods of Module Environment Records">
           <table>
             <tbody>
@@ -5560,20 +5560,6 @@
           </emu-alg>
           <emu-note>
             <p>Because a |Module| is always strict mode code, calls to GetBindingValue should always pass *true* as the value of _S_.</p>
-          </emu-note>
-        </emu-clause>
-
-        <!-- es6num="8.1.1.5.2" -->
-        <emu-clause id="sec-module-environment-records-deletebinding-n">
-          <h1>DeleteBinding (_N_)</h1>
-          <p>The concrete Environment Record method DeleteBinding for module Environment Records refuses to delete bindings.</p>
-          <emu-alg>
-            1. Let _envRec_ be the module Environment Record for which the method was invoked.
-            1. If _envRec_ does not have a binding for the name that is the value of _N_, return *true*.
-            1. Return *false*.
-          </emu-alg>
-          <emu-note>
-            <p>The bindings of a module Environment Record are not deletable.</p>
           </emu-note>
         </emu-clause>
 


### PR DESCRIPTION
The DeleteBinding method of any Environment Record is only called when the
`delete` operator is applied to a value of type Reference. Because module
environment records (and therefore module bindings) are only accessible from
module code, the module Environment Record's version of this method would only
be called if the `delete` expression occurred within module code.

All module code is strict mode code, so the `delete` expression would
necessarily have to exist within strict mode. However, static semantics of the
operator explicitly prohibit its application to an IdentifierReference from
within strict mode.

Because the preconditions for calling this method cannot be satisfied, it may
be removed from the specification.

@domenic I'm wondering if this method is actually defined for layering purposes. I don't see any reference to it in the WhatWG loader spec (for example), but I was hoping to get your perspective on this.