### PR TITLE
Normative: Return this on %TypedArray%.prototype.set

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31373,7 +31373,7 @@ THH:mm:ss.sss
               1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _kNumber_).
               1. Set _k_ to _k_ + 1.
               1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
-            1. Return *undefined*.
+            1. Return _target_.
           </emu-alg>
         </emu-clause>
 
@@ -31424,7 +31424,7 @@ THH:mm:ss.sss
                 1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
-            1. Return *undefined*.
+            1. Return _target_.
           </emu-alg>
         </emu-clause>
       </emu-clause>


### PR DESCRIPTION
Even if this change is super small, it's good to have more feedback, mostly from implementors.

Historically, `%TypedArray%#set` returns `undefined` in the Khronos spec, I believe that's the reason we have it this way.

I've talked to some developers with background experience on TypedArrays and WebGL and asked if this change would be useful. They confirmed it's a handy change. Plus, it allows chainable calls and makes it a bit more consistent with the other JS methods, like TypedArrays or even `Map#set`.

The main and only concern is performance. I _informally_ asked a few implementors and it looks the impact wouldn't be a problem, if any. I would like to have more feedback on this part.