### PR TITLE
[normative] Promote consistent scoping for classes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19009,7 +19009,10 @@ eval("1;var a;")
             1. Let _constructorParent_ be the intrinsic object %FunctionPrototype%.
           1. Else if IsConstructor(_superclass_) is *false*, throw a *TypeError* exception.
           1. Else,
-            1. Let _protoParent_ be ? Get(_superclass_, `"prototype"`).
+            1. Set the running execution context's LexicalEnvironment to _classScope_.
+            1. Let _protoParent_ be Get(_superclass_, `"prototype"`).
+            1. Set the running execution context's LexicalEnvironment to _lex_.
+            1. ReturnIfAbrupt(_protoParent_).
             1. If Type(_protoParent_) is neither Object nor Null, throw a *TypeError* exception.
             1. Let _constructorParent_ be _superclass_.
         1. Let _proto_ be ObjectCreate(_protoParent_).


### PR DESCRIPTION
> Prior to evaluating the optional class heritage, the running execution
> context's LexicalEnvironment is set to `classScope`, an environment
> dedicated to the class's "name" binding. This may be observed from
> ECMAScript code such as:
> 
>     let C = null;
>     {
>       (class C extends C {}); // ReferenceError: C is not initialized
>     }
> 
> The following access of the `prototype` property of the class's parent
> constructor (where defined) is an observable operation. As such, the
> LexicalEnvironment at this time can be detected here, as well:
> 
>     let C = null;
>     {
>       (class C extends new Proxy(function() {}, { get() { return C; } }) {});
>     }
> 
> As written, the running execution context's LexicalEnvironment is *not*
> set to the environment created for the class's "name" binding (e.g. the
> `classScope`). Therefore, this second example would *not* produce a
> ReferenceError.
> 
> This interleaving lexical environments during ClassDefinitionEvaluation
> is inconsistent. Modify the specification text to explicitly re-set the
> running execution's LexicalEnvironment when retrieving the `prototype`
> property of the parent constructor.

A couple notes:

- V8 and SpiderMonkey already implement the semantics defined by this patch
- An alternative would be to only set the running execution context to
  _classScope_ **once** in this branch, and un-setting it as necessary. This
  seemed more natural at first, but there are a total of four locations where
  un-setting would need to occur (two of which require expanding shorthands
  like ReturnIfAbrupt and the "?" notation). I elected to take this approach in
  order to promote the readability of the surrounding text, but I'm happy to
  re-factor if necessary.