### PR TITLE
[editorial] Insert omitted parameter

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4382,7 +4382,7 @@
     </emu-clause>
 
     <emu-clause id="sec-enumerableownproperties" aoid="EnumerableOwnProperties">
-      <h1>EnumerableOwnProperties (_O_)</h1>
+      <h1>EnumerableOwnProperties ( _O_, _kind_ )</h1>
       <p>When the abstract operation EnumerableOwnProperties is called with Object _O_ and String _kind_ the following steps are taken:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.


### PR DESCRIPTION
The EnumerableOwnProperties abstract operation accepts two parameters,
but the second was omitted from its signature. Document the required
_kind_ parameter in the signature.