### PR TITLE
Read global and sticky from [[OriginalFlags]] in RegExpBuiltinExec

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28850,11 +28850,11 @@ Date.parse(x.toLocaleString())
             1. Assert: Type(_S_) is String.
             1. Let _length_ be the number of code units in _S_.
             1. Let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
-            1. Let _global_ be ToBoolean(? Get(_R_, `"global"`)).
-            1. Let _sticky_ be ToBoolean(? Get(_R_, `"sticky"`)).
+            1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
+            1. If _flags_ contains `"g"`, let _global_ be *true*, else let _global_ be *false*.
+            1. If _flags_ contains `"y"`, let _sticky_ be *true*, else let _sticky_ be *false*.
             1. If _global_ is *false* and _sticky_ is *false*, let _lastIndex_ be 0.
             1. Let _matcher_ be the value of _R_'s [[RegExpMatcher]] internal slot.
-            1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
             1. If _flags_ contains `"u"`, let _fullUnicode_ be *true*, else let _fullUnicode_ be *false*.
             1. Let _matchSucceeded_ be *false*.
             1. Repeat, while _matchSucceeded_ is *false*


### PR DESCRIPTION
This closes #489. RegExpBuiltinExec reads other flags from
[[OriginalFlags]], based on the fact that it is operating on a RegExp
instance. In ES2015, however, it accessed 'global' and 'sticky' via
property accesses. This patch changes RegExpBuiltinExec to access
those flags via [[OriginalFlags]] as well.