### PR TITLE
Layering: take care of edge cases for GetActiveScriptOrModule()

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5984,15 +5984,12 @@
 
     <emu-clause id="sec-getactivescriptormodule" aoid="GetActiveScriptOrModule">
       <h1>GetActiveScriptOrModule ()</h1>
-      <p>The GetActiveScriptOrModule abstract operation is used to determine the running script or module, based on the active function object. GetActiveScriptOrModule performs the following steps:</p>
+      <p>The GetActiveScriptOrModule abstract operation is used to determine the running script or module, based on the running execution context. GetActiveScriptOrModule performs the following steps:</p>
 
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
-        1. Let _ec_ be the topmost execution context on the execution context stack whose Function component's [[ScriptOrModule]] component is not *null*.
-        1. If such an execution context exists, return _ec_'s Function component's [[ScriptOrModule]] slot's value.
-        1. Otherwise, let _ec_ be the running execution context.
-        1. Assert: _ec_'s ScriptOrModule component is not *null*.
-        1. Return _ec_'s ScriptOrModule component.
+        1. Let _ec_ be the topmost execution context on the execution context stack whose ScriptOrModule component is not *null*.
+        1. If no such execution context exists, return *null*. Otherwise, return _ec_'s ScriptOrModule component.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Instead of only looking at Function components, and falling back to the running execution context, simply go for the topmost execution context with a ScriptOrModule component.

The "no such context exists" case can in fact be reached, if GetActiveScriptOrModule() is called with a stack that only contains the "realm execution context" (i.e. if this is called without being initiated by ScriptEvaluation or ModuleEvaluation).