### PR TITLE
add date field to ES2016 draft

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15,6 +15,7 @@
   shortname: ECMA-262 (Ecma/TC39/2016/010)
   version: 7ᵗʰ Edition
   status: draft
+  date: 2016-03-01
   location: https://tc39.github.io/ecma262/
 </pre>
 <emu-intro>


### PR DESCRIPTION
Currently, it is showing the date the latest draft was built, not the date the es2016 draft was last revised.