### PR TITLE
[editorial] Assert normal completion value

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8052,7 +8052,7 @@
           1. Let _exports_ be the value of _O_'s [[Exports]] internal slot.
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _m_ be the value of _O_'s [[Module]] internal slot.
-          1. Let _binding_ be ? _m_.ResolveExport(_P_, &laquo; &raquo;, &laquo; &raquo;).
+          1. Let _binding_ be ! _m_.ResolveExport(_P_, &laquo; &raquo;, &laquo; &raquo;).
           1. Assert: _binding_ is neither *null* nor `"ambiguous"`.
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.


### PR DESCRIPTION
Immediately prior to invoking ResolveExport, the [[Get]] method ensures
that the property key exists in the [[Exports]] list. In
ModuleNamespaceCreate, the [[Exports]] slot is set to the list of all
bindings that may be resolved unambiguously from the requested module.
This means that this invocation of ResolveExport cannot return an abrupt
completion.

Document this fact in the text of the algorithm.