### PR TITLE
[editorial] Remove tautological condition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36454,7 +36454,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, let _t_ be *+0*; otherwise, let _t_ be LocalTime(_t_).
           1. Let _y_ be ? ToNumber(_year_).
           1. If _y_ is *NaN*, set the [[DateValue]] internal slot of this Date object to *NaN* and return *NaN*.
-          1. If _y_ is not *NaN* and 0 &le; ToInteger(_y_) &le; 99, let _yyyy_ be ToInteger(_y_) + 1900.
+          1. If 0 &le; ToInteger(_y_) &le; 99, let _yyyy_ be ToInteger(_y_) + 1900.
           1. Else, let _yyyy_ be _y_.
           1. Let _d_ be MakeDay(_yyyy_, MonthFromTime(_t_), DateFromTime(_t_)).
           1. Let _date_ be UTC(MakeDate(_d_, TimeWithinDay(_t_))).


### PR DESCRIPTION
At this step of the algorithm, `y` cannot take the value NaN because the
previous branch would have been taken, terminating algorithm execution.
This makes the explicit condition superfluous.