### PR TITLE
Replace each abstract op's preamble with a structured 'header'.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -996,9 +996,16 @@
       <p>In this specification, the phrase "the <dfn id="string-concatenation">string-concatenation</dfn> of _A_, _B_, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
       <p>The phrase "the <dfn id="substring">substring</dfn> of _S_ from _inclusiveStart_ to _exclusiveEnd_" (where _S_ is a String value or a sequence of code units and _inclusiveStart_ and _exclusiveEnd_ are integers) denotes the String value consisting of the consecutive code units of _S_ beginning at index _inclusiveStart_ and ending immediately before index _exclusiveEnd_ (which is the empty String when _inclusiveStart_ = _exclusiveEnd_). If the "to" suffix is omitted, the length of _S_ is used as the value of _exclusiveEnd_.</p>
 
-      <emu-clause id="sec-stringindexof" aoid="StringIndexOf">
-        <h1>StringIndexOf ( _string_, _searchValue_, _fromIndex_ )</h1>
-        <p>The abstract operation StringIndexOf takes arguments _string_ (a String), _searchValue_ (a String), and _fromIndex_ (a non-negative integer). It performs the following steps when called:</p>
+      <emu-clause id="sec-stringindexof" type="abstract operation">
+        <h1>
+          StringIndexOf (
+            _string_: a String,
+            _searchValue_: a String,
+            _fromIndex_: a non-negative integer,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Type(_string_) is String.
           1. Assert: Type(_searchValue_) is String.
@@ -1526,27 +1533,45 @@
 
         <p>The Number::unit value is *1*<sub>𝔽</sub>.</p>
 
-        <emu-clause id="sec-numeric-types-number-unaryMinus">
-          <h1>Number::unaryMinus ( _x_ )</h1>
-          <p>The abstract operation Number::unaryMinus takes argument _x_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-unaryMinus" type="numeric method">
+          <h1>
+            Number::unaryMinus (
+              _x_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN*, return *NaN*.
             1. Return the result of negating _x_; that is, compute a Number with the same magnitude but opposite sign.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-bitwiseNOT">
-          <h1>Number::bitwiseNOT ( _x_ )</h1>
-          <p>The abstract operation Number::bitwiseNOT takes argument _x_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-bitwiseNOT" type="numeric method">
+          <h1>
+            Number::bitwiseNOT (
+              _x_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _oldValue_ be ! ToInt32(_x_).
             1. Return the result of applying bitwise complement to _oldValue_. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-exponentiate" oldids="sec-applying-the-exp-operator">
-          <h1>Number::exponentiate ( _base_, _exponent_ )</h1>
-          <p>The abstract operation Number::exponentiate takes arguments _base_ (a Number) and _exponent_ (a Number). It returns an implementation-approximated value representing the result of raising _base_ to the _exponent_ power. It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-exponentiate" type="numeric method" oldids="sec-applying-the-exp-operator">
+          <h1>
+            Number::exponentiate (
+              _base_: a Number,
+              _exponent_: a Number,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns an implementation-approximated value representing the result of raising _base_ to the _exponent_ power.</dd>
+          </dl>
           <emu-alg>
             1. If _exponent_ is *NaN*, return *NaN*.
             1. If _exponent_ is *+0*<sub>𝔽</sub> or _exponent_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
@@ -1583,9 +1608,17 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-multiply" oldids="sec-applying-the-mul-operator">
-          <h1>Number::multiply ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::multiply takes arguments _x_ (a Number) and _y_ (a Number). It performs multiplication according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the product of _x_ and _y_. It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-multiply" type="numeric method" oldids="sec-applying-the-mul-operator">
+          <h1>
+            Number::multiply (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It performs multiplication according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the product of _x_ and _y_.</dd>
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
             1. If _x_ is *+&infin;*<sub>𝔽</sub> or _x_ is *-&infin;*<sub>𝔽</sub>, then
@@ -1603,9 +1636,17 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-divide" oldids="sec-applying-the-div-operator">
-          <h1>Number::divide ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::divide takes arguments _x_ (a Number) and _y_ (a Number). It performs division according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the quotient of _x_ and _y_ where _x_ is the dividend and _y_ is the divisor. It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-divide" type="numeric method" oldids="sec-applying-the-div-operator">
+          <h1>
+            Number::divide (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It performs division according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the quotient of _x_ and _y_ where _x_ is the dividend and _y_ is the divisor.</dd>
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
             1. If _x_ is *+&infin;*<sub>𝔽</sub> or _x_ is *-&infin;*<sub>𝔽</sub>, then
@@ -1628,9 +1669,17 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-remainder" oldids="sec-applying-the-mod-operator">
-          <h1>Number::remainder ( _n_, _d_ )</h1>
-          <p>The abstract operation Number::remainder takes arguments _n_ (a Number) and _d_ (a Number). It yields the remainder from an implied division of its operands where _n_ is the dividend and _d_ is the divisor. It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-remainder" type="numeric method" oldids="sec-applying-the-mod-operator">
+          <h1>
+            Number::remainder (
+              _n_: a Number,
+              _d_: a Number,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It yields the remainder from an implied division of its operands where _n_ is the dividend and _d_ is the divisor.</dd>
+          </dl>
           <emu-alg>
             1. If _n_ is *NaN* or _d_ is *NaN*, return *NaN*.
             1. If _n_ is *+&infin;*<sub>𝔽</sub> or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
@@ -1647,9 +1696,17 @@
           <emu-note>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2019. The IEEE 754-2019 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual <emu-not-ref>integer</emu-not-ref> remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java <emu-not-ref>integer</emu-not-ref> remainder operator; this may be compared with the C library function fmod.</emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-add" oldids="sec-applying-the-additive-operators-to-numbers">
-          <h1>Number::add ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::add takes arguments _x_ (a Number) and _y_ (a Number). It performs addition according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the sum of its arguments. It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-add" type="numeric method" oldids="sec-applying-the-additive-operators-to-numbers">
+          <h1>
+            Number::add (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It performs addition according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the sum of its arguments.</dd>
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
             1. If _x_ is *+&infin;*<sub>𝔽</sub> and _y_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
@@ -1665,9 +1722,17 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-subtract">
-          <h1>Number::subtract ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::subtract takes arguments _x_ (a Number) and _y_ (a Number). It performs subtraction, producing the difference of its operands; _x_ is the minuend and _y_ is the subtrahend. It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-subtract" type="numeric method">
+          <h1>
+            Number::subtract (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It performs subtraction, producing the difference of its operands; _x_ is the minuend and _y_ is the subtrahend.</dd>
+          </dl>
           <emu-alg>
             1. Return Number::add(_x_, Number::unaryMinus(_y_)).
           </emu-alg>
@@ -1676,9 +1741,15 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-leftShift">
-          <h1>Number::leftShift ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::leftShift takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-leftShift" type="numeric method">
+          <h1>
+            Number::leftShift (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
@@ -1687,9 +1758,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-signedRightShift">
-          <h1>Number::signedRightShift ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::signedRightShift takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-signedRightShift" type="numeric method">
+          <h1>
+            Number::signedRightShift (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
@@ -1698,9 +1775,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-unsignedRightShift">
-          <h1>Number::unsignedRightShift ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::unsignedRightShift takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-unsignedRightShift" type="numeric method">
+          <h1>
+            Number::unsignedRightShift (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _lnum_ be ! ToUint32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
@@ -1709,9 +1792,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-lessThan">
-          <h1>Number::lessThan ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::lessThan takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-lessThan" type="numeric method">
+          <h1>
+            Number::lessThan (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN*, return *undefined*.
             1. If _y_ is *NaN*, return *undefined*.
@@ -1727,9 +1816,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-equal">
-          <h1>Number::equal ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::equal takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-equal" type="numeric method">
+          <h1>
+            Number::equal (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN*, return *false*.
             1. If _y_ is *NaN*, return *false*.
@@ -1740,9 +1835,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-sameValue">
-          <h1>Number::sameValue ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::sameValue takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-sameValue" type="numeric method">
+          <h1>
+            Number::sameValue (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
             1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *false*.
@@ -1752,9 +1853,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-sameValueZero">
-          <h1>Number::sameValueZero ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::sameValueZero takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-sameValueZero" type="numeric method">
+          <h1>
+            Number::sameValueZero (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
             1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *true*.
@@ -1764,9 +1871,16 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numberbitwiseop" aoid="NumberBitwiseOp">
-          <h1>NumberBitwiseOp ( _op_, _x_, _y_ )</h1>
-          <p>The abstract operation NumberBitwiseOp takes arguments _op_ (a sequence of Unicode code points), _x_, and _y_. It performs the following steps when called:</p>
+        <emu-clause id="sec-numberbitwiseop" type="abstract operation">
+          <h1>
+            NumberBitwiseOp (
+              _op_: a sequence of Unicode code points,
+              _x_: unknown,
+              _y_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _op_ is `&amp;`, `^`, or `|`.
             1. Let _lnum_ be ! ToInt32(_x_).
@@ -1780,33 +1894,58 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-bitwiseAND">
-          <h1>Number::bitwiseAND ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::bitwiseAND takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-bitwiseAND" type="numeric method">
+          <h1>
+            Number::bitwiseAND (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return NumberBitwiseOp(`&amp;`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-bitwiseXOR">
-          <h1>Number::bitwiseXOR ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::bitwiseXOR takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-bitwiseXOR" type="numeric method">
+          <h1>
+            Number::bitwiseXOR (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return NumberBitwiseOp(`^`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-bitwiseOR">
-          <h1>Number::bitwiseOR ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::bitwiseOR takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-bitwiseOR" type="numeric method">
+          <h1>
+            Number::bitwiseOR (
+              _x_: a Number,
+              _y_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return NumberBitwiseOp(`|`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-number-tostring" aoid="Number::toString" oldids="sec-tostring-applied-to-the-number-type">
-          <h1>Number::toString ( _x_ )</h1>
-          <p>The abstract operation Number::toString takes argument _x_ (a Number). It converts _x_ to String format. It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-number-tostring" type="numeric method" oldids="sec-tostring-applied-to-the-number-type">
+          <h1>
+            Number::toString (
+              _x_: a Number,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It converts _x_ to String format.</dd>
+          </dl>
           <emu-alg>
             1. If _x_ is *NaN*, return the String *"NaN"*.
             1. If _x_ is *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return the String *"0"*.
@@ -1874,23 +2013,41 @@
 
         <p>The BigInt::unit value is *1*<sub>ℤ</sub>.</p>
 
-        <emu-clause id="sec-numeric-types-bigint-unaryMinus">
-          <h1>BigInt::unaryMinus ( _x_ )</h1>
-          <p>The abstract operation BigInt::unaryMinus takes argument _x_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-unaryMinus" type="numeric method">
+          <h1>
+            BigInt::unaryMinus (
+              _x_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _x_ is *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
             1. Return the BigInt value that represents the negation of ℝ(_x_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-bitwiseNOT">
-          <h1>BigInt::bitwiseNOT ( _x_ )</h1>
-          <p>The abstract operation BigInt::bitwiseNOT takes argument _x_ (a BigInt). It returns the one's complement of _x_; that is, -_x_ - *1*<sub>ℤ</sub>.</p>
+        <emu-clause id="sec-numeric-types-bigint-bitwiseNOT" type="numeric method">
+          <h1>
+            BigInt::bitwiseNOT (
+              _x_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns the one's complement of _x_; that is, -_x_ - *1*<sub>ℤ</sub>.</dd>
+          </dl>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-exponentiate">
-          <h1>BigInt::exponentiate ( _base_, _exponent_ )</h1>
-          <p>The abstract operation BigInt::exponentiate takes arguments _base_ (a BigInt) and _exponent_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-exponentiate" type="numeric method">
+          <h1>
+            BigInt::exponentiate (
+              _base_: a BigInt,
+              _exponent_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _exponent_ &lt; *0*<sub>ℤ</sub>, throw a *RangeError* exception.
             1. If _base_ is *0*<sub>ℤ</sub> and _exponent_ is *0*<sub>ℤ</sub>, return *1*<sub>ℤ</sub>.
@@ -1898,15 +2055,29 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-multiply">
-          <h1>BigInt::multiply ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::multiply takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns the BigInt value that represents the result of multiplying _x_ and _y_.</p>
+        <emu-clause id="sec-numeric-types-bigint-multiply" type="numeric method">
+          <h1>
+            BigInt::multiply (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns the BigInt value that represents the result of multiplying _x_ and _y_.</dd>
+          </dl>
           <emu-note>Even if the result has a much larger bit width than the input, the exact mathematical answer is given.</emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-divide">
-          <h1>BigInt::divide ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::divide takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-divide" type="numeric method">
+          <h1>
+            BigInt::divide (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _y_ is *0*<sub>ℤ</sub>, throw a *RangeError* exception.
             1. Let _quotient_ be ℝ(_x_) / ℝ(_y_).
@@ -1914,9 +2085,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-remainder">
-          <h1>BigInt::remainder ( _n_, _d_ )</h1>
-          <p>The abstract operation BigInt::remainder takes arguments _n_ (a BigInt) and _d_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-remainder" type="numeric method">
+          <h1>
+            BigInt::remainder (
+              _n_: a BigInt,
+              _d_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _d_ is *0*<sub>ℤ</sub>, throw a *RangeError* exception.
             1. If _n_ is *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
@@ -1926,19 +2103,41 @@
           <emu-note>The sign of the result equals the sign of the dividend.</emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-add">
-          <h1>BigInt::add ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::add takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns the BigInt value that represents the sum of _x_ and _y_.</p>
+        <emu-clause id="sec-numeric-types-bigint-add" type="numeric method">
+          <h1>
+            BigInt::add (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns the BigInt value that represents the sum of _x_ and _y_.</dd>
+          </dl>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-subtract">
-          <h1>BigInt::subtract ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::subtract takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns the BigInt value that represents the difference _x_ minus _y_.</p>
+        <emu-clause id="sec-numeric-types-bigint-subtract" type="numeric method">
+          <h1>
+            BigInt::subtract (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns the BigInt value that represents the difference _x_ minus _y_.</dd>
+          </dl>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-leftShift">
-          <h1>BigInt::leftShift ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::leftShift takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-leftShift" type="numeric method">
+          <h1>
+            BigInt::leftShift (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _y_ &lt; *0*<sub>ℤ</sub>, then
               1. Return the BigInt value that represents ℝ(_x_) / 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.
@@ -1947,51 +2146,97 @@
           <emu-note>Semantics here should be equivalent to a bitwise shift, treating the BigInt as an infinite length string of binary two's complement digits.</emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-signedRightShift">
-          <h1>BigInt::signedRightShift ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::signedRightShift takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-signedRightShift" type="numeric method">
+          <h1>
+            BigInt::signedRightShift (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return BigInt::leftShift(_x_, -_y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-unsignedRightShift">
-          <h1>BigInt::unsignedRightShift ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::unsignedRightShift takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-unsignedRightShift" type="numeric method">
+          <h1>
+            BigInt::unsignedRightShift (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Throw a *TypeError* exception.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-lessThan">
-          <h1>BigInt::lessThan ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::lessThan takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns *true* if ℝ(_x_) &lt; ℝ(_y_) and *false* otherwise.</p>
+        <emu-clause id="sec-numeric-types-bigint-lessThan" type="numeric method">
+          <h1>
+            BigInt::lessThan (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns *true* if ℝ(_x_) &lt; ℝ(_y_) and *false* otherwise.</dd>
+          </dl>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-equal">
-          <h1>BigInt::equal ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::equal takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns *true* if ℝ(_x_) = ℝ(_y_) and *false* otherwise.</p>
+        <emu-clause id="sec-numeric-types-bigint-equal" type="numeric method">
+          <h1>
+            BigInt::equal (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns *true* if ℝ(_x_) = ℝ(_y_) and *false* otherwise.</dd>
+          </dl>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-sameValue">
-          <h1>BigInt::sameValue ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::sameValue takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-sameValue" type="numeric method">
+          <h1>
+            BigInt::sameValue (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return BigInt::equal(_x_, _y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-sameValueZero">
-          <h1>BigInt::sameValueZero ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::sameValueZero takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-sameValueZero" type="numeric method">
+          <h1>
+            BigInt::sameValueZero (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return BigInt::equal(_x_, _y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-binaryand" aoid="BinaryAnd">
-          <h1>BinaryAnd ( _x_, _y_ )</h1>
-          <p>The abstract operation BinaryAnd takes arguments _x_ and _y_. It performs the following steps when called:</p>
+        <emu-clause id="sec-binaryand" type="abstract operation">
+          <h1>
+            BinaryAnd (
+              _x_: unknown,
+              _y_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _x_ is 0 or 1.
             1. Assert: _y_ is 0 or 1.
@@ -2000,9 +2245,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-binaryor" aoid="BinaryOr">
-          <h1>BinaryOr ( _x_, _y_ )</h1>
-          <p>The abstract operation BinaryOr takes arguments _x_ and _y_. It performs the following steps when called:</p>
+        <emu-clause id="sec-binaryor" type="abstract operation">
+          <h1>
+            BinaryOr (
+              _x_: unknown,
+              _y_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _x_ is 0 or 1.
             1. Assert: _y_ is 0 or 1.
@@ -2011,9 +2262,15 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-binaryxor" aoid="BinaryXor">
-          <h1>BinaryXor ( _x_, _y_ )</h1>
-          <p>The abstract operation BinaryXor takes arguments _x_ and _y_. It performs the following steps when called:</p>
+        <emu-clause id="sec-binaryxor" type="abstract operation">
+          <h1>
+            BinaryXor (
+              _x_: unknown,
+              _y_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _x_ is 0 or 1.
             1. Assert: _y_ is 0 or 1.
@@ -2023,9 +2280,16 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-bigintbitwiseop" aoid="BigIntBitwiseOp">
-          <h1>BigIntBitwiseOp ( _op_, _x_, _y_ )</h1>
-          <p>The abstract operation BigIntBitwiseOp takes arguments _op_ (a sequence of Unicode code points), _x_ (a BigInt), and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-bigintbitwiseop" type="abstract operation">
+          <h1>
+            BigIntBitwiseOp (
+              _op_: a sequence of Unicode code points,
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _op_ is `&amp;`, `^`, or `|`.
             1. Set _x_ to ℝ(_x_).
@@ -2055,33 +2319,58 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-bitwiseAND">
-          <h1>BigInt::bitwiseAND ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::bitwiseAND takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-bitwiseAND" type="numeric method">
+          <h1>
+            BigInt::bitwiseAND (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return BigIntBitwiseOp(`&amp;`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-bitwiseXOR">
-          <h1>BigInt::bitwiseXOR ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::bitwiseXOR takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-bitwiseXOR" type="numeric method">
+          <h1>
+            BigInt::bitwiseXOR (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return BigIntBitwiseOp(`^`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-bitwiseOR">
-          <h1>BigInt::bitwiseOR ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::bitwiseOR takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-bitwiseOR" type="numeric method">
+          <h1>
+            BigInt::bitwiseOR (
+              _x_: a BigInt,
+              _y_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return BigIntBitwiseOp(`|`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-tostring" aoid="BigInt::toString">
-          <h1>BigInt::toString ( _x_ )</h1>
-          <p>The abstract operation BigInt::toString takes argument _x_ (a BigInt). It converts _x_ to String format. It performs the following steps when called:</p>
+        <emu-clause id="sec-numeric-types-bigint-tostring" type="numeric method">
+          <h1>
+            BigInt::toString (
+              _x_: a BigInt,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It converts _x_ to String format.</dd>
+          </dl>
           <emu-alg>
             1. If _x_ &lt; *0*<sub>ℤ</sub>, return the string-concatenation of the String *"-"* and ! BigInt::toString(-_x_).
             1. Return the String value consisting of the code units of the digits of the decimal representation of _x_.
@@ -3627,9 +3916,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-updateempty" aoid="UpdateEmpty">
-        <h1>UpdateEmpty ( _completionRecord_, _value_ )</h1>
-        <p>The abstract operation UpdateEmpty takes arguments _completionRecord_ and _value_. It performs the following steps when called:</p>
+      <emu-clause id="sec-updateempty" type="abstract operation">
+        <h1>
+          UpdateEmpty (
+            _completionRecord_: unknown,
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: If _completionRecord_.[[Type]] is either ~return~ or ~throw~, then _completionRecord_.[[Value]] is not ~empty~.
           1. If _completionRecord_.[[Value]] is not ~empty~, return Completion(_completionRecord_).
@@ -3690,9 +3985,14 @@
 
       <p>The following abstract operations are used in this specification to operate upon Reference Records:</p>
 
-      <emu-clause id="sec-ispropertyreference" aoid="IsPropertyReference" oldids="ao-ispropertyreference">
-        <h1>IsPropertyReference ( _V_ )</h1>
-        <p>The abstract operation IsPropertyReference takes argument _V_. It performs the following steps when called:</p>
+      <emu-clause id="sec-ispropertyreference" type="abstract operation" oldids="ao-ispropertyreference">
+        <h1>
+          IsPropertyReference (
+            _V_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _V_ is a Reference Record.
           1. If _V_.[[Base]] is ~unresolvable~, return *false*.
@@ -3700,36 +4000,56 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isunresolvablereference" aoid="IsUnresolvableReference" oldids="ao-isunresolvablereference">
-        <h1>IsUnresolvableReference ( _V_ )</h1>
-        <p>The abstract operation IsUnresolvableReference takes argument _V_. It performs the following steps when called:</p>
+      <emu-clause id="sec-isunresolvablereference" type="abstract operation" oldids="ao-isunresolvablereference">
+        <h1>
+          IsUnresolvableReference (
+            _V_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _V_ is a Reference Record.
           1. If _V_.[[Base]] is ~unresolvable~, return *true*; otherwise return *false*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-issuperreference" aoid="IsSuperReference" oldids="ao-issuperreference">
-        <h1>IsSuperReference ( _V_ )</h1>
-        <p>The abstract operation IsSuperReference takes argument _V_. It performs the following steps when called:</p>
+      <emu-clause id="sec-issuperreference" type="abstract operation" oldids="ao-issuperreference">
+        <h1>
+          IsSuperReference (
+            _V_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _V_ is a Reference Record.
           1. If _V_.[[ThisValue]] is not ~empty~, return *true*; otherwise return *false*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isprivatereference" aoid="IsPrivateReference">
-        <h1>IsPrivateReference ( _V_ )</h1>
-        <p>The abstract operation IsPrivateReference takes argument _V_. It performs the following steps when called:</p>
+      <emu-clause id="sec-isprivatereference" type="abstract operation">
+        <h1>
+          IsPrivateReference (
+            _V_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _V_ is a Reference Record.
           1. If _V_.[[ReferencedName]] is a Private Name, return *true*; otherwise return *false*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-getvalue" aoid="GetValue">
-        <h1>GetValue ( _V_ )</h1>
-        <p>The abstract operation GetValue takes argument _V_. It performs the following steps when called:</p>
+      <emu-clause id="sec-getvalue" type="abstract operation">
+        <h1>
+          GetValue (
+            _V_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. ReturnIfAbrupt(_V_).
           1. If _V_ is not a Reference Record, return _V_.
@@ -3749,9 +4069,15 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-putvalue" aoid="PutValue">
-        <h1>PutValue ( _V_, _W_ )</h1>
-        <p>The abstract operation PutValue takes arguments _V_ and _W_. It performs the following steps when called:</p>
+      <emu-clause id="sec-putvalue" type="abstract operation">
+        <h1>
+          PutValue (
+            _V_: unknown,
+            _W_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. ReturnIfAbrupt(_V_).
           1. ReturnIfAbrupt(_W_).
@@ -3777,18 +4103,29 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-getthisvalue" aoid="GetThisValue">
-        <h1>GetThisValue ( _V_ )</h1>
-        <p>The abstract operation GetThisValue takes argument _V_. It performs the following steps when called:</p>
+      <emu-clause id="sec-getthisvalue" type="abstract operation">
+        <h1>
+          GetThisValue (
+            _V_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyReference(_V_) is *true*.
           1. If IsSuperReference(_V_) is *true*, return _V_.[[ThisValue]]; otherwise return _V_.[[Base]].
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-initializereferencedbinding" aoid="InitializeReferencedBinding">
-        <h1>InitializeReferencedBinding ( _V_, _W_ )</h1>
-        <p>The abstract operation InitializeReferencedBinding takes arguments _V_ and _W_. It performs the following steps when called:</p>
+      <emu-clause id="sec-initializereferencedbinding" type="abstract operation">
+        <h1>
+          InitializeReferencedBinding (
+            _V_: unknown,
+            _W_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. ReturnIfAbrupt(_V_).
           1. ReturnIfAbrupt(_W_).
@@ -3800,9 +4137,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-makeprivatereference" aoid="MakePrivateReference">
-        <h1>MakePrivateReference ( _baseValue_, _privateIdentifier_ )</h1>
-        <p>The abstract operation MakePrivateReference takes arguments _baseValue_ (an ECMAScript language value) and _privateIdentifier_ (a String). It performs the following steps when called:</p>
+      <emu-clause id="sec-makeprivatereference" type="abstract operation">
+        <h1>
+          MakePrivateReference (
+            _baseValue_: an ECMAScript language value,
+            _privateIdentifier_: a String,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _privEnv_ be the running execution context's PrivateEnvironment.
           1. Assert: _privEnv_ is not *null*.
@@ -3818,9 +4161,14 @@
       <p>Property Descriptor values may be further classified as data Property Descriptors and accessor Property Descriptors based upon the existence or use of certain fields. A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]]. An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]]. Any Property Descriptor may have fields named [[Enumerable]] and [[Configurable]]. A Property Descriptor value may not be both a data Property Descriptor and an accessor Property Descriptor; however, it may be neither. A generic Property Descriptor is a Property Descriptor value that is neither a data Property Descriptor nor an accessor Property Descriptor. A fully populated Property Descriptor is one that is either an accessor Property Descriptor or a data Property Descriptor and that has all of the fields that correspond to the property attributes defined in either <emu-xref href="#table-data-property-attributes"></emu-xref> or <emu-xref href="#table-accessor-property-attributes"></emu-xref>.</p>
       <p>The following abstract operations are used in this specification to operate upon Property Descriptor values:</p>
 
-      <emu-clause id="sec-isaccessordescriptor" aoid="IsAccessorDescriptor">
-        <h1>IsAccessorDescriptor ( _Desc_ )</h1>
-        <p>The abstract operation IsAccessorDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
+      <emu-clause id="sec-isaccessordescriptor" type="abstract operation">
+        <h1>
+          IsAccessorDescriptor (
+            _Desc_: a Property Descriptor or *undefined*,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
           1. If both _Desc_.[[Get]] and _Desc_.[[Set]] are absent, return *false*.
@@ -3828,9 +4176,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isdatadescriptor" aoid="IsDataDescriptor">
-        <h1>IsDataDescriptor ( _Desc_ )</h1>
-        <p>The abstract operation IsDataDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
+      <emu-clause id="sec-isdatadescriptor" type="abstract operation">
+        <h1>
+          IsDataDescriptor (
+            _Desc_: a Property Descriptor or *undefined*,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
           1. If both _Desc_.[[Value]] and _Desc_.[[Writable]] are absent, return *false*.
@@ -3838,9 +4191,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isgenericdescriptor" aoid="IsGenericDescriptor">
-        <h1>IsGenericDescriptor ( _Desc_ )</h1>
-        <p>The abstract operation IsGenericDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
+      <emu-clause id="sec-isgenericdescriptor" type="abstract operation">
+        <h1>
+          IsGenericDescriptor (
+            _Desc_: a Property Descriptor or *undefined*,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
           1. If IsAccessorDescriptor(_Desc_) and IsDataDescriptor(_Desc_) are both *false*, return *true*.
@@ -3848,9 +4206,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-frompropertydescriptor" aoid="FromPropertyDescriptor">
-        <h1>FromPropertyDescriptor ( _Desc_ )</h1>
-        <p>The abstract operation FromPropertyDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
+      <emu-clause id="sec-frompropertydescriptor" type="abstract operation">
+        <h1>
+          FromPropertyDescriptor (
+            _Desc_: a Property Descriptor or *undefined*,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *undefined*.
           1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
@@ -3871,9 +4234,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-topropertydescriptor" aoid="ToPropertyDescriptor">
-        <h1>ToPropertyDescriptor ( _Obj_ )</h1>
-        <p>The abstract operation ToPropertyDescriptor takes argument _Obj_. It performs the following steps when called:</p>
+      <emu-clause id="sec-topropertydescriptor" type="abstract operation">
+        <h1>
+          ToPropertyDescriptor (
+            _Obj_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If Type(_Obj_) is not Object, throw a *TypeError* exception.
           1. Let _desc_ be a new Property Descriptor that initially has no fields.
@@ -3909,9 +4277,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-completepropertydescriptor" aoid="CompletePropertyDescriptor">
-        <h1>CompletePropertyDescriptor ( _Desc_ )</h1>
-        <p>The abstract operation CompletePropertyDescriptor takes argument _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-completepropertydescriptor" type="abstract operation">
+        <h1>
+          CompletePropertyDescriptor (
+            _Desc_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _Desc_ is a Property Descriptor.
           1. Let _like_ be the Record { [[Value]]: *undefined*, [[Writable]]: *false*, [[Get]]: *undefined*, [[Set]]: *undefined*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -3957,9 +4330,14 @@
       <p>Shared Data Block events are modeled by Records, defined in the memory model.</p>
       <p>The following abstract operations are used in this specification to operate upon Data Block values:</p>
 
-      <emu-clause id="sec-createbytedatablock" aoid="CreateByteDataBlock">
-        <h1>CreateByteDataBlock ( _size_ )</h1>
-        <p>The abstract operation CreateByteDataBlock takes argument _size_ (an integer). It performs the following steps when called:</p>
+      <emu-clause id="sec-createbytedatablock" type="abstract operation">
+        <h1>
+          CreateByteDataBlock (
+            _size_: an integer,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _size_ &ge; 0.
           1. Let _db_ be a new Data Block value consisting of _size_ bytes. If it is impossible to create such a Data Block, throw a *RangeError* exception.
@@ -3968,9 +4346,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-createsharedbytedatablock" aoid="CreateSharedByteDataBlock">
-        <h1>CreateSharedByteDataBlock ( _size_ )</h1>
-        <p>The abstract operation CreateSharedByteDataBlock takes argument _size_ (a non-negative integer). It performs the following steps when called:</p>
+      <emu-clause id="sec-createsharedbytedatablock" type="abstract operation">
+        <h1>
+          CreateSharedByteDataBlock (
+            _size_: a non-negative integer,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _size_ &ge; 0.
           1. Let _db_ be a new Shared Data Block value consisting of _size_ bytes. If it is impossible to create such a Shared Data Block, throw a *RangeError* exception.
@@ -3983,9 +4366,18 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-copydatablockbytes" aoid="CopyDataBlockBytes">
-        <h1>CopyDataBlockBytes ( _toBlock_, _toIndex_, _fromBlock_, _fromIndex_, _count_ )</h1>
-        <p>The abstract operation CopyDataBlockBytes takes arguments _toBlock_, _toIndex_ (a non-negative integer), _fromBlock_, _fromIndex_ (a non-negative integer), and _count_ (a non-negative integer). It performs the following steps when called:</p>
+      <emu-clause id="sec-copydatablockbytes" type="abstract operation">
+        <h1>
+          CopyDataBlockBytes (
+            _toBlock_: unknown,
+            _toIndex_: a non-negative integer,
+            _fromBlock_: unknown,
+            _fromIndex_: a non-negative integer,
+            _count_: a non-negative integer,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _fromBlock_ and _toBlock_ are distinct Data Block or Shared Data Block values.
           1. Let _fromSize_ be the number of bytes in _fromBlock_.
@@ -4173,9 +4565,17 @@
     <p>The ECMAScript language implicitly performs automatic type conversion as needed. To clarify the semantics of certain constructs it is useful to define a set of conversion abstract operations. The conversion abstract operations are polymorphic; they can accept a value of any ECMAScript language type. But no other specification types are used with these operations.</p>
     <p>The BigInt type has no implicit conversions in the ECMAScript language; programmers must call BigInt explicitly to convert values from other types.</p>
 
-    <emu-clause id="sec-toprimitive" aoid="ToPrimitive" oldids="table-9">
-      <h1>ToPrimitive ( _input_ [ , _preferredType_ ] )</h1>
-      <p>The abstract operation ToPrimitive takes argument _input_ and optional argument _preferredType_. It converts its _input_ argument to a non-Object type. If an object is capable of converting to more than one primitive type, it may use the optional hint _preferredType_ to favour that type. It performs the following steps when called:</p>
+    <emu-clause id="sec-toprimitive" type="abstract operation" oldids="table-9">
+      <h1>
+        ToPrimitive (
+          _input_: unknown,
+          optional _preferredType_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts its _input_ argument to a non-Object type. If an object is capable of converting to more than one primitive type, it may use the optional hint _preferredType_ to favour that type.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _input_ is an ECMAScript language value.
         1. If Type(_input_) is Object, then
@@ -4197,9 +4597,15 @@
         <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were ~number~. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Date objects treat no hint as if the hint were ~string~.</p>
       </emu-note>
 
-      <emu-clause id="sec-ordinarytoprimitive" aoid="OrdinaryToPrimitive">
-        <h1>OrdinaryToPrimitive ( _O_, _hint_ )</h1>
-        <p>The abstract operation OrdinaryToPrimitive takes arguments _O_ and _hint_. It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarytoprimitive" type="abstract operation">
+        <h1>
+          OrdinaryToPrimitive (
+            _O_: unknown,
+            _hint_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Type(_O_) is Object.
           1. Assert: _hint_ is either ~string~ or ~number~.
@@ -4217,9 +4623,16 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-toboolean" aoid="ToBoolean">
-      <h1>ToBoolean ( _argument_ )</h1>
-      <p>The abstract operation ToBoolean takes argument _argument_. It converts _argument_ to a value of type Boolean according to <emu-xref href="#table-toboolean-conversions"></emu-xref>:</p>
+    <emu-clause id="sec-toboolean" type="abstract operation">
+      <h1>
+        ToBoolean (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to a value of type Boolean according to <emu-xref href="#table-toboolean-conversions"></emu-xref>:</dd>
+      </dl>
       <emu-table id="table-toboolean-conversions" caption="ToBoolean Conversions" oldids="table-10">
         <table>
           <tbody>
@@ -4303,9 +4716,16 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-tonumeric" aoid="ToNumeric">
-      <h1>ToNumeric ( _value_ )</h1>
-      <p>The abstract operation ToNumeric takes argument _value_. It returns _value_ converted to a Number or a BigInt. It performs the following steps when called:</p>
+    <emu-clause id="sec-tonumeric" type="abstract operation">
+      <h1>
+        ToNumeric (
+          _value_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns _value_ converted to a Number or a BigInt.</dd>
+      </dl>
       <emu-alg>
         1. Let _primValue_ be ? ToPrimitive(_value_, ~number~).
         1. If Type(_primValue_) is BigInt, return _primValue_.
@@ -4313,9 +4733,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-tonumber" aoid="ToNumber">
-      <h1>ToNumber ( _argument_ )</h1>
-      <p>The abstract operation ToNumber takes argument _argument_. It converts _argument_ to a value of type Number according to <emu-xref href="#table-tonumber-conversions"></emu-xref>:</p>
+    <emu-clause id="sec-tonumber" type="abstract operation">
+      <h1>
+        ToNumber (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to a value of type Number according to <emu-xref href="#table-tonumber-conversions"></emu-xref>:</dd>
+      </dl>
       <emu-table id="table-tonumber-conversions" caption="ToNumber Conversions" oldids="table-11">
         <table>
           <tbody>
@@ -4510,9 +4937,16 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-roundmvresult" aoid="RoundMVResult">
-          <h1>RoundMVResult ( _n_ )</h1>
-          <p>The abstract operation RoundMVResult takes argument _n_ (a mathematical value). It converts _n_ to a Number in an implementation-defined manner. For the purposes of this abstract operation, a digit is significant if it is not zero or there is a non-zero digit to its left and there is a non-zero digit to its right. For the purposes of this abstract operation, "the mathematical value denoted by" a representation of a mathematical value is the inverse of "the decimal representation of" a mathematical value. It performs the following steps when called:</p>
+        <emu-clause id="sec-roundmvresult" type="abstract operation">
+          <h1>
+            RoundMVResult (
+              _n_: a mathematical value,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It converts _n_ to a Number in an implementation-defined manner. For the purposes of this abstract operation, a digit is significant if it is not zero or there is a non-zero digit to its left and there is a non-zero digit to its right. For the purposes of this abstract operation, "the mathematical value denoted by" a representation of a mathematical value is the inverse of "the decimal representation of" a mathematical value.</dd>
+          </dl>
           <emu-alg>
             1. If the decimal representation of _n_ has 20 or fewer significant digits, return 𝔽(_n_).
             1. Let _option1_ be the mathematical value denoted by the result of replacing each significant digit in the decimal representation of _n_ after the 20th with a 0 digit.
@@ -4524,9 +4958,16 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-tointegerorinfinity" aoid="ToIntegerOrInfinity" oldids="sec-tointeger">
-      <h1>ToIntegerOrInfinity ( _argument_ )</h1>
-      <p>The abstract operation ToIntegerOrInfinity takes argument _argument_. It converts _argument_ to an integer, +&infin;, or -&infin;. It performs the following steps when called:</p>
+    <emu-clause id="sec-tointegerorinfinity" type="abstract operation" oldids="sec-tointeger">
+      <h1>
+        ToIntegerOrInfinity (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to an integer, +&infin;, or -&infin;.</dd>
+      </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return 0.
@@ -4538,9 +4979,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-toint32" aoid="ToInt32">
-      <h1>ToInt32 ( _argument_ )</h1>
-      <p>The abstract operation ToInt32 takes argument _argument_. It converts _argument_ to one of 2<sup>32</sup> integral Number values in the range 𝔽(<emu-eqn>-2<sup>31</sup></emu-eqn>) through 𝔽(<emu-eqn>2<sup>31</sup> - 1</emu-eqn>), inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-toint32" type="abstract operation">
+      <h1>
+        ToInt32 (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>32</sup> integral Number values in the range 𝔽(<emu-eqn>-2<sup>31</sup></emu-eqn>) through 𝔽(<emu-eqn>2<sup>31</sup> - 1</emu-eqn>), inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
@@ -4564,9 +5012,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-touint32" aoid="ToUint32">
-      <h1>ToUint32 ( _argument_ )</h1>
-      <p>The abstract operation ToUint32 takes argument _argument_. It converts _argument_ to one of 2<sup>32</sup> integral Number values in the range *+0*<sub>𝔽</sub> through 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>), inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-touint32" type="abstract operation">
+      <h1>
+        ToUint32 (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>32</sup> integral Number values in the range *+0*<sub>𝔽</sub> through 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>), inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
@@ -4593,9 +5048,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-toint16" aoid="ToInt16">
-      <h1>ToInt16 ( _argument_ )</h1>
-      <p>The abstract operation ToInt16 takes argument _argument_. It converts _argument_ to one of 2<sup>16</sup> integral Number values in the range 𝔽(<emu-eqn>-2<sup>15</sup></emu-eqn>) through 𝔽(<emu-eqn>2<sup>15</sup> - 1</emu-eqn>), inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-toint16" type="abstract operation">
+      <h1>
+        ToInt16 (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>16</sup> integral Number values in the range 𝔽(<emu-eqn>-2<sup>15</sup></emu-eqn>) through 𝔽(<emu-eqn>2<sup>15</sup> - 1</emu-eqn>), inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
@@ -4605,9 +5067,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-touint16" aoid="ToUint16">
-      <h1>ToUint16 ( _argument_ )</h1>
-      <p>The abstract operation ToUint16 takes argument _argument_. It converts _argument_ to one of 2<sup>16</sup> integral Number values in the range *+0*<sub>𝔽</sub> through 𝔽(<emu-eqn>2<sup>16</sup> - 1</emu-eqn>), inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-touint16" type="abstract operation">
+      <h1>
+        ToUint16 (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>16</sup> integral Number values in the range *+0*<sub>𝔽</sub> through 𝔽(<emu-eqn>2<sup>16</sup> - 1</emu-eqn>), inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
@@ -4628,9 +5097,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-toint8" aoid="ToInt8">
-      <h1>ToInt8 ( _argument_ )</h1>
-      <p>The abstract operation ToInt8 takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *-128*<sub>𝔽</sub> through *127*<sub>𝔽</sub>, inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-toint8" type="abstract operation">
+      <h1>
+        ToInt8 (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *-128*<sub>𝔽</sub> through *127*<sub>𝔽</sub>, inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
@@ -4640,9 +5116,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-touint8" aoid="ToUint8">
-      <h1>ToUint8 ( _argument_ )</h1>
-      <p>The abstract operation ToUint8 takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *+0*<sub>𝔽</sub> through *255*<sub>𝔽</sub>, inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-touint8" type="abstract operation">
+      <h1>
+        ToUint8 (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *+0*<sub>𝔽</sub> through *255*<sub>𝔽</sub>, inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
@@ -4652,9 +5135,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-touint8clamp" aoid="ToUint8Clamp">
-      <h1>ToUint8Clamp ( _argument_ )</h1>
-      <p>The abstract operation ToUint8Clamp takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *+0*<sub>𝔽</sub> through *255*<sub>𝔽</sub>, inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-touint8clamp" type="abstract operation">
+      <h1>
+        ToUint8Clamp (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *+0*<sub>𝔽</sub> through *255*<sub>𝔽</sub>, inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, return *+0*<sub>𝔽</sub>.
@@ -4671,9 +5161,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-tobigint" aoid="ToBigInt">
-      <h1>ToBigInt ( _argument_ )</h1>
-      <p>The abstract operation ToBigInt takes argument _argument_. It converts _argument_ to a BigInt value, or throws if an implicit conversion from Number would be required. It performs the following steps when called:</p>
+    <emu-clause id="sec-tobigint" type="abstract operation">
+      <h1>
+        ToBigInt (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to a BigInt value, or throws if an implicit conversion from Number would be required.</dd>
+      </dl>
       <emu-alg>
         1. Let _prim_ be ? ToPrimitive(_argument_, ~number~).
         1. Return the value that _prim_ corresponds to in <emu-xref href="#table-tobigint"></emu-xref>.
@@ -4754,8 +5251,14 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-stringtobigint" aoid="StringToBigInt">
-      <h1>StringToBigInt ( _argument_ )</h1>
+    <emu-clause id="sec-stringtobigint" type="abstract operation">
+      <h1>
+        StringToBigInt (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <p>Apply the algorithm in <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref> with the following changes:</p>
       <ul>
         <li>Replace the |StrUnsignedDecimalLiteral| production with |DecimalDigits| to not allow *Infinity*, decimal points, or exponents.</li>
@@ -4763,9 +5266,16 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-tobigint64" aoid="ToBigInt64">
-      <h1>ToBigInt64 ( _argument_ )</h1>
-      <p>The abstract operation ToBigInt64 takes argument _argument_. It converts _argument_ to one of 2<sup>64</sup> BigInt values in the range ℤ(-2<sup>63</sup>) through ℤ(2<sup>63</sup>-1), inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-tobigint64" type="abstract operation">
+      <h1>
+        ToBigInt64 (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>64</sup> BigInt values in the range ℤ(-2<sup>63</sup>) through ℤ(2<sup>63</sup>-1), inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
         1. Let _int64bit_ be ℝ(_n_) modulo 2<sup>64</sup>.
@@ -4773,9 +5283,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-tobiguint64" aoid="ToBigUint64">
-      <h1>ToBigUint64 ( _argument_ )</h1>
-      <p>The abstract operation ToBigUint64 takes argument _argument_. It converts _argument_ to one of 2<sup>64</sup> BigInt values in the range *0*<sub>ℤ</sub> through the BigInt value for ℤ(2<sup>64</sup>-1), inclusive. It performs the following steps when called:</p>
+    <emu-clause id="sec-tobiguint64" type="abstract operation">
+      <h1>
+        ToBigUint64 (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to one of 2<sup>64</sup> BigInt values in the range *0*<sub>ℤ</sub> through the BigInt value for ℤ(2<sup>64</sup>-1), inclusive.</dd>
+      </dl>
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
         1. Let _int64bit_ be ℝ(_n_) modulo 2<sup>64</sup>.
@@ -4783,9 +5300,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-tostring" aoid="ToString">
-      <h1>ToString ( _argument_ )</h1>
-      <p>The abstract operation ToString takes argument _argument_. It converts _argument_ to a value of type String according to <emu-xref href="#table-tostring-conversions"></emu-xref>:</p>
+    <emu-clause id="sec-tostring" type="abstract operation">
+      <h1>
+        ToString (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to a value of type String according to <emu-xref href="#table-tostring-conversions"></emu-xref>:</dd>
+      </dl>
       <emu-table id="table-tostring-conversions" caption="ToString Conversions" oldids="table-12">
         <table>
           <tbody>
@@ -4871,9 +5395,16 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-toobject" aoid="ToObject">
-      <h1>ToObject ( _argument_ )</h1>
-      <p>The abstract operation ToObject takes argument _argument_. It converts _argument_ to a value of type Object according to <emu-xref href="#table-toobject-conversions"></emu-xref>:</p>
+    <emu-clause id="sec-toobject" type="abstract operation">
+      <h1>
+        ToObject (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to a value of type Object according to <emu-xref href="#table-toobject-conversions"></emu-xref>:</dd>
+      </dl>
       <emu-table id="table-toobject-conversions" caption="ToObject Conversions" oldids="table-13">
         <table>
           <tbody>
@@ -4954,9 +5485,16 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-topropertykey" aoid="ToPropertyKey">
-      <h1>ToPropertyKey ( _argument_ )</h1>
-      <p>The abstract operation ToPropertyKey takes argument _argument_. It converts _argument_ to a value that can be used as a property key. It performs the following steps when called:</p>
+    <emu-clause id="sec-topropertykey" type="abstract operation">
+      <h1>
+        ToPropertyKey (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to a value that can be used as a property key.</dd>
+      </dl>
       <emu-alg>
         1. Let _key_ be ? ToPrimitive(_argument_, ~string~).
         1. If Type(_key_) is Symbol, then
@@ -4965,9 +5503,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-tolength" aoid="ToLength">
-      <h1>ToLength ( _argument_ )</h1>
-      <p>The abstract operation ToLength takes argument _argument_. It converts _argument_ to an integral Number suitable for use as the length of an array-like object. It performs the following steps when called:</p>
+    <emu-clause id="sec-tolength" type="abstract operation">
+      <h1>
+        ToLength (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _argument_ to an integral Number suitable for use as the length of an array-like object.</dd>
+      </dl>
       <emu-alg>
         1. Let _len_ be ? ToIntegerOrInfinity(_argument_).
         1. If _len_ &le; 0, return *+0*<sub>𝔽</sub>.
@@ -4975,9 +5520,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-canonicalnumericindexstring" aoid="CanonicalNumericIndexString">
-      <h1>CanonicalNumericIndexString ( _argument_ )</h1>
-      <p>The abstract operation CanonicalNumericIndexString takes argument _argument_. It returns _argument_ converted to a Number value if it is a String representation of a Number that would be produced by ToString, or the string *"-0"*. Otherwise, it returns *undefined*. It performs the following steps when called:</p>
+    <emu-clause id="sec-canonicalnumericindexstring" type="abstract operation">
+      <h1>
+        CanonicalNumericIndexString (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns _argument_ converted to a Number value if it is a String representation of a Number that would be produced by ToString, or the string *"-0"*. Otherwise, it returns *undefined*.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_argument_) is String.
         1. If _argument_ is *"-0"*, return *-0*<sub>𝔽</sub>.
@@ -4988,9 +5540,16 @@
       <p>A <em>canonical numeric string</em> is any String value for which the CanonicalNumericIndexString abstract operation does not return *undefined*.</p>
     </emu-clause>
 
-    <emu-clause id="sec-toindex" aoid="ToIndex">
-      <h1>ToIndex ( _value_ )</h1>
-      <p>The abstract operation ToIndex takes argument _value_. It returns _value_ argument converted to a non-negative integer if it is a valid integer index value. It performs the following steps when called:</p>
+    <emu-clause id="sec-toindex" type="abstract operation">
+      <h1>
+        ToIndex (
+          _value_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns _value_ argument converted to a non-negative integer if it is a valid integer index value.</dd>
+      </dl>
       <emu-alg>
         1. If _value_ is *undefined*, then
           1. Return 0.
@@ -5007,9 +5566,16 @@
   <emu-clause id="sec-testing-and-comparison-operations">
     <h1>Testing and Comparison Operations</h1>
 
-    <emu-clause id="sec-requireobjectcoercible" aoid="RequireObjectCoercible">
-      <h1>RequireObjectCoercible ( _argument_ )</h1>
-      <p>The abstract operation RequireObjectCoercible takes argument _argument_. It throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-requireobjectcoercible-results"></emu-xref>:</p>
+    <emu-clause id="sec-requireobjectcoercible" type="abstract operation">
+      <h1>
+        RequireObjectCoercible (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-requireobjectcoercible-results"></emu-xref>:</dd>
+      </dl>
       <emu-table id="table-requireobjectcoercible-results" caption="RequireObjectCoercible Results" oldids="table-14">
         <table>
           <tbody>
@@ -5090,9 +5656,14 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-isarray" aoid="IsArray">
-      <h1>IsArray ( _argument_ )</h1>
-      <p>The abstract operation IsArray takes argument _argument_. It performs the following steps when called:</p>
+    <emu-clause id="sec-isarray" type="abstract operation">
+      <h1>
+        IsArray (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ is an Array exotic object, return *true*.
@@ -5104,9 +5675,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iscallable" aoid="IsCallable">
-      <h1>IsCallable ( _argument_ )</h1>
-      <p>The abstract operation IsCallable takes argument _argument_ (an ECMAScript language value). It determines if _argument_ is a callable function with a [[Call]] internal method. It performs the following steps when called:</p>
+    <emu-clause id="sec-iscallable" type="abstract operation">
+      <h1>
+        IsCallable (
+          _argument_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines if _argument_ is a callable function with a [[Call]] internal method.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ has a [[Call]] internal method, return *true*.
@@ -5114,9 +5692,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isconstructor" aoid="IsConstructor">
-      <h1>IsConstructor ( _argument_ )</h1>
-      <p>The abstract operation IsConstructor takes argument _argument_ (an ECMAScript language value). It determines if _argument_ is a function object with a [[Construct]] internal method. It performs the following steps when called:</p>
+    <emu-clause id="sec-isconstructor" type="abstract operation">
+      <h1>
+        IsConstructor (
+          _argument_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines if _argument_ is a function object with a [[Construct]] internal method.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ has a [[Construct]] internal method, return *true*.
@@ -5124,18 +5709,32 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isextensible-o" aoid="IsExtensible">
-      <h1>IsExtensible ( _O_ )</h1>
-      <p>The abstract operation IsExtensible takes argument _O_ (an Object) and returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether additional properties can be added to _O_. It performs the following steps when called:</p>
+    <emu-clause id="sec-isextensible-o" type="abstract operation">
+      <h1>
+        IsExtensible (
+          _O_: an Object,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether additional properties can be added to _O_.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Return ? _O_.[[IsExtensible]]().
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isintegralnumber" aoid="IsIntegralNumber" oldids="sec-isinteger">
-      <h1>IsIntegralNumber ( _argument_ )</h1>
-      <p>The abstract operation IsIntegralNumber takes argument _argument_. It determines if _argument_ is a finite integral Number value. It performs the following steps when called:</p>
+    <emu-clause id="sec-isintegralnumber" type="abstract operation" oldids="sec-isinteger">
+      <h1>
+        IsIntegralNumber (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines if _argument_ is a finite integral Number value.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_argument_) is not Number, return *false*.
         1. If _argument_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
@@ -5144,9 +5743,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-ispropertykey" aoid="IsPropertyKey">
-      <h1>IsPropertyKey ( _argument_ )</h1>
-      <p>The abstract operation IsPropertyKey takes argument _argument_ (an ECMAScript language value). It determines if _argument_ is a value that may be used as a property key. It performs the following steps when called:</p>
+    <emu-clause id="sec-ispropertykey" type="abstract operation">
+      <h1>
+        IsPropertyKey (
+          _argument_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines if _argument_ is a value that may be used as a property key.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_argument_) is String, return *true*.
         1. If Type(_argument_) is Symbol, return *true*.
@@ -5154,9 +5760,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isregexp" aoid="IsRegExp">
-      <h1>IsRegExp ( _argument_ )</h1>
-      <p>The abstract operation IsRegExp takes argument _argument_. It performs the following steps when called:</p>
+    <emu-clause id="sec-isregexp" type="abstract operation">
+      <h1>
+        IsRegExp (
+          _argument_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. Let _matcher_ be ? Get(_argument_, @@match).
@@ -5166,9 +5777,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isstringprefix" aoid="IsStringPrefix">
-      <h1>IsStringPrefix ( _p_, _q_ )</h1>
-      <p>The abstract operation IsStringPrefix takes arguments _p_ (a String) and _q_ (a String). It determines if _p_ is a prefix of _q_. It performs the following steps when called:</p>
+    <emu-clause id="sec-isstringprefix" type="abstract operation">
+      <h1>
+        IsStringPrefix (
+          _p_: a String,
+          _q_: a String,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines if _p_ is a prefix of _q_.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_p_) is String.
         1. Assert: Type(_q_) is String.
@@ -5179,9 +5798,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-samevalue" aoid="SameValue">
-      <h1>SameValue ( _x_, _y_ )</h1>
-      <p>The abstract operation SameValue takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value) and returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean. It performs the following steps when called:</p>
+    <emu-clause id="sec-samevalue" type="abstract operation">
+      <h1>
+        SameValue (
+          _x_: an ECMAScript language value,
+          _y_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number or BigInt, then
@@ -5193,9 +5820,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-samevaluezero" aoid="SameValueZero">
-      <h1>SameValueZero ( _x_, _y_ )</h1>
-      <p>The abstract operation SameValueZero takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value) and returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean. It performs the following steps when called:</p>
+    <emu-clause id="sec-samevaluezero" type="abstract operation">
+      <h1>
+        SameValueZero (
+          _x_: an ECMAScript language value,
+          _y_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number or BigInt, then
@@ -5207,9 +5842,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-samevaluenonnumeric" aoid="SameValueNonNumeric" oldids="sec-samevaluenonnumber">
-      <h1>SameValueNonNumeric ( _x_, _y_ )</h1>
-      <p>The abstract operation SameValueNonNumeric takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value) and returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean. It performs the following steps when called:</p>
+    <emu-clause id="sec-samevaluenonnumeric" type="abstract operation" oldids="sec-samevaluenonnumber">
+      <h1>
+        SameValueNonNumeric (
+          _x_: an ECMAScript language value,
+          _y_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_x_) is not Number or BigInt.
         1. Assert: Type(_x_) is the same as Type(_y_).
@@ -5225,9 +5868,18 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-islessthan" aoid="IsLessThan" oldids="sec-abstract-relational-comparison">
-      <h1>IsLessThan ( _x_, _y_, _LeftFirst_ )</h1>
-      <p>The abstract operation IsLessThan takes arguments _x_ (an ECMAScript language value), _y_ (an ECMAScript language value), and _LeftFirst_ (a Boolean). It provides the semantics for the comparison _x_ &lt; _y_, returning *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). The _LeftFirst_ flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. If _LeftFirst_ is *true*, the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_. It performs the following steps when called:</p>
+    <emu-clause id="sec-islessthan" type="abstract operation" oldids="sec-abstract-relational-comparison">
+      <h1>
+        IsLessThan (
+          _x_: an ECMAScript language value,
+          _y_: an ECMAScript language value,
+          _LeftFirst_: a Boolean,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It provides the semantics for the comparison _x_ &lt; _y_, returning *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). The _LeftFirst_ flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. If _LeftFirst_ is *true*, the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_.</dd>
+      </dl>
       <emu-alg>
         1. If the _LeftFirst_ flag is *true*, then
           1. Let _px_ be ? ToPrimitive(_x_, ~number~).
@@ -5270,9 +5922,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-islooselyequal" aoid="IsLooselyEqual" oldids="sec-abstract-equality-comparison">
-      <h1>IsLooselyEqual ( _x_, _y_ )</h1>
-      <p>The abstract operation IsLooselyEqual takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value). It provides the semantics for the comparison _x_ == _y_, returning *true* or *false*. It performs the following steps when called:</p>
+    <emu-clause id="sec-islooselyequal" type="abstract operation" oldids="sec-abstract-equality-comparison">
+      <h1>
+        IsLooselyEqual (
+          _x_: an ECMAScript language value,
+          _y_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It provides the semantics for the comparison _x_ == _y_, returning *true* or *false*.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_x_) is the same as Type(_y_), then
           1. Return IsStrictlyEqual(_x_, _y_).
@@ -5297,9 +5957,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isstrictlyequal" aoid="IsStrictlyEqual" oldids="sec-strict-equality-comparison">
-      <h1>IsStrictlyEqual ( _x_, _y_ )</h1>
-      <p>The abstract operation IsStrictlyEqual takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value). It provides the semantics for the comparison _x_ === _y_, returning *true* or *false*. It performs the following steps when called:</p>
+    <emu-clause id="sec-isstrictlyequal" type="abstract operation" oldids="sec-strict-equality-comparison">
+      <h1>
+        IsStrictlyEqual (
+          _x_: an ECMAScript language value,
+          _y_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It provides the semantics for the comparison _x_ === _y_, returning *true* or *false*.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number or BigInt, then
@@ -5315,9 +5983,16 @@
   <emu-clause id="sec-operations-on-objects">
     <h1>Operations on Objects</h1>
 
-    <emu-clause id="sec-makebasicobject" aoid="MakeBasicObject">
-      <h1>MakeBasicObject ( _internalSlotsList_ )</h1>
-      <p>The abstract operation MakeBasicObject takes argument _internalSlotsList_. It is the source of all ECMAScript objects that are created algorithmically, including both ordinary objects and exotic objects. It factors out common steps used in creating all objects, and centralizes object creation. It performs the following steps when called:</p>
+    <emu-clause id="sec-makebasicobject" type="abstract operation">
+      <h1>
+        MakeBasicObject (
+          _internalSlotsList_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is the source of all ECMAScript objects that are created algorithmically, including both ordinary objects and exotic objects. It factors out common steps used in creating all objects, and centralizes object creation.</dd>
+      </dl>
 
       <emu-alg>
         1. Assert: _internalSlotsList_ is a List of internal slot names.
@@ -5334,9 +6009,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-get-o-p" aoid="Get">
-      <h1>Get ( _O_, _P_ )</h1>
-      <p>The abstract operation Get takes arguments _O_ (an Object) and _P_ (a property key). It is used to retrieve the value of a specific property of an object. It performs the following steps when called:</p>
+    <emu-clause id="sec-get-o-p" type="abstract operation">
+      <h1>
+        Get (
+          _O_: an Object,
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to retrieve the value of a specific property of an object.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5344,9 +6027,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getv" aoid="GetV">
-      <h1>GetV ( _V_, _P_ )</h1>
-      <p>The abstract operation GetV takes arguments _V_ (an ECMAScript language value) and _P_ (a property key). It is used to retrieve the value of a specific property of an ECMAScript language value. If the value is not an object, the property lookup is performed using a wrapper object appropriate for the type of the value. It performs the following steps when called:</p>
+    <emu-clause id="sec-getv" type="abstract operation">
+      <h1>
+        GetV (
+          _V_: an ECMAScript language value,
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to retrieve the value of a specific property of an ECMAScript language value. If the value is not an object, the property lookup is performed using a wrapper object appropriate for the type of the value.</dd>
+      </dl>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _O_ be ? ToObject(_V_).
@@ -5354,9 +6045,19 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-set-o-p-v-throw" aoid="Set">
-      <h1>Set ( _O_, _P_, _V_, _Throw_ )</h1>
-      <p>The abstract operation Set takes arguments _O_ (an Object), _P_ (a property key), _V_ (an ECMAScript language value), and _Throw_ (a Boolean). It is used to set the value of a specific property of an object. _V_ is the new value for the property. It performs the following steps when called:</p>
+    <emu-clause id="sec-set-o-p-v-throw" type="abstract operation">
+      <h1>
+        Set (
+          _O_: an Object,
+          _P_: a property key,
+          _V_: an ECMAScript language value,
+          _Throw_: a Boolean,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to set the value of a specific property of an object. _V_ is the new value for the property.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5367,9 +6068,18 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-createdataproperty" aoid="CreateDataProperty">
-      <h1>CreateDataProperty ( _O_, _P_, _V_ )</h1>
-      <p>The abstract operation CreateDataProperty takes arguments _O_ (an Object), _P_ (a property key), and _V_ (an ECMAScript language value). It is used to create a new own property of an object. It performs the following steps when called:</p>
+    <emu-clause id="sec-createdataproperty" type="abstract operation">
+      <h1>
+        CreateDataProperty (
+          _O_: an Object,
+          _P_: a property key,
+          _V_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to create a new own property of an object.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5381,9 +6091,18 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-createmethodproperty" aoid="CreateMethodProperty">
-      <h1>CreateMethodProperty ( _O_, _P_, _V_ )</h1>
-      <p>The abstract operation CreateMethodProperty takes arguments _O_ (an Object), _P_ (a property key), and _V_ (an ECMAScript language value). It is used to create a new own property of an object. It performs the following steps when called:</p>
+    <emu-clause id="sec-createmethodproperty" type="abstract operation">
+      <h1>
+        CreateMethodProperty (
+          _O_: an Object,
+          _P_: a property key,
+          _V_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to create a new own property of an object.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5395,9 +6114,18 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-createdatapropertyorthrow" aoid="CreateDataPropertyOrThrow">
-      <h1>CreateDataPropertyOrThrow ( _O_, _P_, _V_ )</h1>
-      <p>The abstract operation CreateDataPropertyOrThrow takes arguments _O_ (an Object), _P_ (a property key), and _V_ (an ECMAScript language value). It is used to create a new own property of an object. It throws a *TypeError* exception if the requested property update cannot be performed. It performs the following steps when called:</p>
+    <emu-clause id="sec-createdatapropertyorthrow" type="abstract operation">
+      <h1>
+        CreateDataPropertyOrThrow (
+          _O_: an Object,
+          _P_: a property key,
+          _V_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to create a new own property of an object. It throws a *TypeError* exception if the requested property update cannot be performed.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5410,9 +6138,18 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-definepropertyorthrow" aoid="DefinePropertyOrThrow">
-      <h1>DefinePropertyOrThrow ( _O_, _P_, _desc_ )</h1>
-      <p>The abstract operation DefinePropertyOrThrow takes arguments _O_ (an Object), _P_ (a property key), and _desc_ (a Property Descriptor). It is used to call the [[DefineOwnProperty]] internal method of an object in a manner that will throw a *TypeError* exception if the requested property update cannot be performed. It performs the following steps when called:</p>
+    <emu-clause id="sec-definepropertyorthrow" type="abstract operation">
+      <h1>
+        DefinePropertyOrThrow (
+          _O_: an Object,
+          _P_: a property key,
+          _desc_: a Property Descriptor,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to call the [[DefineOwnProperty]] internal method of an object in a manner that will throw a *TypeError* exception if the requested property update cannot be performed.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5422,9 +6159,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-deletepropertyorthrow" aoid="DeletePropertyOrThrow">
-      <h1>DeletePropertyOrThrow ( _O_, _P_ )</h1>
-      <p>The abstract operation DeletePropertyOrThrow takes arguments _O_ (an Object) and _P_ (a property key). It is used to remove a specific own property of an object. It throws an exception if the property is not configurable. It performs the following steps when called:</p>
+    <emu-clause id="sec-deletepropertyorthrow" type="abstract operation">
+      <h1>
+        DeletePropertyOrThrow (
+          _O_: an Object,
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to remove a specific own property of an object. It throws an exception if the property is not configurable.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5434,9 +6179,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getmethod" aoid="GetMethod">
-      <h1>GetMethod ( _V_, _P_ )</h1>
-      <p>The abstract operation GetMethod takes arguments _V_ (an ECMAScript language value) and _P_ (a property key). It is used to get the value of a specific property of an ECMAScript language value when the value of the property is expected to be a function. It performs the following steps when called:</p>
+    <emu-clause id="sec-getmethod" type="abstract operation">
+      <h1>
+        GetMethod (
+          _V_: an ECMAScript language value,
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to get the value of a specific property of an ECMAScript language value when the value of the property is expected to be a function.</dd>
+      </dl>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _func_ be ? GetV(_V_, _P_).
@@ -5446,9 +6199,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-hasproperty" aoid="HasProperty">
-      <h1>HasProperty ( _O_, _P_ )</h1>
-      <p>The abstract operation HasProperty takes arguments _O_ (an Object) and _P_ (a property key) and returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has a property with the specified property key. The property may be either an own or inherited. It performs the following steps when called:</p>
+    <emu-clause id="sec-hasproperty" type="abstract operation">
+      <h1>
+        HasProperty (
+          _O_: an Object,
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has a property with the specified property key. The property may be either an own or inherited.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5456,9 +6217,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-hasownproperty" aoid="HasOwnProperty">
-      <h1>HasOwnProperty ( _O_, _P_ )</h1>
-      <p>The abstract operation HasOwnProperty takes arguments _O_ (an Object) and _P_ (a property key) and returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has an own property with the specified property key. It performs the following steps when called:</p>
+    <emu-clause id="sec-hasownproperty" type="abstract operation">
+      <h1>
+        HasOwnProperty (
+          _O_: an Object,
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has an own property with the specified property key.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5468,9 +6237,18 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-call" aoid="Call">
-      <h1>Call ( _F_, _V_ [ , _argumentsList_ ] )</h1>
-      <p>The abstract operation Call takes arguments _F_ (an ECMAScript language value) and _V_ (an ECMAScript language value) and optional argument _argumentsList_ (a List of ECMAScript language values). It is used to call the [[Call]] internal method of a function object. _F_ is the function object, _V_ is an ECMAScript language value that is the *this* value of the [[Call]], and _argumentsList_ is the value passed to the corresponding argument of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. It performs the following steps when called:</p>
+    <emu-clause id="sec-call" type="abstract operation">
+      <h1>
+        Call (
+          _F_: an ECMAScript language value,
+          _V_: an ECMAScript language value,
+          optional _argumentsList_: a List of ECMAScript language values,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to call the [[Call]] internal method of a function object. _F_ is the function object, _V_ is an ECMAScript language value that is the *this* value of the [[Call]], and _argumentsList_ is the value passed to the corresponding argument of the internal method. If _argumentsList_ is not present, a new empty List is used as its value.</dd>
+      </dl>
       <emu-alg>
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
         1. If IsCallable(_F_) is *false*, throw a *TypeError* exception.
@@ -5478,9 +6256,18 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-construct" aoid="Construct">
-      <h1>Construct ( _F_ [ , _argumentsList_ [ , _newTarget_ ] ] )</h1>
-      <p>The abstract operation Construct takes argument _F_ (a function object) and optional arguments _argumentsList_ and _newTarget_. It is used to call the [[Construct]] internal method of a function object. _argumentsList_ and _newTarget_ are the values to be passed as the corresponding arguments of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. If _newTarget_ is not present, _F_ is used as its value. It performs the following steps when called:</p>
+    <emu-clause id="sec-construct" type="abstract operation">
+      <h1>
+        Construct (
+          _F_: a function object,
+          optional _argumentsList_: unknown,
+          optional _newTarget_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to call the [[Construct]] internal method of a function object. _argumentsList_ and _newTarget_ are the values to be passed as the corresponding arguments of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. If _newTarget_ is not present, _F_ is used as its value.</dd>
+      </dl>
       <emu-alg>
         1. If _newTarget_ is not present, set _newTarget_ to _F_.
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
@@ -5493,9 +6280,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-setintegritylevel" aoid="SetIntegrityLevel">
-      <h1>SetIntegrityLevel ( _O_, _level_ )</h1>
-      <p>The abstract operation SetIntegrityLevel takes arguments _O_ and _level_. It is used to fix the set of own properties of an object. It performs the following steps when called:</p>
+    <emu-clause id="sec-setintegritylevel" type="abstract operation">
+      <h1>
+        SetIntegrityLevel (
+          _O_: unknown,
+          _level_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to fix the set of own properties of an object.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: _level_ is either ~sealed~ or ~frozen~.
@@ -5519,9 +6314,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-testintegritylevel" aoid="TestIntegrityLevel">
-      <h1>TestIntegrityLevel ( _O_, _level_ )</h1>
-      <p>The abstract operation TestIntegrityLevel takes arguments _O_ and _level_. It is used to determine if the set of own properties of an object are fixed. It performs the following steps when called:</p>
+    <emu-clause id="sec-testintegritylevel" type="abstract operation">
+      <h1>
+        TestIntegrityLevel (
+          _O_: unknown,
+          _level_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to determine if the set of own properties of an object are fixed.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: _level_ is either ~sealed~ or ~frozen~.
@@ -5539,9 +6342,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-createarrayfromlist" aoid="CreateArrayFromList">
-      <h1>CreateArrayFromList ( _elements_ )</h1>
-      <p>The abstract operation CreateArrayFromList takes argument _elements_ (a List). It is used to create an Array object whose elements are provided by _elements_. It performs the following steps when called:</p>
+    <emu-clause id="sec-createarrayfromlist" type="abstract operation">
+      <h1>
+        CreateArrayFromList (
+          _elements_: a List,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to create an Array object whose elements are provided by _elements_.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _elements_ is a List whose elements are all ECMAScript language values.
         1. Let _array_ be ! ArrayCreate(0).
@@ -5553,9 +6363,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-lengthofarraylike" aoid="LengthOfArrayLike">
-      <h1>LengthOfArrayLike ( _obj_ )</h1>
-      <p>The abstract operation LengthOfArrayLike takes argument _obj_. It returns the value of the *"length"* property of an array-like object (as a non-negative integer). It performs the following steps when called:</p>
+    <emu-clause id="sec-lengthofarraylike" type="abstract operation">
+      <h1>
+        LengthOfArrayLike (
+          _obj_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the value of the *"length"* property of an array-like object (as a non-negative integer).</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_obj_) is Object.
         1. Return ℝ(? ToLength(? Get(_obj_, *"length"*))).
@@ -5569,9 +6386,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-createlistfromarraylike" aoid="CreateListFromArrayLike">
-      <h1>CreateListFromArrayLike ( _obj_ [ , _elementTypes_ ] )</h1>
-      <p>The abstract operation CreateListFromArrayLike takes argument _obj_ and optional argument _elementTypes_ (a List of names of ECMAScript Language Types). It is used to create a List value whose elements are provided by the indexed properties of _obj_. _elementTypes_ contains the names of ECMAScript Language Types that are allowed for element values of the List that is created. It performs the following steps when called:</p>
+    <emu-clause id="sec-createlistfromarraylike" type="abstract operation">
+      <h1>
+        CreateListFromArrayLike (
+          _obj_: unknown,
+          optional _elementTypes_: a List of names of ECMAScript Language Types,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to create a List value whose elements are provided by the indexed properties of _obj_. _elementTypes_ contains the names of ECMAScript Language Types that are allowed for element values of the List that is created.</dd>
+      </dl>
       <emu-alg>
         1. If _elementTypes_ is not present, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, BigInt, Object &raquo;.
         1. If Type(_obj_) is not Object, throw a *TypeError* exception.
@@ -5588,9 +6413,18 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-invoke" aoid="Invoke">
-      <h1>Invoke ( _V_, _P_ [ , _argumentsList_ ] )</h1>
-      <p>The abstract operation Invoke takes arguments _V_ (an ECMAScript language value) and _P_ (a property key) and optional argument _argumentsList_ (a List of ECMAScript language values). It is used to call a method property of an ECMAScript language value. _V_ serves as both the lookup point for the property and the *this* value of the call. _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, a new empty List is used as its value. It performs the following steps when called:</p>
+    <emu-clause id="sec-invoke" type="abstract operation">
+      <h1>
+        Invoke (
+          _V_: an ECMAScript language value,
+          _P_: a property key,
+          optional _argumentsList_: a List of ECMAScript language values,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to call a method property of an ECMAScript language value. _V_ serves as both the lookup point for the property and the *this* value of the call. _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, a new empty List is used as its value.</dd>
+      </dl>
 
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5600,9 +6434,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-ordinaryhasinstance" aoid="OrdinaryHasInstance">
-      <h1>OrdinaryHasInstance ( _C_, _O_ )</h1>
-      <p>The abstract operation OrdinaryHasInstance takes arguments _C_ (an ECMAScript language value) and _O_. It implements the default algorithm for determining if _O_ inherits from the instance object inheritance path provided by _C_. It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinaryhasinstance" type="abstract operation">
+      <h1>
+        OrdinaryHasInstance (
+          _C_: an ECMAScript language value,
+          _O_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It implements the default algorithm for determining if _O_ inherits from the instance object inheritance path provided by _C_.</dd>
+      </dl>
       <emu-alg>
         1. If IsCallable(_C_) is *false*, return *false*.
         1. If _C_ has a [[BoundTargetFunction]] internal slot, then
@@ -5618,9 +6460,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-speciesconstructor" aoid="SpeciesConstructor">
-      <h1>SpeciesConstructor ( _O_, _defaultConstructor_ )</h1>
-      <p>The abstract operation SpeciesConstructor takes arguments _O_ (an Object) and _defaultConstructor_ (a constructor). It is used to retrieve the constructor that should be used to create new objects that are derived from _O_. _defaultConstructor_ is the constructor to use if a constructor @@species property cannot be found starting from _O_. It performs the following steps when called:</p>
+    <emu-clause id="sec-speciesconstructor" type="abstract operation">
+      <h1>
+        SpeciesConstructor (
+          _O_: an Object,
+          _defaultConstructor_: a constructor,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to retrieve the constructor that should be used to create new objects that are derived from _O_. _defaultConstructor_ is the constructor to use if a constructor @@species property cannot be found starting from _O_.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Let _C_ be ? Get(_O_, *"constructor"*).
@@ -5633,9 +6483,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-enumerableownpropertynames" aoid="EnumerableOwnPropertyNames" oldids="sec-enumerableownproperties">
-      <h1>EnumerableOwnPropertyNames ( _O_, _kind_ )</h1>
-      <p>The abstract operation EnumerableOwnPropertyNames takes arguments _O_ (an Object) and _kind_ (one of ~key~, ~value~, or ~key+value~). It performs the following steps when called:</p>
+    <emu-clause id="sec-enumerableownpropertynames" type="abstract operation" oldids="sec-enumerableownproperties">
+      <h1>
+        EnumerableOwnPropertyNames (
+          _O_: an Object,
+          _kind_: one of ~key~, ~value~, or ~key+value~,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Let _ownKeys_ be ? _O_.[[OwnPropertyKeys]]().
@@ -5656,9 +6512,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getfunctionrealm" aoid="GetFunctionRealm">
-      <h1>GetFunctionRealm ( _obj_ )</h1>
-      <p>The abstract operation GetFunctionRealm takes argument _obj_. It performs the following steps when called:</p>
+    <emu-clause id="sec-getfunctionrealm" type="abstract operation">
+      <h1>
+        GetFunctionRealm (
+          _obj_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: ! IsCallable(_obj_) is *true*.
         1. If _obj_ has a [[Realm]] internal slot, then
@@ -5677,9 +6538,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-copydataproperties" aoid="CopyDataProperties">
-      <h1>CopyDataProperties ( _target_, _source_, _excludedItems_ )</h1>
-      <p>The abstract operation CopyDataProperties takes arguments _target_, _source_, and _excludedItems_. It performs the following steps when called:</p>
+    <emu-clause id="sec-copydataproperties" type="abstract operation">
+      <h1>
+        CopyDataProperties (
+          _target_: unknown,
+          _source_: unknown,
+          _excludedItems_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: Type(_target_) is Object.
         1. Assert: _excludedItems_ is a List of property keys.
@@ -5703,9 +6571,15 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-privateelementfind" aoid="PrivateElementFind">
-      <h1>PrivateElementFind ( _P_, _O_ )</h1>
-      <p>The abstract operation PrivateElementFind takes arguments _P_ (a Private Name) and _O_ (an Object). It performs the following steps when called:</p>
+    <emu-clause id="sec-privateelementfind" type="abstract operation">
+      <h1>
+        PrivateElementFind (
+          _P_: a Private Name,
+          _O_: an Object,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If _O_.[[PrivateElements]] contains a PrivateElement whose [[Key]] is _P_, then
           1. Let _entry_ be that PrivateElement.
@@ -5714,9 +6588,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-privatefieldadd" aoid="PrivateFieldAdd">
-      <h1>PrivateFieldAdd ( _P_, _O_, _value_ )</h1>
-      <p>The abstract operation PrivateFieldAdd takes arguments _P_ (a Private Name), _O_ (an Object), and _value_ (an ECMAScript language value). It performs the following steps when called:</p>
+    <emu-clause id="sec-privatefieldadd" type="abstract operation">
+      <h1>
+        PrivateFieldAdd (
+          _P_: a Private Name,
+          _O_: an Object,
+          _value_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _entry_ be ! PrivateElementFind(_P_, _O_).
         1. If _entry_ is not ~empty~, throw a *TypeError* exception.
@@ -5724,9 +6605,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-privatemethodoraccessoradd" aoid="PrivateMethodOrAccessorAdd">
-      <h1>PrivateMethodOrAccessorAdd ( _method_, _O_ )</h1>
-      <p>The abstract operation PrivateMethodOrAccessorAdd takes arguments _method_ (a PrivateElement) and _O_ (an Object). It performs the following steps when called:</p>
+    <emu-clause id="sec-privatemethodoraccessoradd" type="abstract operation">
+      <h1>
+        PrivateMethodOrAccessorAdd (
+          _method_: a PrivateElement,
+          _O_: an Object,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: _method_.[[Kind]] is either ~method~ or ~accessor~.
         1. Let _entry_ be ! PrivateElementFind(_method_.[[Key]], _O_).
@@ -5736,9 +6623,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-privateget" aoid="PrivateGet">
-      <h1>PrivateGet ( _P_, _O_ )</h1>
-      <p>The abstract operation PrivateGet takes arguments _P_ (a Private Name) and _O_ (an Object). It performs the following steps when called:</p>
+    <emu-clause id="sec-privateget" type="abstract operation">
+      <h1>
+        PrivateGet (
+          _P_: a Private Name,
+          _O_: an Object,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _entry_ be ! PrivateElementFind(_P_, _O_).
         1. If _entry_ is ~empty~, throw a *TypeError* exception.
@@ -5751,9 +6644,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-privateset" aoid="PrivateSet">
-      <h1>PrivateSet ( _P_, _O_, _value_ )</h1>
-      <p>The abstract operation PrivateSet takes arguments _P_ (a Private Name), _O_ (an Object), and _value_ (an ECMAScript language value). It performs the following steps when called:</p>
+    <emu-clause id="sec-privateset" type="abstract operation">
+      <h1>
+        PrivateSet (
+          _P_: a Private Name,
+          _O_: an Object,
+          _value_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _entry_ be ! PrivateElementFind(_P_, _O_).
         1. If _entry_ is ~empty~, throw a *TypeError* exception.
@@ -5769,9 +6669,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-definefield" aoid="DefineField">
-      <h1>DefineField ( _receiver_, _fieldRecord_ )</h1>
-      <p>The abstract operation DefineField takes arguments _receiver_ (an Object) and _fieldRecord_ (a ClassFieldDefinition Record). It performs the following steps when called:</p>
+    <emu-clause id="sec-definefield" type="abstract operation">
+      <h1>
+        DefineField (
+          _receiver_: an Object,
+          _fieldRecord_: a ClassFieldDefinition Record,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _fieldName_ be _fieldRecord_.[[Name]].
         1. Let _initializer_ be _fieldRecord_.[[Initializer]].
@@ -5786,9 +6692,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-initializeinstanceelements" aoid="InitializeInstanceElements">
-      <h1>InitializeInstanceElements ( _O_, _constructor_ )</h1>
-      <p>The abstract operation InitializeInstanceElements takes arguments _O_ (an Object) and _constructor_ (an ECMAScript function object). It performs the following steps when called:</p>
+    <emu-clause id="sec-initializeinstanceelements" type="abstract operation">
+      <h1>
+        InitializeInstanceElements (
+          _O_: an Object,
+          _constructor_: an ECMAScript function object,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _methods_ be the value of _constructor_.[[PrivateMethods]].
         1. For each PrivateElement _method_ of _methods_, do
@@ -5804,9 +6716,16 @@
     <h1>Operations on Iterator Objects</h1>
     <p>See Common Iteration Interfaces (<emu-xref href="#sec-iteration"></emu-xref>).</p>
 
-    <emu-clause id="sec-getiterator" aoid="GetIterator">
-      <h1>GetIterator ( _obj_ [ , _hint_ [ , _method_ ] ] )</h1>
-      <p>The abstract operation GetIterator takes argument _obj_ and optional arguments _hint_ and _method_. It performs the following steps when called:</p>
+    <emu-clause id="sec-getiterator" type="abstract operation">
+      <h1>
+        GetIterator (
+          _obj_: unknown,
+          optional _hint_: unknown,
+          optional _method_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If _hint_ is not present, set _hint_ to ~sync~.
         1. Assert: _hint_ is either ~sync~ or ~async~.
@@ -5826,9 +6745,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iteratornext" aoid="IteratorNext">
-      <h1>IteratorNext ( _iteratorRecord_ [ , _value_ ] )</h1>
-      <p>The abstract operation IteratorNext takes argument _iteratorRecord_ and optional argument _value_. It performs the following steps when called:</p>
+    <emu-clause id="sec-iteratornext" type="abstract operation">
+      <h1>
+        IteratorNext (
+          _iteratorRecord_: unknown,
+          optional _value_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If _value_ is not present, then
           1. Let _result_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]]).
@@ -5839,27 +6764,44 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iteratorcomplete" aoid="IteratorComplete">
-      <h1>IteratorComplete ( _iterResult_ )</h1>
-      <p>The abstract operation IteratorComplete takes argument _iterResult_. It performs the following steps when called:</p>
+    <emu-clause id="sec-iteratorcomplete" type="abstract operation">
+      <h1>
+        IteratorComplete (
+          _iterResult_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: Type(_iterResult_) is Object.
         1. Return ! ToBoolean(? Get(_iterResult_, *"done"*)).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iteratorvalue" aoid="IteratorValue">
-      <h1>IteratorValue ( _iterResult_ )</h1>
-      <p>The abstract operation IteratorValue takes argument _iterResult_. It performs the following steps when called:</p>
+    <emu-clause id="sec-iteratorvalue" type="abstract operation">
+      <h1>
+        IteratorValue (
+          _iterResult_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: Type(_iterResult_) is Object.
         1. Return ? Get(_iterResult_, *"value"*).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iteratorstep" aoid="IteratorStep">
-      <h1>IteratorStep ( _iteratorRecord_ )</h1>
-      <p>The abstract operation IteratorStep takes argument _iteratorRecord_. It requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either *false* indicating that the iterator has reached its end or the IteratorResult object if a next value is available. It performs the following steps when called:</p>
+    <emu-clause id="sec-iteratorstep" type="abstract operation">
+      <h1>
+        IteratorStep (
+          _iteratorRecord_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either *false* indicating that the iterator has reached its end or the IteratorResult object if a next value is available.</dd>
+      </dl>
       <emu-alg>
         1. Let _result_ be ? IteratorNext(_iteratorRecord_).
         1. Let _done_ be ? IteratorComplete(_result_).
@@ -5868,9 +6810,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iteratorclose" aoid="IteratorClose">
-      <h1>IteratorClose ( _iteratorRecord_, _completion_ )</h1>
-      <p>The abstract operation IteratorClose takes arguments _iteratorRecord_ and _completion_. It is used to notify an iterator that it should perform any actions it would normally perform when it has reached its completed state. It performs the following steps when called:</p>
+    <emu-clause id="sec-iteratorclose" type="abstract operation">
+      <h1>
+        IteratorClose (
+          _iteratorRecord_: unknown,
+          _completion_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to notify an iterator that it should perform any actions it would normally perform when it has reached its completed state.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Assert: _completion_ is a Completion Record.
@@ -5887,9 +6837,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-asynciteratorclose" aoid="AsyncIteratorClose">
-      <h1>AsyncIteratorClose ( _iteratorRecord_, _completion_ )</h1>
-      <p>The abstract operation AsyncIteratorClose takes arguments _iteratorRecord_ and _completion_. It is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state. It performs the following steps when called:</p>
+    <emu-clause id="sec-asynciteratorclose" type="abstract operation">
+      <h1>
+        AsyncIteratorClose (
+          _iteratorRecord_: unknown,
+          _completion_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Assert: _completion_ is a Completion Record.
@@ -5907,9 +6865,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-createiterresultobject" aoid="CreateIterResultObject">
-      <h1>CreateIterResultObject ( _value_, _done_ )</h1>
-      <p>The abstract operation CreateIterResultObject takes arguments _value_ and _done_. It creates an object that supports the IteratorResult interface. It performs the following steps when called:</p>
+    <emu-clause id="sec-createiterresultobject" type="abstract operation">
+      <h1>
+        CreateIterResultObject (
+          _value_: unknown,
+          _done_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates an object that supports the IteratorResult interface.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_done_) is Boolean.
         1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
@@ -5919,9 +6885,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-createlistiteratorRecord" oldids="sec-createlistiterator,sec-listiteratornext-functions,sec-listiterator-next" aoid="CreateListIteratorRecord">
-      <h1>CreateListIteratorRecord ( _list_ )</h1>
-      <p>The abstract operation CreateListIteratorRecord takes argument _list_. It creates an Iterator (<emu-xref href="#sec-iterator-interface"></emu-xref>) object record whose `next` method returns the successive elements of _list_. It performs the following steps when called:</p>
+    <emu-clause id="sec-createlistiteratorRecord" type="abstract operation" oldids="sec-createlistiterator,sec-listiteratornext-functions,sec-listiterator-next">
+      <h1>
+        CreateListIteratorRecord (
+          _list_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates an Iterator (<emu-xref href="#sec-iterator-interface"></emu-xref>) object record whose `next` method returns the successive elements of _list_.</dd>
+      </dl>
       <emu-alg>
         1. Let _closure_ be a new Abstract Closure with no parameters that captures _list_ and performs the following steps when called:
           1. For each element _E_ of _list_, do
@@ -5935,9 +6908,15 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-iterabletolist" aoid="IterableToList">
-      <h1>IterableToList ( _items_ [ , _method_ ] )</h1>
-      <p>The abstract operation IterableToList takes argument _items_ and optional argument _method_. It performs the following steps when called:</p>
+    <emu-clause id="sec-iterabletolist" type="abstract operation">
+      <h1>
+        IterableToList (
+          _items_: unknown,
+          optional _method_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If _method_ is present, then
           1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~, _method_).
@@ -7775,9 +8754,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isanonymousfunctiondefinition" aoid="IsAnonymousFunctionDefinition">
-      <h1>Static Semantics: IsAnonymousFunctionDefinition ( _expr_ )</h1>
-      <p>The abstract operation IsAnonymousFunctionDefinition takes argument _expr_ (a Parse Node for |AssignmentExpression| or a Parse Node for |Initializer|). It determines if its argument is a function definition that does not bind a name. It performs the following steps when called:</p>
+    <emu-clause id="sec-isanonymousfunctiondefinition" type="abstract operation">
+      <h1>
+        Static Semantics: IsAnonymousFunctionDefinition (
+          _expr_: a Parse Node for |AssignmentExpression| or a Parse Node for |Initializer|,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines if its argument is a function definition that does not bind a name.</dd>
+      </dl>
       <emu-alg>
         1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
         1. Let _hasName_ be HasName of _expr_.
@@ -8162,9 +9148,16 @@
         1. Let _excludedNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
         1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
       </emu-alg>
-      <emu-clause id="sec-initializeboundname" aoid="InitializeBoundName">
-        <h1>InitializeBoundName ( _name_, _value_, _environment_ )</h1>
-        <p>The abstract operation InitializeBoundName takes arguments _name_, _value_, and _environment_. It performs the following steps when called:</p>
+      <emu-clause id="sec-initializeboundname" type="abstract operation">
+        <h1>
+          InitializeBoundName (
+            _name_: unknown,
+            _value_: unknown,
+            _environment_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Type(_name_) is String.
           1. If _environment_ is not *undefined*, then
@@ -8716,18 +9709,39 @@
         <p>Each <dfn>declarative Environment Record</dfn> is associated with an ECMAScript program scope containing variable, constant, let, class, module, import, and/or function declarations. A declarative Environment Record binds the set of identifiers defined by the declarations contained within its scope.</p>
         <p>The behaviour of the concrete specification methods for declarative Environment Records is defined by the following algorithms.</p>
 
-        <emu-clause id="sec-declarative-environment-records-hasbinding-n">
-          <h1>HasBinding ( _N_ )</h1>
-          <p>The HasBinding concrete method of a declarative Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier is one of the identifiers bound by the record. It performs the following steps when called:</p>
+        <emu-clause id="sec-declarative-environment-records-hasbinding-n" type="concrete method">
+          <h1>
+            HasBinding (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It determines if the argument identifier is one of the identifiers bound by the record.</dd>
+          </dl>
           <emu-alg>
             1. If _envRec_ has a binding for the name that is the value of _N_, return *true*.
             1. Return *false*.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-createmutablebinding-n-d">
-          <h1>CreateMutableBinding ( _N_, _D_ )</h1>
-          <p>The CreateMutableBinding concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String) and _D_ (a Boolean). It creates a new mutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _D_ has the value *true*, the new binding is marked as being subject to deletion. It performs the following steps when called:</p>
+        <emu-clause id="sec-declarative-environment-records-createmutablebinding-n-d" type="concrete method">
+          <h1>
+            CreateMutableBinding (
+              _N_: a String,
+              _D_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It creates a new mutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _D_ has the value *true*, the new binding is marked as being subject to deletion.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Create a mutable binding in _envRec_ for _N_ and record that it is uninitialized. If _D_ is *true*, record that the newly created binding may be deleted by a subsequent DeleteBinding call.
@@ -8735,9 +9749,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-createimmutablebinding-n-s">
-          <h1>CreateImmutableBinding ( _N_, _S_ )</h1>
-          <p>The CreateImmutableBinding concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _S_ has the value *true*, the new binding is marked as a strict binding. It performs the following steps when called:</p>
+        <emu-clause id="sec-declarative-environment-records-createimmutablebinding-n-s" type="concrete method">
+          <h1>
+            CreateImmutableBinding (
+              _N_: a String,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _S_ has the value *true*, the new binding is marked as a strict binding.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Create an immutable binding in _envRec_ for _N_ and record that it is uninitialized. If _S_ is *true*, record that the newly created binding is a strict binding.
@@ -8745,9 +9770,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-initializebinding-n-v">
-          <h1>InitializeBinding ( _N_, _V_ )</h1>
-          <p>The InitializeBinding concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String) and _V_ (an ECMAScript language value). It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist. It performs the following steps when called:</p>
+        <emu-clause id="sec-declarative-environment-records-initializebinding-n-v" type="concrete method">
+          <h1>
+            InitializeBinding (
+              _N_: a String,
+              _V_: an ECMAScript language value,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _envRec_ must have an uninitialized binding for _N_.
             1. Set the bound value for _N_ in _envRec_ to _V_.
@@ -8756,9 +9792,21 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-setmutablebinding-n-v-s">
-          <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
-          <p>The SetMutableBinding concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String), _V_ (an ECMAScript language value), and _S_ (a Boolean). It attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. A binding for _N_ normally already exists, but in rare cases it may not. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*. It performs the following steps when called:</p>
+        <emu-clause id="sec-declarative-environment-records-setmutablebinding-n-v-s" type="concrete method">
+          <h1>
+            SetMutableBinding (
+              _N_: a String,
+              _V_: an ECMAScript language value,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. A binding for _N_ normally already exists, but in rare cases it may not. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*.</dd>
+          </dl>
           <emu-alg>
             1. [id="step-setmutablebinding-missing-binding"] If _envRec_ does not have a binding for _N_, then
               1. If _S_ is *true*, throw a *ReferenceError* exception.
@@ -8779,9 +9827,20 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-getbindingvalue-n-s">
-          <h1>GetBindingValue ( _N_, _S_ )</h1>
-          <p>The GetBindingValue concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It returns the value of its bound identifier whose name is the value of the argument _N_. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_. It performs the following steps when called:</p>
+        <emu-clause id="sec-declarative-environment-records-getbindingvalue-n-s" type="concrete method">
+          <h1>
+            GetBindingValue (
+              _N_: a String,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It returns the value of its bound identifier whose name is the value of the argument _N_. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _envRec_ has a binding for _N_.
             1. If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.
@@ -8789,9 +9848,19 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-deletebinding-n">
-          <h1>DeleteBinding ( _N_ )</h1>
-          <p>The DeleteBinding concrete method of a declarative Environment Record _envRec_ takes argument _N_ (a String). It can only delete bindings that have been explicitly designated as being subject to deletion. It performs the following steps when called:</p>
+        <emu-clause id="sec-declarative-environment-records-deletebinding-n" type="concrete method">
+          <h1>
+            DeleteBinding (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It can only delete bindings that have been explicitly designated as being subject to deletion.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _envRec_ has a binding for the name that is the value of _N_.
             1. If the binding for _N_ in _envRec_ cannot be deleted, return *false*.
@@ -8800,9 +9869,12 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-hasthisbinding">
+        <emu-clause id="sec-declarative-environment-records-hasthisbinding" type="concrete method">
           <h1>HasThisBinding ( )</h1>
-          <p>The HasThisBinding concrete method of a declarative Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
@@ -8811,9 +9883,12 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-hassuperbinding">
+        <emu-clause id="sec-declarative-environment-records-hassuperbinding" type="concrete method">
           <h1>HasSuperBinding ( )</h1>
-          <p>The HasSuperBinding concrete method of a declarative Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
@@ -8822,9 +9897,12 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-declarative-environment-records-withbaseobject">
+        <emu-clause id="sec-declarative-environment-records-withbaseobject" type="concrete method">
           <h1>WithBaseObject ( )</h1>
-          <p>The WithBaseObject concrete method of a declarative Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a declarative Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *undefined*.
           </emu-alg>
@@ -8877,9 +9955,19 @@
         </emu-table>
         <p>The behaviour of the concrete specification methods for object Environment Records is defined by the following algorithms.</p>
 
-        <emu-clause id="sec-object-environment-records-hasbinding-n">
-          <h1>HasBinding ( _N_ )</h1>
-          <p>The HasBinding concrete method of an object Environment Record _envRec_ takes argument _N_ (a String). It determines if its associated binding object has a property whose name is the value of the argument _N_. It performs the following steps when called:</p>
+        <emu-clause id="sec-object-environment-records-hasbinding-n" type="concrete method">
+          <h1>
+            HasBinding (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It determines if its associated binding object has a property whose name is the value of the argument _N_.</dd>
+          </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
             1. Let _foundBinding_ be ? HasProperty(_bindingObject_, _N_).
@@ -8893,9 +9981,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-object-environment-records-createmutablebinding-n-d">
-          <h1>CreateMutableBinding ( _N_, _D_ )</h1>
-          <p>The CreateMutableBinding concrete method of an object Environment Record _envRec_ takes arguments _N_ (a String) and _D_ (a Boolean). It creates in an Environment Record's associated binding object a property whose name is the String value and initializes it to the value *undefined*. If _D_ has the value *true*, the new property's [[Configurable]] attribute is set to *true*; otherwise it is set to *false*. It performs the following steps when called:</p>
+        <emu-clause id="sec-object-environment-records-createmutablebinding-n-d" type="concrete method">
+          <h1>
+            CreateMutableBinding (
+              _N_: a String,
+              _D_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It creates in an Environment Record's associated binding object a property whose name is the String value and initializes it to the value *undefined*. If _D_ has the value *true*, the new property's [[Configurable]] attribute is set to *true*; otherwise it is set to *false*.</dd>
+          </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
             1. Return ? DefinePropertyOrThrow(_bindingObject_, _N_, PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: _D_ }).
@@ -8910,9 +10009,20 @@
           <p>The CreateImmutableBinding concrete method of an object Environment Record is never used within this specification.</p>
         </emu-clause>
 
-        <emu-clause id="sec-object-environment-records-initializebinding-n-v">
-          <h1>InitializeBinding ( _N_, _V_ )</h1>
-          <p>The InitializeBinding concrete method of an object Environment Record _envRec_ takes arguments _N_ (a String) and _V_ (an ECMAScript language value). It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. It performs the following steps when called:</p>
+        <emu-clause id="sec-object-environment-records-initializebinding-n-v" type="concrete method">
+          <h1>
+            InitializeBinding (
+              _N_: a String,
+              _V_: an ECMAScript language value,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_.</dd>
+          </dl>
           <emu-alg>
             1. Return ? _envRec_.SetMutableBinding(_N_, _V_, *false*).
           </emu-alg>
@@ -8921,9 +10031,21 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-object-environment-records-setmutablebinding-n-v-s">
-          <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
-          <p>The SetMutableBinding concrete method of an object Environment Record _envRec_ takes arguments _N_ (a String), _V_ (an ECMAScript language value), and _S_ (a Boolean). It attempts to set the value of the Environment Record's associated binding object's property whose name is the value of the argument _N_ to the value of argument _V_. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_. It performs the following steps when called:</p>
+        <emu-clause id="sec-object-environment-records-setmutablebinding-n-v-s" type="concrete method">
+          <h1>
+            SetMutableBinding (
+              _N_: a String,
+              _V_: an ECMAScript language value,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It attempts to set the value of the Environment Record's associated binding object's property whose name is the value of the argument _N_ to the value of argument _V_. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
+          </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
             1. Let _stillExists_ be ? HasProperty(_bindingObject_, _N_).
@@ -8932,9 +10054,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-object-environment-records-getbindingvalue-n-s">
-          <h1>GetBindingValue ( _N_, _S_ )</h1>
-          <p>The GetBindingValue concrete method of an object Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It returns the value of its associated binding object's property whose name is the String value of the argument identifier _N_. The property should already exist but if it does not the result depends upon _S_. It performs the following steps when called:</p>
+        <emu-clause id="sec-object-environment-records-getbindingvalue-n-s" type="concrete method">
+          <h1>
+            GetBindingValue (
+              _N_: a String,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It returns the value of its associated binding object's property whose name is the String value of the argument identifier _N_. The property should already exist but if it does not the result depends upon _S_.</dd>
+          </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
             1. Let _value_ be ? HasProperty(_bindingObject_, _N_).
@@ -8944,18 +10077,31 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-object-environment-records-deletebinding-n">
-          <h1>DeleteBinding ( _N_ )</h1>
-          <p>The DeleteBinding concrete method of an object Environment Record _envRec_ takes argument _N_ (a String). It can only delete bindings that correspond to properties of the environment object whose [[Configurable]] attribute have the value *true*. It performs the following steps when called:</p>
+        <emu-clause id="sec-object-environment-records-deletebinding-n" type="concrete method">
+          <h1>
+            DeleteBinding (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It can only delete bindings that correspond to properties of the environment object whose [[Configurable]] attribute have the value *true*.</dd>
+          </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
             1. Return ? _bindingObject_.[[Delete]](_N_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-object-environment-records-hasthisbinding">
+        <emu-clause id="sec-object-environment-records-hasthisbinding" type="concrete method">
           <h1>HasThisBinding ( )</h1>
-          <p>The HasThisBinding concrete method of an object Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
@@ -8964,9 +10110,12 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-object-environment-records-hassuperbinding">
+        <emu-clause id="sec-object-environment-records-hassuperbinding" type="concrete method">
           <h1>HasSuperBinding ( )</h1>
-          <p>The HasSuperBinding concrete method of an object Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
@@ -8975,9 +10124,12 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-object-environment-records-withbaseobject">
+        <emu-clause id="sec-object-environment-records-withbaseobject" type="concrete method">
           <h1>WithBaseObject ( )</h1>
-          <p>The WithBaseObject concrete method of an object Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>an object Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. If _envRec_.[[IsWithEnvironment]] is *true*, return _envRec_.[[BindingObject]].
             1. Otherwise, return *undefined*.
@@ -9091,9 +10243,16 @@
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for function Environment Records is defined by the following algorithms:</p>
 
-        <emu-clause id="sec-bindthisvalue">
-          <h1>BindThisValue ( _V_ )</h1>
-          <p>The BindThisValue concrete method of a function Environment Record _envRec_ takes argument _V_ (an ECMAScript language value). It performs the following steps when called:</p>
+        <emu-clause id="sec-bindthisvalue" type="concrete method">
+          <h1>
+            BindThisValue (
+              _V_: an ECMAScript language value,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a function Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Assert: _envRec_.[[ThisBindingStatus]] is not ~lexical~.
             1. If _envRec_.[[ThisBindingStatus]] is ~initialized~, throw a *ReferenceError* exception.
@@ -9103,26 +10262,35 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-function-environment-records-hasthisbinding">
+        <emu-clause id="sec-function-environment-records-hasthisbinding" type="concrete method">
           <h1>HasThisBinding ( )</h1>
-          <p>The HasThisBinding concrete method of a function Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a function Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*; otherwise, return *true*.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-function-environment-records-hassuperbinding">
+        <emu-clause id="sec-function-environment-records-hassuperbinding" type="concrete method">
           <h1>HasSuperBinding ( )</h1>
-          <p>The HasSuperBinding concrete method of a function Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a function Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*.
             1. If _envRec_.[[FunctionObject]].[[HomeObject]] has the value *undefined*, return *false*; otherwise, return *true*.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-function-environment-records-getthisbinding">
+        <emu-clause id="sec-function-environment-records-getthisbinding" type="concrete method">
           <h1>GetThisBinding ( )</h1>
-          <p>The GetThisBinding concrete method of a function Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a function Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Assert: _envRec_.[[ThisBindingStatus]] is not ~lexical~.
             1. If _envRec_.[[ThisBindingStatus]] is ~uninitialized~, throw a *ReferenceError* exception.
@@ -9130,9 +10298,12 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-getsuperbase">
+        <emu-clause id="sec-getsuperbase" type="concrete method">
           <h1>GetSuperBase ( )</h1>
-          <p>The GetSuperBase concrete method of a function Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a function Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Let _home_ be _envRec_.[[FunctionObject]].[[HomeObject]].
             1. If _home_ has the value *undefined*, return *undefined*.
@@ -9289,9 +10460,19 @@
         </emu-table>
         <p>The behaviour of the concrete specification methods for global Environment Records is defined by the following algorithms.</p>
 
-        <emu-clause id="sec-global-environment-records-hasbinding-n">
-          <h1>HasBinding ( _N_ )</h1>
-          <p>The HasBinding concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier is one of the identifiers bound by the record. It performs the following steps when called:</p>
+        <emu-clause id="sec-global-environment-records-hasbinding-n" type="concrete method">
+          <h1>
+            HasBinding (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It determines if the argument identifier is one of the identifiers bound by the record.</dd>
+          </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, return *true*.
@@ -9300,9 +10481,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-createmutablebinding-n-d">
-          <h1>CreateMutableBinding ( _N_, _D_ )</h1>
-          <p>The CreateMutableBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _D_ (a Boolean). It creates a new mutable binding for the name _N_ that is uninitialized. The binding is created in the associated DeclarativeRecord. A binding for _N_ must not already exist in the DeclarativeRecord. If _D_ has the value *true*, the new binding is marked as being subject to deletion. It performs the following steps when called:</p>
+        <emu-clause id="sec-global-environment-records-createmutablebinding-n-d" type="concrete method">
+          <h1>
+            CreateMutableBinding (
+              _N_: a String,
+              _D_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It creates a new mutable binding for the name _N_ that is uninitialized. The binding is created in the associated DeclarativeRecord. A binding for _N_ must not already exist in the DeclarativeRecord. If _D_ has the value *true*, the new binding is marked as being subject to deletion.</dd>
+          </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, throw a *TypeError* exception.
@@ -9310,9 +10502,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-createimmutablebinding-n-s">
-          <h1>CreateImmutableBinding ( _N_, _S_ )</h1>
-          <p>The CreateImmutableBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _S_ has the value *true*, the new binding is marked as a strict binding. It performs the following steps when called:</p>
+        <emu-clause id="sec-global-environment-records-createimmutablebinding-n-s" type="concrete method">
+          <h1>
+            CreateImmutableBinding (
+              _N_: a String,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _S_ has the value *true*, the new binding is marked as a strict binding.</dd>
+          </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, throw a *TypeError* exception.
@@ -9320,9 +10523,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-initializebinding-n-v">
-          <h1>InitializeBinding ( _N_, _V_ )</h1>
-          <p>The InitializeBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _V_ (an ECMAScript language value). It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist. It performs the following steps when called:</p>
+        <emu-clause id="sec-global-environment-records-initializebinding-n-v" type="concrete method">
+          <h1>
+            InitializeBinding (
+              _N_: a String,
+              _V_: an ECMAScript language value,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</dd>
+          </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, then
@@ -9333,9 +10547,21 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-setmutablebinding-n-v-s">
-          <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
-          <p>The SetMutableBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String), _V_ (an ECMAScript language value), and _S_ (a Boolean). It attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_. It performs the following steps when called:</p>
+        <emu-clause id="sec-global-environment-records-setmutablebinding-n-v-s" type="concrete method">
+          <h1>
+            SetMutableBinding (
+              _N_: a String,
+              _V_: an ECMAScript language value,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
+          </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, then
@@ -9345,9 +10571,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-getbindingvalue-n-s">
-          <h1>GetBindingValue ( _N_, _S_ )</h1>
-          <p>The GetBindingValue concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It returns the value of its bound identifier whose name is the value of the argument _N_. If the binding is an uninitialized binding throw a *ReferenceError* exception. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_. It performs the following steps when called:</p>
+        <emu-clause id="sec-global-environment-records-getbindingvalue-n-s" type="concrete method">
+          <h1>
+            GetBindingValue (
+              _N_: a String,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It returns the value of its bound identifier whose name is the value of the argument _N_. If the binding is an uninitialized binding throw a *ReferenceError* exception. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
+          </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, then
@@ -9357,9 +10594,19 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-deletebinding-n">
-          <h1>DeleteBinding ( _N_ )</h1>
-          <p>The DeleteBinding concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It can only delete bindings that have been explicitly designated as being subject to deletion. It performs the following steps when called:</p>
+        <emu-clause id="sec-global-environment-records-deletebinding-n" type="concrete method">
+          <h1>
+            DeleteBinding (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It can only delete bindings that have been explicitly designated as being subject to deletion.</dd>
+          </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, then
@@ -9377,9 +10624,12 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-hasthisbinding">
+        <emu-clause id="sec-global-environment-records-hasthisbinding" type="concrete method">
           <h1>HasThisBinding ( )</h1>
-          <p>The HasThisBinding concrete method of a global Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *true*.
           </emu-alg>
@@ -9388,9 +10638,12 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-hassuperbinding">
+        <emu-clause id="sec-global-environment-records-hassuperbinding" type="concrete method">
           <h1>HasSuperBinding ( )</h1>
-          <p>The HasSuperBinding concrete method of a global Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
@@ -9399,25 +10652,41 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-withbaseobject">
+        <emu-clause id="sec-global-environment-records-withbaseobject" type="concrete method">
           <h1>WithBaseObject ( )</h1>
-          <p>The WithBaseObject concrete method of a global Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *undefined*.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-global-environment-records-getthisbinding">
+        <emu-clause id="sec-global-environment-records-getthisbinding" type="concrete method">
           <h1>GetThisBinding ( )</h1>
-          <p>The GetThisBinding concrete method of a global Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return _envRec_.[[GlobalThisValue]].
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-hasvardeclaration">
-          <h1>HasVarDeclaration ( _N_ )</h1>
-          <p>The HasVarDeclaration concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier has a binding in this record that was created using a |VariableStatement| or a |FunctionDeclaration|. It performs the following steps when called:</p>
+        <emu-clause id="sec-hasvardeclaration" type="concrete method">
+          <h1>
+            HasVarDeclaration (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It determines if the argument identifier has a binding in this record that was created using a |VariableStatement| or a |FunctionDeclaration|.</dd>
+          </dl>
           <emu-alg>
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
             1. If _varDeclaredNames_ contains _N_, return *true*.
@@ -9425,18 +10694,38 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-haslexicaldeclaration">
-          <h1>HasLexicalDeclaration ( _N_ )</h1>
-          <p>The HasLexicalDeclaration concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier has a binding in this record that was created using a lexical declaration such as a |LexicalDeclaration| or a |ClassDeclaration|. It performs the following steps when called:</p>
+        <emu-clause id="sec-haslexicaldeclaration" type="concrete method">
+          <h1>
+            HasLexicalDeclaration (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It determines if the argument identifier has a binding in this record that was created using a lexical declaration such as a |LexicalDeclaration| or a |ClassDeclaration|.</dd>
+          </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. Return _DclRec_.HasBinding(_N_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-hasrestrictedglobalproperty">
-          <h1>HasRestrictedGlobalProperty ( _N_ )</h1>
-          <p>The HasRestrictedGlobalProperty concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier is the name of a property of the global object that must not be shadowed by a global lexical binding. It performs the following steps when called:</p>
+        <emu-clause id="sec-hasrestrictedglobalproperty" type="concrete method">
+          <h1>
+            HasRestrictedGlobalProperty (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It determines if the argument identifier is the name of a property of the global object that must not be shadowed by a global lexical binding.</dd>
+          </dl>
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
@@ -9450,9 +10739,19 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-candeclareglobalvar">
-          <h1>CanDeclareGlobalVar ( _N_ )</h1>
-          <p>The CanDeclareGlobalVar concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if a corresponding CreateGlobalVarBinding call would succeed if called for the same argument _N_. Redundant var declarations and var declarations for pre-existing global object properties are allowed. It performs the following steps when called:</p>
+        <emu-clause id="sec-candeclareglobalvar" type="concrete method">
+          <h1>
+            CanDeclareGlobalVar (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It determines if a corresponding CreateGlobalVarBinding call would succeed if called for the same argument _N_. Redundant var declarations and var declarations for pre-existing global object properties are allowed.</dd>
+          </dl>
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
@@ -9462,9 +10761,19 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-candeclareglobalfunction">
-          <h1>CanDeclareGlobalFunction ( _N_ )</h1>
-          <p>The CanDeclareGlobalFunction concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if a corresponding CreateGlobalFunctionBinding call would succeed if called for the same argument _N_. It performs the following steps when called:</p>
+        <emu-clause id="sec-candeclareglobalfunction" type="concrete method">
+          <h1>
+            CanDeclareGlobalFunction (
+              _N_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It determines if a corresponding CreateGlobalFunctionBinding call would succeed if called for the same argument _N_.</dd>
+          </dl>
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
@@ -9476,9 +10785,20 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-createglobalvarbinding">
-          <h1>CreateGlobalVarBinding ( _N_, _D_ )</h1>
-          <p>The CreateGlobalVarBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _D_ (a Boolean). It creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is reused and assumed to be initialized. It performs the following steps when called:</p>
+        <emu-clause id="sec-createglobalvarbinding" type="concrete method">
+          <h1>
+            CreateGlobalVarBinding (
+              _N_: a String,
+              _D_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is reused and assumed to be initialized.</dd>
+          </dl>
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
@@ -9494,9 +10814,21 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-createglobalfunctionbinding">
-          <h1>CreateGlobalFunctionBinding ( _N_, _V_, _D_ )</h1>
-          <p>The CreateGlobalFunctionBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String), _V_ (an ECMAScript language value), and _D_ (a Boolean). It creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is replaced. It performs the following steps when called:</p>
+        <emu-clause id="sec-createglobalfunctionbinding" type="concrete method">
+          <h1>
+            CreateGlobalFunctionBinding (
+              _N_: a String,
+              _V_: an ECMAScript language value,
+              _D_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a global Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is replaced.</dd>
+          </dl>
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
@@ -9554,9 +10886,20 @@
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
 
-        <emu-clause id="sec-module-environment-records-getbindingvalue-n-s">
-          <h1>GetBindingValue ( _N_, _S_ )</h1>
-          <p>The GetBindingValue concrete method of a module Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown. It performs the following steps when called:</p>
+        <emu-clause id="sec-module-environment-records-getbindingvalue-n-s" type="concrete method">
+          <h1>
+            GetBindingValue (
+              _N_: a String,
+              _S_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a module Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _S_ is *true*.
             1. Assert: _envRec_ has a binding for _N_.
@@ -9581,9 +10924,12 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-module-environment-records-hasthisbinding">
+        <emu-clause id="sec-module-environment-records-hasthisbinding" type="concrete method">
           <h1>HasThisBinding ( )</h1>
-          <p>The HasThisBinding concrete method of a module Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a module Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *true*.
           </emu-alg>
@@ -9592,17 +10938,32 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-module-environment-records-getthisbinding">
+        <emu-clause id="sec-module-environment-records-getthisbinding" type="concrete method">
           <h1>GetThisBinding ( )</h1>
-          <p>The GetThisBinding concrete method of a module Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a module Environment Record _envRec_</dd>
+          </dl>
           <emu-alg>
             1. Return *undefined*.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-createimportbinding">
-          <h1>CreateImportBinding ( _N_, _M_, _N2_ )</h1>
-          <p>The CreateImportBinding concrete method of a module Environment Record _envRec_ takes arguments _N_ (a String), _M_ (a Module Record), and _N2_ (a String). It creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _N2_ is the name of a binding that exists in _M_'s module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding. It performs the following steps when called:</p>
+        <emu-clause id="sec-createimportbinding" type="concrete method">
+          <h1>
+            CreateImportBinding (
+              _N_: a String,
+              _M_: a Module Record,
+              _N2_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a module Environment Record _envRec_</dd>
+
+            <dt>description</dt>
+            <dd>It creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _N2_ is the name of a binding that exists in _M_'s module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Assert: _M_ is a Module Record.
@@ -9618,9 +10979,16 @@
       <h1>Environment Record Operations</h1>
       <p>The following abstract operations are used in this specification to operate upon Environment Records:</p>
 
-      <emu-clause id="sec-getidentifierreference" aoid="GetIdentifierReference">
-        <h1>GetIdentifierReference ( _env_, _name_, _strict_ )</h1>
-        <p>The abstract operation GetIdentifierReference takes arguments _env_ (an Environment Record or *null*), _name_ (a String), and _strict_ (a Boolean). It performs the following steps when called:</p>
+      <emu-clause id="sec-getidentifierreference" type="abstract operation">
+        <h1>
+          GetIdentifierReference (
+            _env_: an Environment Record or *null*,
+            _name_: a String,
+            _strict_: a Boolean,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _env_ is the value *null*, then
             1. Return the Reference Record { [[Base]]: ~unresolvable~, [[ReferencedName]]: _name_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
@@ -9633,9 +11001,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-newdeclarativeenvironment" aoid="NewDeclarativeEnvironment">
-        <h1>NewDeclarativeEnvironment ( _E_ )</h1>
-        <p>The abstract operation NewDeclarativeEnvironment takes argument _E_ (an Environment Record). It performs the following steps when called:</p>
+      <emu-clause id="sec-newdeclarativeenvironment" type="abstract operation">
+        <h1>
+          NewDeclarativeEnvironment (
+            _E_: an Environment Record,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _env_ be a new declarative Environment Record containing no bindings.
           1. Set _env_.[[OuterEnv]] to _E_.
@@ -9643,9 +11016,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-newobjectenvironment" aoid="NewObjectEnvironment">
-        <h1>NewObjectEnvironment ( _O_, _W_, _E_ )</h1>
-        <p>The abstract operation NewObjectEnvironment takes arguments _O_ (an Object), _W_ (a Boolean), and _E_ (an Environment Record or *null*). It performs the following steps when called:</p>
+      <emu-clause id="sec-newobjectenvironment" type="abstract operation">
+        <h1>
+          NewObjectEnvironment (
+            _O_: an Object,
+            _W_: a Boolean,
+            _E_: an Environment Record or *null*,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _env_ be a new object Environment Record.
           1. Set _env_.[[BindingObject]] to _O_.
@@ -9655,9 +11035,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-newfunctionenvironment" aoid="NewFunctionEnvironment">
-        <h1>NewFunctionEnvironment ( _F_, _newTarget_ )</h1>
-        <p>The abstract operation NewFunctionEnvironment takes arguments _F_ and _newTarget_. It performs the following steps when called:</p>
+      <emu-clause id="sec-newfunctionenvironment" type="abstract operation">
+        <h1>
+          NewFunctionEnvironment (
+            _F_: unknown,
+            _newTarget_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _F_ is an ECMAScript function.
           1. Assert: Type(_newTarget_) is Undefined or Object.
@@ -9671,9 +11057,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-newglobalenvironment" aoid="NewGlobalEnvironment">
-        <h1>NewGlobalEnvironment ( _G_, _thisValue_ )</h1>
-        <p>The abstract operation NewGlobalEnvironment takes arguments _G_ and _thisValue_. It performs the following steps when called:</p>
+      <emu-clause id="sec-newglobalenvironment" type="abstract operation">
+        <h1>
+          NewGlobalEnvironment (
+            _G_: unknown,
+            _thisValue_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _objRec_ be NewObjectEnvironment(_G_, *false*, *null*).
           1. Let _dclRec_ be a new declarative Environment Record containing no bindings.
@@ -9687,9 +11079,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-newmoduleenvironment" aoid="NewModuleEnvironment">
-        <h1>NewModuleEnvironment ( _E_ )</h1>
-        <p>The abstract operation NewModuleEnvironment takes argument _E_ (an Environment Record). It performs the following steps when called:</p>
+      <emu-clause id="sec-newmoduleenvironment" type="abstract operation">
+        <h1>
+          NewModuleEnvironment (
+            _E_: an Environment Record,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _env_ be a new module Environment Record containing no bindings.
           1. Set _env_.[[OuterEnv]] to _E_.
@@ -9749,18 +11146,29 @@
       <h1>PrivateEnvironment Record Operations</h1>
       <p>The following abstract operations are used in this specification to operate upon PrivateEnvironment Records:</p>
 
-      <emu-clause id="sec-newprivateenvironment" aoid="NewPrivateEnvironment">
-        <h1>NewPrivateEnvironment ( _outerPrivEnv_ )</h1>
-        <p>The abstract operation NewPrivateEnvironment takes argument _outerPrivEnv_ (a PrivateEnvironment Record or *null*). It performs the following steps when called:</p>
+      <emu-clause id="sec-newprivateenvironment" type="abstract operation">
+        <h1>
+          NewPrivateEnvironment (
+            _outerPrivEnv_: a PrivateEnvironment Record or *null*,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _names_ be a new empty List.
           1. Return the PrivateEnvironment Record { [[OuterPrivateEnvironment]]: _outerPrivEnv_, [[Names]]: _names_ }.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-resolve-private-identifier" aoid="ResolvePrivateIdentifier">
-        <h1>ResolvePrivateIdentifier ( _privEnv_, _identifier_ )</h1>
-        <p>The abstract operation ResolvePrivateIdentifier takes arguments _privEnv_ (a PrivateEnvironment Record) and _identifier_ (a String). It performs the following steps when called:</p>
+      <emu-clause id="sec-resolve-private-identifier" type="abstract operation">
+        <h1>
+          ResolvePrivateIdentifier (
+            _privEnv_: a PrivateEnvironment Record,
+            _identifier_: a String,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _names_ be _privEnv_.[[Names]].
           1. If _names_ contains a Private Name whose [[Description]] is _identifier_, then
@@ -9853,9 +11261,10 @@
       </table>
     </emu-table>
 
-    <emu-clause id="sec-createrealm" aoid="CreateRealm">
+    <emu-clause id="sec-createrealm" type="abstract operation">
       <h1>CreateRealm ( )</h1>
-      <p>The abstract operation CreateRealm takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _realmRec_ be a new Realm Record.
         1. Perform CreateIntrinsics(_realmRec_).
@@ -9866,9 +11275,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-createintrinsics" aoid="CreateIntrinsics">
-      <h1>CreateIntrinsics ( _realmRec_ )</h1>
-      <p>The abstract operation CreateIntrinsics takes argument _realmRec_. It performs the following steps when called:</p>
+    <emu-clause id="sec-createintrinsics" type="abstract operation">
+      <h1>
+        CreateIntrinsics (
+          _realmRec_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _intrinsics_ be a new Record.
         1. Set _realmRec_.[[Intrinsics]] to _intrinsics_.
@@ -9878,9 +11292,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-setrealmglobalobject" aoid="SetRealmGlobalObject">
-      <h1>SetRealmGlobalObject ( _realmRec_, _globalObj_, _thisValue_ )</h1>
-      <p>The abstract operation SetRealmGlobalObject takes arguments _realmRec_, _globalObj_, and _thisValue_. It performs the following steps when called:</p>
+    <emu-clause id="sec-setrealmglobalobject" type="abstract operation">
+      <h1>
+        SetRealmGlobalObject (
+          _realmRec_: unknown,
+          _globalObj_: unknown,
+          _thisValue_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If _globalObj_ is *undefined*, then
           1. Let _intrinsics_ be _realmRec_.[[Intrinsics]].
@@ -9894,9 +11315,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-setdefaultglobalbindings" aoid="SetDefaultGlobalBindings">
-      <h1>SetDefaultGlobalBindings ( _realmRec_ )</h1>
-      <p>The abstract operation SetDefaultGlobalBindings takes argument _realmRec_. It performs the following steps when called:</p>
+    <emu-clause id="sec-setdefaultglobalbindings" type="abstract operation">
+      <h1>
+        SetDefaultGlobalBindings (
+          _realmRec_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _global_ be _realmRec_.[[GlobalObject]].
         1. For each property of the Global Object specified in clause <emu-xref href="#sec-global-object"></emu-xref>, do
@@ -10027,9 +11453,12 @@
     <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms &ldquo;LexicalEnvironment&rdquo;, and &ldquo;VariableEnvironment&rdquo; are used without qualification they are in reference to those components of the running execution context.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 
-    <emu-clause id="sec-getactivescriptormodule" aoid="GetActiveScriptOrModule">
+    <emu-clause id="sec-getactivescriptormodule" type="abstract operation">
       <h1>GetActiveScriptOrModule ( )</h1>
-      <p>The abstract operation GetActiveScriptOrModule takes no arguments. It is used to determine the running script or module, based on the running execution context. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to determine the running script or module, based on the running execution context.</dd>
+      </dl>
 
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
@@ -10038,9 +11467,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-resolvebinding" aoid="ResolveBinding">
-      <h1>ResolveBinding ( _name_ [ , _env_ ] )</h1>
-      <p>The abstract operation ResolveBinding takes argument _name_ (a String) and optional argument _env_ (an Environment Record). It is used to determine the binding of _name_. _env_ can be used to explicitly provide the Environment Record that is to be searched for the binding. It performs the following steps when called:</p>
+    <emu-clause id="sec-resolvebinding" type="abstract operation">
+      <h1>
+        ResolveBinding (
+          _name_: a String,
+          optional _env_: an Environment Record,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to determine the binding of _name_. _env_ can be used to explicitly provide the Environment Record that is to be searched for the binding.</dd>
+      </dl>
       <emu-alg>
         1. If _env_ is not present or if _env_ is *undefined*, then
           1. Set _env_ to the running execution context's LexicalEnvironment.
@@ -10053,9 +11490,12 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-getthisenvironment" aoid="GetThisEnvironment">
+    <emu-clause id="sec-getthisenvironment" type="abstract operation">
       <h1>GetThisEnvironment ( )</h1>
-      <p>The abstract operation GetThisEnvironment takes no arguments. It finds the Environment Record that currently supplies the binding of the keyword `this`. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It finds the Environment Record that currently supplies the binding of the keyword `this`.</dd>
+      </dl>
       <emu-alg>
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. [id="step-getthisenvironment-loop"] Repeat,
@@ -10070,18 +11510,24 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-resolvethisbinding" aoid="ResolveThisBinding">
+    <emu-clause id="sec-resolvethisbinding" type="abstract operation">
       <h1>ResolveThisBinding ( )</h1>
-      <p>The abstract operation ResolveThisBinding takes no arguments. It determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context.</dd>
+      </dl>
       <emu-alg>
         1. Let _envRec_ be GetThisEnvironment().
         1. Return ? _envRec_.GetThisBinding().
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getnewtarget" aoid="GetNewTarget">
+    <emu-clause id="sec-getnewtarget" type="abstract operation">
       <h1>GetNewTarget ( )</h1>
-      <p>The abstract operation GetNewTarget takes no arguments. It determines the NewTarget value using the LexicalEnvironment of the running execution context. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines the NewTarget value using the LexicalEnvironment of the running execution context.</dd>
+      </dl>
       <emu-alg>
         1. Let _envRec_ be GetThisEnvironment().
         1. Assert: _envRec_ has a [[NewTarget]] field.
@@ -10089,9 +11535,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getglobalobject" aoid="GetGlobalObject">
+    <emu-clause id="sec-getglobalobject" type="abstract operation">
       <h1>GetGlobalObject ( )</h1>
-      <p>The abstract operation GetGlobalObject takes no arguments. It returns the global object used by the currently running execution context. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the global object used by the currently running execution context.</dd>
+      </dl>
       <emu-alg>
         1. Let _currentRealm_ be the current Realm Record.
         1. Return _currentRealm_.[[GlobalObject]].
@@ -10188,9 +11637,14 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-hostmakejobcallback" aoid="HostMakeJobCallback">
-      <h1>HostMakeJobCallback ( _callback_ )</h1>
-      <p>The host-defined abstract operation HostMakeJobCallback takes argument _callback_ (a function object).</p>
+    <emu-clause id="sec-hostmakejobcallback" type="host-defined abstract operation">
+      <h1>
+        HostMakeJobCallback (
+          _callback_: a function object,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <p>The implementation of HostMakeJobCallback must conform to the following requirements:</p>
       <ul>
         <li>It must always complete normally (i.e., not return an abrupt completion).</li>
@@ -10207,9 +11661,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-hostcalljobcallback" aoid="HostCallJobCallback">
-      <h1>HostCallJobCallback ( _jobCallback_, _V_, _argumentsList_ )</h1>
-      <p>The host-defined abstract operation HostCallJobCallback takes arguments _jobCallback_ (a JobCallback Record), _V_ (an ECMAScript language value), and _argumentsList_ (a List of ECMAScript language values).</p>
+    <emu-clause id="sec-hostcalljobcallback" type="host-defined abstract operation">
+      <h1>
+        HostCallJobCallback (
+          _jobCallback_: a JobCallback Record,
+          _V_: an ECMAScript language value,
+          _argumentsList_: a List of ECMAScript language values,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <p>The implementation of HostCallJobCallback must conform to the following requirements:</p>
       <ul>
         <li>It must always perform and return the result of Call(_jobCallback_.[[Callback]], _V_, _argumentsList_).</li>
@@ -10225,9 +11686,17 @@
       <p>ECMAScript hosts that are not web browsers must use the default implementation of HostCallJobCallback.</p>
     </emu-clause>
 
-    <emu-clause id="sec-hostenqueuepromisejob" aoid="HostEnqueuePromiseJob">
-      <h1>HostEnqueuePromiseJob ( _job_, _realm_ )</h1>
-      <p>The host-defined abstract operation HostEnqueuePromiseJob takes arguments _job_ (a Job Abstract Closure) and _realm_ (a Realm Record or *null*). It schedules _job_ to be performed at some future time. The Abstract Closures used with this algorithm are intended to be related to the handling of Promises, or otherwise, to be scheduled with equal priority to Promise handling operations.</p>
+    <emu-clause id="sec-hostenqueuepromisejob" type="host-defined abstract operation">
+      <h1>
+        HostEnqueuePromiseJob (
+          _job_: a Job Abstract Closure,
+          _realm_: a Realm Record or *null*,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It schedules _job_ to be performed at some future time. The Abstract Closures used with this algorithm are intended to be related to the handling of Promises, or otherwise, to be scheduled with equal priority to Promise handling operations.</dd>
+      </dl>
 
       <p>The implementation of HostEnqueuePromiseJob must conform to the requirements in <emu-xref href="#sec-jobs"></emu-xref> as well as the following:</p>
       <ul>
@@ -10242,9 +11711,10 @@
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-initializehostdefinedrealm" aoid="InitializeHostDefinedRealm">
+  <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation">
     <h1>InitializeHostDefinedRealm ( )</h1>
-    <p>The abstract operation InitializeHostDefinedRealm takes no arguments. It performs the following steps when called:</p>
+    <dl class="header">
+    </dl>
 
     <emu-alg>
       1. Let _realm_ be CreateRealm().
@@ -10339,18 +11809,20 @@
       <p>An agent is a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation.</p>
     </emu-note>
 
-    <emu-clause id="sec-agentsignifier" aoid="AgentSignifier">
+    <emu-clause id="sec-agentsignifier" type="abstract operation">
       <h1>AgentSignifier ( )</h1>
-      <p>The abstract operation AgentSignifier takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _AR_ be the Agent Record of the surrounding agent.
         1. Return _AR_.[[Signifier]].
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-agentcansuspend" aoid="AgentCanSuspend">
+    <emu-clause id="sec-agentcansuspend" type="abstract operation">
       <h1>AgentCanSuspend ( )</h1>
-      <p>The abstract operation AgentCanSuspend takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _AR_ be the Agent Record of the surrounding agent.
         1. Return _AR_.[[CanBlock]].
@@ -10531,25 +12003,40 @@
     <emu-clause id="sec-weakref-host-hooks">
       <h1>Host Hooks</h1>
 
-      <emu-clause id="sec-host-cleanup-finalization-registry" aoid="HostEnqueueFinalizationRegistryCleanupJob">
-        <h1>HostEnqueueFinalizationRegistryCleanupJob ( _finalizationRegistry_ )</h1>
-        <p>The abstract operation HostEnqueueFinalizationRegistryCleanupJob takes argument _finalizationRegistry_ (a FinalizationRegistry). HostEnqueueFinalizationRegistryCleanupJob is an implementation-defined abstract operation that is expected to call CleanupFinalizationRegistry(_finalizationRegistry_) at some point in the future, if possible. The host's responsibility is to make this call at a time which does not interrupt synchronous ECMAScript code execution.</p>
+      <emu-clause id="sec-host-cleanup-finalization-registry" type="abstract operation">
+        <h1>
+          HostEnqueueFinalizationRegistryCleanupJob (
+            _finalizationRegistry_: a FinalizationRegistry,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>HostEnqueueFinalizationRegistryCleanupJob is an implementation-defined abstract operation that is expected to call CleanupFinalizationRegistry(_finalizationRegistry_) at some point in the future, if possible. The host's responsibility is to make this call at a time which does not interrupt synchronous ECMAScript code execution.</dd>
+        </dl>
       </emu-clause>
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-clear-kept-objects" aoid="ClearKeptObjects">
+  <emu-clause id="sec-clear-kept-objects" type="abstract operation">
     <h1>ClearKeptObjects ( )</h1>
-    <p>The abstract operation ClearKeptObjects takes no arguments. ECMAScript implementations are expected to call ClearKeptObjects when a synchronous sequence of ECMAScript executions completes. It performs the following steps when called:</p>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>ECMAScript implementations are expected to call ClearKeptObjects when a synchronous sequence of ECMAScript executions completes.</dd>
+    </dl>
     <emu-alg>
       1. Let _agentRecord_ be the surrounding agent's Agent Record.
       1. Set _agentRecord_.[[KeptAlive]] to a new empty List.
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-addtokeptobjects" aoid="AddToKeptObjects">
-    <h1>AddToKeptObjects ( _object_ )</h1>
-    <p>The abstract operation AddToKeptObjects takes argument _object_ (an Object). It performs the following steps when called:</p>
+  <emu-clause id="sec-addtokeptobjects" type="abstract operation">
+    <h1>
+      AddToKeptObjects (
+        _object_: an Object,
+      )
+    </h1>
+    <dl class="header">
+    </dl>
     <emu-alg>
       1. Let _agentRecord_ be the surrounding agent's Agent Record.
       1. Append _object_ to _agentRecord_.[[KeptAlive]].
@@ -10559,9 +12046,14 @@
     </emu-note>
   </emu-clause>
 
-  <emu-clause id="sec-cleanup-finalization-registry" aoid="CleanupFinalizationRegistry">
-    <h1>CleanupFinalizationRegistry ( _finalizationRegistry_ )</h1>
-    <p>The abstract operation CleanupFinalizationRegistry takes argument _finalizationRegistry_ (a FinalizationRegistry). It performs the following steps when called:</p>
+  <emu-clause id="sec-cleanup-finalization-registry" type="abstract operation">
+    <h1>
+      CleanupFinalizationRegistry (
+        _finalizationRegistry_: a FinalizationRegistry,
+      )
+    </h1>
+    <dl class="header">
+    </dl>
     <emu-alg>
       1. Assert: _finalizationRegistry_ has [[Cells]] and [[CleanupCallback]] internal slots.
       1. Let _callback_ be _finalizationRegistry_.[[CleanupCallback]].
@@ -10584,32 +12076,53 @@
     <p>In the following algorithm descriptions, assume _O_ is an ordinary object, _P_ is a property key value, _V_ is any ECMAScript language value, and _Desc_ is a Property Descriptor record.</p>
     <p>Each ordinary object internal method delegates to a similarly-named abstract operation. If such an abstract operation depends on another internal method, then the internal method is invoked on _O_ rather than calling the similarly-named abstract operation directly. These semantics ensure that exotic objects have their overridden internal methods invoked when ordinary object internal methods are applied to them.</p>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof">
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof" type="internal method">
       <h1>[[GetPrototypeOf]] ( )</h1>
-      <p>The [[GetPrototypeOf]] internal method of an ordinary object _O_ takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ! OrdinaryGetPrototypeOf(_O_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinarygetprototypeof" aoid="OrdinaryGetPrototypeOf">
-        <h1>OrdinaryGetPrototypeOf ( _O_ )</h1>
-        <p>The abstract operation OrdinaryGetPrototypeOf takes argument _O_ (an Object). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarygetprototypeof" type="abstract operation">
+        <h1>
+          OrdinaryGetPrototypeOf (
+            _O_: an Object,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Return _O_.[[Prototype]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v">
-      <h1>[[SetPrototypeOf]] ( _V_ )</h1>
-      <p>The [[SetPrototypeOf]] internal method of an ordinary object _O_ takes argument _V_ (an Object or *null*). It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v" type="internal method">
+      <h1>
+        [[SetPrototypeOf]] (
+          _V_: an Object or *null*,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ! OrdinarySetPrototypeOf(_O_, _V_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinarysetprototypeof" aoid="OrdinarySetPrototypeOf">
-        <h1>OrdinarySetPrototypeOf ( _O_, _V_ )</h1>
-        <p>The abstract operation OrdinarySetPrototypeOf takes arguments _O_ (an Object) and _V_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarysetprototypeof" type="abstract operation">
+        <h1>
+          OrdinarySetPrototypeOf (
+            _O_: an Object,
+            _V_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
           1. Let _current_ be _O_.[[Prototype]].
@@ -10633,32 +12146,48 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-isextensible">
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-isextensible" type="internal method">
       <h1>[[IsExtensible]] ( )</h1>
-      <p>The [[IsExtensible]] internal method of an ordinary object _O_ takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ! OrdinaryIsExtensible(_O_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinaryisextensible" aoid="OrdinaryIsExtensible">
-        <h1>OrdinaryIsExtensible ( _O_ )</h1>
-        <p>The abstract operation OrdinaryIsExtensible takes argument _O_ (an Object). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinaryisextensible" type="abstract operation">
+        <h1>
+          OrdinaryIsExtensible (
+            _O_: an Object,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Return _O_.[[Extensible]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-preventextensions">
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-preventextensions" type="internal method">
       <h1>[[PreventExtensions]] ( )</h1>
-      <p>The [[PreventExtensions]] internal method of an ordinary object _O_ takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ! OrdinaryPreventExtensions(_O_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinarypreventextensions" aoid="OrdinaryPreventExtensions">
-        <h1>OrdinaryPreventExtensions ( _O_ )</h1>
-        <p>The abstract operation OrdinaryPreventExtensions takes argument _O_ (an Object). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarypreventextensions" type="abstract operation">
+        <h1>
+          OrdinaryPreventExtensions (
+            _O_: an Object,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Set _O_.[[Extensible]] to *false*.
           1. Return *true*.
@@ -10666,16 +12195,29 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">
-      <h1>[[GetOwnProperty]] ( _P_ )</h1>
-      <p>The [[GetOwnProperty]] internal method of an ordinary object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p" type="internal method">
+      <h1>
+        [[GetOwnProperty]] (
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ! OrdinaryGetOwnProperty(_O_, _P_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinarygetownproperty" aoid="OrdinaryGetOwnProperty">
-        <h1>OrdinaryGetOwnProperty ( _O_, _P_ )</h1>
-        <p>The abstract operation OrdinaryGetOwnProperty takes arguments _O_ (an Object) and _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarygetownproperty" type="abstract operation">
+        <h1>
+          OrdinaryGetOwnProperty (
+            _O_: an Object,
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If _O_ does not have an own property with key _P_, return *undefined*.
@@ -10695,16 +12237,31 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">
-      <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-      <p>The [[DefineOwnProperty]] internal method of an ordinary object _O_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc" type="internal method">
+      <h1>
+        [[DefineOwnProperty]] (
+          _P_: a property key,
+          _Desc_: a Property Descriptor,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ? OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinarydefineownproperty" aoid="OrdinaryDefineOwnProperty">
-        <h1>OrdinaryDefineOwnProperty ( _O_, _P_, _Desc_ )</h1>
-        <p>The abstract operation OrdinaryDefineOwnProperty takes arguments _O_ (an Object), _P_ (a property key), and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarydefineownproperty" type="abstract operation">
+        <h1>
+          OrdinaryDefineOwnProperty (
+            _O_: an Object,
+            _P_: a property key,
+            _Desc_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
           1. Let _extensible_ be ? IsExtensible(_O_).
@@ -10712,17 +12269,33 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iscompatiblepropertydescriptor" aoid="IsCompatiblePropertyDescriptor">
-        <h1>IsCompatiblePropertyDescriptor ( _Extensible_, _Desc_, _Current_ )</h1>
-        <p>The abstract operation IsCompatiblePropertyDescriptor takes arguments _Extensible_ (a Boolean), _Desc_ (a Property Descriptor), and _Current_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-iscompatiblepropertydescriptor" type="abstract operation">
+        <h1>
+          IsCompatiblePropertyDescriptor (
+            _Extensible_: a Boolean,
+            _Desc_: a Property Descriptor,
+            _Current_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Return ValidateAndApplyPropertyDescriptor(*undefined*, *undefined*, _Extensible_, _Desc_, _Current_).
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-validateandapplypropertydescriptor" aoid="ValidateAndApplyPropertyDescriptor">
-        <h1>ValidateAndApplyPropertyDescriptor ( _O_, _P_, _extensible_, _Desc_, _current_ )</h1>
-        <p>The abstract operation ValidateAndApplyPropertyDescriptor takes arguments _O_ (an Object or *undefined*), _P_ (a property key), _extensible_ (a Boolean), _Desc_ (a Property Descriptor), and _current_ (a Property Descriptor).</p>
+      <emu-clause id="sec-validateandapplypropertydescriptor" type="abstract operation">
+        <h1>
+          ValidateAndApplyPropertyDescriptor (
+            _O_: an Object or *undefined*,
+            _P_: a property key,
+            _extensible_: a Boolean,
+            _Desc_: a Property Descriptor,
+            _current_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>If *undefined* is passed as _O_, only validation is performed and no object updates are performed.</p>
         </emu-note>
@@ -10768,16 +12341,29 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p">
-      <h1>[[HasProperty]] ( _P_ )</h1>
-      <p>The [[HasProperty]] internal method of an ordinary object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p" type="internal method">
+      <h1>
+        [[HasProperty]] (
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ? OrdinaryHasProperty(_O_, _P_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinaryhasproperty" aoid="OrdinaryHasProperty">
-        <h1>OrdinaryHasProperty ( _O_, _P_ )</h1>
-        <p>The abstract operation OrdinaryHasProperty takes arguments _O_ (an Object) and _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinaryhasproperty" type="abstract operation">
+        <h1>
+          OrdinaryHasProperty (
+            _O_: an Object,
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Let _hasOwn_ be ? _O_.[[GetOwnProperty]](_P_).
@@ -10790,17 +12376,32 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">
-      <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-      <p>The [[Get]] internal method of an ordinary object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver" type="internal method">
+      <h1>
+        [[Get]] (
+          _P_: a property key,
+          _Receiver_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
 
       <emu-alg>
         1. Return ? OrdinaryGet(_O_, _P_, _Receiver_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinaryget" aoid="OrdinaryGet">
-        <h1>OrdinaryGet ( _O_, _P_, _Receiver_ )</h1>
-        <p>The abstract operation OrdinaryGet takes arguments _O_ (an Object), _P_ (a property key), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinaryget" type="abstract operation">
+        <h1>
+          OrdinaryGet (
+            _O_: an Object,
+            _P_: a property key,
+            _Receiver_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
 
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
@@ -10818,16 +12419,33 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">
-      <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-      <p>The [[Set]] internal method of an ordinary object _O_ takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver" type="internal method">
+      <h1>
+        [[Set]] (
+          _P_: a property key,
+          _V_: an ECMAScript language value,
+          _Receiver_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ? OrdinarySet(_O_, _P_, _V_, _Receiver_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinaryset" aoid="OrdinarySet">
-        <h1>OrdinarySet ( _O_, _P_, _V_, _Receiver_ )</h1>
-        <p>The abstract operation OrdinarySet takes arguments _O_ (an Object), _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinaryset" type="abstract operation">
+        <h1>
+          OrdinarySet (
+            _O_: an Object,
+            _P_: a property key,
+            _V_: an ECMAScript language value,
+            _Receiver_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
 
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
@@ -10836,9 +12454,18 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-ordinarysetwithowndescriptor" aoid="OrdinarySetWithOwnDescriptor">
-        <h1>OrdinarySetWithOwnDescriptor ( _O_, _P_, _V_, _Receiver_, _ownDesc_ )</h1>
-        <p>The abstract operation OrdinarySetWithOwnDescriptor takes arguments _O_ (an Object), _P_ (a property key), _V_ (an ECMAScript language value), _Receiver_ (an ECMAScript language value), and _ownDesc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarysetwithowndescriptor" type="abstract operation">
+        <h1>
+          OrdinarySetWithOwnDescriptor (
+            _O_: an Object,
+            _P_: a property key,
+            _V_: an ECMAScript language value,
+            _Receiver_: an ECMAScript language value,
+            _ownDesc_: a Property Descriptor or *undefined*,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
 
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
@@ -10869,16 +12496,29 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-delete-p">
-      <h1>[[Delete]] ( _P_ )</h1>
-      <p>The [[Delete]] internal method of an ordinary object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-delete-p" type="internal method">
+      <h1>
+        [[Delete]] (
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ? OrdinaryDelete(_O_, _P_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinarydelete" aoid="OrdinaryDelete">
-        <h1>OrdinaryDelete ( _O_, _P_ )</h1>
-        <p>The abstract operation OrdinaryDelete takes arguments _O_ (an Object) and _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarydelete" type="abstract operation">
+        <h1>
+          OrdinaryDelete (
+            _O_: an Object,
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
@@ -10891,16 +12531,24 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">
+    <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" type="internal method">
       <h1>[[OwnPropertyKeys]] ( )</h1>
-      <p>The [[OwnPropertyKeys]] internal method of an ordinary object _O_ takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ordinary object _O_</dd>
+      </dl>
       <emu-alg>
         1. Return ! OrdinaryOwnPropertyKeys(_O_).
       </emu-alg>
 
-      <emu-clause id="sec-ordinaryownpropertykeys" aoid="OrdinaryOwnPropertyKeys">
-        <h1>OrdinaryOwnPropertyKeys ( _O_ )</h1>
-        <p>The abstract operation OrdinaryOwnPropertyKeys takes argument _O_ (an Object). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinaryownpropertykeys" type="abstract operation">
+        <h1>
+          OrdinaryOwnPropertyKeys (
+            _O_: an Object,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
 
         <emu-alg>
           1. Let _keys_ be a new empty List.
@@ -10915,9 +12563,17 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ordinaryobjectcreate" aoid="OrdinaryObjectCreate" oldids="sec-objectcreate">
-      <h1>OrdinaryObjectCreate ( _proto_ [ , _additionalInternalSlotsList_ ] )</h1>
-      <p>The abstract operation OrdinaryObjectCreate takes argument _proto_ (an Object or *null*) and optional argument _additionalInternalSlotsList_ (a List of names of internal slots). It is used to specify the runtime creation of new ordinary objects. _additionalInternalSlotsList_ contains the names of additional internal slots that must be defined as part of the object, beyond [[Prototype]] and [[Extensible]]. If _additionalInternalSlotsList_ is not provided, a new empty List is used. It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinaryobjectcreate" type="abstract operation" oldids="sec-objectcreate">
+      <h1>
+        OrdinaryObjectCreate (
+          _proto_: an Object or *null*,
+          optional _additionalInternalSlotsList_: a List of names of internal slots,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to specify the runtime creation of new ordinary objects. _additionalInternalSlotsList_ contains the names of additional internal slots that must be defined as part of the object, beyond [[Prototype]] and [[Extensible]]. If _additionalInternalSlotsList_ is not provided, a new empty List is used.</dd>
+      </dl>
       <emu-alg>
         1. Let _internalSlotsList_ be &laquo; [[Prototype]], [[Extensible]] &raquo;.
         1. If _additionalInternalSlotsList_ is present, append each of its elements to _internalSlotsList_.
@@ -10931,9 +12587,18 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-ordinarycreatefromconstructor" aoid="OrdinaryCreateFromConstructor">
-      <h1>OrdinaryCreateFromConstructor ( _constructor_, _intrinsicDefaultProto_ [ , _internalSlotsList_ ] )</h1>
-      <p>The abstract operation OrdinaryCreateFromConstructor takes arguments _constructor_ and _intrinsicDefaultProto_ and optional argument _internalSlotsList_ (a List of names of internal slots). It creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. _internalSlotsList_ contains the names of additional internal slots that must be defined as part of the object. If _internalSlotsList_ is not provided, a new empty List is used. It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinarycreatefromconstructor" type="abstract operation">
+      <h1>
+        OrdinaryCreateFromConstructor (
+          _constructor_: unknown,
+          _intrinsicDefaultProto_: unknown,
+          optional _internalSlotsList_: a List of names of internal slots,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. _internalSlotsList_ contains the names of additional internal slots that must be defined as part of the object. If _internalSlotsList_ is not provided, a new empty List is used.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Let _proto_ be ? GetPrototypeFromConstructor(_constructor_, _intrinsicDefaultProto_).
@@ -10941,9 +12606,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getprototypefromconstructor" aoid="GetPrototypeFromConstructor">
-      <h1>GetPrototypeFromConstructor ( _constructor_, _intrinsicDefaultProto_ )</h1>
-      <p>The abstract operation GetPrototypeFromConstructor takes arguments _constructor_ and _intrinsicDefaultProto_. It determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. It performs the following steps when called:</p>
+    <emu-clause id="sec-getprototypefromconstructor" type="abstract operation">
+      <h1>
+        GetPrototypeFromConstructor (
+          _constructor_: unknown,
+          _intrinsicDefaultProto_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]].</dd>
+      </dl>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Assert: IsCallable(_constructor_) is *true*.
@@ -10958,9 +12631,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-requireinternalslot" aoid="RequireInternalSlot">
-      <h1>RequireInternalSlot ( _O_, _internalSlot_ )</h1>
-      <p>The abstract operation RequireInternalSlot takes arguments _O_ and _internalSlot_. It throws an exception unless _O_ is an Object and has the given internal slot. It performs the following steps when called:</p>
+    <emu-clause id="sec-requireinternalslot" type="abstract operation">
+      <h1>
+        RequireInternalSlot (
+          _O_: unknown,
+          _internalSlot_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It throws an exception unless _O_ is an Object and has the given internal slot.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_O_) is not Object, throw a *TypeError* exception.
         1. If _O_ does not have an _internalSlot_ internal slot, throw a *TypeError* exception.
@@ -11156,9 +12837,17 @@
     </emu-table>
     <p>All ECMAScript function objects have the [[Call]] internal method defined here. ECMAScript functions that are also constructors in addition have the [[Construct]] internal method.</p>
 
-    <emu-clause id="sec-ecmascript-function-objects-call-thisargument-argumentslist">
-      <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
-      <p>The [[Call]] internal method of an ECMAScript function object _F_ takes arguments _thisArgument_ (an ECMAScript language value) and _argumentsList_ (a List of ECMAScript language values). It performs the following steps when called:</p>
+    <emu-clause id="sec-ecmascript-function-objects-call-thisargument-argumentslist" type="internal method">
+      <h1>
+        [[Call]] (
+          _thisArgument_: an ECMAScript language value,
+          _argumentsList_: a List of ECMAScript language values,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ECMAScript function object _F_</dd>
+      </dl>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Let _callerContext_ be the running execution context.
@@ -11180,9 +12869,15 @@
         <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is suspended and retained for later resumption by an accessible generator object.</p>
       </emu-note>
 
-      <emu-clause id="sec-prepareforordinarycall" aoid="PrepareForOrdinaryCall">
-        <h1>PrepareForOrdinaryCall ( _F_, _newTarget_ )</h1>
-        <p>The abstract operation PrepareForOrdinaryCall takes arguments _F_ (a function object) and _newTarget_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-prepareforordinarycall" type="abstract operation">
+        <h1>
+          PrepareForOrdinaryCall (
+            _F_: a function object,
+            _newTarget_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Type(_newTarget_) is Undefined or Object.
           1. Let _callerContext_ be the running execution context.
@@ -11202,9 +12897,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-ordinarycallbindthis" aoid="OrdinaryCallBindThis">
-        <h1>OrdinaryCallBindThis ( _F_, _calleeContext_, _thisArgument_ )</h1>
-        <p>The abstract operation OrdinaryCallBindThis takes arguments _F_ (a function object), _calleeContext_ (an execution context), and _thisArgument_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarycallbindthis" type="abstract operation">
+        <h1>
+          OrdinaryCallBindThis (
+            _F_: a function object,
+            _calleeContext_: an execution context,
+            _thisArgument_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _thisMode_ be _F_.[[ThisMode]].
           1. If _thisMode_ is ~lexical~, return NormalCompletion(*undefined*).
@@ -11277,18 +12979,32 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-ordinarycallevaluatebody" aoid="OrdinaryCallEvaluateBody">
-        <h1>OrdinaryCallEvaluateBody ( _F_, _argumentsList_ )</h1>
-        <p>The abstract operation OrdinaryCallEvaluateBody takes arguments _F_ (a function object) and _argumentsList_ (a List). It performs the following steps when called:</p>
+      <emu-clause id="sec-ordinarycallevaluatebody" type="abstract operation">
+        <h1>
+          OrdinaryCallEvaluateBody (
+            _F_: a function object,
+            _argumentsList_: a List,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Return the result of EvaluateBody of the parsed code that is _F_.[[ECMAScriptCode]] passing _F_ and _argumentsList_ as the arguments.
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ecmascript-function-objects-construct-argumentslist-newtarget">
-      <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-      <p>The [[Construct]] internal method of an ECMAScript function object _F_ takes arguments _argumentsList_ (a List of ECMAScript language values) and _newTarget_ (a constructor). It performs the following steps when called:</p>
+    <emu-clause id="sec-ecmascript-function-objects-construct-argumentslist-newtarget" type="internal method">
+      <h1>
+        [[Construct]] (
+          _argumentsList_: a List of ECMAScript language values,
+          _newTarget_: a constructor,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>an ECMAScript function object _F_</dd>
+      </dl>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: Type(_newTarget_) is Object.
@@ -11316,9 +13032,22 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-ordinaryfunctioncreate" aoid="OrdinaryFunctionCreate" oldids="sec-functionallocate,sec-functioninitialize,sec-functioncreate,sec-generatorfunctioncreate,sec-asyncgeneratorfunctioncreate,sec-async-functions-abstract-operations-async-function-create">
-      <h1>OrdinaryFunctionCreate ( _functionPrototype_, _sourceText_, _ParameterList_, _Body_, _thisMode_, _Scope_, _PrivateScope_ )</h1>
-      <p>The abstract operation OrdinaryFunctionCreate takes arguments _functionPrototype_ (an Object), _sourceText_ (a sequence of Unicode code points), _ParameterList_ (a Parse Node), _Body_ (a Parse Node), _thisMode_ (either ~lexical-this~ or ~non-lexical-this~), _Scope_ (an Environment Record), and _PrivateScope_ (a PrivateEnvironment Record or *null*). _sourceText_ is the source text of the syntactic definition of the function to be created. It performs the following steps when called:</p>
+    <emu-clause id="sec-ordinaryfunctioncreate" type="abstract operation" oldids="sec-functionallocate,sec-functioninitialize,sec-functioncreate,sec-generatorfunctioncreate,sec-asyncgeneratorfunctioncreate,sec-async-functions-abstract-operations-async-function-create">
+      <h1>
+        OrdinaryFunctionCreate (
+          _functionPrototype_: an Object,
+          _sourceText_: a sequence of Unicode code points,
+          _ParameterList_: a Parse Node,
+          _Body_: a Parse Node,
+          _thisMode_: either ~lexical-this~ or ~non-lexical-this~,
+          _Scope_: an Environment Record,
+          _PrivateScope_: a PrivateEnvironment Record or *null*,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>_sourceText_ is the source text of the syntactic definition of the function to be created.</dd>
+      </dl>
       <emu-alg>
         1. Assert: Type(_functionPrototype_) is Object.
         1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>.
@@ -11345,9 +13074,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-addrestrictedfunctionproperties" aoid="AddRestrictedFunctionProperties">
-      <h1>AddRestrictedFunctionProperties ( _F_, _realm_ )</h1>
-      <p>The abstract operation AddRestrictedFunctionProperties takes arguments _F_ (a function object) and _realm_ (a Realm Record). It performs the following steps when called:</p>
+    <emu-clause id="sec-addrestrictedfunctionproperties" type="abstract operation">
+      <h1>
+        AddRestrictedFunctionProperties (
+          _F_: a function object,
+          _realm_: a Realm Record,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: _realm_.[[Intrinsics]].[[%ThrowTypeError%]] exists and has been initialized.
         1. Let _thrower_ be _realm_.[[Intrinsics]].[[%ThrowTypeError%]].
@@ -11367,9 +13102,18 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-makeconstructor" aoid="MakeConstructor">
-      <h1>MakeConstructor ( _F_ [ , _writablePrototype_ [ , _prototype_ ] ] )</h1>
-      <p>The abstract operation MakeConstructor takes argument _F_ (a function object) and optional arguments _writablePrototype_ (a Boolean) and _prototype_ (an Object). It converts _F_ into a constructor. It performs the following steps when called:</p>
+    <emu-clause id="sec-makeconstructor" type="abstract operation">
+      <h1>
+        MakeConstructor (
+          _F_: a function object,
+          optional _writablePrototype_: a Boolean,
+          optional _prototype_: an Object,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _F_ into a constructor.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object or a built-in function object.
         1. If _F_ is an ECMAScript function object, then
@@ -11386,9 +13130,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-makeclassconstructor" aoid="MakeClassConstructor">
-      <h1>MakeClassConstructor ( _F_ )</h1>
-      <p>The abstract operation MakeClassConstructor takes argument _F_. It performs the following steps when called:</p>
+    <emu-clause id="sec-makeclassconstructor" type="abstract operation">
+      <h1>
+        MakeClassConstructor (
+          _F_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: _F_.[[IsClassConstructor]] is *false*.
@@ -11397,9 +13146,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-makemethod" aoid="MakeMethod">
-      <h1>MakeMethod ( _F_, _homeObject_ )</h1>
-      <p>The abstract operation MakeMethod takes arguments _F_ and _homeObject_. It configures _F_ as a method. It performs the following steps when called:</p>
+    <emu-clause id="sec-makemethod" type="abstract operation">
+      <h1>
+        MakeMethod (
+          _F_: unknown,
+          _homeObject_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It configures _F_ as a method.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: Type(_homeObject_) is Object.
@@ -11408,9 +13165,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-definemethodproperty" aoid="DefineMethodProperty">
-      <h1>DefineMethodProperty ( _key_, _homeObject_, _closure_, _enumerable_ )</h1>
-      <p>The abstract operation DefineMethodProperty takes arguments _key_ (a property key or Private Name), _homeObject_ (an Object), _closure_ (a function object), and _enumerable_ (a Boolean). It performs the following steps when called:</p>
+    <emu-clause id="sec-definemethodproperty" type="abstract operation">
+      <h1>
+        DefineMethodProperty (
+          _key_: a property key or Private Name,
+          _homeObject_: an Object,
+          _closure_: a function object,
+          _enumerable_: a Boolean,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Perform ! SetFunctionName(_closure_, _key_).
         1. If _key_ is a Private Name, then
@@ -11422,9 +13187,18 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-setfunctionname" aoid="SetFunctionName">
-      <h1>SetFunctionName ( _F_, _name_ [ , _prefix_ ] )</h1>
-      <p>The abstract operation SetFunctionName takes arguments _F_ (a function object) and _name_ (a property key or Private Name) and optional argument _prefix_ (a String). It adds a *"name"* property to _F_. It performs the following steps when called:</p>
+    <emu-clause id="sec-setfunctionname" type="abstract operation">
+      <h1>
+        SetFunctionName (
+          _F_: a function object,
+          _name_: a property key or Private Name,
+          optional _prefix_: a String,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It adds a *"name"* property to _F_.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _F_ is an extensible object that does not have a *"name"* own property.
         1. If Type(_name_) is Symbol, then
@@ -11443,18 +13217,34 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-setfunctionlength" aoid="SetFunctionLength">
-      <h1>SetFunctionLength ( _F_, _length_ )</h1>
-      <p>The abstract operation SetFunctionLength takes arguments _F_ (a function object) and _length_ (a non-negative integer or +&infin;). It adds a *"length"* property to _F_. It performs the following steps when called:</p>
+    <emu-clause id="sec-setfunctionlength" type="abstract operation">
+      <h1>
+        SetFunctionLength (
+          _F_: a function object,
+          _length_: a non-negative integer or +&infin;,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It adds a *"length"* property to _F_.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _F_ is an extensible object that does not have a *"length"* own property.
         1. Return ! DefinePropertyOrThrow(_F_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-functiondeclarationinstantiation" aoid="FunctionDeclarationInstantiation">
-      <h1>FunctionDeclarationInstantiation ( _func_, _argumentsList_ )</h1>
-      <p>The abstract operation FunctionDeclarationInstantiation takes arguments _func_ (a function object) and _argumentsList_. _func_ is the function object for which the execution context is being established.</p>
+    <emu-clause id="sec-functiondeclarationinstantiation" type="abstract operation">
+      <h1>
+        FunctionDeclarationInstantiation (
+          _func_: a function object,
+          _argumentsList_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>_func_ is the function object for which the execution context is being established.</dd>
+      </dl>
       <emu-note>
         <p>When an execution context is established for evaluating an ECMAScript function a new function Environment Record is created and bindings for each formal parameter are instantiated in that Environment Record. Each declaration in the function body is also instantiated. If the function's formal parameters do not include any default value initializers then the body declarations are instantiated in the same Environment Record as the parameters. If default value parameter initializers exist, a second Environment Record is created for the body declarations. Formal parameters and functions are initialized as part of FunctionDeclarationInstantiation. All other bindings are initialized during evaluation of the function body.</p>
       </emu-note>
@@ -11591,9 +13381,17 @@
     <p>Built-in functions have an [[InitialName]] internal slot.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
 
-    <emu-clause id="sec-built-in-function-objects-call-thisargument-argumentslist">
-      <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
-      <p>The [[Call]] internal method of a built-in function object _F_ takes arguments _thisArgument_ (an ECMAScript language value) and _argumentsList_ (a List of ECMAScript language values). It performs the following steps when called:</p>
+    <emu-clause id="sec-built-in-function-objects-call-thisargument-argumentslist" type="internal method">
+      <h1>
+        [[Call]] (
+          _thisArgument_: an ECMAScript language value,
+          _argumentsList_: a List of ECMAScript language values,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a built-in function object _F_</dd>
+      </dl>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
         1. If _callerContext_ is not already suspended, suspend _callerContext_.
@@ -11613,17 +13411,41 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-built-in-function-objects-construct-argumentslist-newtarget">
-      <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-      <p>The [[Construct]] internal method of a built-in function object _F_ takes arguments _argumentsList_ (a List of ECMAScript language values) and _newTarget_ (a constructor). The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step <emu-xref href="#step-call-builtin-function-result"></emu-xref> is replaced by:</p>
+    <emu-clause id="sec-built-in-function-objects-construct-argumentslist-newtarget" type="internal method">
+      <h1>
+        [[Construct]] (
+          _argumentsList_: a List of ECMAScript language values,
+          _newTarget_: a constructor,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a built-in function object _F_</dd>
+
+        <dt>description</dt>
+        <dd>The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step <emu-xref href="#step-call-builtin-function-result"></emu-xref> is replaced by:</dd>
+      </dl>
       <emu-alg replaces-step="step-call-builtin-function-result">
         1. Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. The *this* value is uninitialized, _argumentsList_ provides the named parameters, and _newTarget_ provides the NewTarget value.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-createbuiltinfunction" aoid="CreateBuiltinFunction">
-      <h1>CreateBuiltinFunction ( _behaviour_, _length_, _name_, _internalSlotsList_ [ , _realm_ [ , _prototype_ [ , _prefix_ ] ] ] )</h1>
-      <p>The abstract operation CreateBuiltinFunction takes arguments _behaviour_, _length_ (a non-negative integer or +&infin;), _name_ (a property key), and _internalSlotsList_ (a List of names of internal slots) and optional arguments _realm_ (a Realm Record), _prototype_ (an Object or *null*), and _prefix_ (a String). _internalSlotsList_ contains the names of additional internal slots that must be defined as part of the object. This operation creates a built-in function object. It performs the following steps when called:</p>
+    <emu-clause id="sec-createbuiltinfunction" type="abstract operation">
+      <h1>
+        CreateBuiltinFunction (
+          _behaviour_: unknown,
+          _length_: a non-negative integer or +&infin;,
+          _name_: a property key,
+          _internalSlotsList_: a List of names of internal slots,
+          optional _realm_: a Realm Record,
+          optional _prototype_: an Object or *null*,
+          optional _prefix_: a String,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>_internalSlotsList_ contains the names of additional internal slots that must be defined as part of the object. This operation creates a built-in function object.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _behaviour_ is either an Abstract Closure, a set of algorithm steps, or some other definition of a function's behaviour provided in this specification.
         1. If _realm_ is not present, set _realm_ to the current Realm Record.
@@ -11707,9 +13529,17 @@
         </table>
       </emu-table>
 
-      <emu-clause id="sec-bound-function-exotic-objects-call-thisargument-argumentslist">
-        <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
-        <p>The [[Call]] internal method of a bound function exotic object _F_ takes arguments _thisArgument_ (an ECMAScript language value) and _argumentsList_ (a List of ECMAScript language values). It performs the following steps when called:</p>
+      <emu-clause id="sec-bound-function-exotic-objects-call-thisargument-argumentslist" type="internal method">
+        <h1>
+          [[Call]] (
+            _thisArgument_: an ECMAScript language value,
+            _argumentsList_: a List of ECMAScript language values,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a bound function exotic object _F_</dd>
+        </dl>
         <emu-alg>
           1. Let _target_ be _F_.[[BoundTargetFunction]].
           1. Let _boundThis_ be _F_.[[BoundThis]].
@@ -11719,9 +13549,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-bound-function-exotic-objects-construct-argumentslist-newtarget">
-        <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-        <p>The [[Construct]] internal method of a bound function exotic object _F_ takes arguments _argumentsList_ (a List of ECMAScript language values) and _newTarget_ (a constructor). It performs the following steps when called:</p>
+      <emu-clause id="sec-bound-function-exotic-objects-construct-argumentslist-newtarget" type="internal method">
+        <h1>
+          [[Construct]] (
+            _argumentsList_: a List of ECMAScript language values,
+            _newTarget_: a constructor,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a bound function exotic object _F_</dd>
+        </dl>
         <emu-alg>
           1. Let _target_ be _F_.[[BoundTargetFunction]].
           1. Assert: IsConstructor(_target_) is *true*.
@@ -11732,9 +13570,18 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-boundfunctioncreate" aoid="BoundFunctionCreate">
-        <h1>BoundFunctionCreate ( _targetFunction_, _boundThis_, _boundArgs_ )</h1>
-        <p>The abstract operation BoundFunctionCreate takes arguments _targetFunction_, _boundThis_, and _boundArgs_. It is used to specify the creation of new bound function exotic objects. It performs the following steps when called:</p>
+      <emu-clause id="sec-boundfunctioncreate" type="abstract operation">
+        <h1>
+          BoundFunctionCreate (
+            _targetFunction_: unknown,
+            _boundThis_: unknown,
+            _boundArgs_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to specify the creation of new bound function exotic objects.</dd>
+        </dl>
         <emu-alg>
           1. Assert: Type(_targetFunction_) is Object.
           1. Let _proto_ be ? _targetFunction_.[[GetPrototypeOf]]().
@@ -11761,9 +13608,17 @@
 
       <p>An object is an <dfn id="array-exotic-object">Array exotic object</dfn> (or simply, an Array object) if its [[DefineOwnProperty]] internal method uses the following implementation, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in ArrayCreate.</p>
 
-      <emu-clause id="sec-array-exotic-objects-defineownproperty-p-desc">
-        <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>The [[DefineOwnProperty]] internal method of an Array exotic object _A_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-array-exotic-objects-defineownproperty-p-desc" type="internal method">
+        <h1>
+          [[DefineOwnProperty]] (
+            _P_: a property key,
+            _Desc_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an Array exotic object _A_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If _P_ is *"length"*, then
@@ -11787,9 +13642,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-arraycreate" aoid="ArrayCreate">
-        <h1>ArrayCreate ( _length_ [ , _proto_ ] )</h1>
-        <p>The abstract operation ArrayCreate takes argument _length_ (a non-negative integer) and optional argument _proto_. It is used to specify the creation of new Array exotic objects. It performs the following steps when called:</p>
+      <emu-clause id="sec-arraycreate" type="abstract operation">
+        <h1>
+          ArrayCreate (
+            _length_: a non-negative integer,
+            optional _proto_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to specify the creation of new Array exotic objects.</dd>
+        </dl>
         <emu-alg>
           1. If _length_ &gt; 2<sup>32</sup> - 1, throw a *RangeError* exception.
           1. If _proto_ is not present, set _proto_ to %Array.prototype%.
@@ -11801,9 +13664,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-arrayspeciescreate" aoid="ArraySpeciesCreate">
-        <h1>ArraySpeciesCreate ( _originalArray_, _length_ )</h1>
-        <p>The abstract operation ArraySpeciesCreate takes arguments _originalArray_ and _length_ (a non-negative integer). It is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_. It performs the following steps when called:</p>
+      <emu-clause id="sec-arrayspeciescreate" type="abstract operation">
+        <h1>
+          ArraySpeciesCreate (
+            _originalArray_: unknown,
+            _length_: a non-negative integer,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_.</dd>
+        </dl>
         <emu-alg>
           1. Let _isArray_ be ? IsArray(_originalArray_).
           1. If _isArray_ is *false*, return ? ArrayCreate(_length_).
@@ -11825,9 +13696,15 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-arraysetlength" aoid="ArraySetLength">
-        <h1>ArraySetLength ( _A_, _Desc_ )</h1>
-        <p>The abstract operation ArraySetLength takes arguments _A_ (an Array object) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-arraysetlength" type="abstract operation">
+        <h1>
+          ArraySetLength (
+            _A_: an Array object,
+            _Desc_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _Desc_.[[Value]] is absent, then
             1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _Desc_).
@@ -11876,9 +13753,16 @@
 
       <p>String exotic objects have the same internal slots as ordinary objects. They also have a [[StringData]] internal slot.</p>
 
-      <emu-clause id="sec-string-exotic-objects-getownproperty-p">
-        <h1>[[GetOwnProperty]] ( _P_ )</h1>
-        <p>The [[GetOwnProperty]] internal method of a String exotic object _S_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-string-exotic-objects-getownproperty-p" type="internal method">
+        <h1>
+          [[GetOwnProperty]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a String exotic object _S_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Let _desc_ be OrdinaryGetOwnProperty(_S_, _P_).
@@ -11887,9 +13771,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-string-exotic-objects-defineownproperty-p-desc">
-        <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>The [[DefineOwnProperty]] internal method of a String exotic object _S_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-string-exotic-objects-defineownproperty-p-desc" type="internal method">
+        <h1>
+          [[DefineOwnProperty]] (
+            _P_: a property key,
+            _Desc_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a String exotic object _S_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Let _stringDesc_ be ! StringGetOwnProperty(_S_, _P_).
@@ -11900,9 +13792,12 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-string-exotic-objects-ownpropertykeys">
+      <emu-clause id="sec-string-exotic-objects-ownpropertykeys" type="internal method">
         <h1>[[OwnPropertyKeys]] ( )</h1>
-        <p>The [[OwnPropertyKeys]] internal method of a String exotic object _O_ takes no arguments. It performs the following steps when called:</p>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a String exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Let _keys_ be a new empty List.
           1. Let _str_ be _O_.[[StringData]].
@@ -11920,9 +13815,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-stringcreate" aoid="StringCreate">
-        <h1>StringCreate ( _value_, _prototype_ )</h1>
-        <p>The abstract operation StringCreate takes arguments _value_ (a String) and _prototype_. It is used to specify the creation of new String exotic objects. It performs the following steps when called:</p>
+      <emu-clause id="sec-stringcreate" type="abstract operation">
+        <h1>
+          StringCreate (
+            _value_: a String,
+            _prototype_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to specify the creation of new String exotic objects.</dd>
+        </dl>
         <emu-alg>
           1. Let _S_ be ! MakeBasicObject(&laquo; [[Prototype]], [[Extensible]], [[StringData]] &raquo;).
           1. Set _S_.[[Prototype]] to _prototype_.
@@ -11936,9 +13839,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-stringgetownproperty" aoid="StringGetOwnProperty">
-        <h1>StringGetOwnProperty ( _S_, _P_ )</h1>
-        <p>The abstract operation StringGetOwnProperty takes arguments _S_ and _P_. It performs the following steps when called:</p>
+      <emu-clause id="sec-stringgetownproperty" type="abstract operation">
+        <h1>
+          StringGetOwnProperty (
+            _S_: unknown,
+            _P_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _S_ is an Object that has a [[StringData]] internal slot.
           1. Assert: IsPropertyKey(_P_) is *true*.
@@ -11983,9 +13892,16 @@
         <p>ECMAScript implementations of arguments exotic objects have historically contained an accessor property named *"caller"*. Prior to ECMAScript 2017, this specification included the definition of a throwing *"caller"* property on ordinary arguments objects. Since implementations do not contain this extension any longer, ECMAScript 2017 dropped the requirement for a throwing *"caller"* accessor.</p>
       </emu-note>
 
-      <emu-clause id="sec-arguments-exotic-objects-getownproperty-p">
-        <h1>[[GetOwnProperty]] ( _P_ )</h1>
-        <p>The [[GetOwnProperty]] internal method of an arguments exotic object _args_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-arguments-exotic-objects-getownproperty-p" type="internal method">
+        <h1>
+          [[GetOwnProperty]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an arguments exotic object _args_</dd>
+        </dl>
         <emu-alg>
           1. Let _desc_ be OrdinaryGetOwnProperty(_args_, _P_).
           1. If _desc_ is *undefined*, return _desc_.
@@ -11997,9 +13913,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-arguments-exotic-objects-defineownproperty-p-desc">
-        <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>The [[DefineOwnProperty]] internal method of an arguments exotic object _args_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-arguments-exotic-objects-defineownproperty-p-desc" type="internal method">
+        <h1>
+          [[DefineOwnProperty]] (
+            _P_: a property key,
+            _Desc_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an arguments exotic object _args_</dd>
+        </dl>
         <emu-alg>
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be HasOwnProperty(_map_, _P_).
@@ -12023,9 +13947,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-arguments-exotic-objects-get-p-receiver">
-        <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-        <p>The [[Get]] internal method of an arguments exotic object _args_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-arguments-exotic-objects-get-p-receiver" type="internal method">
+        <h1>
+          [[Get]] (
+            _P_: a property key,
+            _Receiver_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an arguments exotic object _args_</dd>
+        </dl>
         <emu-alg>
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
@@ -12037,9 +13969,18 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-arguments-exotic-objects-set-p-v-receiver">
-        <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-        <p>The [[Set]] internal method of an arguments exotic object _args_ takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-arguments-exotic-objects-set-p-v-receiver" type="internal method">
+        <h1>
+          [[Set]] (
+            _P_: a property key,
+            _V_: an ECMAScript language value,
+            _Receiver_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an arguments exotic object _args_</dd>
+        </dl>
         <emu-alg>
           1. If SameValue(_args_, _Receiver_) is *false*, then
             1. Let _isMapped_ be *false*.
@@ -12053,9 +13994,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-arguments-exotic-objects-delete-p">
-        <h1>[[Delete]] ( _P_ )</h1>
-        <p>The [[Delete]] internal method of an arguments exotic object _args_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-arguments-exotic-objects-delete-p" type="internal method">
+        <h1>
+          [[Delete]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an arguments exotic object _args_</dd>
+        </dl>
         <emu-alg>
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
@@ -12066,9 +14014,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-createunmappedargumentsobject" aoid="CreateUnmappedArgumentsObject">
-        <h1>CreateUnmappedArgumentsObject ( _argumentsList_ )</h1>
-        <p>The abstract operation CreateUnmappedArgumentsObject takes argument _argumentsList_. It performs the following steps when called:</p>
+      <emu-clause id="sec-createunmappedargumentsobject" type="abstract operation">
+        <h1>
+          CreateUnmappedArgumentsObject (
+            _argumentsList_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _len_ be the number of elements in _argumentsList_.
           1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
@@ -12085,9 +14038,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-createmappedargumentsobject" aoid="CreateMappedArgumentsObject">
-        <h1>CreateMappedArgumentsObject ( _func_, _formals_, _argumentsList_, _env_ )</h1>
-        <p>The abstract operation CreateMappedArgumentsObject takes arguments _func_ (an Object), _formals_ (a Parse Node), _argumentsList_ (a List), and _env_ (an Environment Record). It performs the following steps when called:</p>
+      <emu-clause id="sec-createmappedargumentsobject" type="abstract operation">
+        <h1>
+          CreateMappedArgumentsObject (
+            _func_: an Object,
+            _formals_: a Parse Node,
+            _argumentsList_: a List,
+            _env_: an Environment Record,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _formals_ does not contain a rest parameter, any binding patterns, or any initializers. It may contain duplicate identifiers.
           1. Let _len_ be the number of elements in _argumentsList_.
@@ -12124,9 +14085,17 @@
           1. Return _obj_.
         </emu-alg>
 
-        <emu-clause id="sec-makearggetter" aoid="MakeArgGetter">
-          <h1>MakeArgGetter ( _name_, _env_ )</h1>
-          <p>The abstract operation MakeArgGetter takes arguments _name_ (a String) and _env_ (an Environment Record). It creates a built-in function object that when executed returns the value bound for _name_ in _env_. It performs the following steps when called:</p>
+        <emu-clause id="sec-makearggetter" type="abstract operation">
+          <h1>
+            MakeArgGetter (
+              _name_: a String,
+              _env_: an Environment Record,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It creates a built-in function object that when executed returns the value bound for _name_ in _env_.</dd>
+          </dl>
           <emu-alg>
             1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _name_ and _env_ and performs the following steps when called:
               1. Return _env_.GetBindingValue(_name_, *false*).
@@ -12136,9 +14105,17 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-makeargsetter" aoid="MakeArgSetter">
-          <h1>MakeArgSetter ( _name_, _env_ )</h1>
-          <p>The abstract operation MakeArgSetter takes arguments _name_ (a String) and _env_ (an Environment Record). It creates a built-in function object that when executed sets the value bound for _name_ in _env_. It performs the following steps when called:</p>
+        <emu-clause id="sec-makeargsetter" type="abstract operation">
+          <h1>
+            MakeArgSetter (
+              _name_: a String,
+              _env_: an Environment Record,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It creates a built-in function object that when executed sets the value bound for _name_ in _env_.</dd>
+          </dl>
           <emu-alg>
             1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _name_ and _env_ and performs the following steps when called:
               1. Return _env_.SetMutableBinding(_name_, _value_, *false*).
@@ -12156,9 +14133,16 @@
       <p><emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref> have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
       <p>An object is an <dfn id="integer-indexed-exotic-object">Integer-Indexed exotic object</dfn> if its [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by IntegerIndexedObjectCreate.</p>
 
-      <emu-clause id="sec-integer-indexed-exotic-objects-getownproperty-p">
-        <h1>[[GetOwnProperty]] ( _P_ )</h1>
-        <p>The [[GetOwnProperty]] internal method of an Integer-Indexed exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-integer-indexed-exotic-objects-getownproperty-p" type="internal method">
+        <h1>
+          [[GetOwnProperty]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an Integer-Indexed exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -12172,9 +14156,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integer-indexed-exotic-objects-hasproperty-p">
-        <h1>[[HasProperty]] ( _P_ )</h1>
-        <p>The [[HasProperty]] internal method of an Integer-Indexed exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-integer-indexed-exotic-objects-hasproperty-p" type="internal method">
+        <h1>
+          [[HasProperty]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an Integer-Indexed exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -12185,9 +14176,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integer-indexed-exotic-objects-defineownproperty-p-desc">
-        <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>The [[DefineOwnProperty]] internal method of an Integer-Indexed exotic object _O_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-integer-indexed-exotic-objects-defineownproperty-p-desc" type="internal method">
+        <h1>
+          [[DefineOwnProperty]] (
+            _P_: a property key,
+            _Desc_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an Integer-Indexed exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -12205,9 +14204,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integer-indexed-exotic-objects-get-p-receiver">
-        <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-        <p>The [[Get]] internal method of an Integer-Indexed exotic object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-integer-indexed-exotic-objects-get-p-receiver" type="internal method">
+        <h1>
+          [[Get]] (
+            _P_: a property key,
+            _Receiver_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an Integer-Indexed exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is String, then
@@ -12218,9 +14225,18 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integer-indexed-exotic-objects-set-p-v-receiver">
-        <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-        <p>The [[Set]] internal method of an Integer-Indexed exotic object _O_ takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-integer-indexed-exotic-objects-set-p-v-receiver" type="internal method">
+        <h1>
+          [[Set]] (
+            _P_: a property key,
+            _V_: an ECMAScript language value,
+            _Receiver_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an Integer-Indexed exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is String, then
@@ -12232,9 +14248,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integer-indexed-exotic-objects-delete-p">
-        <h1>[[Delete]] ( _P_ )</h1>
-        <p>The [[Delete]] internal method of an Integer-Indexed exotic object _O_ takes arguments _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-integer-indexed-exotic-objects-delete-p" type="internal method">
+        <h1>
+          [[Delete]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an Integer-Indexed exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -12246,9 +14269,12 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integer-indexed-exotic-objects-ownpropertykeys">
+      <emu-clause id="sec-integer-indexed-exotic-objects-ownpropertykeys" type="internal method">
         <h1>[[OwnPropertyKeys]] ( )</h1>
-        <p>The [[OwnPropertyKeys]] internal method of an Integer-Indexed exotic object _O_ takes no arguments. It performs the following steps when called:</p>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an Integer-Indexed exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Let _keys_ be a new empty List.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -12263,9 +14289,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integerindexedobjectcreate" aoid="IntegerIndexedObjectCreate">
-        <h1>IntegerIndexedObjectCreate ( _prototype_ )</h1>
-        <p>The abstract operation IntegerIndexedObjectCreate takes argument _prototype_. It is used to specify the creation of new <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>. It performs the following steps when called:</p>
+      <emu-clause id="sec-integerindexedobjectcreate" type="abstract operation">
+        <h1>
+          IntegerIndexedObjectCreate (
+            _prototype_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to specify the creation of new <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>.</dd>
+        </dl>
         <emu-alg>
           1. Let _internalSlotsList_ be &laquo; [[Prototype]], [[Extensible]], [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;.
           1. Let _A_ be ! MakeBasicObject(_internalSlotsList_).
@@ -12281,9 +14314,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isvalidintegerindex" aoid="IsValidIntegerIndex">
-        <h1>IsValidIntegerIndex ( _O_, _index_ )</h1>
-        <p>The abstract operation IsValidIntegerIndex takes arguments _O_ and _index_ (a Number). It performs the following steps when called:</p>
+      <emu-clause id="sec-isvalidintegerindex" type="abstract operation">
+        <h1>
+          IsValidIntegerIndex (
+            _O_: unknown,
+            _index_: a Number,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, return *false*.
@@ -12294,9 +14333,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integerindexedelementget" aoid="IntegerIndexedElementGet">
-        <h1>IntegerIndexedElementGet ( _O_, _index_ )</h1>
-        <p>The abstract operation IntegerIndexedElementGet takes arguments _O_ and _index_ (a Number). It performs the following steps when called:</p>
+      <emu-clause id="sec-integerindexedelementget" type="abstract operation">
+        <h1>
+          IntegerIndexedElementGet (
+            _O_: unknown,
+            _index_: a Number,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
           1. If ! IsValidIntegerIndex(_O_, _index_) is *false*, return *undefined*.
@@ -12309,9 +14354,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-integerindexedelementset" aoid="IntegerIndexedElementSet">
-        <h1>IntegerIndexedElementSet ( _O_, _index_, _value_ )</h1>
-        <p>The abstract operation IntegerIndexedElementSet takes arguments _O_, _index_ (a Number), and _value_. It performs the following steps when called:</p>
+      <emu-clause id="sec-integerindexedelementset" type="abstract operation">
+        <h1>
+          IntegerIndexedElementSet (
+            _O_: unknown,
+            _index_: a Number,
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
           1. If _O_.[[ContentType]] is ~BigInt~, let _numValue_ be ? ToBigInt(_value_).
@@ -12388,33 +14440,53 @@
       </emu-table>
       <p>Module namespace exotic objects provide alternative definitions for all of the internal methods except [[GetPrototypeOf]], which behaves as defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>.</p>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-setprototypeof-v">
-        <h1>[[SetPrototypeOf]] ( _V_ )</h1>
-        <p>The [[SetPrototypeOf]] internal method of a module namespace exotic object _O_ takes argument _V_ (an Object or *null*). It performs the following steps when called:</p>
+      <emu-clause id="sec-module-namespace-exotic-objects-setprototypeof-v" type="internal method">
+        <h1>
+          [[SetPrototypeOf]] (
+            _V_: an Object or *null*,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Return ? SetImmutablePrototype(_O_, _V_).
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-isextensible">
+      <emu-clause id="sec-module-namespace-exotic-objects-isextensible" type="internal method">
         <h1>[[IsExtensible]] ( )</h1>
-        <p>The [[IsExtensible]] internal method of a module namespace exotic object takes no arguments. It performs the following steps when called:</p>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object</dd>
+        </dl>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-preventextensions">
+      <emu-clause id="sec-module-namespace-exotic-objects-preventextensions" type="internal method">
         <h1>[[PreventExtensions]] ( )</h1>
-        <p>The [[PreventExtensions]] internal method of a module namespace exotic object takes no arguments. It performs the following steps when called:</p>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object</dd>
+        </dl>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-getownproperty-p">
-        <h1>[[GetOwnProperty]] ( _P_ )</h1>
-        <p>The [[GetOwnProperty]] internal method of a module namespace exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-module-namespace-exotic-objects-getownproperty-p" type="internal method">
+        <h1>
+          [[GetOwnProperty]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryGetOwnProperty(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
@@ -12424,9 +14496,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-defineownproperty-p-desc">
-        <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>The [[DefineOwnProperty]] internal method of a module namespace exotic object _O_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+      <emu-clause id="sec-module-namespace-exotic-objects-defineownproperty-p-desc" type="internal method">
+        <h1>
+          [[DefineOwnProperty]] (
+            _P_: a property key,
+            _Desc_: a Property Descriptor,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
           1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
@@ -12440,9 +14520,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-hasproperty-p">
-        <h1>[[HasProperty]] ( _P_ )</h1>
-        <p>The [[HasProperty]] internal method of a module namespace exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-module-namespace-exotic-objects-hasproperty-p" type="internal method">
+        <h1>
+          [[HasProperty]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryHasProperty(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
@@ -12451,9 +14538,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-get-p-receiver">
-        <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-        <p>The [[Get]] internal method of a module namespace exotic object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-module-namespace-exotic-objects-get-p-receiver" type="internal method">
+        <h1>
+          [[Get]] (
+            _P_: a property key,
+            _Receiver_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is Symbol, then
@@ -12476,17 +14571,33 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-set-p-v-receiver">
-        <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-        <p>The [[Set]] internal method of a module namespace exotic object takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-module-namespace-exotic-objects-set-p-v-receiver" type="internal method">
+        <h1>
+          [[Set]] (
+            _P_: a property key,
+            _V_: an ECMAScript language value,
+            _Receiver_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object</dd>
+        </dl>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-delete-p">
-        <h1>[[Delete]] ( _P_ )</h1>
-        <p>The [[Delete]] internal method of a module namespace exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+      <emu-clause id="sec-module-namespace-exotic-objects-delete-p" type="internal method">
+        <h1>
+          [[Delete]] (
+            _P_: a property key,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is Symbol, then
@@ -12497,9 +14608,12 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-namespace-exotic-objects-ownpropertykeys">
+      <emu-clause id="sec-module-namespace-exotic-objects-ownpropertykeys" type="internal method">
         <h1>[[OwnPropertyKeys]] ( )</h1>
-        <p>The [[OwnPropertyKeys]] internal method of a module namespace exotic object _O_ takes no arguments. It performs the following steps when called:</p>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a module namespace exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Let _exports_ be _O_.[[Exports]].
           1. Let _symbolKeys_ be ! OrdinaryOwnPropertyKeys(_O_).
@@ -12507,9 +14621,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-modulenamespacecreate" aoid="ModuleNamespaceCreate">
-        <h1>ModuleNamespaceCreate ( _module_, _exports_ )</h1>
-        <p>The abstract operation ModuleNamespaceCreate takes arguments _module_ and _exports_. It is used to specify the creation of new module namespace exotic objects. It performs the following steps when called:</p>
+      <emu-clause id="sec-modulenamespacecreate" type="abstract operation">
+        <h1>
+          ModuleNamespaceCreate (
+            _module_: unknown,
+            _exports_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to specify the creation of new module namespace exotic objects.</dd>
+        </dl>
         <emu-alg>
           1. Assert: _module_ is a Module Record.
           1. Assert: _module_.[[Namespace]] is *undefined*.
@@ -12538,17 +14660,30 @@
         <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %Object.prototype% and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>
       </emu-note>
 
-      <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v">
-        <h1>[[SetPrototypeOf]] ( _V_ )</h1>
-        <p>The [[SetPrototypeOf]] internal method of an immutable prototype exotic object _O_ takes argument _V_ (an Object or *null*). It performs the following steps when called:</p>
+      <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v" type="internal method">
+        <h1>
+          [[SetPrototypeOf]] (
+            _V_: an Object or *null*,
+          )
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>an immutable prototype exotic object _O_</dd>
+        </dl>
         <emu-alg>
           1. Return ? SetImmutablePrototype(_O_, _V_).
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-set-immutable-prototype" aoid="SetImmutablePrototype">
-        <h1>SetImmutablePrototype ( _O_, _V_ )</h1>
-        <p>The abstract operation SetImmutablePrototype takes arguments _O_ and _V_. It performs the following steps when called:</p>
+      <emu-clause id="sec-set-immutable-prototype" type="abstract operation">
+        <h1>
+          SetImmutablePrototype (
+            _O_: unknown,
+            _V_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
           1. Let _current_ be ? _O_.[[GetPrototypeOf]]().
@@ -12688,9 +14823,12 @@
     <p>Because proxy objects permit the implementation of internal methods to be provided by arbitrary ECMAScript code, it is possible to define a proxy object whose handler methods violates the invariants defined in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref>. Some of the internal method invariants defined in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref> are essential integrity invariants. These invariants are explicitly enforced by the proxy object internal methods specified in this section. An ECMAScript implementation must be robust in the presence of all possible invariant violations.</p>
     <p>In the following algorithm descriptions, assume _O_ is an ECMAScript proxy object, _P_ is a property key value, _V_ is any ECMAScript language value and _Desc_ is a Property Descriptor record.</p>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getprototypeof">
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getprototypeof" type="internal method">
       <h1>[[GetPrototypeOf]] ( )</h1>
-      <p>The [[GetPrototypeOf]] internal method of a Proxy exotic object _O_ takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -12720,9 +14858,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v">
-      <h1>[[SetPrototypeOf]] ( _V_ )</h1>
-      <p>The [[SetPrototypeOf]] internal method of a Proxy exotic object _O_ takes argument _V_ (an Object or *null*). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v" type="internal method">
+      <h1>
+        [[SetPrototypeOf]] (
+          _V_: an Object or *null*,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -12753,9 +14898,12 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-isextensible">
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-isextensible" type="internal method">
       <h1>[[IsExtensible]] ( )</h1>
-      <p>The [[IsExtensible]] internal method of a Proxy exotic object _O_ takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -12782,9 +14930,12 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-preventextensions">
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-preventextensions" type="internal method">
       <h1>[[PreventExtensions]] ( )</h1>
-      <p>The [[PreventExtensions]] internal method of a Proxy exotic object _O_ takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -12812,9 +14963,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p">
-      <h1>[[GetOwnProperty]] ( _P_ )</h1>
-      <p>The [[GetOwnProperty]] internal method of a Proxy exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p" type="internal method">
+      <h1>
+        [[GetOwnProperty]] (
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -12870,9 +15028,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc">
-      <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-      <p>The [[DefineOwnProperty]] internal method of a Proxy exotic object _O_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc" type="internal method">
+      <h1>
+        [[DefineOwnProperty]] (
+          _P_: a property key,
+          _Desc_: a Property Descriptor,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -12922,9 +15088,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p">
-      <h1>[[HasProperty]] ( _P_ )</h1>
-      <p>The [[HasProperty]] internal method of a Proxy exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p" type="internal method">
+      <h1>
+        [[HasProperty]] (
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -12959,9 +15132,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver">
-      <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-      <p>The [[Get]] internal method of a Proxy exotic object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver" type="internal method">
+      <h1>
+        [[Get]] (
+          _P_: a property key,
+          _Receiver_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -12993,9 +15174,18 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver">
-      <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-      <p>The [[Set]] internal method of a Proxy exotic object _O_ takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver" type="internal method">
+      <h1>
+        [[Set]] (
+          _P_: a property key,
+          _V_: an ECMAScript language value,
+          _Receiver_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -13031,9 +15221,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-delete-p">
-      <h1>[[Delete]] ( _P_ )</h1>
-      <p>The [[Delete]] internal method of a Proxy exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-delete-p" type="internal method">
+      <h1>
+        [[Delete]] (
+          _P_: a property key,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -13068,9 +15265,12 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys" type="internal method">
       <h1>[[OwnPropertyKeys]] ( )</h1>
-      <p>The [[OwnPropertyKeys]] internal method of a Proxy exotic object _O_ takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -13129,9 +15329,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist">
-      <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
-      <p>The [[Call]] internal method of a Proxy exotic object _O_ takes arguments _thisArgument_ (an ECMAScript language value) and _argumentsList_ (a List of ECMAScript language values). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist" type="internal method">
+      <h1>
+        [[Call]] (
+          _thisArgument_: an ECMAScript language value,
+          _argumentsList_: a List of ECMAScript language values,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -13148,9 +15356,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget">
-      <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-      <p>The [[Construct]] internal method of a Proxy exotic object _O_ takes arguments _argumentsList_ (a List of ECMAScript language values) and _newTarget_ (a constructor). It performs the following steps when called:</p>
+    <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget" type="internal method">
+      <h1>
+        [[Construct]] (
+          _argumentsList_: a List of ECMAScript language values,
+          _newTarget_: a constructor,
+        )
+      </h1>
+      <dl class="header">
+        <dt>for</dt>
+        <dd>a Proxy exotic object _O_</dd>
+      </dl>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -13178,9 +15394,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-proxycreate" aoid="ProxyCreate">
-      <h1>ProxyCreate ( _target_, _handler_ )</h1>
-      <p>The abstract operation ProxyCreate takes arguments _target_ and _handler_. It is used to specify the creation of new Proxy exotic objects. It performs the following steps when called:</p>
+    <emu-clause id="sec-proxycreate" type="abstract operation">
+      <h1>
+        ProxyCreate (
+          _target_: unknown,
+          _handler_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to specify the creation of new Proxy exotic objects.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. If Type(_handler_) is not Object, throw a *TypeError* exception.
@@ -13215,9 +15439,14 @@
       <p>ECMAScript differs from the Java programming language in the behaviour of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a string literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a string literal&mdash;one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the String value of a string literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a string literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the string literal.</p>
     </emu-note>
 
-    <emu-clause id="sec-utf16encodecodepoint" aoid="UTF16EncodeCodePoint" oldids="sec-utf16encoding,sec-codepointtoutf16codeunits">
-      <h1>Static Semantics: UTF16EncodeCodePoint ( _cp_ )</h1>
-      <p>The abstract operation UTF16EncodeCodePoint takes argument _cp_ (a Unicode code point). It performs the following steps when called:</p>
+    <emu-clause id="sec-utf16encodecodepoint" type="abstract operation" oldids="sec-utf16encoding,sec-codepointtoutf16codeunits">
+      <h1>
+        Static Semantics: UTF16EncodeCodePoint (
+          _cp_: a Unicode code point,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: 0 &le; _cp_ &le; 0x10FFFF.
         1. If _cp_ &le; 0xFFFF, return the String value consisting of the code unit whose value is _cp_.
@@ -13227,9 +15456,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-codepointstostring" aoid="CodePointsToString" oldids="sec-utf16encode">
-      <h1>Static Semantics: CodePointsToString ( _text_ )</h1>
-      <p>The abstract operation CodePointsToString takes argument _text_ (a sequence of Unicode code points). It converts _text_ into a String value, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
+    <emu-clause id="sec-codepointstostring" type="abstract operation" oldids="sec-utf16encode">
+      <h1>
+        Static Semantics: CodePointsToString (
+          _text_: a sequence of Unicode code points,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _text_ into a String value, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</dd>
+      </dl>
       <emu-alg>
         1. Let _result_ be the empty String.
         1. For each code point _cp_ of _text_, do
@@ -13238,9 +15474,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-utf16decodesurrogatepair" aoid="UTF16SurrogatePairToCodePoint" oldids="sec-utf16decode,utf16decodesurrogatepair">
-      <h1>Static Semantics: UTF16SurrogatePairToCodePoint ( _lead_, _trail_ )</h1>
-      <p>The abstract operation UTF16SurrogatePairToCodePoint takes arguments _lead_ (a code unit) and _trail_ (a code unit). Two code units that form a UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> are converted to a code point. It performs the following steps when called:</p>
+    <emu-clause id="sec-utf16decodesurrogatepair" type="abstract operation" oldids="sec-utf16decode,utf16decodesurrogatepair">
+      <h1>
+        Static Semantics: UTF16SurrogatePairToCodePoint (
+          _lead_: a code unit,
+          _trail_: a code unit,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>Two code units that form a UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> are converted to a code point.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _lead_ is a <emu-xref href="#leading-surrogate"></emu-xref> and _trail_ is a <emu-xref href="#trailing-surrogate"></emu-xref>.
         1. Let _cp_ be (_lead_ - 0xD800) &times; 0x400 + (_trail_ - 0xDC00) + 0x10000.
@@ -13248,9 +15492,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-codepointat" aoid="CodePointAt">
-      <h1>Static Semantics: CodePointAt ( _string_, _position_ )</h1>
-      <p>The abstract operation CodePointAt takes arguments _string_ (a String) and _position_ (a non-negative integer). It interprets _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and reads from it a single code point starting with the code unit at index _position_. It performs the following steps when called:</p>
+    <emu-clause id="sec-codepointat" type="abstract operation">
+      <h1>
+        Static Semantics: CodePointAt (
+          _string_: a String,
+          _position_: a non-negative integer,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It interprets _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and reads from it a single code point starting with the code unit at index _position_.</dd>
+      </dl>
       <emu-alg>
         1. Let _size_ be the length of _string_.
         1. Assert: _position_ &ge; 0 and _position_ &lt; _size_.
@@ -13268,9 +15520,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-stringtocodepoints" aoid="StringToCodePoints" oldids="sec-utf16decodestring">
-      <h1>Static Semantics: StringToCodePoints ( _string_ )</h1>
-      <p>The abstract operation StringToCodePoints takes argument _string_ (a String). It returns the sequence of Unicode code points that results from interpreting _string_ as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
+    <emu-clause id="sec-stringtocodepoints" type="abstract operation" oldids="sec-utf16decodestring">
+      <h1>
+        Static Semantics: StringToCodePoints (
+          _string_: a String,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the sequence of Unicode code points that results from interpreting _string_ as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</dd>
+      </dl>
       <emu-alg>
         1. Let _codePoints_ be a new empty List.
         1. Let _size_ be the length of _string_.
@@ -13283,9 +15542,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-parsetext" aoid="ParseText">
-      <h1>Static Semantics: ParseText ( _sourceText_, _goalSymbol_ )</h1>
-      <p>The abstract operation ParseText takes arguments _sourceText_ (a sequence of Unicode code points) and _goalSymbol_ (a nonterminal in one of the ECMAScript grammars). It performs the following steps when called:</p>
+    <emu-clause id="sec-parsetext" type="abstract operation">
+      <h1>
+        Static Semantics: ParseText (
+          _sourceText_: a sequence of Unicode code points,
+          _goalSymbol_: a nonterminal in one of the ECMAScript grammars,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Attempt to parse _sourceText_ using _goalSymbol_ as the goal symbol, and analyse the parse result for any early error conditions. Parsing and early error detection may be interleaved in an implementation-defined manner.
         1. If the parse succeeded and no early errors were found, return the Parse Node (an instance of _goalSymbol_) at the root of the parse tree resulting from the parse.
@@ -15618,9 +17883,16 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-isvalidregularexpressionliteral" aoid="IsValidRegularExpressionLiteral">
-        <h1>Static Semantics: IsValidRegularExpressionLiteral ( _literal_ )</h1>
-        <p>The abstract operation IsValidRegularExpressionLiteral takes argument _literal_. It determines if its argument is a valid regular expression literal. It performs the following steps when called:</p>
+      <emu-clause id="sec-isvalidregularexpressionliteral" type="abstract operation">
+        <h1>
+          Static Semantics: IsValidRegularExpressionLiteral (
+            _literal_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It determines if its argument is a valid regular expression literal.</dd>
+        </dl>
         <emu-alg>
           1. Assert: _literal_ is a |RegularExpressionLiteral|.
           1. If FlagText of _literal_ contains any code points other than `g`, `i`, `m`, `s`, `u`, or `y`, or if it contains the same code point more than once, return *false*.
@@ -15771,9 +18043,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-gettemplateobject" aoid="GetTemplateObject">
-        <h1>GetTemplateObject ( _templateLiteral_ )</h1>
-        <p>The abstract operation GetTemplateObject takes argument _templateLiteral_ (a Parse Node). It performs the following steps when called:</p>
+      <emu-clause id="sec-gettemplateobject" type="abstract operation">
+        <h1>
+          GetTemplateObject (
+            _templateLiteral_: a Parse Node,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _realm_ be the current Realm Record.
           1. Let _templateRegistry_ be _realm_.[[TemplateMap]].
@@ -16143,9 +18420,16 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-evaluate-property-access-with-expression-key" aoid="EvaluatePropertyAccessWithExpressionKey" oldids="sec-evaluate-expression-key-property-access">
-      <h1>EvaluatePropertyAccessWithExpressionKey ( _baseValue_, _expression_, _strict_ )</h1>
-      <p>The abstract operation EvaluatePropertyAccessWithExpressionKey takes arguments _baseValue_ (an ECMAScript language value), _expression_ (a Parse Node), and _strict_ (a Boolean). It performs the following steps when called:</p>
+    <emu-clause id="sec-evaluate-property-access-with-expression-key" type="abstract operation" oldids="sec-evaluate-expression-key-property-access">
+      <h1>
+        EvaluatePropertyAccessWithExpressionKey (
+          _baseValue_: an ECMAScript language value,
+          _expression_: a Parse Node,
+          _strict_: a Boolean,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _propertyNameReference_ be the result of evaluating _expression_.
         1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
@@ -16154,9 +18438,16 @@
         1. Return the Reference Record { [[Base]]: _bv_, [[ReferencedName]]: _propertyKey_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
-    <emu-clause id="sec-evaluate-property-access-with-identifier-key" aoid="EvaluatePropertyAccessWithIdentifierKey" oldids="sec-evaluate-identifier-key-property-access">
-      <h1>EvaluatePropertyAccessWithIdentifierKey ( _baseValue_, _identifierName_, _strict_ )</h1>
-      <p>The abstract operation EvaluatePropertyAccessWithIdentifierKey takes arguments _baseValue_ (an ECMAScript language value), _identifierName_ (a Parse Node), and _strict_ (a Boolean). It performs the following steps when called:</p>
+    <emu-clause id="sec-evaluate-property-access-with-identifier-key" type="abstract operation" oldids="sec-evaluate-identifier-key-property-access">
+      <h1>
+        EvaluatePropertyAccessWithIdentifierKey (
+          _baseValue_: an ECMAScript language value,
+          _identifierName_: a Parse Node,
+          _strict_: a Boolean,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: _identifierName_ is an |IdentifierName|.
         1. Let _bv_ be ? RequireObjectCoercible(_baseValue_).
@@ -16179,9 +18470,15 @@
           1. Return ? EvaluateNew(|MemberExpression|, |Arguments|).
         </emu-alg>
 
-        <emu-clause id="sec-evaluatenew" aoid="EvaluateNew">
-          <h1>EvaluateNew ( _constructExpr_, _arguments_ )</h1>
-          <p>The abstract operation EvaluateNew takes arguments _constructExpr_ and _arguments_. It performs the following steps when called:</p>
+        <emu-clause id="sec-evaluatenew" type="abstract operation">
+          <h1>
+            EvaluateNew (
+              _constructExpr_: unknown,
+              _arguments_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _constructExpr_ is either a |NewExpression| or a |MemberExpression|.
             1. Assert: _arguments_ is either ~empty~ or an |Arguments|.
@@ -16232,9 +18529,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-evaluatecall" aoid="EvaluateCall" oldids="sec-evaluatedirectcall">
-        <h1>EvaluateCall ( _func_, _ref_, _arguments_, _tailPosition_ )</h1>
-        <p>The abstract operation EvaluateCall takes arguments _func_ (an ECMAScript language value), _ref_ (an ECMAScript language value or a Reference Record), _arguments_ (a Parse Node), and _tailPosition_ (a Boolean). It performs the following steps when called:</p>
+      <emu-clause id="sec-evaluatecall" type="abstract operation" oldids="sec-evaluatedirectcall">
+        <h1>
+          EvaluateCall (
+            _func_: an ECMAScript language value,
+            _ref_: an ECMAScript language value or a Reference Record,
+            _arguments_: a Parse Node,
+            _tailPosition_: a Boolean,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _ref_ is a Reference Record, then
             1. If IsPropertyReference(_ref_) is *true*, then
@@ -16297,9 +18602,10 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-getsuperconstructor" aoid="GetSuperConstructor">
+      <emu-clause id="sec-getsuperconstructor" type="abstract operation">
         <h1>GetSuperConstructor ( )</h1>
-        <p>The abstract operation GetSuperConstructor takes no arguments. It performs the following steps when called:</p>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _envRec_ be GetThisEnvironment().
           1. Assert: _envRec_ is a function Environment Record.
@@ -16310,9 +18616,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-makesuperpropertyreference" aoid="MakeSuperPropertyReference">
-        <h1>MakeSuperPropertyReference ( _actualThis_, _propertyKey_, _strict_ )</h1>
-        <p>The abstract operation MakeSuperPropertyReference takes arguments _actualThis_, _propertyKey_, and _strict_. It performs the following steps when called:</p>
+      <emu-clause id="sec-makesuperpropertyreference" type="abstract operation">
+        <h1>
+          MakeSuperPropertyReference (
+            _actualThis_: unknown,
+            _propertyKey_: unknown,
+            _strict_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
           1. Assert: _env_.HasSuperBinding() is *true*.
@@ -16572,9 +18885,16 @@
             1. Return _importMeta_.
         </emu-alg>
 
-        <emu-clause id="sec-hostgetimportmetaproperties" aoid="HostGetImportMetaProperties">
-          <h1>HostGetImportMetaProperties ( _moduleRecord_ )</h1>
-          <p>The host-defined abstract operation HostGetImportMetaProperties takes argument _moduleRecord_ (a Module Record). It allows hosts to provide property keys and values for the object returned from `import.meta`.</p>
+        <emu-clause id="sec-hostgetimportmetaproperties" type="host-defined abstract operation">
+          <h1>
+            HostGetImportMetaProperties (
+              _moduleRecord_: a Module Record,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It allows hosts to provide property keys and values for the object returned from `import.meta`.</dd>
+          </dl>
 
           <p>The implementation of HostGetImportMetaProperties must conform to the following requirements:</p>
           <ul>
@@ -16587,9 +18907,17 @@
           <p>The default implementation of HostGetImportMetaProperties is to return a new empty List.</p>
         </emu-clause>
 
-        <emu-clause id="sec-hostfinalizeimportmeta" aoid="HostFinalizeImportMeta">
-          <h1>HostFinalizeImportMeta ( _importMeta_, _moduleRecord_ )</h1>
-          <p>The host-defined abstract operation HostFinalizeImportMeta takes arguments _importMeta_ (an Object) and _moduleRecord_ (a Module Record). It allows hosts to perform any extraordinary operations to prepare the object returned from `import.meta`.</p>
+        <emu-clause id="sec-hostfinalizeimportmeta" type="host-defined abstract operation">
+          <h1>
+            HostFinalizeImportMeta (
+              _importMeta_: an Object,
+              _moduleRecord_: a Module Record,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It allows hosts to perform any extraordinary operations to prepare the object returned from `import.meta`.</dd>
+          </dl>
 
           <p>Most hosts will be able to simply define HostGetImportMetaProperties, and leave HostFinalizeImportMeta with its default behaviour. However, HostFinalizeImportMeta provides an "escape hatch" for hosts which need to directly manipulate the object before it is exposed to ECMAScript code.</p>
 
@@ -17200,9 +19528,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
-      <h1>InstanceofOperator ( _V_, _target_ )</h1>
-      <p>The abstract operation InstanceofOperator takes arguments _V_ (an ECMAScript language value) and _target_ (an ECMAScript language value). It implements the generic algorithm for determining if _V_ is an instance of _target_ either by consulting _target_'s @@hasInstance method or, if absent, determining whether the value of _target_'s *"prototype"* property is present in _V_'s prototype chain. It performs the following steps when called:</p>
+    <emu-clause id="sec-instanceofoperator" type="abstract operation">
+      <h1>
+        InstanceofOperator (
+          _V_: an ECMAScript language value,
+          _target_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It implements the generic algorithm for determining if _V_ is an instance of _target_ either by consulting _target_'s @@hasInstance method or, if absent, determining whether the value of _target_'s *"prototype"* property is present in _V_'s prototype chain.</dd>
+      </dl>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _instOfHandler_ be ? GetMethod(_target_, @@hasInstance).
@@ -17579,9 +19915,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-applystringornumericbinaryoperator" aoid="ApplyStringOrNumericBinaryOperator">
-      <h1>ApplyStringOrNumericBinaryOperator ( _lval_, _opText_, _rval_ )</h1>
-      <p>The abstract operation ApplyStringOrNumericBinaryOperator takes arguments _lval_ (an ECMAScript language value), _opText_ (a sequence of Unicode code points), and _rval_ (an ECMAScript language value). It performs the following steps when called:</p>
+    <emu-clause id="sec-applystringornumericbinaryoperator" type="abstract operation">
+      <h1>
+        ApplyStringOrNumericBinaryOperator (
+          _lval_: an ECMAScript language value,
+          _opText_: a sequence of Unicode code points,
+          _rval_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: _opText_ is present in the table in step <emu-xref href="#step-applystringornumericbinaryoperator-operations-table"></emu-xref>.
         1. If _opText_ is `+`, then
@@ -17628,9 +19971,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-evaluatestringornumericbinaryexpression" aoid="EvaluateStringOrNumericBinaryExpression">
-      <h1>EvaluateStringOrNumericBinaryExpression ( _leftOperand_, _opText_, _rightOperand_ )</h1>
-      <p>The abstract operation EvaluateStringOrNumericBinaryExpression takes arguments _leftOperand_ (a Parse Node), _opText_ (a sequence of Unicode code points), and _rightOperand_ (a Parse Node). It performs the following steps when called:</p>
+    <emu-clause id="sec-evaluatestringornumericbinaryexpression" type="abstract operation">
+      <h1>
+        EvaluateStringOrNumericBinaryExpression (
+          _leftOperand_: a Parse Node,
+          _opText_: a sequence of Unicode code points,
+          _rightOperand_: a Parse Node,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _lref_ be the result of evaluating _leftOperand_.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -18137,9 +20487,17 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-blockdeclarationinstantiation" aoid="BlockDeclarationInstantiation">
-      <h1>BlockDeclarationInstantiation ( _code_, _env_ )</h1>
-      <p>The abstract operation BlockDeclarationInstantiation takes arguments _code_ (a Parse Node) and _env_ (an Environment Record). _code_ is the Parse Node corresponding to the body of the block. _env_ is the Environment Record in which bindings are to be created.</p>
+    <emu-clause id="sec-blockdeclarationinstantiation" type="abstract operation">
+      <h1>
+        BlockDeclarationInstantiation (
+          _code_: a Parse Node,
+          _env_: an Environment Record,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>_code_ is the Parse Node corresponding to the body of the block. _env_ is the Environment Record in which bindings are to be created.</dd>
+      </dl>
       <emu-note>
         <p>When a |Block| or |CaseBlock| is evaluated a new declarative Environment Record is created and bindings for each block scoped variable, constant, function, or class declared in the block are instantiated in the Environment Record.</p>
       </emu-note>
@@ -18548,9 +20906,15 @@
     <emu-clause id="sec-iteration-statements-semantics">
       <h1>Semantics</h1>
 
-      <emu-clause id="sec-loopcontinues" aoid="LoopContinues">
-        <h1>LoopContinues ( _completion_, _labelSet_ )</h1>
-        <p>The abstract operation LoopContinues takes arguments _completion_ and _labelSet_. It performs the following steps when called:</p>
+      <emu-clause id="sec-loopcontinues" type="abstract operation">
+        <h1>
+          LoopContinues (
+            _completion_: unknown,
+            _labelSet_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _completion_.[[Type]] is ~normal~, return *true*.
           1. If _completion_.[[Type]] is not ~continue~, return *false*.
@@ -18734,9 +21098,18 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-forbodyevaluation" aoid="ForBodyEvaluation">
-        <h1>ForBodyEvaluation ( _test_, _increment_, _stmt_, _perIterationBindings_, _labelSet_ )</h1>
-        <p>The abstract operation ForBodyEvaluation takes arguments _test_, _increment_, _stmt_, _perIterationBindings_, and _labelSet_. It performs the following steps when called:</p>
+      <emu-clause id="sec-forbodyevaluation" type="abstract operation">
+        <h1>
+          ForBodyEvaluation (
+            _test_: unknown,
+            _increment_: unknown,
+            _stmt_: unknown,
+            _perIterationBindings_: unknown,
+            _labelSet_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
@@ -18755,9 +21128,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-createperiterationenvironment" aoid="CreatePerIterationEnvironment">
-        <h1>CreatePerIterationEnvironment ( _perIterationBindings_ )</h1>
-        <p>The abstract operation CreatePerIterationEnvironment takes argument _perIterationBindings_. It performs the following steps when called:</p>
+      <emu-clause id="sec-createperiterationenvironment" type="abstract operation">
+        <h1>
+          CreatePerIterationEnvironment (
+            _perIterationBindings_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _perIterationBindings_ has any elements, then
             1. Let _lastIterationEnv_ be the running execution context's LexicalEnvironment.
@@ -18991,9 +21369,16 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-forinofheadevaluation" oldids="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
-        <h1>ForIn/OfHeadEvaluation ( _uninitializedBoundNames_, _expr_, _iterationKind_ )</h1>
-        <p>The abstract operation ForIn/OfHeadEvaluation takes arguments _uninitializedBoundNames_, _expr_, and _iterationKind_ (either ~enumerate~, ~iterate~, or ~async-iterate~). It performs the following steps when called:</p>
+      <emu-clause id="sec-runtime-semantics-forinofheadevaluation" type="abstract operation" oldids="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind">
+        <h1>
+          ForIn/OfHeadEvaluation (
+            _uninitializedBoundNames_: unknown,
+            _expr_: unknown,
+            _iterationKind_: either ~enumerate~, ~iterate~, or ~async-iterate~,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. If _uninitializedBoundNames_ is not an empty List, then
@@ -19020,9 +21405,20 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" aoid="ForIn/OfBodyEvaluation">
-        <h1>ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ] )</h1>
-        <p>The abstract operation ForIn/OfBodyEvaluation takes arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_ (either ~assignment~, ~varBinding~ or ~lexicalBinding~), and _labelSet_ and optional argument _iteratorKind_ (either ~sync~ or ~async~). It performs the following steps when called:</p>
+      <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" type="abstract operation">
+        <h1>
+          ForIn/OfBodyEvaluation (
+            _lhs_: unknown,
+            _stmt_: unknown,
+            _iteratorRecord_: unknown,
+            _iterationKind_: unknown,
+            _lhsKind_: either ~assignment~, ~varBinding~ or ~lexicalBinding~,
+            _labelSet_: unknown,
+            optional _iteratorKind_: either ~sync~ or ~async~,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _iteratorKind_ is not present, set _iteratorKind_ to ~sync~.
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
@@ -19099,9 +21495,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-enumerate-object-properties" aoid="EnumerateObjectProperties">
-        <h1>EnumerateObjectProperties ( _O_ )</h1>
-        <p>The abstract operation EnumerateObjectProperties takes argument _O_. It performs the following steps when called:</p>
+      <emu-clause id="sec-enumerate-object-properties" type="abstract operation">
+        <h1>
+          EnumerateObjectProperties (
+            _O_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Type(_O_) is Object.
           1. Return an Iterator object (<emu-xref href="#sec-iterator-interface"></emu-xref>) whose `next` method iterates over all the String-valued keys of enumerable properties of _O_. The iterator object is never directly accessible to ECMAScript code. The mechanics and order of enumerating the properties is not specified but must conform to the rules specified below.
@@ -19147,9 +21548,16 @@
         <h1>For-In Iterator Objects</h1>
         <p>A For-In Iterator is an object that represents a specific iteration over some specific object. For-In Iterator objects are never directly accessible to ECMAScript code; they exist solely to illustrate the behaviour of EnumerateObjectProperties.</p>
 
-        <emu-clause id="sec-createforiniterator" aoid="CreateForInIterator">
-          <h1>CreateForInIterator ( _object_ )</h1>
-          <p>The abstract operation CreateForInIterator takes argument _object_. It is used to create a For-In Iterator object which iterates over the own and inherited enumerable string properties of _object_ in a specific order. It performs the following steps when called:</p>
+        <emu-clause id="sec-createforiniterator" type="abstract operation">
+          <h1>
+            CreateForInIterator (
+              _object_: unknown,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It is used to create a For-In Iterator object which iterates over the own and inherited enumerable string properties of _object_ in a specific order.</dd>
+          </dl>
           <emu-alg>
             1. Assert: Type(_object_) is Object.
             1. Let _iterator_ be ! OrdinaryObjectCreate(%ForInIteratorPrototype%, &laquo; [[Object]], [[ObjectWasVisited]], [[VisitedKeys]], [[RemainingKeys]] &raquo;).
@@ -19499,9 +21907,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-caseclauseisselected" aoid="CaseClauseIsSelected" oldids="sec-runtime-semantics-caseselectorevaluation">
-      <h1>CaseClauseIsSelected ( _C_, _input_ )</h1>
-      <p>The abstract operation CaseClauseIsSelected takes arguments _C_ (a Parse Node for |CaseClause|) and _input_ (an ECMAScript language value). It determines whether _C_ matches _input_. It performs the following steps when called:</p>
+    <emu-clause id="sec-runtime-semantics-caseclauseisselected" type="abstract operation" oldids="sec-runtime-semantics-caseselectorevaluation">
+      <h1>
+        CaseClauseIsSelected (
+          _C_: a Parse Node for |CaseClause|,
+          _input_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines whether _C_ matches _input_.</dd>
+      </dl>
       <emu-alg>
         1. Assert: _C_ is an instance of the production <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>.
         1. Let _exprRef_ be the result of evaluating the |Expression| of _C_.
@@ -19577,9 +21993,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-islabelledfunction" aoid="IsLabelledFunction">
-      <h1>Static Semantics: IsLabelledFunction ( _stmt_ )</h1>
-      <p>The abstract operation IsLabelledFunction takes argument _stmt_. It performs the following steps when called:</p>
+    <emu-clause id="sec-islabelledfunction" type="abstract operation">
+      <h1>
+        Static Semantics: IsLabelledFunction (
+          _stmt_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If _stmt_ is not a |LabelledStatement|, return *false*.
         1. Let _item_ be the |LabelledItem| of _stmt_.
@@ -21921,9 +24342,14 @@
   <emu-clause id="sec-tail-position-calls">
     <h1>Tail Position Calls</h1>
 
-    <emu-clause id="sec-isintailposition" aoid="IsInTailPosition">
-      <h1>Static Semantics: IsInTailPosition ( _call_ )</h1>
-      <p>The abstract operation IsInTailPosition takes argument _call_. It performs the following steps when called:</p>
+    <emu-clause id="sec-isintailposition" type="abstract operation">
+      <h1>
+        Static Semantics: IsInTailPosition (
+          _call_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: _call_ is a Parse Node.
         1. If the source code matching _call_ is non-strict code, return *false*.
@@ -22264,9 +24690,10 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-preparefortailcall" aoid="PrepareForTailCall">
+    <emu-clause id="sec-preparefortailcall" type="abstract operation">
       <h1>PrepareForTailCall ( )</h1>
-      <p>The abstract operation PrepareForTailCall takes no arguments. It performs the following steps when called:</p>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _leafContext_ be the running execution context.
         1. Suspend _leafContext_.
@@ -22404,9 +24831,18 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-parse-script" aoid="ParseScript">
-      <h1>ParseScript ( _sourceText_, _realm_, _hostDefined_ )</h1>
-      <p>The abstract operation ParseScript takes arguments _sourceText_, _realm_, and _hostDefined_. It creates a Script Record based upon the result of parsing _sourceText_ as a |Script|. It performs the following steps when called:</p>
+    <emu-clause id="sec-parse-script" type="abstract operation">
+      <h1>
+        ParseScript (
+          _sourceText_: unknown,
+          _realm_: unknown,
+          _hostDefined_: unknown,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates a Script Record based upon the result of parsing _sourceText_ as a |Script|.</dd>
+      </dl>
 
       <emu-alg>
         1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
@@ -22419,9 +24855,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-scriptevaluation" aoid="ScriptEvaluation">
-      <h1>ScriptEvaluation ( _scriptRecord_ )</h1>
-      <p>The abstract operation ScriptEvaluation takes argument _scriptRecord_. It performs the following steps when called:</p>
+    <emu-clause id="sec-runtime-semantics-scriptevaluation" type="abstract operation">
+      <h1>
+        ScriptEvaluation (
+          _scriptRecord_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
 
       <emu-alg>
         1. Let _globalEnv_ be _scriptRecord_.[[Realm]].[[GlobalEnv]].
@@ -22447,9 +24888,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-globaldeclarationinstantiation" aoid="GlobalDeclarationInstantiation">
-      <h1>GlobalDeclarationInstantiation ( _script_, _env_ )</h1>
-      <p>The abstract operation GlobalDeclarationInstantiation takes arguments _script_ (a Parse Node for |ScriptBody|) and _env_ (an Environment Record). _script_ is the |ScriptBody| for which the execution context is being established. _env_ is the global environment in which bindings are to be created.</p>
+    <emu-clause id="sec-globaldeclarationinstantiation" type="abstract operation">
+      <h1>
+        GlobalDeclarationInstantiation (
+          _script_: a Parse Node for |ScriptBody|,
+          _env_: an Environment Record,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>_script_ is the |ScriptBody| for which the execution context is being established. _env_ is the global environment in which bindings are to be created.</dd>
+      </dl>
       <emu-note>
         <p>When an execution context is established for evaluating scripts, declarations are instantiated in the current global environment. Each global binding declared in the code is instantiated.</p>
       </emu-note>
@@ -22581,9 +25030,16 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-importedlocalnames" aoid="ImportedLocalNames">
-        <h1>Static Semantics: ImportedLocalNames ( _importEntries_ )</h1>
-        <p>The abstract operation ImportedLocalNames takes argument _importEntries_ (a List of ImportEntry Records (see <emu-xref href="#table-importentry-record-fields"></emu-xref>)). It creates a List of all of the local name bindings defined by _importEntries_. It performs the following steps when called:</p>
+      <emu-clause id="sec-importedlocalnames" type="abstract operation">
+        <h1>
+          Static Semantics: ImportedLocalNames (
+            _importEntries_: a List of ImportEntry Records (see <emu-xref href="#table-importentry-record-fields"></emu-xref>),
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It creates a List of all of the local name bindings defined by _importEntries_.</dd>
+        </dl>
         <emu-alg>
           1. Let _localNames_ be a new empty List.
           1. For each ImportEntry Record _i_ of _importEntries_, do
@@ -22868,9 +25324,15 @@
           </table>
         </emu-table>
 
-        <emu-clause id="sec-moduledeclarationlinking" oldids="sec-moduledeclarationinstantiation">
+        <emu-clause id="sec-moduledeclarationlinking" type="concrete method" oldids="sec-moduledeclarationinstantiation">
           <h1>Link ( )</h1>
-          <p>The Link concrete method of a Cyclic Module Record _module_ takes no arguments. On success, Link transitions this module's [[Status]] from ~unlinked~ to ~linked~. On failure, an exception is thrown and this module's [[Status]] remains ~unlinked~. (Most of the work is done by the auxiliary function InnerModuleLinking.) It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a Cyclic Module Record _module_</dd>
+
+            <dt>description</dt>
+            <dd>On success, Link transitions this module's [[Status]] from ~unlinked~ to ~linked~. On failure, an exception is thrown and this module's [[Status]] remains ~unlinked~. (Most of the work is done by the auxiliary function InnerModuleLinking.)</dd>
+          </dl>
 
           <emu-alg>
             1. Assert: _module_.[[Status]] is not ~linking~ or ~evaluating~.
@@ -22890,9 +25352,18 @@
             1. Return *undefined*.
           </emu-alg>
 
-          <emu-clause id="sec-InnerModuleLinking" oldids="sec-innermoduleinstantiation" aoid="InnerModuleLinking">
-            <h1>InnerModuleLinking ( _module_, _stack_, _index_ )</h1>
-            <p>The abstract operation InnerModuleLinking takes arguments _module_ (a Cyclic Module Record), _stack_, and _index_ (a non-negative integer). It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together. It performs the following steps when called:</p>
+          <emu-clause id="sec-InnerModuleLinking" type="abstract operation" oldids="sec-innermoduleinstantiation">
+            <h1>
+              InnerModuleLinking (
+                _module_: a Cyclic Module Record,
+                _stack_: unknown,
+                _index_: a non-negative integer,
+              )
+            </h1>
+            <dl class="header">
+              <dt>description</dt>
+              <dd>It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together.</dd>
+            </dl>
 
             <emu-alg>
               1. If _module_ is not a Cyclic Module Record, then
@@ -22930,9 +25401,15 @@
           </emu-clause>
         </emu-clause>
 
-        <emu-clause id="sec-moduleevaluation">
+        <emu-clause id="sec-moduleevaluation" type="concrete method">
           <h1>Evaluate ( )</h1>
-          <p>The Evaluate concrete method of a Cyclic Module Record _module_ takes no arguments. Evaluate transitions this module's [[Status]] from ~linked~ to ~evaluated~. If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate. (Most of the work is done by the auxiliary function InnerModuleEvaluation.) It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a Cyclic Module Record _module_</dd>
+
+            <dt>description</dt>
+            <dd>Evaluate transitions this module's [[Status]] from ~linked~ to ~evaluated~. If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate. (Most of the work is done by the auxiliary function InnerModuleEvaluation.)</dd>
+          </dl>
 
           <emu-alg>
             1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
@@ -22951,9 +25428,18 @@
             1. Return *undefined*.
           </emu-alg>
 
-          <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
-            <h1>InnerModuleEvaluation ( _module_, _stack_, _index_ )</h1>
-            <p>The abstract operation InnerModuleEvaluation takes arguments _module_ (a Module Record), _stack_, and _index_ (a non-negative integer). It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking. It performs the following steps when called:</p>
+          <emu-clause id="sec-innermoduleevaluation" type="abstract operation">
+            <h1>
+              InnerModuleEvaluation (
+                _module_: a Module Record,
+                _stack_: unknown,
+                _index_: a non-negative integer,
+              )
+            </h1>
+            <dl class="header">
+              <dt>description</dt>
+              <dd>It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking.</dd>
+            </dl>
 
             <emu-alg>
               1. If _module_ is not a Cyclic Module Record, then
@@ -23537,9 +26023,18 @@
         </emu-note>
         <p>The following definitions specify the required concrete methods and other abstract operations for Source Text Module Records</p>
 
-        <emu-clause id="sec-parsemodule" aoid="ParseModule">
-          <h1>ParseModule ( _sourceText_, _realm_, _hostDefined_ )</h1>
-          <p>The abstract operation ParseModule takes arguments _sourceText_ (ECMAScript source text), _realm_, and _hostDefined_. It creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. It performs the following steps when called:</p>
+        <emu-clause id="sec-parsemodule" type="abstract operation">
+          <h1>
+            ParseModule (
+              _sourceText_: ECMAScript source text,
+              _realm_: unknown,
+              _hostDefined_: unknown,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
             1. Let _body_ be ParseText(_sourceText_, |Module|).
@@ -23574,9 +26069,16 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-getexportednames">
-          <h1>GetExportedNames ( [ _exportStarSet_ ] )</h1>
-          <p>The GetExportedNames concrete method of a Source Text Module Record _module_ takes optional argument _exportStarSet_. It performs the following steps when called:</p>
+        <emu-clause id="sec-getexportednames" type="concrete method">
+          <h1>
+            GetExportedNames (
+              optional _exportStarSet_: unknown,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a Source Text Module Record _module_</dd>
+          </dl>
           <emu-alg>
             1. If _exportStarSet_ is not present, set _exportStarSet_ to a new empty List.
             1. Assert: _exportStarSet_ is a List of Source Text Module Records.
@@ -23605,12 +26107,23 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-resolveexport">
-          <h1>ResolveExport ( _exportName_ [ , _resolveSet_ ] )</h1>
-          <p>The ResolveExport concrete method of a Source Text Module Record _module_ takes argument _exportName_ (a String) and optional argument _resolveSet_.</p>
-          <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
-          <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to *"\*namespace\*"*. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string *"ambiguous"* is returned.</p>
-          <p>This concrete method performs the following steps when called:</p>
+        <emu-clause id="sec-resolveexport" type="concrete method">
+          <h1>
+            ResolveExport (
+              _exportName_: a String,
+              optional _resolveSet_: unknown,
+            )
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a Source Text Module Record _module_</dd>
+
+            <dt>description</dt>
+            <dd>
+              <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
+              <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to *"\*namespace\*"*. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string *"ambiguous"* is returned.</p>
+            </dd>
+          </dl>
 
           <emu-alg>
             1. If _resolveSet_ is not present, set _resolveSet_ to a new empty List.
@@ -23652,9 +26165,12 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-source-text-module-record-initialize-environment" aoid="InitializeEnvironment">
+        <emu-clause id="sec-source-text-module-record-initialize-environment" type="concrete method">
           <h1>InitializeEnvironment ( )</h1>
-          <p>The InitializeEnvironment concrete method of a Source Text Module Record _module_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a Source Text Module Record _module_</dd>
+          </dl>
 
           <emu-alg>
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
@@ -23717,9 +26233,12 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-source-text-module-record-execute-module" aoid="ExecuteModule">
+        <emu-clause id="sec-source-text-module-record-execute-module" type="concrete method">
           <h1>ExecuteModule ( )</h1>
-          <p>The ExecuteModule concrete method of a Source Text Module Record _module_ takes no arguments. It performs the following steps when called:</p>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a Source Text Module Record _module_</dd>
+          </dl>
 
           <emu-alg>
             1. Suspend the currently running execution context.
@@ -23733,9 +26252,17 @@
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-hostresolveimportedmodule" aoid="HostResolveImportedModule">
-        <h1>HostResolveImportedModule ( _referencingScriptOrModule_, _specifier_ )</h1>
-        <p>The host-defined abstract operation HostResolveImportedModule takes arguments _referencingScriptOrModule_ (a Script Record or Module Record or *null*) and _specifier_ (a |ModuleSpecifier| String). It provides the concrete Module Record subclass instance that corresponds to _specifier_ occurring within the context of the script or module represented by _referencingScriptOrModule_. _referencingScriptOrModule_ may be *null* if the resolution is being performed in the context of an <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression and there is no active script or module at that time.</p>
+      <emu-clause id="sec-hostresolveimportedmodule" type="host-defined abstract operation">
+        <h1>
+          HostResolveImportedModule (
+            _referencingScriptOrModule_: a Script Record or Module Record or *null*,
+            _specifier_: a |ModuleSpecifier| String,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It provides the concrete Module Record subclass instance that corresponds to _specifier_ occurring within the context of the script or module represented by _referencingScriptOrModule_. _referencingScriptOrModule_ may be *null* if the resolution is being performed in the context of an <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression and there is no active script or module at that time.</dd>
+        </dl>
 
         <emu-note>
           <p>An example of when _referencingScriptOrModule_ can be *null* is in a web browser host. There, if a user clicks on a control given by</p>
@@ -23760,9 +26287,18 @@
         <p>Multiple different _referencingScriptOrModule_, _specifier_ pairs may map to the same Module Record instance. The actual mapping semantic is host-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>
       </emu-clause>
 
-      <emu-clause id="sec-hostimportmoduledynamically" aoid="HostImportModuleDynamically">
-        <h1>HostImportModuleDynamically ( _referencingScriptOrModule_, _specifier_, _promiseCapability_ )</h1>
-        <p>The host-defined abstract operation HostImportModuleDynamically takes arguments _referencingScriptOrModule_ (a Script Record or Module Record or *null*), _specifier_ (a |ModuleSpecifier| String), and _promiseCapability_ (a PromiseCapability Record). It performs any necessary setup work in order to make available the module corresponding to _specifier_ occurring within the context of the script or module represented by _referencingScriptOrModule_. _referencingScriptOrModule_ may be *null* if there is no active script or module when the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression occurs. It then performs FinishDynamicImport to finish the dynamic import process.</p>
+      <emu-clause id="sec-hostimportmoduledynamically" type="host-defined abstract operation">
+        <h1>
+          HostImportModuleDynamically (
+            _referencingScriptOrModule_: a Script Record or Module Record or *null*,
+            _specifier_: a |ModuleSpecifier| String,
+            _promiseCapability_: a PromiseCapability Record,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It performs any necessary setup work in order to make available the module corresponding to _specifier_ occurring within the context of the script or module represented by _referencingScriptOrModule_. _referencingScriptOrModule_ may be *null* if there is no active script or module when the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression occurs. It then performs FinishDynamicImport to finish the dynamic import process.</dd>
+        </dl>
         <p>The implementation of HostImportModuleDynamically must conform to the following requirements:</p>
 
         <ul>
@@ -23804,9 +26340,19 @@
         <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to allow HostResolveImportedModule to synchronously retrieve the appropriate Module Record, and then calling its Evaluate concrete method. This might require performing similar normalization as HostResolveImportedModule does.</p>
       </emu-clause>
 
-      <emu-clause id="sec-finishdynamicimport" aoid="FinishDynamicImport">
-        <h1>FinishDynamicImport ( _referencingScriptOrModule_, _specifier_, _promiseCapability_, _completion_ )</h1>
-        <p>The abstract operation FinishDynamicImport takes arguments _referencingScriptOrModule_, _specifier_, _promiseCapability_ (a PromiseCapability Record), and _completion_. FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically. It performs the following steps when called:</p>
+      <emu-clause id="sec-finishdynamicimport" type="abstract operation">
+        <h1>
+          FinishDynamicImport (
+            _referencingScriptOrModule_: unknown,
+            _specifier_: unknown,
+            _promiseCapability_: a PromiseCapability Record,
+            _completion_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically.</dd>
+        </dl>
         <emu-alg>
           1. If _completion_ is an abrupt completion, perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
           1. Else,
@@ -23819,9 +26365,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-getmodulenamespace" aoid="GetModuleNamespace">
-        <h1>GetModuleNamespace ( _module_ )</h1>
-        <p>The abstract operation GetModuleNamespace takes argument _module_. It retrieves the Module Namespace Object representing _module_'s exports, lazily creating it the first time it was requested, and storing it in _module_.[[Namespace]] for future retrieval. It performs the following steps when called:</p>
+      <emu-clause id="sec-getmodulenamespace" type="abstract operation">
+        <h1>
+          GetModuleNamespace (
+            _module_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It retrieves the Module Namespace Object representing _module_'s exports, lazily creating it the first time it was requested, and storing it in _module_.[[Namespace]] for future retrieval.</dd>
+        </dl>
 
         <emu-alg>
           1. Assert: _module_ is an instance of a concrete subclass of Module Record.
@@ -24514,9 +27067,17 @@
         1. Return ? PerformEval(_x_, _callerRealm_, *false*, *false*).
       </emu-alg>
 
-      <emu-clause id="sec-performeval" aoid="PerformEval" oldids="sec-performeval-rules-outside-functions,sec-performeval-rules-outside-methods,sec-performeval-rules-outside-constructors">
-        <h1>PerformEval ( _x_, _callerRealm_, _strictCaller_, _direct_ )</h1>
-        <p>The abstract operation PerformEval takes arguments _x_, _callerRealm_, _strictCaller_, and _direct_. It performs the following steps when called:</p>
+      <emu-clause id="sec-performeval" type="abstract operation" oldids="sec-performeval-rules-outside-functions,sec-performeval-rules-outside-methods,sec-performeval-rules-outside-constructors">
+        <h1>
+          PerformEval (
+            _x_: unknown,
+            _callerRealm_: unknown,
+            _strictCaller_: unknown,
+            _direct_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
           1. If Type(_x_) is not String, return _x_.
@@ -24580,15 +27141,32 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-hostensurecancompilestrings" aoid="HostEnsureCanCompileStrings">
-        <h1>HostEnsureCanCompileStrings ( _callerRealm_, _calleeRealm_ )</h1>
-        <p>The host-defined abstract operation HostEnsureCanCompileStrings takes arguments _callerRealm_ (a Realm Record) and _calleeRealm_ (a Realm Record). It allows host environments to block certain ECMAScript functions which allow developers to compile strings into ECMAScript code.</p>
+      <emu-clause id="sec-hostensurecancompilestrings" type="host-defined abstract operation">
+        <h1>
+          HostEnsureCanCompileStrings (
+            _callerRealm_: a Realm Record,
+            _calleeRealm_: a Realm Record,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It allows host environments to block certain ECMAScript functions which allow developers to compile strings into ECMAScript code.</dd>
+        </dl>
         <p>An implementation of HostEnsureCanCompileStrings may complete normally or abruptly. Any abrupt completions will be propagated to its callers. The default implementation of HostEnsureCanCompileStrings is to unconditionally return an empty normal completion.</p>
       </emu-clause>
 
-      <emu-clause id="sec-evaldeclarationinstantiation" aoid="EvalDeclarationInstantiation">
-        <h1>EvalDeclarationInstantiation ( _body_, _varEnv_, _lexEnv_, _privateEnv_, _strict_ )</h1>
-        <p>The abstract operation EvalDeclarationInstantiation takes arguments _body_, _varEnv_, _lexEnv_, _privateEnv_, and _strict_. It performs the following steps when called:</p>
+      <emu-clause id="sec-evaldeclarationinstantiation" type="abstract operation">
+        <h1>
+          EvalDeclarationInstantiation (
+            _body_: unknown,
+            _varEnv_: unknown,
+            _lexEnv_: unknown,
+            _privateEnv_: unknown,
+            _strict_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <!--
           WARNING: If you add, remove, rename, or repurpose any variable names
                    within this algorithm, you may need to update
@@ -24812,9 +27390,17 @@
         <h2>Runtime Semantics</h2>
         <p>When a code unit to be included in a URI is not listed above or is not intended to have the special meaning sometimes given to the reserved code units, that code unit must be encoded. The code unit is transformed into its UTF-8 encoding, with <emu-xref href="#surrogate-pair">surrogate pairs</emu-xref> first converted from UTF-16 to the corresponding code point value. (Note that for code units in the range [0, 127] this results in a single octet with the same value.) The resulting sequence of octets is then transformed into a String with each octet represented by an escape sequence of the form *"%xx"*.</p>
 
-        <emu-clause id="sec-encode" aoid="Encode">
-          <h1>Encode ( _string_, _unescapedSet_ )</h1>
-          <p>The abstract operation Encode takes arguments _string_ (a String) and _unescapedSet_ (a String). It performs URI encoding and escaping. It performs the following steps when called:</p>
+        <emu-clause id="sec-encode" type="abstract operation">
+          <h1>
+            Encode (
+              _string_: a String,
+              _unescapedSet_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It performs URI encoding and escaping.</dd>
+          </dl>
           <emu-alg>
             1. Let _strLen_ be the number of code units in _string_.
             1. Let _R_ be the empty String.
@@ -24838,9 +27424,17 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-decode" aoid="Decode">
-          <h1>Decode ( _string_, _reservedSet_ )</h1>
-          <p>The abstract operation Decode takes arguments _string_ (a String) and _reservedSet_ (a String). It performs URI unescaping and decoding. It performs the following steps when called:</p>
+        <emu-clause id="sec-decode" type="abstract operation">
+          <h1>
+            Decode (
+              _string_: a String,
+              _reservedSet_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It performs URI unescaping and decoding.</dd>
+          </dl>
           <emu-alg>
             1. Let _strLen_ be the length of _string_.
             1. Let _R_ be the empty String.
@@ -25415,9 +28009,15 @@
           1. Return ? ObjectDefineProperties(_O_, _Properties_).
         </emu-alg>
 
-        <emu-clause id="sec-objectdefineproperties" aoid="ObjectDefineProperties">
-          <h1>ObjectDefineProperties ( _O_, _Properties_ )</h1>
-          <p>The abstract operation ObjectDefineProperties takes arguments _O_ and _Properties_. It performs the following steps when called:</p>
+        <emu-clause id="sec-objectdefineproperties" type="abstract operation">
+          <h1>
+            ObjectDefineProperties (
+              _O_: unknown,
+              _Properties_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_O_) is Object.
             1. Let _props_ be ? ToObject(_Properties_).
@@ -25531,9 +28131,15 @@
           1. Return ? GetOwnPropertyKeys(_O_, ~symbol~).
         </emu-alg>
 
-        <emu-clause id="sec-getownpropertykeys" aoid="GetOwnPropertyKeys">
-          <h1>GetOwnPropertyKeys ( _O_, _type_ )</h1>
-          <p>The abstract operation GetOwnPropertyKeys takes arguments _O_ and _type_ (either ~string~ or ~symbol~). It performs the following steps when called:</p>
+        <emu-clause id="sec-getownpropertykeys" type="abstract operation">
+          <h1>
+            GetOwnPropertyKeys (
+              _O_: unknown,
+              _type_: either ~string~ or ~symbol~,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _obj_ be ? ToObject(_O_).
             1. Let _keys_ be ? _obj_.[[OwnPropertyKeys]]().
@@ -25803,9 +28409,19 @@
           </code></pre>
         </emu-note>
 
-        <emu-clause id="sec-createdynamicfunction" aoid="CreateDynamicFunction">
-          <h1>CreateDynamicFunction ( _constructor_, _newTarget_, _kind_, _args_ )</h1>
-          <p>The abstract operation CreateDynamicFunction takes arguments _constructor_ (a constructor), _newTarget_ (a constructor), _kind_ (either ~normal~, ~generator~, ~async~, or ~asyncGenerator~), and _args_ (a List of ECMAScript language values). _constructor_ is the constructor function that is performing this action. _newTarget_ is the constructor that `new` was initially applied to. _args_ is the argument values that were passed to _constructor_. It performs the following steps when called:</p>
+        <emu-clause id="sec-createdynamicfunction" type="abstract operation">
+          <h1>
+            CreateDynamicFunction (
+              _constructor_: a constructor,
+              _newTarget_: a constructor,
+              _kind_: either ~normal~, ~generator~, ~async~, or ~asyncGenerator~,
+              _args_: a List of ECMAScript language values,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>_constructor_ is the constructor function that is performing this action. _newTarget_ is the constructor that `new` was initially applied to. _args_ is the argument values that were passed to _constructor_.</dd>
+          </dl>
           <emu-alg>
             1. Assert: The execution context stack has at least two elements.
             1. Let _callerContext_ be the second to top element of the execution context stack.
@@ -26082,9 +28698,16 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-hosthassourcetextavailable" aoid="HostHasSourceTextAvailable">
-      <h1>HostHasSourceTextAvailable ( _func_ )</h1>
-      <p>The host-defined abstract operation HostHasSourceTextAvailable takes argument _func_ (a function object). It allows host environments to prevent the source text from being provided for _func_.</p>
+    <emu-clause id="sec-hosthassourcetextavailable" type="host-defined abstract operation">
+      <h1>
+        HostHasSourceTextAvailable (
+          _func_: a function object,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It allows host environments to prevent the source text from being provided for _func_.</dd>
+      </dl>
       <p>An implementation of HostHasSourceTextAvailable must complete normally in all cases. This operation must be deterministic with respect to its parameters. Each time it is called with a specific _func_ as its argument, it must return the same completion record. The default implementation of HostHasSourceTextAvailable is to unconditionally return a normal completion with a value of *true*.</p>
     </emu-clause>
   </emu-clause>
@@ -26407,9 +29030,14 @@
           1. Return SymbolDescriptiveString(_sym_).
         </emu-alg>
 
-        <emu-clause id="sec-symboldescriptivestring" aoid="SymbolDescriptiveString">
-          <h1>SymbolDescriptiveString ( _sym_ )</h1>
-          <p>The abstract operation SymbolDescriptiveString takes argument _sym_. It performs the following steps when called:</p>
+        <emu-clause id="sec-symboldescriptivestring" type="abstract operation">
+          <h1>
+            SymbolDescriptiveString (
+              _sym_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_sym_) is Symbol.
             1. Let _desc_ be _sym_'s [[Description]] value.
@@ -27119,9 +29747,14 @@
           1. Otherwise, return ? ToBigInt(_value_).
         </emu-alg>
 
-        <emu-clause id="sec-numbertobigint" aoid="NumberToBigInt">
-          <h1>NumberToBigInt ( _number_ )</h1>
-          <p>The abstract operation NumberToBigInt takes argument _number_ (a Number). It performs the following steps when called:</p>
+        <emu-clause id="sec-numbertobigint" type="abstract operation">
+          <h1>
+            NumberToBigInt (
+              _number_: a Number,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If IsIntegralNumber(_number_) is *false*, throw a *RangeError* exception.
             1. Return the BigInt value that represents ℝ(_number_).
@@ -27923,9 +30556,17 @@
         <p>A weekday value of *+0*<sub>𝔽</sub> specifies Sunday; *1*<sub>𝔽</sub> specifies Monday; *2*<sub>𝔽</sub> specifies Tuesday; *3*<sub>𝔽</sub> specifies Wednesday; *4*<sub>𝔽</sub> specifies Thursday; *5*<sub>𝔽</sub> specifies Friday; and *6*<sub>𝔽</sub> specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = *4*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</p>
       </emu-clause>
 
-      <emu-clause id="sec-local-time-zone-adjustment" aoid="LocalTZA">
-        <h1>LocalTZA ( _t_, _isUTC_ )</h1>
-        <p>The implementation-defined abstract operation LocalTZA takes arguments _t_ and _isUTC_. It returns an integral Number representing the local time zone adjustment, or offset, in milliseconds. The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.</p>
+      <emu-clause id="sec-local-time-zone-adjustment" type="implementation-defined abstract operation">
+        <h1>
+          LocalTZA (
+            _t_: unknown,
+            _isUTC_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns an integral Number representing the local time zone adjustment, or offset, in milliseconds. The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.</dd>
+        </dl>
         <p>When _isUTC_ is true, <emu-eqn>LocalTZA( _t_<sub>UTC</sub>, true )</emu-eqn> should return the offset of the local time zone from UTC measured in milliseconds at time represented by time value <emu-eqn>_t_<sub>UTC</sub></emu-eqn>. When the result is added to <emu-eqn>_t_<sub>UTC</sub></emu-eqn>, it should yield the corresponding Number <emu-eqn>_t_<sub>local</sub></emu-eqn>.</p>
         <p>When _isUTC_ is false, <emu-eqn>LocalTZA( _t_<sub>local</sub>, false )</emu-eqn> should return the offset of the local time zone from UTC measured in milliseconds at local time represented by Number <emu-eqn>_t_<sub>local</sub></emu-eqn>. When the result is subtracted from <emu-eqn>_t_<sub>local</sub></emu-eqn>, it should yield the corresponding time value <emu-eqn>_t_<sub>UTC</sub></emu-eqn>.</p>
         <p>Input _t_ is nominally a time value but may be any Number value. This can occur when _isUTC_ is false and _t_<sub>local</sub> represents a time value that is already offset outside of the time value range at the range boundaries. The algorithm must not limit _t_<sub>local</sub> to the time value range, so that such inputs are supported.</p>
@@ -27939,9 +30580,16 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-localtime" aoid="LocalTime">
-        <h1>LocalTime ( _t_ )</h1>
-        <p>The abstract operation LocalTime takes argument _t_. It converts _t_ from UTC to local time. It performs the following steps when called:</p>
+      <emu-clause id="sec-localtime" type="abstract operation">
+        <h1>
+          LocalTime (
+            _t_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It converts _t_ from UTC to local time.</dd>
+        </dl>
         <emu-alg>
           1. Return _t_ + LocalTZA(_t_, *true*).
         </emu-alg>
@@ -27951,9 +30599,16 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-utc-t" aoid="UTC">
-        <h1>UTC ( _t_ )</h1>
-        <p>The abstract operation UTC takes argument _t_. It converts _t_ from local time to UTC. It performs the following steps when called:</p>
+      <emu-clause id="sec-utc-t" type="abstract operation">
+        <h1>
+          UTC (
+            _t_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It converts _t_ from local time to UTC.</dd>
+        </dl>
         <emu-alg>
           1. Return _t_ - LocalTZA(_t_, *false*).
         </emu-alg>
@@ -27978,9 +30633,19 @@
         <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = *3600000*<sub>𝔽</sub> = msPerMinute &times; 𝔽(MinutesPerHour)</emu-eqn>
       </emu-clause>
 
-      <emu-clause id="sec-maketime" aoid="MakeTime">
-        <h1>MakeTime ( _hour_, _min_, _sec_, _ms_ )</h1>
-        <p>The abstract operation MakeTime takes arguments _hour_ (a Number), _min_ (a Number), _sec_ (a Number), and _ms_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
+      <emu-clause id="sec-maketime" type="abstract operation">
+        <h1>
+          MakeTime (
+            _hour_: a Number,
+            _min_: a Number,
+            _sec_: a Number,
+            _ms_: a Number,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It calculates a number of milliseconds.</dd>
+        </dl>
         <emu-alg>
           1. If _hour_ is not finite or _min_ is not finite or _sec_ is not finite or _ms_ is not finite, return *NaN*.
           1. Let _h_ be 𝔽(! ToIntegerOrInfinity(_hour_)).
@@ -27992,9 +30657,18 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-makeday" aoid="MakeDay">
-        <h1>MakeDay ( _year_, _month_, _date_ )</h1>
-        <p>The abstract operation MakeDay takes arguments _year_ (a Number), _month_ (a Number), and _date_ (a Number). It calculates a number of days. It performs the following steps when called:</p>
+      <emu-clause id="sec-makeday" type="abstract operation">
+        <h1>
+          MakeDay (
+            _year_: a Number,
+            _month_: a Number,
+            _date_: a Number,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It calculates a number of days.</dd>
+        </dl>
         <emu-alg>
           1. If _year_ is not finite or _month_ is not finite or _date_ is not finite, return *NaN*.
           1. Let _y_ be 𝔽(! ToIntegerOrInfinity(_year_)).
@@ -28008,9 +30682,17 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-makedate" aoid="MakeDate">
-        <h1>MakeDate ( _day_, _time_ )</h1>
-        <p>The abstract operation MakeDate takes arguments _day_ (a Number) and _time_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
+      <emu-clause id="sec-makedate" type="abstract operation">
+        <h1>
+          MakeDate (
+            _day_: a Number,
+            _time_: a Number,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It calculates a number of milliseconds.</dd>
+        </dl>
         <emu-alg>
           1. If _day_ is not finite or _time_ is not finite, return *NaN*.
           1. Let _tv_ be _day_ &times; msPerDay + _time_.
@@ -28019,9 +30701,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-timeclip" aoid="TimeClip">
-        <h1>TimeClip ( _time_ )</h1>
-        <p>The abstract operation TimeClip takes argument _time_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
+      <emu-clause id="sec-timeclip" type="abstract operation">
+        <h1>
+          TimeClip (
+            _time_: a Number,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It calculates a number of milliseconds.</dd>
+        </dl>
         <emu-alg>
           1. If _time_ is not finite, return *NaN*.
           1. If abs(ℝ(_time_)) &gt; 8.64 &times; 10<sup>15</sup>, return *NaN*.
@@ -28850,9 +31539,14 @@ THH:mm:ss.sss
           <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Date object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <emu-clause id="sec-timestring" aoid="TimeString">
-          <h1>TimeString ( _tv_ )</h1>
-          <p>The abstract operation TimeString takes argument _tv_. It performs the following steps when called:</p>
+        <emu-clause id="sec-timestring" type="abstract operation">
+          <h1>
+            TimeString (
+              _tv_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
@@ -28863,9 +31557,14 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-datestring" aoid="DateString">
-          <h1>DateString ( _tv_ )</h1>
-          <p>The abstract operation DateString takes argument _tv_. It performs the following steps when called:</p>
+        <emu-clause id="sec-datestring" type="abstract operation">
+          <h1>
+            DateString (
+              _tv_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
@@ -29060,9 +31759,14 @@ THH:mm:ss.sss
           </emu-table>
         </emu-clause>
 
-        <emu-clause id="sec-timezoneestring" aoid="TimeZoneString">
-          <h1>TimeZoneString ( _tv_ )</h1>
-          <p>The abstract operation TimeZoneString takes argument _tv_. It performs the following steps when called:</p>
+        <emu-clause id="sec-timezoneestring" type="abstract operation">
+          <h1>
+            TimeZoneString (
+              _tv_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
@@ -29080,9 +31784,14 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-todatestring" aoid="ToDateString">
-          <h1>ToDateString ( _tv_ )</h1>
-          <p>The abstract operation ToDateString takes argument _tv_. It performs the following steps when called:</p>
+        <emu-clause id="sec-todatestring" type="abstract operation">
+          <h1>
+            ToDateString (
+              _tv_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. If _tv_ is *NaN*, return *"Invalid Date"*.
@@ -29569,9 +32278,17 @@ THH:mm:ss.sss
           1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~start~).
         </emu-alg>
 
-        <emu-clause id="sec-stringpad" aoid="StringPad">
-          <h1>StringPad ( _O_, _maxLength_, _fillString_, _placement_ )</h1>
-          <p>The abstract operation StringPad takes arguments _O_, _maxLength_, _fillString_, and _placement_. It performs the following steps when called:</p>
+        <emu-clause id="sec-stringpad" type="abstract operation">
+          <h1>
+            StringPad (
+              _O_: unknown,
+              _maxLength_: unknown,
+              _fillString_: unknown,
+              _placement_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _placement_ is ~start~ or ~end~.
             1. Let _S_ be ? ToString(_O_).
@@ -29644,9 +32361,19 @@ THH:mm:ss.sss
           <p>The `replace` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <emu-clause id="sec-getsubstitution" aoid="GetSubstitution">
-          <h1>GetSubstitution ( _matched_, _str_, _position_, _captures_, _namedCaptures_, _replacement_ )</h1>
-          <p>The abstract operation GetSubstitution takes arguments _matched_, _str_, _position_ (a non-negative integer), _captures_, _namedCaptures_, and _replacement_. It performs the following steps when called:</p>
+        <emu-clause id="sec-getsubstitution" type="abstract operation">
+          <h1>
+            GetSubstitution (
+              _matched_: unknown,
+              _str_: unknown,
+              _position_: a non-negative integer,
+              _captures_: unknown,
+              _namedCaptures_: unknown,
+              _replacement_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_matched_) is String.
             1. Let _matchLength_ be the number of code units in _matched_.
@@ -29928,9 +32655,18 @@ THH:mm:ss.sss
           <p>The `split` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <emu-clause id="sec-splitmatch" aoid="SplitMatch">
-          <h1>SplitMatch ( _S_, _q_, _R_ )</h1>
-          <p>The abstract operation SplitMatch takes arguments _S_ (a String), _q_ (a non-negative integer), and _R_ (a String). It returns either ~not-matched~ or the end index of a match. It performs the following steps when called:</p>
+        <emu-clause id="sec-splitmatch" type="abstract operation">
+          <h1>
+            SplitMatch (
+              _S_: a String,
+              _q_: a non-negative integer,
+              _R_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns either ~not-matched~ or the end index of a match.</dd>
+          </dl>
           <emu-alg>
             1. Let _r_ be the number of code units in _R_.
             1. Let _s_ be the number of code units in _S_.
@@ -30068,9 +32804,17 @@ THH:mm:ss.sss
           <p>The `trim` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <emu-clause id="sec-trimstring" aoid="TrimString">
-          <h1>TrimString ( _string_, _where_ )</h1>
-          <p>The abstract operation TrimString takes arguments _string_ and _where_. It interprets _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
+        <emu-clause id="sec-trimstring" type="abstract operation">
+          <h1>
+            TrimString (
+              _string_: unknown,
+              _where_: unknown,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It interprets _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</dd>
+          </dl>
           <emu-alg>
             1. Let _str_ be ? RequireObjectCoercible(_string_).
             1. Let _S_ be ? ToString(_str_).
@@ -30934,9 +33678,21 @@ THH:mm:ss.sss
             1. Return ! RepeatMatcher(_m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_).
         </emu-alg>
 
-        <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" aoid="RepeatMatcher">
-          <h1>RepeatMatcher ( _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_ )</h1>
-          <p>The abstract operation RepeatMatcher takes arguments _m_ (a Matcher), _min_ (a non-negative integer), _max_ (a non-negative integer or +&infin;), _greedy_ (a Boolean), _x_ (a State), _c_ (a Continuation), _parenIndex_ (a non-negative integer), and _parenCount_ (a non-negative integer). It performs the following steps when called:</p>
+        <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" type="abstract operation">
+          <h1>
+            RepeatMatcher (
+              _m_: a Matcher,
+              _min_: a non-negative integer,
+              _max_: a non-negative integer or +&infin;,
+              _greedy_: a Boolean,
+              _x_: a State,
+              _c_: a Continuation,
+              _parenIndex_: a non-negative integer,
+              _parenCount_: a non-negative integer,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _max_ = 0, return _c_(_x_).
             1. Let _d_ be a new Continuation with parameters (_y_) that captures _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, and _parenCount_ and performs the following steps when called:
@@ -31109,9 +33865,14 @@ THH:mm:ss.sss
             1. Return _c_(_x_).
         </emu-alg>
 
-        <emu-clause id="sec-runtime-semantics-iswordchar-abstract-operation" aoid="IsWordChar">
-          <h1>IsWordChar ( _e_ )</h1>
-          <p>The abstract operation IsWordChar takes argument _e_ (an integer). It performs the following steps when called:</p>
+        <emu-clause id="sec-runtime-semantics-iswordchar-abstract-operation" type="abstract operation">
+          <h1>
+            IsWordChar (
+              _e_: an integer,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _e_ = -1 or _e_ is _InputLength_, return *false*.
             1. Let _c_ be the character _Input_[_e_].
@@ -31216,9 +33977,16 @@ THH:mm:ss.sss
           1. Return the Matcher that is the result of evaluating |Disjunction| with argument _direction_.
         </emu-alg>
 
-        <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" aoid="CharacterSetMatcher">
-          <h1>CharacterSetMatcher ( _A_, _invert_, _direction_ )</h1>
-          <p>The abstract operation CharacterSetMatcher takes arguments _A_ (a CharSet), _invert_ (a Boolean), and _direction_ (1 or -1). It performs the following steps when called:</p>
+        <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" type="abstract operation">
+          <h1>
+            CharacterSetMatcher (
+              _A_: a CharSet,
+              _invert_: a Boolean,
+              _direction_: 1 or -1,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Return a new Matcher with parameters (_x_, _c_) that captures _A_, _invert_, and _direction_ and performs the following steps when called:
               1. Assert: _x_ is a State.
@@ -31238,9 +34006,14 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-runtime-semantics-canonicalize-ch" aoid="Canonicalize">
-          <h1>Canonicalize ( _ch_ )</h1>
-          <p>The abstract operation Canonicalize takes argument _ch_ (a character). It performs the following steps when called:</p>
+        <emu-clause id="sec-runtime-semantics-canonicalize-ch" type="abstract operation">
+          <h1>
+            Canonicalize (
+              _ch_: a character,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _Unicode_ is *true* and _IgnoreCase_ is *true*, then
               1. If the file CaseFolding.txt of the Unicode Character Database provides a simple or common case folding mapping for _ch_, return the result of applying that mapping to _ch_.
@@ -31281,9 +34054,14 @@ THH:mm:ss.sss
             <p>In case-insignificant matches when _Unicode_ is *true*, all characters are implicitly case-folded using the simple mapping provided by the Unicode standard immediately before they are compared. The simple mapping always maps to a single code point, so it does not map, for example, `&szlig;` (U+00DF) to `SS`. It may however map a code point outside the Basic Latin range to a character within, for example, `&#x17f;` (U+017F) to `s`. Such characters are not mapped if _Unicode_ is *false*. This prevents Unicode code points such as U+017F and U+212A from matching regular expressions such as `/[a-z]/i`, but they will match `/[a-z]/ui`.</p>
           </emu-note>
         </emu-clause>
-        <emu-clause id="sec-runtime-semantics-unicodematchproperty-p" aoid="UnicodeMatchProperty">
-          <h1>UnicodeMatchProperty ( _p_ )</h1>
-          <p>The abstract operation UnicodeMatchProperty takes argument _p_ (a List of Unicode code points). It performs the following steps when called:</p>
+        <emu-clause id="sec-runtime-semantics-unicodematchproperty-p" type="abstract operation">
+          <h1>
+            UnicodeMatchProperty (
+              _p_: a List of Unicode code points,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _p_ is a List of Unicode code points that is identical to a List of Unicode code points that is a Unicode <emu-not-ref>property name</emu-not-ref> or property alias listed in the &ldquo;<emu-not-ref>Property name</emu-not-ref> and aliases&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref> or <emu-xref href="#table-binary-unicode-properties"></emu-xref>.
             1. Let _c_ be the canonical <emu-not-ref>property name</emu-not-ref> of _p_ as given in the &ldquo;Canonical <emu-not-ref>property name</emu-not-ref>&rdquo; column of the corresponding row.
@@ -31299,9 +34077,15 @@ THH:mm:ss.sss
           <emu-import href="table-nonbinary-unicode-properties.html"></emu-import>
           <emu-import href="table-binary-unicode-properties.html"></emu-import>
         </emu-clause>
-        <emu-clause id="sec-runtime-semantics-unicodematchpropertyvalue-p-v" aoid="UnicodeMatchPropertyValue">
-          <h1>UnicodeMatchPropertyValue ( _p_, _v_ )</h1>
-          <p>The abstract operation UnicodeMatchPropertyValue takes arguments _p_ (a List of Unicode code points) and _v_ (a List of Unicode code points). It performs the following steps when called:</p>
+        <emu-clause id="sec-runtime-semantics-unicodematchpropertyvalue-p-v" type="abstract operation">
+          <h1>
+            UnicodeMatchPropertyValue (
+              _p_: a List of Unicode code points,
+              _v_: a List of Unicode code points,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _p_ is a List of Unicode code points that is identical to a List of Unicode code points that is a canonical, unaliased Unicode property name listed in the &ldquo;Canonical property name&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
             1. Assert: _v_ is a List of Unicode code points that is identical to a List of Unicode code points that is a property value or property value alias for Unicode property _p_ listed in the &ldquo;Property value and aliases&rdquo; column of <emu-xref href="#table-unicode-general-category-values"></emu-xref> or <emu-xref href="#table-unicode-script-values"></emu-xref>.
@@ -31351,9 +34135,15 @@ THH:mm:ss.sss
           1. Return ! BackreferenceMatcher(_parenIndex_, _direction_).
         </emu-alg>
 
-        <emu-clause id="sec-backreference-matcher" aoid="BackreferenceMatcher">
-          <h1>BackreferenceMatcher ( _n_, _direction_ )</h1>
-          <p>The abstract operation BackreferenceMatcher takes arguments _n_ (a positive integer) and _direction_ (1 or -1). It performs the following steps when called:</p>
+        <emu-clause id="sec-backreference-matcher" type="abstract operation">
+          <h1>
+            BackreferenceMatcher (
+              _n_: a positive integer,
+              _direction_: 1 or -1,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _n_ &ge; 1.
             1. Return a new Matcher with parameters (_x_, _c_) that captures _n_ and _direction_ and performs the following steps when called:
@@ -31505,9 +34295,15 @@ THH:mm:ss.sss
           1. Return the union of _D_ and _C_.
         </emu-alg>
 
-        <emu-clause id="sec-runtime-semantics-characterrange-abstract-operation" aoid="CharacterRange">
-          <h1>CharacterRange ( _A_, _B_ )</h1>
-          <p>The abstract operation CharacterRange takes arguments _A_ (a CharSet) and _B_ (a CharSet). It performs the following steps when called:</p>
+        <emu-clause id="sec-runtime-semantics-characterrange-abstract-operation" type="abstract operation">
+          <h1>
+            CharacterRange (
+              _A_: a CharSet,
+              _B_: a CharSet,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _A_ and _B_ each contain exactly one character.
             1. Let _a_ be the one character in CharSet _A_.
@@ -31646,9 +34442,14 @@ THH:mm:ss.sss
       <emu-clause id="sec-abstract-operations-for-the-regexp-constructor">
         <h1>Abstract Operations for the RegExp Constructor</h1>
 
-        <emu-clause id="sec-regexpalloc" aoid="RegExpAlloc">
-          <h1>RegExpAlloc ( _newTarget_ )</h1>
-          <p>The abstract operation RegExpAlloc takes argument _newTarget_. It performs the following steps when called:</p>
+        <emu-clause id="sec-regexpalloc" type="abstract operation">
+          <h1>
+            RegExpAlloc (
+              _newTarget_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%RegExp.prototype%"*, &laquo; [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] &raquo;).
             1. Perform ! DefinePropertyOrThrow(_obj_, *"lastIndex"*, PropertyDescriptor { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
@@ -31656,9 +34457,16 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-regexpinitialize" aoid="RegExpInitialize">
-          <h1>RegExpInitialize ( _obj_, _pattern_, _flags_ )</h1>
-          <p>The abstract operation RegExpInitialize takes arguments _obj_, _pattern_, and _flags_. It performs the following steps when called:</p>
+        <emu-clause id="sec-regexpinitialize" type="abstract operation">
+          <h1>
+            RegExpInitialize (
+              _obj_: unknown,
+              _pattern_: unknown,
+              _flags_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _pattern_ is *undefined*, let _P_ be the empty String.
             1. Else, let _P_ be ? ToString(_pattern_).
@@ -31683,9 +34491,15 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-parsepattern" aoid="ParsePattern">
-          <h1>Static Semantics: ParsePattern ( _patternText_, _u_ )</h1>
-          <p>The abstract operation ParsePattern takes arguments _patternText_ (a sequence of Unicode code points) and _u_ (a Boolean). It performs the following steps when called:</p>
+        <emu-clause id="sec-parsepattern" type="abstract operation">
+          <h1>
+            Static Semantics: ParsePattern (
+              _patternText_: a sequence of Unicode code points,
+              _u_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _u_ is *true*, then
               1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+U, +N]|).
@@ -31697,18 +34511,30 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-regexpcreate" aoid="RegExpCreate">
-          <h1>RegExpCreate ( _P_, _F_ )</h1>
-          <p>The abstract operation RegExpCreate takes arguments _P_ and _F_. It performs the following steps when called:</p>
+        <emu-clause id="sec-regexpcreate" type="abstract operation">
+          <h1>
+            RegExpCreate (
+              _P_: unknown,
+              _F_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _obj_ be ? RegExpAlloc(%RegExp%).
             1. Return ? RegExpInitialize(_obj_, _P_, _F_).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-escaperegexppattern" aoid="EscapeRegExpPattern">
-          <h1>EscapeRegExpPattern ( _P_, _F_ )</h1>
-          <p>The abstract operation EscapeRegExpPattern takes arguments _P_ and _F_. It performs the following steps when called:</p>
+        <emu-clause id="sec-escaperegexppattern" type="abstract operation">
+          <h1>
+            EscapeRegExpPattern (
+              _P_: unknown,
+              _F_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _S_ be a String in the form of a |Pattern[~U]| (|Pattern[+U]| if _F_ contains *"u"*) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the Abstract Closure that would result from evaluating _S_ as a |Pattern[~U]| (|Pattern[+U]| if _F_ contains *"u"*) must behave identically to the Abstract Closure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
             1. The code points `/` or any |LineTerminator| occurring in the pattern shall be escaped in _S_ as necessary to ensure that the string-concatenation of *"/"*, _S_, *"/"*, and _F_ can be parsed (in an appropriate lexical context) as a |RegularExpressionLiteral| that behaves identically to the constructed regular expression. For example, if _P_ is *"/"*, then _S_ could be *"\\/"* or *"\\u002F"*, among other possibilities, but not *"/"*, because `///` followed by _F_ would be parsed as a |SingleLineComment| rather than a |RegularExpressionLiteral|. If _P_ is the empty String, this specification can be met by letting _S_ be *"(?:)"*.
@@ -31774,9 +34600,15 @@ THH:mm:ss.sss
           1. Return ? RegExpBuiltinExec(_R_, _S_).
         </emu-alg>
 
-        <emu-clause id="sec-regexpexec" aoid="RegExpExec">
-          <h1>RegExpExec ( _R_, _S_ )</h1>
-          <p>The abstract operation RegExpExec takes arguments _R_ and _S_. It performs the following steps when called:</p>
+        <emu-clause id="sec-regexpexec" type="abstract operation">
+          <h1>
+            RegExpExec (
+              _R_: unknown,
+              _S_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_R_) is Object.
             1. Assert: Type(_S_) is String.
@@ -31793,9 +34625,15 @@ THH:mm:ss.sss
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-regexpbuiltinexec" aoid="RegExpBuiltinExec">
-          <h1>RegExpBuiltinExec ( _R_, _S_ )</h1>
-          <p>The abstract operation RegExpBuiltinExec takes arguments _R_ and _S_. It performs the following steps when called:</p>
+        <emu-clause id="sec-regexpbuiltinexec" type="abstract operation">
+          <h1>
+            RegExpBuiltinExec (
+              _R_: unknown,
+              _S_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _R_ is an initialized RegExp instance.
             1. Assert: Type(_S_) is String.
@@ -31859,9 +34697,16 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-advancestringindex" aoid="AdvanceStringIndex">
-          <h1>AdvanceStringIndex ( _S_, _index_, _unicode_ )</h1>
-          <p>The abstract operation AdvanceStringIndex takes arguments _S_ (a String), _index_ (a non-negative integer), and _unicode_ (a Boolean). It performs the following steps when called:</p>
+        <emu-clause id="sec-advancestringindex" type="abstract operation">
+          <h1>
+            AdvanceStringIndex (
+              _S_: a String,
+              _index_: a non-negative integer,
+              _unicode_: a Boolean,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _index_ &le; 2<sup>53</sup> - 1.
             1. If _unicode_ is *false*, return _index_ + 1.
@@ -31882,9 +34727,15 @@ THH:mm:ss.sss
           1. Return ? RegExpHasFlag(_R_, _cu_).
         </emu-alg>
 
-        <emu-clause id="sec-regexphasflag" aoid="RegExpHasFlag">
-          <h1>RegExpHasFlag ( _R_, _codeUnit_ )</h1>
-          <p>The abstract operation RegExpHasFlag takes arguments _R_ (an ECMAScript language value) and _codeUnit_ (a code unit). It performs the following steps when called:</p>
+        <emu-clause id="sec-regexphasflag" type="abstract operation">
+          <h1>
+            RegExpHasFlag (
+              _R_: an ECMAScript language value,
+              _codeUnit_: a code unit,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If Type(_R_) is not Object, throw a *TypeError* exception.
             1. If _R_ does not have an [[OriginalFlags]] internal slot, then
@@ -32251,9 +35102,17 @@ THH:mm:ss.sss
       <h1>RegExp String Iterator Objects</h1>
       <p>A RegExp String Iterator is an object, that represents a specific iteration over some specific String instance object, matching against some specific RegExp instance object. There is not a named constructor for RegExp String Iterator objects. Instead, RegExp String Iterator objects are created by calling certain methods of RegExp instance objects.</p>
 
-      <emu-clause id="sec-createregexpstringiterator" aoid="CreateRegExpStringIterator" oldids="sec-properties-of-regexp-string-iterator-instances,table-regexp-string-iterator-instance-slots">
-        <h1>CreateRegExpStringIterator ( _R_, _S_, _global_, _fullUnicode_ )</h1>
-        <p>The abstract operation CreateRegExpStringIterator takes arguments _R_, _S_, _global_, and _fullUnicode_. It performs the following steps when called:</p>
+      <emu-clause id="sec-createregexpstringiterator" type="abstract operation" oldids="sec-properties-of-regexp-string-iterator-instances,table-regexp-string-iterator-instance-slots">
+        <h1>
+          CreateRegExpStringIterator (
+            _R_: unknown,
+            _S_: unknown,
+            _global_: unknown,
+            _fullUnicode_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Type(_S_) is String.
           1. Assert: Type(_global_) is Boolean.
@@ -32528,9 +35387,14 @@ THH:mm:ss.sss
           <p>The `concat` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <emu-clause id="sec-isconcatspreadable" aoid="IsConcatSpreadable">
-          <h1>IsConcatSpreadable ( _O_ )</h1>
-          <p>The abstract operation IsConcatSpreadable takes argument _O_. It performs the following steps when called:</p>
+        <emu-clause id="sec-isconcatspreadable" type="abstract operation">
+          <h1>
+            IsConcatSpreadable (
+              _O_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If Type(_O_) is not Object, return *false*.
             1. Let _spreadable_ be ? Get(_O_, @@isConcatSpreadable).
@@ -32772,9 +35636,20 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
 
-        <emu-clause id="sec-flattenintoarray" aoid="FlattenIntoArray">
-          <h1>FlattenIntoArray ( _target_, _source_, _sourceLen_, _start_, _depth_ [ , _mapperFunction_ [ , _thisArg_ ] ] )</h1>
-          <p>The abstract operation FlattenIntoArray takes arguments _target_, _source_, _sourceLen_ (a non-negative integer), _start_ (a non-negative integer), and _depth_ (a non-negative integer or +&infin;) and optional arguments _mapperFunction_ and _thisArg_. It performs the following steps when called:</p>
+        <emu-clause id="sec-flattenintoarray" type="abstract operation">
+          <h1>
+            FlattenIntoArray (
+              _target_: unknown,
+              _source_: unknown,
+              _sourceLen_: a non-negative integer,
+              _start_: a non-negative integer,
+              _depth_: a non-negative integer or +&infin;,
+              optional _mapperFunction_: unknown,
+              optional _thisArg_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: Type(_target_) is Object.
             1. Assert: Type(_source_) is Object.
@@ -33364,9 +36239,17 @@ THH:mm:ss.sss
           <p>The `sort` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <emu-clause id="sec-sortcompare" aoid="SortCompare">
-          <h1>SortCompare ( _x_, _y_ )</h1>
-          <p>The abstract operation SortCompare takes arguments _x_ and _y_. It also has access to the _comparefn_ argument passed to the current invocation of the `sort` method. It performs the following steps when called:</p>
+        <emu-clause id="sec-sortcompare" type="abstract operation">
+          <h1>
+            SortCompare (
+              _x_: unknown,
+              _y_: unknown,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It also has access to the _comparefn_ argument passed to the current invocation of the `sort` method.</dd>
+          </dl>
           <emu-alg>
             1. If _x_ and _y_ are both *undefined*, return *+0*<sub>𝔽</sub>.
             1. If _x_ is *undefined*, return *1*<sub>𝔽</sub>.
@@ -33610,9 +36493,17 @@ THH:mm:ss.sss
       <h1>Array Iterator Objects</h1>
       <p>An Array Iterator is an object, that represents a specific iteration over some specific Array instance object. There is not a named constructor for Array Iterator objects. Instead, Array iterator objects are created by calling certain methods of Array instance objects.</p>
 
-      <emu-clause id="sec-createarrayiterator" aoid="CreateArrayIterator" oldids="sec-properties-of-array-iterator-instances,table-48,table-internal-slots-of-array-iterator-instances">
-        <h1>CreateArrayIterator ( _array_, _kind_ )</h1>
-        <p>The abstract operation CreateArrayIterator takes arguments _array_ and _kind_. It is used to create iterator objects for Array methods that return such iterators. It performs the following steps when called:</p>
+      <emu-clause id="sec-createarrayiterator" type="abstract operation" oldids="sec-properties-of-array-iterator-instances,table-48,table-internal-slots-of-array-iterator-instances">
+        <h1>
+          CreateArrayIterator (
+            _array_: unknown,
+            _kind_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to create iterator objects for Array methods that return such iterators.</dd>
+        </dl>
         <emu-alg>
           1. Assert: Type(_array_) is Object.
           1. Assert: _kind_ is ~key+value~, ~key~, or ~value~.
@@ -34515,9 +37406,18 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
 
-        <emu-clause id="sec-settypedarrayfromtypedarray" aoid="SetTypedArrayFromTypedArray" oldids="sec-%typedarray%.prototype.set-typedarray-offset">
-          <h1>SetTypedArrayFromTypedArray ( _target_, _targetOffset_, _source_ )</h1>
-          <p>The abstract operation SetTypedArrayFromTypedArray takes arguments _target_ (a TypedArray object), _targetOffset_ (a non-negative integer or +&infin;), and _source_ (a TypedArray object). It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_. It performs the following steps when called:</p>
+        <emu-clause id="sec-settypedarrayfromtypedarray" type="abstract operation" oldids="sec-%typedarray%.prototype.set-typedarray-offset">
+          <h1>
+            SetTypedArrayFromTypedArray (
+              _target_: a TypedArray object,
+              _targetOffset_: a non-negative integer or +&infin;,
+              _source_: a TypedArray object,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _source_ is an Object that has a [[TypedArrayName]] internal slot.
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
@@ -34564,9 +37464,18 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-settypedarrayfromarraylike" aoid="SetTypedArrayFromArrayLike" oldids="sec-%typedarray%.prototype.set-array-offset">
-          <h1>SetTypedArrayFromArrayLike ( _target_, _targetOffset_, _source_ )</h1>
-          <p>The abstract operation SetTypedArrayFromArrayLike takes arguments _target_ (a TypedArray object), _targetOffset_ (a non-negative integer or +&infin;), and _source_ (an ECMAScript value other than a TypedArray object). It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_. It performs the following steps when called:</p>
+        <emu-clause id="sec-settypedarrayfromarraylike" type="abstract operation" oldids="sec-%typedarray%.prototype.set-array-offset">
+          <h1>
+            SetTypedArrayFromArrayLike (
+              _target_: a TypedArray object,
+              _targetOffset_: a non-negative integer or +&infin;,
+              _source_: an ECMAScript value other than a TypedArray object,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _source_ is any ECMAScript language value other than an Object with a [[TypedArrayName]] internal slot.
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
@@ -34780,9 +37689,17 @@ THH:mm:ss.sss
     <emu-clause id="sec-abstract-operations-for-typedarray-objects">
       <h1>Abstract Operations for TypedArray Objects</h1>
 
-      <emu-clause id="typedarray-species-create" aoid="TypedArraySpeciesCreate">
-        <h1>TypedArraySpeciesCreate ( _exemplar_, _argumentList_ )</h1>
-        <p>The abstract operation TypedArraySpeciesCreate takes arguments _exemplar_ and _argumentList_. It is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps when called:</p>
+      <emu-clause id="typedarray-species-create" type="abstract operation">
+        <h1>
+          TypedArraySpeciesCreate (
+            _exemplar_: unknown,
+            _argumentList_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_.</dd>
+        </dl>
         <emu-alg>
           1. Assert: _exemplar_ is an Object that has [[TypedArrayName]] and [[ContentType]] internal slots.
           1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _exemplar_.[[TypedArrayName]].
@@ -34794,9 +37711,17 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="typedarray-create" aoid="TypedArrayCreate">
-        <h1>TypedArrayCreate ( _constructor_, _argumentList_ )</h1>
-        <p>The abstract operation TypedArrayCreate takes arguments _constructor_ and _argumentList_. It is used to specify the creation of a new TypedArray object using a constructor function. It performs the following steps when called:</p>
+      <emu-clause id="typedarray-create" type="abstract operation">
+        <h1>
+          TypedArrayCreate (
+            _constructor_: unknown,
+            _argumentList_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to specify the creation of a new TypedArray object using a constructor function.</dd>
+        </dl>
         <emu-alg>
           1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
           1. Perform ? ValidateTypedArray(_newTypedArray_).
@@ -34806,9 +37731,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-validatetypedarray" aoid="ValidateTypedArray">
-        <h1>ValidateTypedArray ( _O_ )</h1>
-        <p>The abstract operation ValidateTypedArray takes argument _O_. It performs the following steps when called:</p>
+      <emu-clause id="sec-validatetypedarray" type="abstract operation">
+        <h1>
+          ValidateTypedArray (
+            _O_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
@@ -34865,9 +37795,19 @@ THH:mm:ss.sss
               1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
         </emu-alg>
 
-        <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
-          <h1>AllocateTypedArray ( _constructorName_, _newTarget_, _defaultProto_ [ , _length_ ] )</h1>
-          <p>The abstract operation AllocateTypedArray takes arguments _constructorName_ (a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>), _newTarget_, and _defaultProto_ and optional argument _length_ (a non-negative integer). It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by _TypedArray_. It performs the following steps when called:</p>
+        <emu-clause id="sec-allocatetypedarray" type="abstract operation">
+          <h1>
+            AllocateTypedArray (
+              _constructorName_: a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>,
+              _newTarget_: unknown,
+              _defaultProto_: unknown,
+              optional _length_: a non-negative integer,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by _TypedArray_.</dd>
+          </dl>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
             1. Let _obj_ be ! IntegerIndexedObjectCreate(_proto_).
@@ -34885,9 +37825,15 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-initializetypedarrayfromtypedarray" aoid="InitializeTypedArrayFromTypedArray" oldids="sec-typedarray-typedarray">
-          <h1>InitializeTypedArrayFromTypedArray ( _O_, _srcArray_ )</h1>
-          <p>The abstract operation InitializeTypedArrayFromTypedArray takes arguments _O_ (a TypedArray object) and _srcArray_ (a TypedArray object). It performs the following steps when called:</p>
+        <emu-clause id="sec-initializetypedarrayfromtypedarray" type="abstract operation" oldids="sec-typedarray-typedarray">
+          <h1>
+            InitializeTypedArrayFromTypedArray (
+              _O_: a TypedArray object,
+              _srcArray_: a TypedArray object,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[TypedArrayName]] internal slot.
             1. Assert: _srcArray_ is an Object that has a [[TypedArrayName]] internal slot.
@@ -34928,9 +37874,17 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-initializetypedarrayfromarraybuffer" aoid="InitializeTypedArrayFromArrayBuffer" oldids="sec-typedarray-buffer-byteoffset-length">
-          <h1>InitializeTypedArrayFromArrayBuffer ( _O_, _buffer_, _byteOffset_, _length_ )</h1>
-          <p>The abstract operation InitializeTypedArrayFromArrayBuffer takes arguments _O_ (a TypedArray object), _buffer_ (an ArrayBuffer object), _byteOffset_ (an ECMAScript language value), and _length_ (an ECMAScript language value). It performs the following steps when called:</p>
+        <emu-clause id="sec-initializetypedarrayfromarraybuffer" type="abstract operation" oldids="sec-typedarray-buffer-byteoffset-length">
+          <h1>
+            InitializeTypedArrayFromArrayBuffer (
+              _O_: a TypedArray object,
+              _buffer_: an ArrayBuffer object,
+              _byteOffset_: an ECMAScript language value,
+              _length_: an ECMAScript language value,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[TypedArrayName]] internal slot.
             1. Assert: _buffer_ is an Object that has an [[ArrayBufferData]] internal slot.
@@ -34956,9 +37910,15 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-initializetypedarrayfromlist" aoid="InitializeTypedArrayFromList">
-          <h1>InitializeTypedArrayFromList ( _O_, _values_ )</h1>
-          <p>The abstract operation InitializeTypedArrayFromList takes arguments _O_ (a TypedArray object) and _values_ (a List of ECMAScript language values). It performs the following steps when called:</p>
+        <emu-clause id="sec-initializetypedarrayfromlist" type="abstract operation">
+          <h1>
+            InitializeTypedArrayFromList (
+              _O_: a TypedArray object,
+              _values_: a List of ECMAScript language values,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[TypedArrayName]] internal slot.
             1. Let _len_ be the number of elements in _values_.
@@ -34973,9 +37933,15 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-initializetypedarrayfromarraylike" aoid="InitializeTypedArrayFromArrayLike">
-          <h1>InitializeTypedArrayFromArrayLike ( _O_, _arrayLike_ )</h1>
-          <p>The abstract operation InitializeTypedArrayFromArrayLike takes arguments _O_ (a TypedArray object) and _arrayLike_ (an Object that is neither a TypedArray object nor an ArrayBuffer object). It performs the following steps when called:</p>
+        <emu-clause id="sec-initializetypedarrayfromarraylike" type="abstract operation">
+          <h1>
+            InitializeTypedArrayFromArrayLike (
+              _O_: a TypedArray object,
+              _arrayLike_: an Object that is neither a TypedArray object nor an ArrayBuffer object,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[TypedArrayName]] internal slot.
             1. Let _len_ be ? LengthOfArrayLike(_arrayLike_).
@@ -34989,9 +37955,17 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-allocatetypedarraybuffer" aoid="AllocateTypedArrayBuffer">
-          <h1>AllocateTypedArrayBuffer ( _O_, _length_ )</h1>
-          <p>The abstract operation AllocateTypedArrayBuffer takes arguments _O_ (a TypedArray object) and _length_ (a non-negative integer). It allocates and associates an ArrayBuffer with _O_. It performs the following steps when called:</p>
+        <emu-clause id="sec-allocatetypedarraybuffer" type="abstract operation">
+          <h1>
+            AllocateTypedArrayBuffer (
+              _O_: a TypedArray object,
+              _length_: a non-negative integer,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It allocates and associates an ArrayBuffer with _O_.</dd>
+          </dl>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
             1. Assert: _O_.[[ViewedArrayBuffer]] is *undefined*.
@@ -35094,9 +38068,18 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-add-entries-from-iterable" aoid="AddEntriesFromIterable">
-        <h1>AddEntriesFromIterable ( _target_, _iterable_, _adder_ )</h1>
-        <p>The abstract operation AddEntriesFromIterable takes arguments _target_, _iterable_, and _adder_ (a function object). _adder_ will be invoked, with _target_ as the receiver. It performs the following steps when called:</p>
+      <emu-clause id="sec-add-entries-from-iterable" type="abstract operation">
+        <h1>
+          AddEntriesFromIterable (
+            _target_: unknown,
+            _iterable_: unknown,
+            _adder_: a function object,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>_adder_ will be invoked, with _target_ as the receiver.</dd>
+        </dl>
         <emu-alg>
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Assert: _iterable_ is present, and is neither *undefined* nor *null*.
@@ -35326,9 +38309,17 @@ THH:mm:ss.sss
       <h1>Map Iterator Objects</h1>
       <p>A Map Iterator is an object, that represents a specific iteration over some specific Map instance object. There is not a named constructor for Map Iterator objects. Instead, map iterator objects are created by calling certain methods of Map instance objects.</p>
 
-      <emu-clause id="sec-createmapiterator" aoid="CreateMapIterator" oldids="sec-properties-of-map-iterator-instances,table-50,table-internal-slots-of-map-iterator-instances">
-        <h1>CreateMapIterator ( _map_, _kind_ )</h1>
-        <p>The abstract operation CreateMapIterator takes arguments _map_ and _kind_. It is used to create iterator objects for Map methods that return such iterators. It performs the following steps when called:</p>
+      <emu-clause id="sec-createmapiterator" type="abstract operation" oldids="sec-properties-of-map-iterator-instances,table-50,table-internal-slots-of-map-iterator-instances">
+        <h1>
+          CreateMapIterator (
+            _map_: unknown,
+            _kind_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to create iterator objects for Map methods that return such iterators.</dd>
+        </dl>
         <emu-alg>
           1. Assert: _kind_ is ~key+value~, ~key~, or ~value~.
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
@@ -35608,9 +38599,17 @@ THH:mm:ss.sss
       <h1>Set Iterator Objects</h1>
       <p>A Set Iterator is an ordinary object, with the structure defined below, that represents a specific iteration over some specific Set instance object. There is not a named constructor for Set Iterator objects. Instead, set iterator objects are created by calling certain methods of Set instance objects.</p>
 
-      <emu-clause id="sec-createsetiterator" aoid="CreateSetIterator" oldids="sec-properties-of-set-iterator-instances,table-51,table-internal-slots-of-set-iterator-instances">
-        <h1>CreateSetIterator ( _set_, _kind_ )</h1>
-        <p>The abstract operation CreateSetIterator takes arguments _set_ and _kind_. It is used to create iterator objects for Set methods that return such iterators. It performs the following steps when called:</p>
+      <emu-clause id="sec-createsetiterator" type="abstract operation" oldids="sec-properties-of-set-iterator-instances,table-51,table-internal-slots-of-set-iterator-instances">
+        <h1>
+          CreateSetIterator (
+            _set_: unknown,
+            _kind_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to create iterator objects for Set methods that return such iterators.</dd>
+        </dl>
         <emu-alg>
           1. Assert: _kind_ is ~key+value~ or ~value~.
           1. Perform ? RequireInternalSlot(_set_, [[SetData]]).
@@ -35968,9 +38967,17 @@ THH:mm:ss.sss
     <emu-clause id="sec-abstract-operations-for-arraybuffer-objects">
       <h1>Abstract Operations For ArrayBuffer Objects</h1>
 
-      <emu-clause id="sec-allocatearraybuffer" aoid="AllocateArrayBuffer">
-        <h1>AllocateArrayBuffer ( _constructor_, _byteLength_ )</h1>
-        <p>The abstract operation AllocateArrayBuffer takes arguments _constructor_ and _byteLength_ (a non-negative integer). It is used to create an ArrayBuffer object. It performs the following steps when called:</p>
+      <emu-clause id="sec-allocatearraybuffer" type="abstract operation">
+        <h1>
+          AllocateArrayBuffer (
+            _constructor_: unknown,
+            _byteLength_: a non-negative integer,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to create an ArrayBuffer object.</dd>
+        </dl>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%ArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] &raquo;).
           1. Let _block_ be ? CreateByteDataBlock(_byteLength_).
@@ -35980,9 +38987,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isdetachedbuffer" aoid="IsDetachedBuffer">
-        <h1>IsDetachedBuffer ( _arrayBuffer_ )</h1>
-        <p>The abstract operation IsDetachedBuffer takes argument _arrayBuffer_. It performs the following steps when called:</p>
+      <emu-clause id="sec-isdetachedbuffer" type="abstract operation">
+        <h1>
+          IsDetachedBuffer (
+            _arrayBuffer_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Type(_arrayBuffer_) is Object and _arrayBuffer_ has an [[ArrayBufferData]] internal slot.
           1. If _arrayBuffer_.[[ArrayBufferData]] is *null*, return *true*.
@@ -35990,9 +39002,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-detacharraybuffer" aoid="DetachArrayBuffer">
-        <h1>DetachArrayBuffer ( _arrayBuffer_ [ , _key_ ] )</h1>
-        <p>The abstract operation DetachArrayBuffer takes argument _arrayBuffer_ and optional argument _key_. It performs the following steps when called:</p>
+      <emu-clause id="sec-detacharraybuffer" type="abstract operation">
+        <h1>
+          DetachArrayBuffer (
+            _arrayBuffer_: unknown,
+            optional _key_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: Type(_arrayBuffer_) is Object and _arrayBuffer_ has [[ArrayBufferData]], [[ArrayBufferByteLength]], and [[ArrayBufferDetachKey]] internal slots.
           1. Assert: IsSharedArrayBuffer(_arrayBuffer_) is *false*.
@@ -36007,9 +39025,19 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-clonearraybuffer" aoid="CloneArrayBuffer">
-        <h1>CloneArrayBuffer ( _srcBuffer_, _srcByteOffset_, _srcLength_, _cloneConstructor_ )</h1>
-        <p>The abstract operation CloneArrayBuffer takes arguments _srcBuffer_ (an ArrayBuffer object), _srcByteOffset_ (a non-negative integer), _srcLength_ (a non-negative integer), and _cloneConstructor_ (a constructor). It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. It performs the following steps when called:</p>
+      <emu-clause id="sec-clonearraybuffer" type="abstract operation">
+        <h1>
+          CloneArrayBuffer (
+            _srcBuffer_: an ArrayBuffer object,
+            _srcByteOffset_: a non-negative integer,
+            _srcLength_: a non-negative integer,
+            _cloneConstructor_: a constructor,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes.</dd>
+        </dl>
         <emu-alg>
           1. Assert: Type(_srcBuffer_) is Object and _srcBuffer_ has an [[ArrayBufferData]] internal slot.
           1. Assert: IsConstructor(_cloneConstructor_) is *true*.
@@ -36022,36 +39050,63 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isunsignedelementtype" aoid="IsUnsignedElementType">
-        <h1>IsUnsignedElementType ( _type_ )</h1>
-        <p>The abstract operation IsUnsignedElementType takes argument _type_. It verifies if the argument _type_ is an unsigned TypedArray element type. It performs the following steps when called:</p>
+      <emu-clause id="sec-isunsignedelementtype" type="abstract operation">
+        <h1>
+          IsUnsignedElementType (
+            _type_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It verifies if the argument _type_ is an unsigned TypedArray element type.</dd>
+        </dl>
         <emu-alg>
           1. If _type_ is ~Uint8~, ~Uint8C~, ~Uint16~, ~Uint32~, or ~BigUint64~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isunclampedintegerelementtype" aoid="IsUnclampedIntegerElementType">
-        <h1>IsUnclampedIntegerElementType ( _type_ )</h1>
-        <p>The abstract operation IsUnclampedIntegerElementType takes argument _type_. It verifies if the argument _type_ is an Integer TypedArray element type not including ~Uint8C~. It performs the following steps when called:</p>
+      <emu-clause id="sec-isunclampedintegerelementtype" type="abstract operation">
+        <h1>
+          IsUnclampedIntegerElementType (
+            _type_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It verifies if the argument _type_ is an Integer TypedArray element type not including ~Uint8C~.</dd>
+        </dl>
         <emu-alg>
           1. If _type_ is ~Int8~, ~Uint8~, ~Int16~, ~Uint16~, ~Int32~, or ~Uint32~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isbigintelementtype" aoid="IsBigIntElementType">
-        <h1>IsBigIntElementType ( _type_ )</h1>
-        <p>The abstract operation IsBigIntElementType takes argument _type_. It verifies if the argument _type_ is a BigInt TypedArray element type. It performs the following steps when called:</p>
+      <emu-clause id="sec-isbigintelementtype" type="abstract operation">
+        <h1>
+          IsBigIntElementType (
+            _type_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It verifies if the argument _type_ is a BigInt TypedArray element type.</dd>
+        </dl>
         <emu-alg>
           1. If _type_ is ~BigUint64~ or ~BigInt64~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-isnotearconfiguration" aoid="IsNoTearConfiguration">
-        <h1>IsNoTearConfiguration ( _type_, _order_ )</h1>
-        <p>The abstract operation IsNoTearConfiguration takes arguments _type_ and _order_. It performs the following steps when called:</p>
+      <emu-clause id="sec-isnotearconfiguration" type="abstract operation">
+        <h1>
+          IsNoTearConfiguration (
+            _type_: unknown,
+            _order_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If ! IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
           1. If ! IsBigIntElementType(_type_) is *true* and _order_ is not ~Init~ or ~Unordered~, return *true*.
@@ -36059,9 +39114,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-rawbytestonumeric" aoid="RawBytesToNumeric" oldids="sec-rawbytestonumber">
-        <h1>RawBytesToNumeric ( _type_, _rawBytes_, _isLittleEndian_ )</h1>
-        <p>The abstract operation RawBytesToNumeric takes arguments _type_ (a TypedArray element type), _rawBytes_ (a List), and _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
+      <emu-clause id="sec-rawbytestonumeric" type="abstract operation" oldids="sec-rawbytestonumber">
+        <h1>
+          RawBytesToNumeric (
+            _type_: a TypedArray element type,
+            _rawBytes_: a List,
+            _isLittleEndian_: a Boolean,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is *false*, reverse the order of the elements of _rawBytes_.
@@ -36082,9 +39144,19 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-getvaluefrombuffer" aoid="GetValueFromBuffer">
-        <h1>GetValueFromBuffer ( _arrayBuffer_, _byteIndex_, _type_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation GetValueFromBuffer takes arguments _arrayBuffer_ (an ArrayBuffer or SharedArrayBuffer), _byteIndex_ (a non-negative integer), _type_ (a TypedArray element type), _isTypedArray_ (a Boolean), and _order_ (either ~SeqCst~ or ~Unordered~) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
+      <emu-clause id="sec-getvaluefrombuffer" type="abstract operation">
+        <h1>
+          GetValueFromBuffer (
+            _arrayBuffer_: an ArrayBuffer or SharedArrayBuffer,
+            _byteIndex_: a non-negative integer,
+            _type_: a TypedArray element type,
+            _isTypedArray_: a Boolean,
+            _order_: either ~SeqCst~ or ~Unordered~,
+            optional _isLittleEndian_: a Boolean,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -36106,9 +39178,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-numerictorawbytes" aoid="NumericToRawBytes" oldids="sec-numbertorawbytes">
-        <h1>NumericToRawBytes ( _type_, _value_, _isLittleEndian_ )</h1>
-        <p>The abstract operation NumericToRawBytes takes arguments _type_ (a TypedArray element type), _value_ (a BigInt or a Number), and _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
+      <emu-clause id="sec-numerictorawbytes" type="abstract operation" oldids="sec-numbertorawbytes">
+        <h1>
+          NumericToRawBytes (
+            _type_: a TypedArray element type,
+            _value_: a BigInt or a Number,
+            _isLittleEndian_: a Boolean,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _type_ is ~Float32~, then
             1. Let _rawBytes_ be a List whose elements are the 4 bytes that are the result of converting _value_ to IEEE 754-2019 binary32 format using roundTiesToEven mode. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary32 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
@@ -36126,9 +39205,20 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-setvalueinbuffer" aoid="SetValueInBuffer">
-        <h1>SetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation SetValueInBuffer takes arguments _arrayBuffer_ (an ArrayBuffer or SharedArrayBuffer), _byteIndex_ (a non-negative integer), _type_ (a TypedArray element type), _value_ (a Number or a BigInt), _isTypedArray_ (a Boolean), and _order_ (one of ~SeqCst~, ~Unordered~, or ~Init~) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
+      <emu-clause id="sec-setvalueinbuffer" type="abstract operation">
+        <h1>
+          SetValueInBuffer (
+            _arrayBuffer_: an ArrayBuffer or SharedArrayBuffer,
+            _byteIndex_: a non-negative integer,
+            _type_: a TypedArray element type,
+            _value_: a Number or a BigInt,
+            _isTypedArray_: a Boolean,
+            _order_: one of ~SeqCst~, ~Unordered~, or ~Init~,
+            optional _isLittleEndian_: a Boolean,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -36147,9 +39237,19 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-getmodifysetvalueinbuffer" aoid="GetModifySetValueInBuffer">
-        <h1>GetModifySetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_, _op_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation GetModifySetValueInBuffer takes arguments _arrayBuffer_ (an ArrayBuffer object or a SharedArrayBuffer object), _byteIndex_ (a non-negative integer), _type_ (a TypedArray element type), _value_ (a Number or a BigInt), and _op_ (a read-modify-write modification function) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
+      <emu-clause id="sec-getmodifysetvalueinbuffer" type="abstract operation">
+        <h1>
+          GetModifySetValueInBuffer (
+            _arrayBuffer_: an ArrayBuffer object or a SharedArrayBuffer object,
+            _byteIndex_: a non-negative integer,
+            _type_: a TypedArray element type,
+            _value_: a Number or a BigInt,
+            _op_: a read-modify-write modification function,
+            optional _isLittleEndian_: a Boolean,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -36317,9 +39417,17 @@ THH:mm:ss.sss
     <emu-clause id="sec-abstract-operations-for-sharedarraybuffer-objects">
       <h1>Abstract Operations for SharedArrayBuffer Objects</h1>
 
-      <emu-clause id="sec-allocatesharedarraybuffer" aoid="AllocateSharedArrayBuffer">
-        <h1>AllocateSharedArrayBuffer ( _constructor_, _byteLength_ )</h1>
-        <p>The abstract operation AllocateSharedArrayBuffer takes arguments _constructor_ and _byteLength_ (a non-negative integer). It is used to create a SharedArrayBuffer object. It performs the following steps when called:</p>
+      <emu-clause id="sec-allocatesharedarraybuffer" type="abstract operation">
+        <h1>
+          AllocateSharedArrayBuffer (
+            _constructor_: unknown,
+            _byteLength_: a non-negative integer,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to create a SharedArrayBuffer object.</dd>
+        </dl>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%SharedArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
           1. Let _block_ be ? CreateSharedByteDataBlock(_byteLength_).
@@ -36329,9 +39437,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-issharedarraybuffer" aoid="IsSharedArrayBuffer">
-        <h1>IsSharedArrayBuffer ( _obj_ )</h1>
-        <p>The abstract operation IsSharedArrayBuffer takes argument _obj_. It tests whether an object is an ArrayBuffer, a SharedArrayBuffer, or a subtype of either. It performs the following steps when called:</p>
+      <emu-clause id="sec-issharedarraybuffer" type="abstract operation">
+        <h1>
+          IsSharedArrayBuffer (
+            _obj_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It tests whether an object is an ArrayBuffer, a SharedArrayBuffer, or a subtype of either.</dd>
+        </dl>
         <emu-alg>
           1. Assert: Type(_obj_) is Object and _obj_ has an [[ArrayBufferData]] internal slot.
           1. Let _bufferData_ be _obj_.[[ArrayBufferData]].
@@ -36475,9 +39590,19 @@ THH:mm:ss.sss
     <emu-clause id="sec-abstract-operations-for-dataview-objects">
       <h1>Abstract Operations For DataView Objects</h1>
 
-      <emu-clause id="sec-getviewvalue" aoid="GetViewValue">
-        <h1>GetViewValue ( _view_, _requestIndex_, _isLittleEndian_, _type_ )</h1>
-        <p>The abstract operation GetViewValue takes arguments _view_, _requestIndex_, _isLittleEndian_, and _type_. It is used by functions on DataView instances to retrieve values from the view's buffer. It performs the following steps when called:</p>
+      <emu-clause id="sec-getviewvalue" type="abstract operation">
+        <h1>
+          GetViewValue (
+            _view_: unknown,
+            _requestIndex_: unknown,
+            _isLittleEndian_: unknown,
+            _type_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used by functions on DataView instances to retrieve values from the view's buffer.</dd>
+        </dl>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
@@ -36494,9 +39619,20 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-setviewvalue" aoid="SetViewValue">
-        <h1>SetViewValue ( _view_, _requestIndex_, _isLittleEndian_, _type_, _value_ )</h1>
-        <p>The abstract operation SetViewValue takes arguments _view_, _requestIndex_, _isLittleEndian_, _type_, and _value_. It is used by functions on DataView instances to store values into the view's buffer. It performs the following steps when called:</p>
+      <emu-clause id="sec-setviewvalue" type="abstract operation">
+        <h1>
+          SetViewValue (
+            _view_: unknown,
+            _requestIndex_: unknown,
+            _isLittleEndian_: unknown,
+            _type_: unknown,
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used by functions on DataView instances to store values into the view's buffer.</dd>
+        </dl>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
@@ -36857,9 +39993,15 @@ THH:mm:ss.sss
     <emu-clause id="sec-abstract-operations-for-atomics">
       <h1>Abstract Operations for Atomics</h1>
 
-      <emu-clause id="sec-validateintegertypedarray" aoid="ValidateIntegerTypedArray" oldids="sec-validatesharedintegertypedarray">
-        <h1>ValidateIntegerTypedArray ( _typedArray_ [ , _waitable_ ] )</h1>
-        <p>The abstract operation ValidateIntegerTypedArray takes argument _typedArray_ and optional argument _waitable_ (a Boolean). It performs the following steps when called:</p>
+      <emu-clause id="sec-validateintegertypedarray" type="abstract operation" oldids="sec-validatesharedintegertypedarray">
+        <h1>
+          ValidateIntegerTypedArray (
+            _typedArray_: unknown,
+            optional _waitable_: a Boolean,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _waitable_ is not present, set _waitable_ to *false*.
           1. Perform ? ValidateTypedArray(_typedArray_).
@@ -36874,9 +40016,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-validateatomicaccess" aoid="ValidateAtomicAccess">
-        <h1>ValidateAtomicAccess ( _typedArray_, _requestIndex_ )</h1>
-        <p>The abstract operation ValidateAtomicAccess takes arguments _typedArray_ and _requestIndex_. It performs the following steps when called:</p>
+      <emu-clause id="sec-validateatomicaccess" type="abstract operation">
+        <h1>
+          ValidateAtomicAccess (
+            _typedArray_: unknown,
+            _requestIndex_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _typedArray_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
           1. Let _length_ be _typedArray_.[[ArrayLength]].
@@ -36890,9 +40038,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-getwaiterlist" aoid="GetWaiterList">
-        <h1>GetWaiterList ( _block_, _i_ )</h1>
-        <p>The abstract operation GetWaiterList takes arguments _block_ (a Shared Data Block) and _i_ (a non-negative integer). It performs the following steps when called:</p>
+      <emu-clause id="sec-getwaiterlist" type="abstract operation">
+        <h1>
+          GetWaiterList (
+            _block_: a Shared Data Block,
+            _i_: a non-negative integer,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _block_ is a Shared Data Block.
           1. Assert: _i_ and _i_ + 3 are valid byte offsets within the memory of _block_.
@@ -36901,9 +40055,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-entercriticalsection" aoid="EnterCriticalSection">
-        <h1>EnterCriticalSection ( _WL_ )</h1>
-        <p>The abstract operation EnterCriticalSection takes argument _WL_ (a WaiterList). It performs the following steps when called:</p>
+      <emu-clause id="sec-entercriticalsection" type="abstract operation">
+        <h1>
+          EnterCriticalSection (
+            _WL_: a WaiterList,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The calling agent is not in the critical section for any WaiterList.
           1. Wait until no agent is in the critical section for _WL_, then enter the critical section for _WL_ (without allowing any other agent to enter).
@@ -36920,9 +40079,14 @@ THH:mm:ss.sss
         <p>EnterCriticalSection has <dfn>contention</dfn> when an agent attempting to enter the critical section must wait for another agent to leave it. When there is no contention, FIFO order of EnterCriticalSection calls is observable. When there is contention, an implementation may choose an arbitrary order but may not cause an agent to wait indefinitely.</p>
       </emu-clause>
 
-      <emu-clause id="sec-leavecriticalsection" aoid="LeaveCriticalSection">
-        <h1>LeaveCriticalSection ( _WL_ )</h1>
-        <p>The abstract operation LeaveCriticalSection takes argument _WL_ (a WaiterList). It performs the following steps when called:</p>
+      <emu-clause id="sec-leavecriticalsection" type="abstract operation">
+        <h1>
+          LeaveCriticalSection (
+            _WL_: a WaiterList,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Let _execution_ be the [[CandidateExecution]] field of the calling surrounding's Agent Record.
@@ -36935,9 +40099,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-addwaiter" aoid="AddWaiter">
-        <h1>AddWaiter ( _WL_, _W_ )</h1>
-        <p>The abstract operation AddWaiter takes arguments _WL_ (a WaiterList) and _W_ (an agent signifier). It performs the following steps when called:</p>
+      <emu-clause id="sec-addwaiter" type="abstract operation">
+        <h1>
+          AddWaiter (
+            _WL_: a WaiterList,
+            _W_: an agent signifier,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is not on the list of waiters in any WaiterList.
@@ -36945,9 +40115,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-removewaiter" aoid="RemoveWaiter">
-        <h1>RemoveWaiter ( _WL_, _W_ )</h1>
-        <p>The abstract operation RemoveWaiter takes arguments _WL_ (a WaiterList) and _W_ (an agent signifier). It performs the following steps when called:</p>
+      <emu-clause id="sec-removewaiter" type="abstract operation">
+        <h1>
+          RemoveWaiter (
+            _WL_: a WaiterList,
+            _W_: an agent signifier,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is on the list of waiters in _WL_.
@@ -36955,9 +40131,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-removewaiters" aoid="RemoveWaiters">
-        <h1>RemoveWaiters ( _WL_, _c_ )</h1>
-        <p>The abstract operation RemoveWaiters takes arguments _WL_ (a WaiterList) and _c_ (a non-negative integer or +&infin;). It performs the following steps when called:</p>
+      <emu-clause id="sec-removewaiters" type="abstract operation">
+        <h1>
+          RemoveWaiters (
+            _WL_: a WaiterList,
+            _c_: a non-negative integer or +&infin;,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Let _L_ be a new empty List.
@@ -36971,9 +40153,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-suspendagent" aoid="SuspendAgent" oldids="sec-suspend">
-        <h1>SuspendAgent ( _WL_, _W_, _timeout_ )</h1>
-        <p>The abstract operation SuspendAgent takes arguments _WL_ (a WaiterList), _W_ (an agent signifier), and _timeout_ (a non-negative integer). It performs the following steps when called:</p>
+      <emu-clause id="sec-suspendagent" type="abstract operation" oldids="sec-suspend">
+        <h1>
+          SuspendAgent (
+            _WL_: a WaiterList,
+            _W_: an agent signifier,
+            _timeout_: a non-negative integer,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is equivalent to AgentSignifier().
@@ -36986,9 +40175,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-notifywaiter" aoid="NotifyWaiter">
-        <h1>NotifyWaiter ( _WL_, _W_ )</h1>
-        <p>The abstract operation NotifyWaiter takes arguments _WL_ (a WaiterList) and _W_ (an agent signifier). It performs the following steps when called:</p>
+      <emu-clause id="sec-notifywaiter" type="abstract operation">
+        <h1>
+          NotifyWaiter (
+            _WL_: a WaiterList,
+            _W_: an agent signifier,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Notify the agent _W_.
@@ -36998,9 +40193,19 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-atomicreadmodifywrite" aoid="AtomicReadModifyWrite">
-        <h1>AtomicReadModifyWrite ( _typedArray_, _index_, _value_, _op_ )</h1>
-        <p>The abstract operation AtomicReadModifyWrite takes arguments _typedArray_, _index_, _value_, and _op_ (a read-modify-write modification function). _op_ takes two List of byte values arguments and returns a List of byte values. This operation atomically loads a value, combines it with another value, and stores the result of the combination. It returns the loaded value. It performs the following steps when called:</p>
+      <emu-clause id="sec-atomicreadmodifywrite" type="abstract operation">
+        <h1>
+          AtomicReadModifyWrite (
+            _typedArray_: unknown,
+            _index_: unknown,
+            _value_: unknown,
+            _op_: a read-modify-write modification function,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>_op_ takes two List of byte values arguments and returns a List of byte values. This operation atomically loads a value, combines it with another value, and stores the result of the combination. It returns the loaded value.</dd>
+        </dl>
         <emu-alg>
           1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
           1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
@@ -37014,9 +40219,18 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-bytelistbitwiseop" aoid="ByteListBitwiseOp">
-        <h1>ByteListBitwiseOp ( _op_, _xBytes_, _yBytes_ )</h1>
-        <p>The abstract operation ByteListBitwiseOp takes arguments _op_ (a sequence of Unicode code points), _xBytes_ (a List of byte values), and _yBytes_ (a List of byte values). The operation atomically performs a bitwise operation on all byte values of the arguments and returns a List of byte values. It performs the following steps when called:</p>
+      <emu-clause id="sec-bytelistbitwiseop" type="abstract operation">
+        <h1>
+          ByteListBitwiseOp (
+            _op_: a sequence of Unicode code points,
+            _xBytes_: a List of byte values,
+            _yBytes_: a List of byte values,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>The operation atomically performs a bitwise operation on all byte values of the arguments and returns a List of byte values.</dd>
+        </dl>
         <emu-alg>
           1. Assert: _op_ is `&amp;`, `^`, or `|`.
           1. Assert: _xBytes_ and _yBytes_ have the same number of elements.
@@ -37033,9 +40247,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-bytelistequal" aoid="ByteListEqual">
-        <h1>ByteListEqual ( _xBytes_, _yBytes_ )</h1>
-        <p>The abstract operation ByteListEqual takes arguments _xBytes_ (a List of byte values) and _yBytes_ (a List of byte values). It performs the following steps when called:</p>
+      <emu-clause id="sec-bytelistequal" type="abstract operation">
+        <h1>
+          ByteListEqual (
+            _xBytes_: a List of byte values,
+            _yBytes_: a List of byte values,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _xBytes_ and _yBytes_ do not have the same number of elements, return *false*.
           1. Let _i_ be 0.
@@ -37326,9 +40546,16 @@ THH:mm:ss.sss
         <p>However, because <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> applies when evaluating ECMAScript source text and does not apply during `JSON.parse`, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the Early Error for duplicate *"__proto__"* properties in object literals, which likewise does not apply during `JSON.parse`, means that not all texts accepted by `JSON.parse` are valid as a |PrimaryExpression|, despite matching the grammar.</p>
       </emu-note>
 
-      <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">
-        <h1>InternalizeJSONProperty ( _holder_, _name_, _reviver_ )</h1>
-        <p>The abstract operation InternalizeJSONProperty takes arguments _holder_ (an Object), _name_ (a String), and _reviver_ (a function object).</p>
+      <emu-clause id="sec-internalizejsonproperty" type="abstract operation">
+        <h1>
+          InternalizeJSONProperty (
+            _holder_: an Object,
+            _name_: a String,
+            _reviver_: a function object,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>This algorithm intentionally does not throw an exception if either [[Delete]] or CreateDataProperty return *false*.</p>
         </emu-note>
@@ -37450,9 +40677,16 @@ THH:mm:ss.sss
         <p>An object is rendered as U+007B (LEFT CURLY BRACKET) followed by zero or more properties, separated with a U+002C (COMMA), closed with a U+007D (RIGHT CURLY BRACKET). A property is a quoted String representing the key or property name, a U+003A (COLON), and then the stringified property value. An array is rendered as an opening U+005B (LEFT SQUARE BRACKET followed by zero or more values, separated with a U+002C (COMMA), closed with a U+005D (RIGHT SQUARE BRACKET).</p>
       </emu-note>
 
-      <emu-clause id="sec-serializejsonproperty" aoid="SerializeJSONProperty">
-        <h1>SerializeJSONProperty ( _state_, _key_, _holder_ )</h1>
-        <p>The abstract operation SerializeJSONProperty takes arguments _state_, _key_, and _holder_. It performs the following steps when called:</p>
+      <emu-clause id="sec-serializejsonproperty" type="abstract operation">
+        <h1>
+          SerializeJSONProperty (
+            _state_: unknown,
+            _key_: unknown,
+            _holder_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _value_ be ? Get(_holder_, _key_).
           1. If Type(_value_) is Object or BigInt, then
@@ -37486,9 +40720,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-quotejsonstring" aoid="QuoteJSONString">
-        <h1>QuoteJSONString ( _value_ )</h1>
-        <p>The abstract operation QuoteJSONString takes argument _value_. It wraps _value_ in 0x0022 (QUOTATION MARK) code units and escapes certain other code units within it. This operation interprets _value_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
+      <emu-clause id="sec-quotejsonstring" type="abstract operation">
+        <h1>
+          QuoteJSONString (
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It wraps _value_ in 0x0022 (QUOTATION MARK) code units and escapes certain other code units within it. This operation interprets _value_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</dd>
+        </dl>
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
           1. For each code point _C_ of ! StringToCodePoints(_value_), do
@@ -37598,9 +40839,16 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-unicodeescape" aoid="UnicodeEscape">
-        <h1>UnicodeEscape ( _C_ )</h1>
-        <p>The abstract operation UnicodeEscape takes argument _C_ (a code unit). It represents _C_ as a Unicode escape sequence. It performs the following steps when called:</p>
+      <emu-clause id="sec-unicodeescape" type="abstract operation">
+        <h1>
+          UnicodeEscape (
+            _C_: a code unit,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It represents _C_ as a Unicode escape sequence.</dd>
+        </dl>
         <emu-alg>
           1. Let _n_ be the numeric value of _C_.
           1. Assert: _n_ &le; 0xFFFF.
@@ -37611,9 +40859,17 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-serializejsonobject" aoid="SerializeJSONObject">
-        <h1>SerializeJSONObject ( _state_, _value_ )</h1>
-        <p>The abstract operation SerializeJSONObject takes arguments _state_ and _value_. It serializes an object. It performs the following steps when called:</p>
+      <emu-clause id="sec-serializejsonobject" type="abstract operation">
+        <h1>
+          SerializeJSONObject (
+            _state_: unknown,
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It serializes an object.</dd>
+        </dl>
         <emu-alg>
           1. If _state_.[[Stack]] contains _value_, throw a *TypeError* exception because the structure is cyclical.
           1. Append _value_ to _state_.[[Stack]].
@@ -37649,9 +40905,17 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-serializejsonarray" aoid="SerializeJSONArray">
-        <h1>SerializeJSONArray ( _state_, _value_ )</h1>
-        <p>The abstract operation SerializeJSONArray takes arguments _state_ and _value_. It serializes an array. It performs the following steps when called:</p>
+      <emu-clause id="sec-serializejsonarray" type="abstract operation">
+        <h1>
+          SerializeJSONArray (
+            _state_: unknown,
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It serializes an array.</dd>
+        </dl>
         <emu-alg>
           1. If _state_.[[Stack]] contains _value_, throw a *TypeError* exception because the structure is cyclical.
           1. Append _value_ to _state_.[[Stack]].
@@ -37808,9 +41072,14 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-weakref-abstract-operations">
       <h1>WeakRef Abstract Operations</h1>
-      <emu-clause id="sec-weakrefderef" aoid="WeakRefDeref">
-        <h1>WeakRefDeref ( _weakRef_ )</h1>
-        <p>The abstract operation WeakRefDeref takes argument _weakRef_ (a WeakRef). It performs the following steps when called:</p>
+      <emu-clause id="sec-weakrefderef" type="abstract operation">
+        <h1>
+          WeakRefDeref (
+            _weakRef_: a WeakRef,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _target_ be _weakRef_.[[WeakRefTarget]].
           1. If _target_ is not ~empty~, then
@@ -38251,9 +41520,16 @@ THH:mm:ss.sss
       <h1>Async-from-Sync Iterator Objects</h1>
       <p>An Async-from-Sync Iterator object is an async iterator that adapts a specific synchronous iterator. There is not a named constructor for Async-from-Sync Iterator objects. Instead, Async-from-Sync iterator objects are created by the CreateAsyncFromSyncIterator abstract operation as needed.</p>
 
-      <emu-clause id="sec-createasyncfromsynciterator" aoid="CreateAsyncFromSyncIterator">
-        <h1>CreateAsyncFromSyncIterator ( _syncIteratorRecord_ )</h1>
-        <p>The abstract operation CreateAsyncFromSyncIterator takes argument _syncIteratorRecord_. It is used to create an async iterator Record from a synchronous iterator Record. It performs the following steps when called:</p>
+      <emu-clause id="sec-createasyncfromsynciterator" type="abstract operation">
+        <h1>
+          CreateAsyncFromSyncIterator (
+            _syncIteratorRecord_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to create an async iterator Record from a synchronous iterator Record.</dd>
+        </dl>
         <emu-alg>
           1. Let _asyncIterator_ be ! OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
           1. Set _asyncIterator_.[[SyncIteratorRecord]] to _syncIteratorRecord_.
@@ -38371,9 +41647,15 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-asyncfromsynciteratorcontinuation" oldids="sec-async-from-sync-iterator-value-unwrap-functions" aoid="AsyncFromSyncIteratorContinuation">
-        <h1>AsyncFromSyncIteratorContinuation ( _result_, _promiseCapability_ )</h1>
-        <p>The abstract operation AsyncFromSyncIteratorContinuation takes arguments _result_ and _promiseCapability_ (a PromiseCapability Record). It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncfromsynciteratorcontinuation" type="abstract operation" oldids="sec-async-from-sync-iterator-value-unwrap-functions">
+        <h1>
+          AsyncFromSyncIteratorContinuation (
+            _result_: unknown,
+            _promiseCapability_: a PromiseCapability Record,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
 
         <emu-alg>
           1. Let _done_ be IteratorComplete(_result_).
@@ -38541,9 +41823,14 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-createresolvingfunctions" aoid="CreateResolvingFunctions">
-        <h1>CreateResolvingFunctions ( _promise_ )</h1>
-        <p>The abstract operation CreateResolvingFunctions takes argument _promise_. It performs the following steps when called:</p>
+      <emu-clause id="sec-createresolvingfunctions" type="abstract operation">
+        <h1>
+          CreateResolvingFunctions (
+            _promise_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _alreadyResolved_ be the Record { [[Value]]: *false* }.
           1. Let _stepsResolve_ be the algorithm steps defined in <emu-xref href="#sec-promise-resolve-functions" title></emu-xref>.
@@ -38606,9 +41893,15 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-fulfillpromise" aoid="FulfillPromise">
-        <h1>FulfillPromise ( _promise_, _value_ )</h1>
-        <p>The abstract operation FulfillPromise takes arguments _promise_ and _value_. It performs the following steps when called:</p>
+      <emu-clause id="sec-fulfillpromise" type="abstract operation">
+        <h1>
+          FulfillPromise (
+            _promise_: unknown,
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The value of _promise_.[[PromiseState]] is ~pending~.
           1. Let _reactions_ be _promise_.[[PromiseFulfillReactions]].
@@ -38620,9 +41913,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-newpromisecapability" oldids="sec-getcapabilitiesexecutor-functions" aoid="NewPromiseCapability">
-        <h1>NewPromiseCapability ( _C_ )</h1>
-        <p>The abstract operation NewPromiseCapability takes argument _C_. It attempts to use _C_ as a constructor in the fashion of the built-in Promise constructor to create a Promise object and extract its `resolve` and `reject` functions. The Promise object plus the `resolve` and `reject` functions are used to initialize a new PromiseCapability Record. It performs the following steps when called:</p>
+      <emu-clause id="sec-newpromisecapability" type="abstract operation" oldids="sec-getcapabilitiesexecutor-functions">
+        <h1>
+          NewPromiseCapability (
+            _C_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It attempts to use _C_ as a constructor in the fashion of the built-in Promise constructor to create a Promise object and extract its `resolve` and `reject` functions. The Promise object plus the `resolve` and `reject` functions are used to initialize a new PromiseCapability Record.</dd>
+        </dl>
         <emu-alg>
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
           1. NOTE: _C_ is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see <emu-xref href="#sec-promise-executor"></emu-xref>).
@@ -38645,9 +41945,16 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-ispromise" aoid="IsPromise">
-        <h1>IsPromise ( _x_ )</h1>
-        <p>The abstract operation IsPromise takes argument _x_. It checks for the promise brand on an object. It performs the following steps when called:</p>
+      <emu-clause id="sec-ispromise" type="abstract operation">
+        <h1>
+          IsPromise (
+            _x_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It checks for the promise brand on an object.</dd>
+        </dl>
         <emu-alg>
           1. If Type(_x_) is not Object, return *false*.
           1. If _x_ does not have a [[PromiseState]] internal slot, return *false*.
@@ -38655,9 +41962,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-rejectpromise" aoid="RejectPromise">
-        <h1>RejectPromise ( _promise_, _reason_ )</h1>
-        <p>The abstract operation RejectPromise takes arguments _promise_ and _reason_. It performs the following steps when called:</p>
+      <emu-clause id="sec-rejectpromise" type="abstract operation">
+        <h1>
+          RejectPromise (
+            _promise_: unknown,
+            _reason_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The value of _promise_.[[PromiseState]] is ~pending~.
           1. Let _reactions_ be _promise_.[[PromiseRejectReactions]].
@@ -38670,9 +41983,17 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-triggerpromisereactions" aoid="TriggerPromiseReactions">
-        <h1>TriggerPromiseReactions ( _reactions_, _argument_ )</h1>
-        <p>The abstract operation TriggerPromiseReactions takes arguments _reactions_ (a List of PromiseReaction Records) and _argument_. It enqueues a new Job for each record in _reactions_. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReaction Record, and if the [[Handler]] is not ~empty~, calls it passing the given argument. If the [[Handler]] is ~empty~, the behaviour is determined by the [[Type]]. It performs the following steps when called:</p>
+      <emu-clause id="sec-triggerpromisereactions" type="abstract operation">
+        <h1>
+          TriggerPromiseReactions (
+            _reactions_: a List of PromiseReaction Records,
+            _argument_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It enqueues a new Job for each record in _reactions_. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReaction Record, and if the [[Handler]] is not ~empty~, calls it passing the given argument. If the [[Handler]] is ~empty~, the behaviour is determined by the [[Type]].</dd>
+        </dl>
         <emu-alg>
           1. For each element _reaction_ of _reactions_, do
             1. Let _job_ be NewPromiseReactionJob(_reaction_, _argument_).
@@ -38681,9 +42002,17 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-host-promise-rejection-tracker" aoid="HostPromiseRejectionTracker">
-        <h1>HostPromiseRejectionTracker ( _promise_, _operation_ )</h1>
-        <p>The host-defined abstract operation HostPromiseRejectionTracker takes arguments _promise_ (a Promise) and _operation_ (*"reject"* or *"handle"*). It allows host environments to track promise rejections.</p>
+      <emu-clause id="sec-host-promise-rejection-tracker" type="host-defined abstract operation">
+        <h1>
+          HostPromiseRejectionTracker (
+            _promise_: a Promise,
+            _operation_: *"reject"* or *"handle"*,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It allows host environments to track promise rejections.</dd>
+        </dl>
         <p>An implementation of HostPromiseRejectionTracker must complete normally in all cases. The default implementation of HostPromiseRejectionTracker is to unconditionally return an empty normal completion.</p>
 
         <emu-note>
@@ -38706,9 +42035,17 @@ THH:mm:ss.sss
     <emu-clause id="sec-promise-jobs">
       <h1>Promise Jobs</h1>
 
-      <emu-clause id="sec-newpromisereactionjob" aoid="NewPromiseReactionJob" oldids="sec-promisereactionjob">
-        <h1>NewPromiseReactionJob ( _reaction_, _argument_ )</h1>
-        <p>The abstract operation NewPromiseReactionJob takes arguments _reaction_ and _argument_. It returns a new Job Abstract Closure that applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler. It performs the following steps when called:</p>
+      <emu-clause id="sec-newpromisereactionjob" type="abstract operation" oldids="sec-promisereactionjob">
+        <h1>
+          NewPromiseReactionJob (
+            _reaction_: unknown,
+            _argument_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns a new Job Abstract Closure that applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler.</dd>
+        </dl>
         <emu-alg>
           1. Let _job_ be a new Job Abstract Closure with no parameters that captures _reaction_ and _argument_ and performs the following steps when called:
             1. Assert: _reaction_ is a PromiseReaction Record.
@@ -38740,9 +42077,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-newpromiseresolvethenablejob" aoid="NewPromiseResolveThenableJob" oldids="sec-promiseresolvethenablejob">
-        <h1>NewPromiseResolveThenableJob ( _promiseToResolve_, _thenable_, _then_ )</h1>
-        <p>The abstract operation NewPromiseResolveThenableJob takes arguments _promiseToResolve_, _thenable_, and _then_. It performs the following steps when called:</p>
+      <emu-clause id="sec-newpromiseresolvethenablejob" type="abstract operation" oldids="sec-promiseresolvethenablejob">
+        <h1>
+          NewPromiseResolveThenableJob (
+            _promiseToResolve_: unknown,
+            _thenable_: unknown,
+            _then_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _job_ be a new Job Abstract Closure with no parameters that captures _promiseToResolve_, _thenable_, and _then_ and performs the following steps when called:
             1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promiseToResolve_).
@@ -38828,9 +42172,14 @@ THH:mm:ss.sss
           <p>The `all` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
-        <emu-clause id="sec-getpromiseresolve" aoid="GetPromiseResolve">
-          <h1>GetPromiseResolve ( _promiseConstructor_ )</h1>
-          <p>The abstract operation GetPromiseResolve takes argument _promiseConstructor_. It performs the following steps when called:</p>
+        <emu-clause id="sec-getpromiseresolve" type="abstract operation">
+          <h1>
+            GetPromiseResolve (
+              _promiseConstructor_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: IsConstructor(_promiseConstructor_) is *true*.
             1. Let _promiseResolve_ be ? Get(_promiseConstructor_, *"resolve"*).
@@ -38839,9 +42188,17 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-performpromiseall" aoid="PerformPromiseAll">
-          <h1>PerformPromiseAll ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
-          <p>The abstract operation PerformPromiseAll takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
+        <emu-clause id="sec-performpromiseall" type="abstract operation">
+          <h1>
+            PerformPromiseAll (
+              _iteratorRecord_: unknown,
+              _constructor_: unknown,
+              _resultCapability_: a PromiseCapability Record,
+              _promiseResolve_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
             1. Assert: IsCallable(_promiseResolve_) is *true*.
@@ -38921,9 +42278,17 @@ THH:mm:ss.sss
           <p>The `allSettled` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
-        <emu-clause id="sec-performpromiseallsettled" aoid="PerformPromiseAllSettled">
-          <h1>PerformPromiseAllSettled ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
-          <p>The abstract operation PerformPromiseAllSettled takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
+        <emu-clause id="sec-performpromiseallsettled" type="abstract operation">
+          <h1>
+            PerformPromiseAllSettled (
+              _iteratorRecord_: unknown,
+              _constructor_: unknown,
+              _resultCapability_: a PromiseCapability Record,
+              _promiseResolve_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: ! IsConstructor(_constructor_) is *true*.
             1. Assert: IsCallable(_promiseResolve_) is *true*.
@@ -39042,9 +42407,17 @@ THH:mm:ss.sss
           <p>The `any` function requires its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
         </emu-note>
 
-        <emu-clause id="sec-performpromiseany" aoid="PerformPromiseAny">
-          <h1>PerformPromiseAny ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
-          <p>The abstract operation PerformPromiseAny takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
+        <emu-clause id="sec-performpromiseany" type="abstract operation">
+          <h1>
+            PerformPromiseAny (
+              _iteratorRecord_: unknown,
+              _constructor_: unknown,
+              _resultCapability_: a PromiseCapability Record,
+              _promiseResolve_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: ! IsConstructor(_constructor_) is *true*.
             1. Assert: ! IsCallable(_promiseResolve_) is *true*.
@@ -39135,9 +42508,17 @@ THH:mm:ss.sss
           <p>The `race` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor. It also expects that its *this* value provides a `resolve` method.</p>
         </emu-note>
 
-        <emu-clause id="sec-performpromiserace" aoid="PerformPromiseRace">
-          <h1>PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
-          <p>The abstract operation PerformPromiseRace takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
+        <emu-clause id="sec-performpromiserace" type="abstract operation">
+          <h1>
+            PerformPromiseRace (
+              _iteratorRecord_: unknown,
+              _constructor_: unknown,
+              _resultCapability_: a PromiseCapability Record,
+              _promiseResolve_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
             1. Assert: IsCallable(_promiseResolve_) is *true*.
@@ -39183,9 +42564,17 @@ THH:mm:ss.sss
           <p>The `resolve` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
-        <emu-clause id="sec-promise-resolve" aoid="PromiseResolve">
-          <h1>PromiseResolve ( _C_, _x_ )</h1>
-          <p>The abstract operation PromiseResolve takes arguments _C_ (a constructor) and _x_ (an ECMAScript language value). It returns a new promise resolved with _x_. It performs the following steps when called:</p>
+        <emu-clause id="sec-promise-resolve" type="abstract operation">
+          <h1>
+            PromiseResolve (
+              _C_: a constructor,
+              _x_: an ECMAScript language value,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns a new promise resolved with _x_.</dd>
+          </dl>
           <emu-alg>
             1. Assert: Type(_C_) is Object.
             1. If IsPromise(_x_) is *true*, then
@@ -39278,9 +42667,19 @@ THH:mm:ss.sss
           1. Return PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_, _resultCapability_).
         </emu-alg>
 
-        <emu-clause id="sec-performpromisethen" aoid="PerformPromiseThen">
-          <h1>PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_ [ , _resultCapability_ ] )</h1>
-          <p>The abstract operation PerformPromiseThen takes arguments _promise_, _onFulfilled_, and _onRejected_ and optional argument _resultCapability_ (a PromiseCapability Record). It performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. If _resultCapability_ is passed, the result is stored by updating _resultCapability_'s promise. If it is not passed, then PerformPromiseThen is being called by a specification-internal operation where the result does not matter. It performs the following steps when called:</p>
+        <emu-clause id="sec-performpromisethen" type="abstract operation">
+          <h1>
+            PerformPromiseThen (
+              _promise_: unknown,
+              _onFulfilled_: unknown,
+              _onRejected_: unknown,
+              optional _resultCapability_: a PromiseCapability Record,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. If _resultCapability_ is passed, the result is stored by updating _resultCapability_'s promise. If it is not passed, then PerformPromiseThen is being called by a specification-internal operation where the result does not matter.</dd>
+          </dl>
           <emu-alg>
             1. Assert: IsPromise(_promise_) is *true*.
             1. If _resultCapability_ is not present, then
@@ -39704,9 +43103,15 @@ THH:mm:ss.sss
     <emu-clause id="sec-generator-abstract-operations">
       <h1>Generator Abstract Operations</h1>
 
-      <emu-clause id="sec-generatorstart" aoid="GeneratorStart">
-        <h1>GeneratorStart ( _generator_, _generatorBody_ )</h1>
-        <p>The abstract operation GeneratorStart takes arguments _generator_ and _generatorBody_ (a Parse Node or an Abstract Closure with no parameters). It performs the following steps when called:</p>
+      <emu-clause id="sec-generatorstart" type="abstract operation">
+        <h1>
+          GeneratorStart (
+            _generator_: unknown,
+            _generatorBody_: a Parse Node or an Abstract Closure with no parameters,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
           1. Let _genContext_ be the running execution context.
@@ -39733,9 +43138,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-generatorvalidate" aoid="GeneratorValidate">
-        <h1>GeneratorValidate ( _generator_, _generatorBrand_ )</h1>
-        <p>The abstract operation GeneratorValidate takes arguments _generator_ and _generatorBrand_. It performs the following steps when called:</p>
+      <emu-clause id="sec-generatorvalidate" type="abstract operation">
+        <h1>
+          GeneratorValidate (
+            _generator_: unknown,
+            _generatorBrand_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_generator_, [[GeneratorState]]).
           1. Perform ? RequireInternalSlot(_generator_, [[GeneratorBrand]]).
@@ -39747,9 +43158,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-generatorresume" aoid="GeneratorResume">
-        <h1>GeneratorResume ( _generator_, _value_, _generatorBrand_ )</h1>
-        <p>The abstract operation GeneratorResume takes arguments _generator_, _value_, and _generatorBrand_. It performs the following steps when called:</p>
+      <emu-clause id="sec-generatorresume" type="abstract operation">
+        <h1>
+          GeneratorResume (
+            _generator_: unknown,
+            _value_: unknown,
+            _generatorBrand_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _state_ be ? GeneratorValidate(_generator_, _generatorBrand_).
           1. If _state_ is ~completed~, return CreateIterResultObject(*undefined*, *true*).
@@ -39765,9 +43183,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-generatorresumeabrupt" aoid="GeneratorResumeAbrupt">
-        <h1>GeneratorResumeAbrupt ( _generator_, _abruptCompletion_, _generatorBrand_ )</h1>
-        <p>The abstract operation GeneratorResumeAbrupt takes arguments _generator_, _abruptCompletion_ (a Completion Record whose [[Type]] is ~return~ or ~throw~), and _generatorBrand_. It performs the following steps when called:</p>
+      <emu-clause id="sec-generatorresumeabrupt" type="abstract operation">
+        <h1>
+          GeneratorResumeAbrupt (
+            _generator_: unknown,
+            _abruptCompletion_: a Completion Record whose [[Type]] is ~return~ or ~throw~,
+            _generatorBrand_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _state_ be ? GeneratorValidate(_generator_, _generatorBrand_).
           1. If _state_ is ~suspendedStart~, then
@@ -39790,9 +43215,10 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-getgeneratorkind" aoid="GetGeneratorKind">
+      <emu-clause id="sec-getgeneratorkind" type="abstract operation">
         <h1>GetGeneratorKind ( )</h1>
-        <p>The abstract operation GetGeneratorKind takes no arguments. It performs the following steps when called:</p>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. If _genContext_ does not have a Generator component, return ~non-generator~.
@@ -39802,9 +43228,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-generatoryield" aoid="GeneratorYield">
-        <h1>GeneratorYield ( _iterNextObj_ )</h1>
-        <p>The abstract operation GeneratorYield takes argument _iterNextObj_. It performs the following steps when called:</p>
+      <emu-clause id="sec-generatoryield" type="abstract operation">
+        <h1>
+          GeneratorYield (
+            _iterNextObj_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _iterNextObj_ is an Object that implements the <i>IteratorResult</i> interface.
           1. Let _genContext_ be the running execution context.
@@ -39821,9 +43252,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-yield" aoid="Yield">
-        <h1>Yield ( _value_ )</h1>
-        <p>The abstract operation Yield takes argument _value_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-clause id="sec-yield" type="abstract operation">
+        <h1>
+          Yield (
+            _value_: an ECMAScript language value,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _generatorKind_ be ! GetGeneratorKind().
           1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(_value_).
@@ -39831,9 +43267,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-createiteratorfromclosure" aoid="CreateIteratorFromClosure">
-        <h1>CreateIteratorFromClosure ( _closure_, _generatorBrand_, _generatorPrototype_ )</h1>
-        <p>The abstract operation CreateIteratorFromClosure takes arguments _closure_ (an Abstract Closure with no parameters), _generatorBrand_, and _generatorPrototype_ (an Object). It performs the following steps when called:</p>
+      <emu-clause id="sec-createiteratorfromclosure" type="abstract operation">
+        <h1>
+          CreateIteratorFromClosure (
+            _closure_: an Abstract Closure with no parameters,
+            _generatorBrand_: unknown,
+            _generatorPrototype_: an Object,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. NOTE: _closure_ can contain uses of the Yield shorthand to yield an IteratorResult object.
           1. Let _internalSlotsList_ be &laquo; [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] &raquo;.
@@ -40012,9 +43455,15 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorstart" aoid="AsyncGeneratorStart">
-        <h1>AsyncGeneratorStart ( _generator_, _generatorBody_ )</h1>
-        <p>The abstract operation AsyncGeneratorStart takes arguments _generator_ and _generatorBody_ (a Parse Node or an Abstract Closure with no parameters). It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratorstart" type="abstract operation">
+        <h1>
+          AsyncGeneratorStart (
+            _generator_: unknown,
+            _generatorBody_: a Parse Node or an Abstract Closure with no parameters,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _generator_ is an AsyncGenerator instance.
           1. Assert: _generator_.[[AsyncGeneratorState]] is *undefined*.
@@ -40041,9 +43490,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorvalidate" aoid="AsyncGeneratorValidate">
-        <h1>AsyncGeneratorValidate ( _generator_, _generatorBrand_ )</h1>
-        <p>The abstract operation AsyncGeneratorValidate takes arguments _generator_ and _generatorBrand_. It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratorvalidate" type="abstract operation">
+        <h1>
+          AsyncGeneratorValidate (
+            _generator_: unknown,
+            _generatorBrand_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorContext]]).
           1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorState]]).
@@ -40052,18 +43507,33 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorenqueue" aoid="AsyncGeneratorEnqueue">
-        <h1>AsyncGeneratorEnqueue ( _generator_, _completion_, _promiseCapability_ )</h1>
-        <p>The abstract operation AsyncGeneratorEnqueue takes arguments _generator_ (an AsyncGenerator), _completion_ (a Completion Record), and _promiseCapability_ (a PromiseCapability Record). It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratorenqueue" type="abstract operation">
+        <h1>
+          AsyncGeneratorEnqueue (
+            _generator_: an AsyncGenerator,
+            _completion_: a Completion Record,
+            _promiseCapability_: a PromiseCapability Record,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _request_ be AsyncGeneratorRequest { [[Completion]]: _completion_, [[Capability]]: _promiseCapability_ }.
           1. Append _request_ to the end of _generator_.[[AsyncGeneratorQueue]].
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorcompletestep" aoid="AsyncGeneratorCompleteStep">
-        <h1>AsyncGeneratorCompleteStep ( _generator_, _completion_, _done_ [ , _realm_ ] )</h1>
-        <p>The abstract operation AsyncGeneratorCompleteStep takes arguments _generator_ (an AsyncGenerator), _completion_ (a Completion Record), and _done_ (a Boolean) and optional argument _realm_ (a Realm Record). It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratorcompletestep" type="abstract operation">
+        <h1>
+          AsyncGeneratorCompleteStep (
+            _generator_: an AsyncGenerator,
+            _completion_: a Completion Record,
+            _done_: a Boolean,
+            optional _realm_: a Realm Record,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
           1. Assert: _queue_ is not empty.
@@ -40086,9 +43556,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorresume" aoid="AsyncGeneratorResume">
-        <h1>AsyncGeneratorResume ( _generator_, _completion_ )</h1>
-        <p>The abstract operation AsyncGeneratorResume takes arguments _generator_ (an AsyncGenerator) and _completion_ (a Completion Record). It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratorresume" type="abstract operation">
+        <h1>
+          AsyncGeneratorResume (
+            _generator_: an AsyncGenerator,
+            _completion_: a Completion Record,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Assert: _generator_.[[AsyncGeneratorState]] is either ~suspendedStart~ or ~suspendedYield~.
           1. Let _genContext_ be _generator_.[[AsyncGeneratorContext]].
@@ -40102,9 +43578,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorunwrapyieldresumption" aoid="AsyncGeneratorUnwrapYieldResumption">
-        <h1>AsyncGeneratorUnwrapYieldResumption ( _resumptionValue_ )</h1>
-        <p>The abstract operation AsyncGeneratorUnwrapYieldResumption takes argument _resumptionValue_ (a Completion Record). It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratorunwrapyieldresumption" type="abstract operation">
+        <h1>
+          AsyncGeneratorUnwrapYieldResumption (
+            _resumptionValue_: a Completion Record,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. If _resumptionValue_.[[Type]] is not ~return~, return Completion(_resumptionValue_).
           1. Let _awaited_ be Await(_resumptionValue_.[[Value]]).
@@ -40114,9 +43595,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratoryield" aoid="AsyncGeneratorYield">
-        <h1>AsyncGeneratorYield ( _value_ )</h1>
-        <p>The abstract operation AsyncGeneratorYield takes argument _value_. It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratoryield" type="abstract operation">
+        <h1>
+          AsyncGeneratorYield (
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
@@ -40145,9 +43631,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorawaitreturn" aoid="AsyncGeneratorAwaitReturn">
-        <h1>AsyncGeneratorAwaitReturn ( _generator_ )</h1>
-        <p>The abstract operation AsyncGeneratorAwaitReturn takes argument _generator_ (an AsyncGenerator). It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratorawaitreturn" type="abstract operation">
+        <h1>
+          AsyncGeneratorAwaitReturn (
+            _generator_: an AsyncGenerator,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
           1. Assert: _queue_ is not empty.
@@ -40173,9 +43664,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratordrainqueue" aoid="AsyncGeneratorDrainQueue">
-        <h1>AsyncGeneratorDrainQueue ( _generator_ )</h1>
-        <p>The abstract operation AsyncGeneratorDrainQueue takes argument _generator_ (an AsyncGenerator). It drains the generator's AsyncGeneratorQueue until it encounters an AsyncGeneratorRequest which holds a completion whose type is ~return~. It performs the following steps when called:</p>
+      <emu-clause id="sec-asyncgeneratordrainqueue" type="abstract operation">
+        <h1>
+          AsyncGeneratorDrainQueue (
+            _generator_: an AsyncGenerator,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It drains the generator's AsyncGeneratorQueue until it encounters an AsyncGeneratorRequest which holds a completion whose type is ~return~.</dd>
+        </dl>
         <emu-alg>
           1. Assert: _generator_.[[AsyncGeneratorState]] is ~completed~.
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
@@ -40196,9 +43694,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-createasynciteratorfromclosure" aoid="CreateAsyncIteratorFromClosure">
-        <h1>CreateAsyncIteratorFromClosure ( _closure_, _generatorBrand_, _generatorPrototype_ )</h1>
-        <p>The abstract operation CreateAsyncIteratorFromClosure takes arguments _closure_ (an Abstract Closure with no parameters), _generatorBrand_, and _generatorPrototype_ (an Object). It performs the following steps when called:</p>
+      <emu-clause id="sec-createasynciteratorfromclosure" type="abstract operation">
+        <h1>
+          CreateAsyncIteratorFromClosure (
+            _closure_: an Abstract Closure with no parameters,
+            _generatorBrand_: unknown,
+            _generatorPrototype_: an Object,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. NOTE: _closure_ can contain uses of the Await shorthand and uses of the Yield shorthand to yield an IteratorResult object.
           1. Let _internalSlotsList_ be &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] &raquo;.
@@ -40320,9 +43825,15 @@ THH:mm:ss.sss
     <emu-clause id="sec-async-functions-abstract-operations">
       <h1>Async Functions Abstract Operations</h1>
 
-      <emu-clause id="sec-async-functions-abstract-operations-async-function-start" aoid="AsyncFunctionStart">
-        <h1>AsyncFunctionStart ( _promiseCapability_, _asyncFunctionBody_ )</h1>
-        <p>The abstract operation AsyncFunctionStart takes arguments _promiseCapability_ (a PromiseCapability Record) and _asyncFunctionBody_. It performs the following steps when called:</p>
+      <emu-clause id="sec-async-functions-abstract-operations-async-function-start" type="abstract operation">
+        <h1>
+          AsyncFunctionStart (
+            _promiseCapability_: a PromiseCapability Record,
+            _asyncFunctionBody_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _runningContext_ be the running execution context.
           1. Let _asyncContext_ be a copy of _runningContext_.
@@ -40848,9 +44359,14 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-abstract-operations-for-the-memory-model" oldids="sec-synchronizeeventset">
     <h1>Abstract Operations for the Memory Model</h1>
-    <emu-clause id="sec-event-set" aoid="EventSet">
-      <h1>EventSet ( _execution_ )</h1>
-      <p>The abstract operation EventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
+    <emu-clause id="sec-event-set" type="abstract operation">
+      <h1>
+        EventSet (
+          _execution_: a candidate execution,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _events_ be an empty Set.
         1. For each Agent Events Record _aer_ of _execution_.[[EventsRecords]], do
@@ -40860,9 +44376,14 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-sharedatablockeventset" aoid="SharedDataBlockEventSet">
-      <h1>SharedDataBlockEventSet ( _execution_ )</h1>
-      <p>The abstract operation SharedDataBlockEventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
+    <emu-clause id="sec-sharedatablockeventset" type="abstract operation">
+      <h1>
+        SharedDataBlockEventSet (
+          _execution_: a candidate execution,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _events_ be an empty Set.
         1. For each event _E_ of EventSet(_execution_), do
@@ -40871,9 +44392,14 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-hosteventset" aoid="HostEventSet">
-      <h1>HostEventSet ( _execution_ )</h1>
-      <p>The abstract operation HostEventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
+    <emu-clause id="sec-hosteventset" type="abstract operation">
+      <h1>
+        HostEventSet (
+          _execution_: a candidate execution,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _events_ be an empty Set.
         1. For each event _E_ of EventSet(_execution_), do
@@ -40882,9 +44408,16 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-composewriteeventbytes" aoid="ComposeWriteEventBytes">
-      <h1>ComposeWriteEventBytes ( _execution_, _byteIndex_, _Ws_ )</h1>
-      <p>The abstract operation ComposeWriteEventBytes takes arguments _execution_ (a candidate execution), _byteIndex_ (a non-negative integer), and _Ws_ (a List of WriteSharedMemory or ReadModifyWriteSharedMemory events). It performs the following steps when called:</p>
+    <emu-clause id="sec-composewriteeventbytes" type="abstract operation">
+      <h1>
+        ComposeWriteEventBytes (
+          _execution_: a candidate execution,
+          _byteIndex_: a non-negative integer,
+          _Ws_: a List of WriteSharedMemory or ReadModifyWriteSharedMemory events,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Let _byteLocation_ be _byteIndex_.
         1. Let _bytesRead_ be a new empty List.
@@ -40910,9 +44443,15 @@ THH:mm:ss.sss
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-valueofreadevent" aoid="ValueOfReadEvent">
-      <h1>ValueOfReadEvent ( _execution_, _R_ )</h1>
-      <p>The abstract operation ValueOfReadEvent takes arguments _execution_ (a candidate execution) and _R_ (a ReadSharedMemory or ReadModifyWriteSharedMemory event). It performs the following steps when called:</p>
+    <emu-clause id="sec-valueofreadevent" type="abstract operation">
+      <h1>
+        ValueOfReadEvent (
+          _execution_: a candidate execution,
+          _R_: a ReadSharedMemory or ReadModifyWriteSharedMemory event,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. Assert: _R_ is a ReadSharedMemory or ReadModifyWriteSharedMemory event.
         1. Let _Ws_ be _execution_.[[ReadsBytesFrom]](_R_).
@@ -42077,9 +45616,15 @@ THH:mm:ss.sss
 
         <emu-note>This production can only be reached from the sequence `\c` within a character class where it is not followed by an acceptable control character.</emu-note>
 
-        <emu-annex id="sec-runtime-semantics-characterrangeorunion-abstract-operation" aoid="CharacterRangeOrUnion">
-          <h1>CharacterRangeOrUnion ( _A_, _B_ )</h1>
-          <p>The abstract operation CharacterRangeOrUnion takes arguments _A_ (a CharSet) and _B_ (a CharSet). It performs the following steps when called:</p>
+        <emu-annex id="sec-runtime-semantics-characterrangeorunion-abstract-operation" type="abstract operation">
+          <h1>
+            CharacterRangeOrUnion (
+              _A_: a CharSet,
+              _B_: a CharSet,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. If _Unicode_ is *false*, then
               1. If _A_ does not contain exactly one character or _B_ does not contain exactly one character, then
@@ -42326,9 +45871,17 @@ THH:mm:ss.sss
           1. Return ? CreateHTML(_S_, *"a"*, *"name"*, _name_).
         </emu-alg>
 
-        <emu-annex id="sec-createhtml" aoid="CreateHTML">
-          <h1>CreateHTML ( _string_, _tag_, _attribute_, _value_ )</h1>
-          <p>The abstract operation CreateHTML takes arguments _string_, _tag_ (a String), _attribute_ (a String), and _value_. It performs the following steps when called:</p>
+        <emu-annex id="sec-createhtml" type="abstract operation">
+          <h1>
+            CreateHTML (
+              _string_: unknown,
+              _tag_: a String,
+              _attribute_: a String,
+              _value_: unknown,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
           <emu-alg>
             1. Let _str_ be ? RequireObjectCoercible(_string_).
             1. Let _S_ be ? ToString(_str_).


### PR DESCRIPTION
Following up on issue 253, specifically https://github.com/tc39/ecma262/issues/253#issuecomment-164852263

For each abstract operation (241 in all), I have taken the information in the prose preamble (or failing that, in the section's h1), and recast it into a structure of the following form:

```
    <emu-operation-header>
      name: ExampleOperation
      parameters:
        * _foo_ : an Object
        * _bar_ : (optional) an integer that indicates something or other
      also has access to:
        * _qux_ : ...
      returns:
        * normal : an Object
        * abrupt : throw *TypeError*
      description: does something exemplary to the given object.
    </emu-operation-header>
```

This structure is just a strawman. If you like the idea but not this particular structure, I should be able to regenerate the info in a different structure. (So far, the conversion is all done by code.)

Here are some things you might want to change (and that I should be able to accomplish):
- You might want to call it something other than `<emu-operation-header>`.
- For parameters, you might want to restrict the after-colon info to just type and optionality;
  any info about how the parameter is interpreted or used would go into the description.
  (Mostly, that's what I've done, but there are exceptions.)
- For returns, rather than the normal/abrupt dichotomy,
  you might want normal/continue/break/return/throw. 
- For the description, you might rename it to 'summary' or 'synopsis',
  and you might want it to appear right after the 'name' line.
  (You might want to split it into a one-liner that appears after the name,
  and (if necessary) a more detailed description that appears later,
  but it's unlikely I'd accomplish that in code.)

(You also might want this notation applied to other kinds of operations, such as concrete methods, internal methods, and syntax-discriminated operations.)

Note that, as much as possible, I've used wording from the existing preambles for the after-colon content, so there are inconsistencies. (E.g., for a parameter, it might say: `Object`, `an Object`, `object`, `an object`, or `the object`.) Eventually, you'd want to eliminate those inconsistencies, but I decided not to presume too much just yet.

Also, you will see lots of "TBD" ("to be determined"), because preambles often leave out details. In a later commit, I could try to fix TBDs based on info in algorithm steps.
