### PR TITLE
[editorial] Document algorithm modification

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21793,6 +21793,7 @@ eval("1;var a;")
                 1. For each _name_ in _varNames_, do
                   1. If _thisEnvRec_.HasBinding(_name_) is *true*, then
                     1. Throw a *SyntaxError* exception.
+                    1. NOTE: Annex <emu-xref href="#sec-variablestatements-in-catch-blocks"></emu-xref> defines alternate semantics for the above step.
                   1. NOTE: A direct eval will not hoist var declaration over a like-named lexical declaration.
               1. Let _thisLex_ be _thisLex_'s outer environment reference.
           1. Let _functionsToInitialize_ be a new empty List.


### PR DESCRIPTION
In cases where Annex B re-defines semantics in the preceding sections,
the relevant sections are generally annotated with a reference to the
relevant extension. This aids discovery by readers and also maintenance
by authors--as section numbers and step numbers change, references in
Annex B prose may need to be updated accordingly.

Explicitly reference the relevant Annex B extension from within the
algorithm steps for EvalDeclarationInstantiation.