### PR TITLE
TypedArrays slice set operation does not throw

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31454,8 +31454,8 @@ THH:mm:ss.sss
             1. Let _n_ be 0.
             1. Repeat, while _k_ &lt; _final_
               1. Let _Pk_ be ! ToString(_k_).
-              1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Perform ? Set(_A_, ! ToString(_n_), _kValue_, *true*).
+              1. Let _kValue_ be ! Get(_O_, _Pk_).
+              1. Perform ! Set(_A_, ! ToString(_n_), _kValue_).
               1. Increase _k_ by 1.
               1. Increase _n_ by 1.
           1. Else if _count_ &gt; 0, then

--- a/spec.html
+++ b/spec.html
@@ -31454,7 +31454,7 @@ THH:mm:ss.sss
             1. Let _n_ be 0.
             1. Repeat, while _k_ &lt; _final_
               1. Let _Pk_ be ! ToString(_k_).
-              1. Let _kValue_ be ! Get(_O_, _Pk_).
+              1. Let _kValue_ be ? Get(_O_, _Pk_).
               1. Perform ! Set(_A_, ! ToString(_n_), _kValue_).
               1. Increase _k_ by 1.
               1. Increase _n_ by 1.


### PR DESCRIPTION
The [step 9 from 22.2.3.24](https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.slice) creates a new TypedArray instance that will be validated on [22.2.4.6 step 2](https://tc39.github.io/ecma262/#typedarray-create), including a validation for a length that is >= the given `count`, which is never gonna be higher than the original instance's length.

It seems it is impossible to have an abrupt completion from the ~~_Get_ and~~ _Set_ operations on steps ~~14.b.ii and~~ 14.b.iii. This patch reflects it.