### PR TITLE
RegExp Processing of CharacterClassEscape for \W should be the same as !\w with unicode and ignoreCase flags.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28310,7 +28310,7 @@ Date.parse(x.toLocaleString())
         <h1>CharacterClassEscape</h1>
         <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates by returning the ten-element set of characters containing the characters `0` through `9` inclusive and the Boolean *false*.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates by returning the set returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> and the Boolean *true*.</p>
-        <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates by returning the set of characters containing the characters that are on the right-hand side of the |WhiteSpace| or |LineTerminator| productions.</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates by returning the set of characters containing the characters that are on the right-hand side of the |WhiteSpace| or |LineTerminator| productions and the Boolean *false*.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates by returning the set returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> and the Boolean *true*.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> evaluates by returning the set of characters containing the sixty-three characters:</p>
         <figure>
@@ -28544,7 +28544,7 @@ Date.parse(x.toLocaleString())
             </tbody>
           </table>
         </figure>
-        <p>and the Boolean *false*.
+        <p>and the Boolean *false*.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates by returning the set returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> and the Boolean *true*.</p>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -28110,8 +28110,8 @@ Date.parse(x.toLocaleString())
         </emu-alg>
         <p>The production <emu-grammar>AtomEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Evaluate |CharacterClassEscape| to obtain a CharSet _A_.
-          1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
+          1. Evaluate |CharacterClassEscape| to obtain a CharSet _A_ and a Boolean _invert_.
+          1. Call CharacterSetMatcher(_A_, _invert_) and return its Matcher result.
         </emu-alg>
         <emu-note>
           <p>An escape sequence of the form `\\` followed by a nonzero decimal number _n_ matches the result of the _n_th set of capturing parentheses (see 0). It is an error if the regular expression has fewer than _n_ capturing parentheses. If the regular expression has _n_ or more capturing parentheses but the _n_th one is *undefined* because it has not captured anything, then the backreference always succeeds.</p>
@@ -28308,10 +28308,10 @@ Date.parse(x.toLocaleString())
       <!-- es6num="21.2.2.12" -->
       <emu-clause id="sec-characterclassescape">
         <h1>CharacterClassEscape</h1>
-        <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates by returning the ten-element set of characters containing the characters `0` through `9` inclusive.</p>
-        <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> .</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates by returning the ten-element set of characters containing the characters `0` through `9` inclusive and the Boolean *false*.</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates by returning the set returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> and the Boolean *true*.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates by returning the set of characters containing the characters that are on the right-hand side of the |WhiteSpace| or |LineTerminator| productions.</p>
-        <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> .</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates by returning the set returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> and the Boolean *true*.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> evaluates by returning the set of characters containing the sixty-three characters:</p>
         <figure>
           <table class="lightweight-table">
@@ -28544,7 +28544,8 @@ Date.parse(x.toLocaleString())
             </tbody>
           </table>
         </figure>
-        <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> .</p>
+        <p>and the Boolean *false*.
+        <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates by returning the set returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> and the Boolean *true*.</p>
       </emu-clause>
 
       <!-- es6num="21.2.2.13" -->


### PR DESCRIPTION
The current specification of CharacterClassEscape's in Regular Expressions introduces surprising behavior of \W when both the `unicode` and `ignoreCase` flags are provided.

There are 6 CharacterClassEscapes defined:
\d is digit character and  \D is not digit character
\s is space character and \S is not space character
\w is word character and \W is not word character
Furthermore, !\d matches the same as \D, !\s matches the same as \S, and !\w matches the same as \W with the exception of `/\W/.ui` and the characters 'k', 'K', 's' and 'S'.

These exceptions should be removed so that `/\W/ui.test("k")` should be `false` given that `/\w/ui.test("k")` is `true`.  The same changes should mode for the other three subject characters.  The proposed changes involve how the _CharSet_ and _invert_ flag are generated for CharacterSetMatcher for CharacterClassEscapes.

The proposed changes are also made for \D and \S CharacterClassEscapes for consistency, even though the changes to impacted what they match.

This change has been discussed in [issue 512](https://github.com/tc39/ecma262/issues/512).