### PR TITLE
Meta: Remove proposals list and point to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,12 @@
 ECMAScript
 ====
 
-
 ## Current Proposals
 Proposals follow [this process document](https://tc39.github.io/process-document/).
 
-|🚀| Proposal                                                                                             | Champion      | Stage
-|---|------------------------------------------------------------------------------------                 |-------------- | ------|------
-| | [Object.values/Object.entries](https://github.com/tc39/proposal-object-values-entries) | Jordan Harband | 4
-| | [SIMD.JS - SIMD APIs](https://docs.google.com/presentation/d/1MY9NHrHmL7ma7C8dyNXvmYNNGgVmmxXk8ZIiQtPlfH4/edit?usp=sharing) +  [polyfill](http://tc39.github.io/ecmascript_simd/)| John McCutchan, Peter Jensen, Dan Gohman, Daniel Ehrenberg |3      |
-| | [Async Functions](https://github.com/tc39/ecmascript-asyncawait)                                |Brian Terlson    |3      |
-| | [String padding](https://github.com/tc39/proposal-string-pad-start-end) | Jordan Harband & Rick Waldron | 3
-| | [Trailing commas in function parameter lists and calls](https://jeffmo.github.io/es-trailing-function-commas/) | Jeff Morrison | 3
-| | [Object.getOwnPropertyDescriptors](https://github.com/ljharb/proposal-object-getownpropertydescriptors) | Jordan Harband & Andrea Giammarchi | 3
-| | [`Function.prototype.toString` revision](https://github.com/tc39/Function-prototype-toString-revision) | Michael Ficarra | 3
-| | [Asynchronous Iterators](https://github.com/tc39/proposal-async-iteration) | Kevin Smith | 2
-| | [function.sent metaproperty](https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md) |  Allen Wirfs-Brock |2      |
-| | [Rest/Spread Properties](https://github.com/sebmarkbage/ecmascript-rest-spread) | Sebastian Markbage | 2
-| | [Shared memory and atomics](https://github.com/tc39/ecmascript_sharedmem) | Lars T Hansen | 2
-| | [System.global](https://github.com/tc39/proposal-global) | Jordan Harband | 2
-| | [ArrayBuffer.transfer](https://gist.github.com/lukewagner/2735af7eea411e18cf20) | Luke Wagneer & Allen Wirfs-Brock | 1
-|🚀| [`export * as ns from "mod";` statements](https://github.com/leebyron/ecmascript-export-ns-from)| Lee Byron | 1
-|🚀| [`export v from "mod";` statements](https://github.com/leebyron/ecmascript-export-default-from)| Lee Byron | 1
-|🚀|[Class and Property Decorators](https://github.com/wycats/javascript-decorators/blob/master/README.md) | Yehuda Katz and Jonathan Turner | 1 |
-| | [Observable](https://github.com/zenparsing/es-observable) | Kevin Smith & Jafar Husain | 1
-| | [String.prototype.{trimLeft,trimRight}](https://github.com/sebmarkbage/ecmascript-string-left-right-trim) | Sebastian Markbage | 1
-| | [Class Property Declarations](https://github.com/jeffmo/es-class-fields-and-static-properties)| Jeff Morrison| 1
-| | [String#matchAll](https://github.com/tc39/String.prototype.matchAll) | Jordan Harband | 1
-| | [Private Fields](https://github.com/zenparsing/es-private-fields) | Kevin Smith | 1
-| | [WeakRefs](https://github.com/tc39/proposal-weakrefs) | Dean Tribble | 1
-| | [Frozen Realms](https://github.com/FUDCo/frozen-realms) | Mark S. Miller, Chip Morningstar, Caridy Patiño | 1
+The list of active proposals has moved [here](https://github.com/tc39/proposals).
 
-🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
-
-See also the [stage 0 proposals](stage0.md).
+See also the [stage 0 proposals](https://github.com/tc39/proposals/blob/master/stage-0-proposals.md).
 
 ### Contributing New Proposals
 

--- a/stage0.md
+++ b/stage0.md
@@ -2,24 +2,4 @@
 
 Stage 0 proposals have been presented to the committee and not rejected definitively, but have not yet achieved any of the criteria to get into stage 1.
 
-
-|🚀| Proposal                                                                                             | Champion      | Stage
-|---|------------------------------------------------------------------------------------                 |-------------- | ------|------
-| | [Defensible Classes](http://wiki.ecmascript.org/doku.php?id=strawman:defensible_classes) | Mark Miller & Doug Crockford | 0
-| | [Relationships](http://wiki.ecmascript.org/doku.php?id=strawman:relationships) | Mark Miller & Waldemar Horwat | 0
-|🚀| [`String.prototype.at`](https://github.com/mathiasbynens/String.prototype.at) | Mathias Bynens & Rick Waldron | 0     |
-| | [Structured Clone](https://github.com/dslomov-chromium/ecmascript-structured-clone)       |Dmitry Lomov   |0
-| | Annex B - HTML Attribute Event Handlers| Allen Wirfs-Brock | 0
-| | [Reflect.isCallable/Reflect.isConstructor](https://github.com/caitp/TC39-Proposals/blob/master/tc39-reflect-isconstructor-iscallable.md)| Caitlin Potter| 0
-| | [Additional metaproperties](https://github.com/allenwb/ESideas/blob/master/ES7MetaProps.md)| Allen Wirfs-Brock| 0
-| | [Function Bind Syntax](https://github.com/zenparsing/es-function-bind)| Kevin Smith | 0
-| | [Do Expressions](http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions) | Andreas Rossberg | 0
-| | [RegExp](https://github.com/goyakin/es-regexp) | Gorkem Yakin, Brian Terlson, & Nozomu Katō | 0
-| | [64-Bit Integer Operations](https://gist.github.com/BrendanEich/4294d5c212a6d2254703) | Brendan Eich | 0
-| | [Method Parameter Decorators](https://goo.gl/r1XT9b) | Igor Minar | 0
-| | [Function Expression Decorators](https://goo.gl/8MmCMG) | Igor Minar | 0
-|🚀| [Zones](https://github.com/domenic/zones) ([spec](https://domenic.github.io/zones/)) | Domenic Denicola & Miško Hevery | 0
-| | [Updates to Tail Calls to include an explicit syntactic opt-in](https://github.com/tc39/proposal-ptc-syntax) | Brian Terlson & Eric Faust | 0
-|🚀| [Object enumerables](https://github.com/leobalter/object-enumerables) | Leo Balter & Jonn-David Dalton | 0
-
-🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
+This list has moved [here](https://github.com/tc39/proposals/blob/master/stage-0-proposals.md).

--- a/withdrawn-proposals.md
+++ b/withdrawn-proposals.md
@@ -1,9 +1,3 @@
 # Withdrawn Proposals
 
-Withdrawn proposals are proposals that at one point were presented to the committee but was subsequently abandoned.
-
-| Proposal | Champion | Rationale |
-|----------|----------|-----------|
-|[Callable class constructors](https://github.com/tc39/ecma262/blob/master/workingdocs/callconstructor.md) | Yehuda Katz and Allen Wirfs-Brock | Can be solved with decorators |
-| [Error.isError](https://github.com/ljharb/proposal-is-error) | Jordan Harband | Withdrawn in favor of a proposal to standardize Error stack traces |
-| [Set/Map.prototype.toJSON](https://github.com/DavidBruant/Map-Set.prototype.toJSON) | David Bruant and Jordan Harband | Better solved by a custom replacer function.
+This list has moved [here](https://github.com/tc39/proposals/blob/master/inactive-proposals.md).


### PR DESCRIPTION
This removes the list of proposals from the main `ecma262` repo, and moves them to a separate repo hosted [here](https://github.com/tc39/proposals).

Some advantages of this include that the specification's commit log no longer need be cluttered with "Meta" commits updating proposal information, and that all TC39 members will now have full push access to edit the proposals list without any concern about too many people having full access to the official spec.