### PR TITLE
Meta: Fix `favicon.ico` path

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="ascii">
-<link rel="icon" href="favicon.ico">
+<link rel="icon" href="img/favicon.ico">
 <link href="ecmarkup.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="ecmarkup.js"></script>


### PR DESCRIPTION
This fixes the first part of #491:

> http://tc39.github.io/ecma262/ seems to have lost it's Ecma favicon.

--

Note: The code from the [`es2016`](https://github.com/tc39/ecma262/tree/es2016) branch also needs to be updated.