### PR TITLE
RegExp.prototype not an instance web compatibility workaround

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28965,7 +28965,9 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot,
+            1. If SameValue(_R_, %RegExpPrototype%), return *undefined*.
+            1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"g"`, return *true*.
           1. Return *false*.
@@ -28979,7 +28981,9 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot,
+            1. If SameValue(_R_, %RegExpPrototype%), return *undefined*.
+            1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"i"`, return *true*.
           1. Return *false*.
@@ -29030,7 +29034,9 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot,
+            1. If SameValue(_R_, %RegExpPrototype%), return *undefined*.
+            1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"m"`, return *true*.
           1. Return *false*.
@@ -29130,8 +29136,10 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalSource]] internal slot, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalSource]] internal slot,
+            1. If SameValue(_R_, %RegExpPrototype%), return `"(?:)"`.
+            1. Otherwise, throw a *TypeError* exception.
+          1. Assert: _R_ has an [[OriginalFlags]] internal slot.
           1. Let _src_ be the value of _R_'s [[OriginalSource]] internal slot.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. Return EscapeRegExpPattern(_src_, _flags_).
@@ -29216,7 +29224,9 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot,
+            1. If SameValue(_R_, %RegExpPrototype%), return *undefined*.
+            1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"y"`, return *true*.
           1. Return *false*.
@@ -29259,7 +29269,9 @@ Date.parse(x.toLocaleString())
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have an [[OriginalFlags]] internal slot, throw a *TypeError* exception.
+          1. If _R_ does not have an [[OriginalFlags]] internal slot,
+            1. If SameValue(_R_, %RegExpPrototype%), return *undefined*.
+            1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
           1. If _flags_ contains the code unit `"u"`, return *true*.
           1. Return *false*.


### PR DESCRIPTION
This patch makes a change to ES2015 RegExp semantics to prevent
certain property accesses and method calls from throwing. Although
the feature testing patterns here are dispreferred, they were found
necessary to ensure web compatibility of ES2015-based RegExp
semantics with respect to old versions of certain libraries.

This closes #262.

This patch attempts to encode the consensus of the March 2016 TC39 meeting.