### PR TITLE
[editorial] Specify order of module namespace keys

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8110,7 +8110,8 @@
           1. Let _M_ be a newly created object.
           1. Set _M_'s essential internal methods to the definitions specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref>.
           1. Set _M_'s [[Module]] internal slot to _module_.
-          1. Set _M_'s [[Exports]] internal slot to _exports_.
+          1. Let _sortedExports_ be a new List containing the same values as the list _exports_ where the values are ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using SortCompare as _comparefn_.
+          1. Set _M_'s [[Exports]] internal slot to _sortedExports_.
           1. Create own properties of _M_ corresponding to the definitions in <emu-xref href="#sec-module-namespace-objects"></emu-xref>.
           1. Set _module_.[[Namespace]] to _M_.
           1. Return _M_.


### PR DESCRIPTION
A module Namespace exotic object's [[Exports]] internal slot is defined
through the following sequence of steps:

1. GetModuleNamespace invokes GetExportedNames
2. GetExportedNames returns a List of strings describing the
   LocalExportEntries in source code order, followed by the
   IndirectExportEntries in source code order, followed by the same for
   each of the module's "star" exports.
3. GetModuleNamespace resolves all `exportedNames`, filters out all
   ambiguous names, and passes the result to ModuleNamespaceCreate
4. ModuleNamespaceCreate sets the object's [[Exports]] internal slot to
   the provided list

There is no normative text that modifies the order of list elements
following its creation in GetExportedNames. This conflicts with the
~~informative~~ text in table 29, "Internal Slots of Module Namespace Exotic
Objects," which describes the [[Exports]] slot as:

> A List containing the String values of the exported names exposed as
> own properties of this object. The list is ordered as if an Array of
> those String values had been sorted using `Array.prototype.sort` using
> SortCompare as _comparefn_.

Because ordering of this list is observable through the
[[OwnPropertyKeys]] method and the ListIterator created by its
[@@iterator] method, the specification should include explicit algorithm
steps that produce this result.

Extend the ModuleNamespaceCreate algorithm to sort the values of
[[Exports]] according to previously-existing text in Table 29.