### PR TITLE
[normative] Specify char case of `escape` output

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36112,9 +36112,9 @@ THH:mm:ss.sss
             1. If _char_ is one of the code units in `"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@*_+-./"`, then
               1. Let _S_ be a String containing the single code unit _char_.
             1. Else if _char_ &ge; 256, then
-              1. Let _S_ be a String containing six code units <code>"%u<var>wxyz</var>"</code> where _wxyz_ are the code units of the four hexadecimal digits encoding the value of _char_.
+              1. Let _S_ be a String containing six code units <code>"%u<var>wxyz</var>"</code> where _wxyz_ are the code units of the four hexadecimal digits encoding the value of _char_. Alphabetic hexadecimal digits are presented as uppercase Latin letters.
             1. Else _char_ &lt; 256,
-              1. Let _S_ be a String containing three code units <code>"%<var>xy</var>"</code> where _xy_ are the code units of two hexadecimal digits encoding the value of _char_.
+              1. Let _S_ be a String containing three code units <code>"%<var>xy</var>"</code> where _xy_ are the code units of two hexadecimal digits encoding the value of _char_. Alphabetic hexadecimal digits are presented as uppercase Latin letters.
             1. Let _R_ be a new String value computed by concatenating the previous value of _R_ and _S_.
             1. Increase _k_ by 1.
           1. Return _R_.

--- a/spec.html
+++ b/spec.html
@@ -36112,9 +36112,9 @@ THH:mm:ss.sss
             1. If _char_ is one of the code units in `"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@*_+-./"`, then
               1. Let _S_ be a String containing the single code unit _char_.
             1. Else if _char_ &ge; 256, then
-              1. Let _S_ be a String containing six code units <code>"%u<var>wxyz</var>"</code> where _wxyz_ are the code units of the four hexadecimal digits encoding the value of _char_. Alphabetic hexadecimal digits are presented as uppercase Latin letters.
+              1. Let _S_ be a String containing six code units <code>"%u<var>wxyz</var>"</code> where _wxyz_ are the code units of the four uppercase hexadecimal digits encoding the value of _char_.
             1. Else _char_ &lt; 256,
-              1. Let _S_ be a String containing three code units <code>"%<var>xy</var>"</code> where _xy_ are the code units of two hexadecimal digits encoding the value of _char_. Alphabetic hexadecimal digits are presented as uppercase Latin letters.
+              1. Let _S_ be a String containing three code units <code>"%<var>xy</var>"</code> where _xy_ are the code units of two uppercase hexadecimal digits encoding the value of _char_.
             1. Let _R_ be a new String value computed by concatenating the previous value of _R_ and _S_.
             1. Increase _k_ by 1.
           1. Return _R_.


### PR DESCRIPTION
Previously, the character case of alphabetic hexidecimal digits rendered
by the `escape` function was unspecified. Specify the case to be "upper
case" in order to reduce ambiguity and match the behavior implemented by
the following web browsers:

Browser           | Version (operating system)
------------------|------------------------------------------------------------
Microsoft Edge    | v13 (Windows 10), v12 (Windows 10)
Internet Explorer | v11 (Windows 10), v6 (Windows XP)
Firefox           | v46 (Windows 10), v32 (Windows 10), v3 (Windows XP)
Chrome            | v50 (Windows 10), v37 (Windows 10), Android v5, Android N
Opera             | v36 (Windows 10), v23 (Windows 10), v10.6 (Windows XP)
Yandex            | v14.12 (Windows 10)
Safari            | v9 (OSX El Capitan), v5.1 (Windows 10), v4 (OSX Snow Leapord), v4 (Windows XP), iOS v9, iOS v7