### PR TITLE
Normative: add `Reflect[Symbol.toStringTag]`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35184,6 +35184,14 @@ my_text = JSON.stringify(a); // This must throw a TypeError.
         1. Return ? _target_.[[SetPrototypeOf]](_proto_).
       </emu-alg>
     </emu-clause>
+
+    <!-- es6num="26.1.15" -->
+    <emu-clause id="sec-reflect-@@tostringtag">
+      <h1>Reflect [ @@toStringTag ]</h1>
+      <p>The initial value of the @@toStringTag property is the String value `"Reflect"`.</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+    </emu-clause>
+
   </emu-clause>
 
   <!-- es6num="26.2" -->


### PR DESCRIPTION
Fixes #495.

This seemed so obvious an omission to me that I went ahead and put up a PR.