### PR TITLE
Editorial: Tweak the syntax of grammatical parameters.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -536,7 +536,7 @@
       <emu-grammar>
         StatementList :
           ReturnStatement
-          ExpressionStatement[In]
+          ExpressionStatement[+In]
       </emu-grammar>
       <p>is equivalent to saying:</p>
       <emu-grammar>
@@ -544,10 +544,22 @@
           ReturnStatement
           ExpressionStatement_In
       </emu-grammar>
+      <p>and</p>
+      <emu-grammar>
+        StatementList :
+          ReturnStatement
+          ExpressionStatement[~In]
+      </emu-grammar>
+      <p>is equivalent to:</p>
+      <emu-grammar>
+        StatementList :
+          ReturnStatement
+          ExpressionStatement
+      </emu-grammar>
       <p>A nonterminal reference may have both a parameter list and an &ldquo;<sub>opt</sub>&rdquo; suffix. For example:</p>
       <emu-grammar>
         VariableDeclaration :
-          BindingIdentifier Initializer[In]?
+          BindingIdentifier Initializer[+In]?
       </emu-grammar>
       <p>is an abbreviation for:</p>
       <emu-grammar>
@@ -10369,17 +10381,17 @@
 
           ReturnStatement[Yield] :
             `return` `;`
-            `return` [no LineTerminator here] Expression[In, ?Yield] `;`
+            `return` [no LineTerminator here] Expression[+In, ?Yield] `;`
 
           ThrowStatement[Yield] :
-            `throw` [no LineTerminator here] Expression[In, ?Yield] `;`
+            `throw` [no LineTerminator here] Expression[+In, ?Yield] `;`
 
           ArrowFunction[In, Yield] :
             ArrowParameters[?Yield] [no LineTerminator here] `=&gt;` ConciseBody[?In]
 
           YieldExpression[In] :
-            `yield` [no LineTerminator here] `*` AssignmentExpression[?In, Yield]
-            `yield` [no LineTerminator here] AssignmentExpression[?In, Yield]
+            `yield` [no LineTerminator here] `*` AssignmentExpression[?In, +Yield]
+            `yield` [no LineTerminator here] AssignmentExpression[?In, +Yield]
         </emu-grammar>
         <p>The practical effect of these restricted productions is as follows:</p>
         <ul>
@@ -10665,12 +10677,12 @@
         CoverParenthesizedExpressionAndArrowParameterList[?Yield] #parencover
 
       CoverParenthesizedExpressionAndArrowParameterList[Yield] :
-        `(` Expression[In, ?Yield] `)`
+        `(` Expression[+In, ?Yield] `)`
         `(` `)`
         `(` `...` BindingIdentifier[?Yield] `)`
         `(` `...` BindingPattern[?Yield] `)`
-        `(` Expression[In, ?Yield] `,` `...` BindingIdentifier[?Yield] `)`
-        `(` Expression[In, ?Yield] `,` `...` BindingPattern[?Yield] `)`
+        `(` Expression[+In, ?Yield] `,` `...` BindingIdentifier[?Yield] `)`
+        `(` Expression[+In, ?Yield] `,` `...` BindingPattern[?Yield] `)`
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
     <p>When processing the production
@@ -10680,7 +10692,7 @@
       the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
     <emu-grammar>
       ParenthesizedExpression[Yield] :
-        `(` Expression[In, ?Yield] `)`
+        `(` Expression[+In, ?Yield] `)`
     </emu-grammar>
 
     <!-- es6num="12.2.1" -->
@@ -10690,9 +10702,9 @@
       <!-- es6num="12.2.1.1" -->
       <emu-clause id="sec-static-semantics-coveredparenthesizedexpression">
         <h1>Static Semantics: CoveredParenthesizedExpression</h1>
-        <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList[Yield] : `(` Expression[In, ?Yield] `)`</emu-grammar>
+        <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList[Yield] : `(` Expression[+In, ?Yield] `)`</emu-grammar>
         <emu-alg>
-          1. Return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList[Yield]| using either |ParenthesizedExpression| or |ParenthesizedExpression[Yield]| as the goal symbol depending upon whether the <sub>[Yield]</sub> grammar parameter was present when |CoverParenthesizedExpressionAndArrowParameterList| was matched.
+          1. Return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList[Yield]| using either |ParenthesizedExpression[~Yield]| or |ParenthesizedExpression[+Yield]| as the goal symbol depending upon whether the <sub>[Yield]</sub> grammar parameter was present when |CoverParenthesizedExpressionAndArrowParameterList| was matched.
         </emu-alg>
       </emu-clause>
 
@@ -10855,9 +10867,9 @@
           `[` ElementList[?Yield] `,` Elision? `]`
 
         ElementList[Yield] :
-          Elision? AssignmentExpression[In, ?Yield]
+          Elision? AssignmentExpression[+In, ?Yield]
           Elision? SpreadElement[?Yield]
-          ElementList[?Yield] `,` Elision? AssignmentExpression[In, ?Yield]
+          ElementList[?Yield] `,` Elision? AssignmentExpression[+In, ?Yield]
           ElementList[?Yield] `,` Elision? SpreadElement[?Yield]
 
         Elision :
@@ -10865,7 +10877,7 @@
           Elision `,`
 
         SpreadElement[Yield] :
-          `...` AssignmentExpression[In, ?Yield]
+          `...` AssignmentExpression[+In, ?Yield]
       </emu-grammar>
 
       <!-- es6num="12.2.5.1" -->
@@ -10989,7 +11001,7 @@
         PropertyDefinition[Yield] :
           IdentifierReference[?Yield]
           CoverInitializedName[?Yield]
-          PropertyName[?Yield] `:` AssignmentExpression[In, ?Yield]
+          PropertyName[?Yield] `:` AssignmentExpression[+In, ?Yield]
           MethodDefinition[?Yield]
 
         PropertyName[Yield] :
@@ -11002,10 +11014,10 @@
           NumericLiteral
 
         ComputedPropertyName[Yield] :
-          `[` AssignmentExpression[In, ?Yield] `]`
+          `[` AssignmentExpression[+In, ?Yield] `]`
 
         CoverInitializedName[Yield] :
-          IdentifierReference[?Yield] Initializer[In, ?Yield]
+          IdentifierReference[?Yield] Initializer[+In, ?Yield]
 
         Initializer[In, Yield] :
           `=` AssignmentExpression[?In, ?Yield]
@@ -11277,15 +11289,15 @@
       <emu-grammar>
         TemplateLiteral[Yield] :
           NoSubstitutionTemplate
-          TemplateHead Expression[In, ?Yield] TemplateSpans[?Yield]
+          TemplateHead Expression[+In, ?Yield] TemplateSpans[?Yield]
 
         TemplateSpans[Yield] :
           TemplateTail
           TemplateMiddleList[?Yield] TemplateTail
 
         TemplateMiddleList[Yield] :
-          TemplateMiddle Expression[In, ?Yield]
-          TemplateMiddleList[?Yield] TemplateMiddle Expression[In, ?Yield]
+          TemplateMiddle Expression[+In, ?Yield]
+          TemplateMiddleList[?Yield] TemplateMiddle Expression[+In, ?Yield]
       </emu-grammar>
 
       <!-- es6num="12.2.9.1" -->
@@ -11560,7 +11572,7 @@
     <emu-grammar>
       MemberExpression[Yield] :
         PrimaryExpression[?Yield]
-        MemberExpression[?Yield] `[` Expression[In, ?Yield] `]`
+        MemberExpression[?Yield] `[` Expression[+In, ?Yield] `]`
         MemberExpression[?Yield] `.` IdentifierName
         MemberExpression[?Yield] TemplateLiteral[?Yield]
         SuperProperty[?Yield]
@@ -11568,7 +11580,7 @@
         `new` MemberExpression[?Yield] Arguments[?Yield]
 
       SuperProperty[Yield] :
-        `super` `[` Expression[In, ?Yield] `]`
+        `super` `[` Expression[+In, ?Yield] `]`
         `super` `.` IdentifierName
 
       MetaProperty :
@@ -11585,7 +11597,7 @@
         MemberExpression[?Yield] Arguments[?Yield]
         SuperCall[?Yield]
         CallExpression[?Yield] Arguments[?Yield]
-        CallExpression[?Yield] `[` Expression[In, ?Yield] `]`
+        CallExpression[?Yield] `[` Expression[+In, ?Yield] `]`
         CallExpression[?Yield] `.` IdentifierName
         CallExpression[?Yield] TemplateLiteral[?Yield]
 
@@ -11597,10 +11609,10 @@
         `(` ArgumentList[?Yield] `)`
 
       ArgumentList[Yield] :
-        AssignmentExpression[In, ?Yield]
-        `...` AssignmentExpression[In, ?Yield]
-        ArgumentList[?Yield] `,` AssignmentExpression[In, ?Yield]
-        ArgumentList[?Yield] `,` `...` AssignmentExpression[In, ?Yield]
+        AssignmentExpression[+In, ?Yield]
+        `...` AssignmentExpression[+In, ?Yield]
+        ArgumentList[?Yield] `,` AssignmentExpression[+In, ?Yield]
+        ArgumentList[?Yield] `,` `...` AssignmentExpression[+In, ?Yield]
 
       LeftHandSideExpression[Yield] :
         NewExpression[?Yield]
@@ -13053,7 +13065,7 @@
         RelationalExpression[?In, ?Yield] `&lt;=` ShiftExpression[?Yield]
         RelationalExpression[?In, ?Yield] `&gt;=` ShiftExpression[?Yield]
         RelationalExpression[?In, ?Yield] `instanceof` ShiftExpression[?Yield]
-        [+In] RelationalExpression[In, ?Yield] `in` ShiftExpression[?Yield]
+        [+In] RelationalExpression[+In, ?Yield] `in` ShiftExpression[?Yield]
     </emu-grammar>
     <emu-note>
       <p>The [In] grammar parameter is needed to avoid confusing the `in` operator in a relational expression with the `in` operator in a `for` statement.</p>
@@ -13444,7 +13456,7 @@
     <emu-grammar>
       ConditionalExpression[In, Yield] :
         LogicalORExpression[?In, ?Yield]
-        LogicalORExpression[?In, ?Yield] `?` AssignmentExpression[In, ?Yield] `:` AssignmentExpression[?In, ?Yield]
+        LogicalORExpression[?In, ?Yield] `?` AssignmentExpression[+In, ?Yield] `:` AssignmentExpression[?In, ?Yield]
     </emu-grammar>
     <emu-note>
       <p>The grammar for a |ConditionalExpression| in ECMAScript is slightly different from that in C and Java, which each allow the second subexpression to be an |Expression| but restrict the third expression to be a |ConditionalExpression|. The motivation for this difference in ECMAScript is to allow an assignment expression to be governed by either arm of a conditional and to eliminate the confusing and fairly useless case of a comma expression as the centre expression.</p>
@@ -13628,11 +13640,11 @@
           Elision? AssignmentElement[?Yield]
 
         AssignmentProperty[Yield] :
-          IdentifierReference[?Yield] Initializer[In, ?Yield]?
+          IdentifierReference[?Yield] Initializer[+In, ?Yield]?
           PropertyName[?Yield] `:` AssignmentElement[?Yield]
 
         AssignmentElement[Yield] :
-          DestructuringAssignmentTarget[?Yield] Initializer[In, ?Yield]?
+          DestructuringAssignmentTarget[?Yield] Initializer[+In, ?Yield]?
 
         AssignmentRestElement[Yield] :
           `...` DestructuringAssignmentTarget[?Yield]
@@ -13818,7 +13830,7 @@
             1. Let _v_ be ? GetValue(_defaultValue_).
           1. Else, let _v_ be _value_.
           1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
-            1. Let _nestedAssignmentPattern_ be the parse of the source text corresponding to |DestructuringAssignmentTarget| using either |AssignmentPattern| or |AssignmentPattern[Yield]| as the goal symbol depending upon whether this |AssignmentElement| has the <sub>[Yield]</sub> parameter.
+            1. Let _nestedAssignmentPattern_ be the parse of the source text corresponding to |DestructuringAssignmentTarget| using either |AssignmentPattern[~Yield]| or |AssignmentPattern[+Yield]| as the goal symbol depending upon whether this |AssignmentElement| has the <sub>[Yield]</sub> parameter.
             1. Return the result of performing DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with _v_ as the argument.
           1. If |Initializer| is present and _value_ is *undefined* and IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
             1. Let _hasNameProperty_ be ? HasOwnProperty(_v_, `"name"`).
@@ -13849,7 +13861,7 @@
               1. Increment _n_ by 1.
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Return ? PutValue(_lref_, _A_).
-          1. Let _nestedAssignmentPattern_ be the parse of the source text corresponding to |DestructuringAssignmentTarget| using either |AssignmentPattern| or |AssignmentPattern[Yield]| as the goal symbol depending upon whether this |AssignmentElement| has the <sub>[Yield]</sub> parameter.
+          1. Let _nestedAssignmentPattern_ be the parse of the source text corresponding to |DestructuringAssignmentTarget| using either |AssignmentPattern[~Yield]| or |AssignmentPattern[+Yield]| as the goal symbol depending upon whether this |AssignmentElement| has the <sub>[Yield]</sub> parameter.
           1. Return the result of performing DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with _A_ as the argument.
         </emu-alg>
       </emu-clause>
@@ -13869,7 +13881,7 @@
             1. Let _rhsValue_ be ? GetValue(_defaultValue_).
           1. Else, let _rhsValue_ be _v_.
           1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
-            1. Let _assignmentPattern_ be the parse of the source text corresponding to |DestructuringAssignmentTarget| using either |AssignmentPattern| or |AssignmentPattern[Yield]| as the goal symbol depending upon whether this |AssignmentElement| has the <sub>[Yield]</sub> parameter.
+            1. Let _assignmentPattern_ be the parse of the source text corresponding to |DestructuringAssignmentTarget| using either |AssignmentPattern[~Yield]| or |AssignmentPattern[+Yield]| as the goal symbol depending upon whether this |AssignmentElement| has the <sub>[Yield]</sub> parameter.
             1. Return the result of performing DestructuringAssignmentEvaluation of _assignmentPattern_ with _rhsValue_ as the argument.
           1. If |Initializer| is present and _v_ is *undefined* and IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
             1. Let _hasNameProperty_ be ? HasOwnProperty(_rhsValue_, `"name"`).
@@ -13949,9 +13961,9 @@
       DebuggerStatement
 
     Declaration[Yield] :
-      HoistableDeclaration[?Yield]
-      ClassDeclaration[?Yield]
-      LexicalDeclaration[In, ?Yield]
+      HoistableDeclaration[?Yield, ~Default]
+      ClassDeclaration[?Yield, ~Default]
+      LexicalDeclaration[+In, ?Yield]
 
     HoistableDeclaration[Yield, Default] :
       FunctionDeclaration[?Yield, ?Default]
@@ -14645,7 +14657,7 @@
       <h2>Syntax</h2>
       <emu-grammar>
         VariableStatement[Yield] :
-          `var` VariableDeclarationList[In, ?Yield] `;`
+          `var` VariableDeclarationList[+In, ?Yield] `;`
 
         VariableDeclarationList[In, Yield] :
           VariableDeclaration[?In, ?Yield]
@@ -14780,10 +14792,10 @@
 
         BindingElement[Yield] :
           SingleNameBinding[?Yield]
-          BindingPattern[?Yield] Initializer[In, ?Yield]?
+          BindingPattern[?Yield] Initializer[+In, ?Yield]?
 
         SingleNameBinding[Yield] :
-          BindingIdentifier[?Yield] Initializer[In, ?Yield]?
+          BindingIdentifier[?Yield] Initializer[+In, ?Yield]?
 
         BindingRestElement[Yield] :
           `...` BindingIdentifier[?Yield]
@@ -15214,7 +15226,7 @@
     <h2>Syntax</h2>
     <emu-grammar>
       ExpressionStatement[Yield] :
-        [lookahead &lt;! {`{`, `function`, `class`, `let [`}] Expression[In, ?Yield] `;`
+        [lookahead &lt;! {`{`, `function`, `class`, `let [`}] Expression[+In, ?Yield] `;`
     </emu-grammar>
     <emu-note>
       <p>An |ExpressionStatement| cannot start with a U+007B (LEFT CURLY BRACKET) because that might make it ambiguous with a |Block|. Also, an |ExpressionStatement| cannot start with the `function` or `class` keywords because that would make it ambiguous with a |FunctionDeclaration|, a |GeneratorDeclaration|, or a |ClassDeclaration|. An |ExpressionStatement| cannot start with the two token sequence `let [` because that would make it ambiguous with a `let` |LexicalDeclaration| whose first |LexicalBinding| was an |ArrayBindingPattern|.</p>
@@ -15237,8 +15249,8 @@
     <h2>Syntax</h2>
     <emu-grammar>
       IfStatement[Yield, Return] :
-        `if` `(` Expression[In, ?Yield] `)` Statement[?Yield, ?Return] `else` Statement[?Yield, ?Return]
-        `if` `(` Expression[In, ?Yield] `)` Statement[?Yield, ?Return]
+        `if` `(` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return] `else` Statement[?Yield, ?Return]
+        `if` `(` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return]
     </emu-grammar>
     <p>Each `else` for which the choice of associated `if` is ambiguous shall be associated with the nearest possible `if` that would otherwise have no corresponding `else`.</p>
 
@@ -15375,17 +15387,17 @@
     <h2>Syntax</h2>
     <emu-grammar>
       IterationStatement[Yield, Return] :
-        `do` Statement[?Yield, ?Return] `while` `(` Expression[In, ?Yield] `)` `;`
-        `while` `(` Expression[In, ?Yield] `)` Statement[?Yield, ?Return]
-        `for` `(` [lookahead &lt;! {`let [`}] Expression[?Yield]? `;` Expression[In, ?Yield]? `;` Expression[In, ?Yield]? `)` Statement[?Yield, ?Return]
-        `for` `(` `var` VariableDeclarationList[?Yield] `;` Expression[In, ?Yield]? `;` Expression[In, ?Yield]? `)` Statement[?Yield, ?Return]
-        `for` `(` LexicalDeclaration[?Yield] Expression[In, ?Yield]? `;` Expression[In, ?Yield]? `)` Statement[?Yield, ?Return]
-        `for` `(` [lookahead &lt;! {`let [`}] LeftHandSideExpression[?Yield] `in` Expression[In, ?Yield] `)` Statement[?Yield, ?Return]
-        `for` `(` `var` ForBinding[?Yield] `in` Expression[In, ?Yield] `)` Statement[?Yield, ?Return]
-        `for` `(` ForDeclaration[?Yield] `in` Expression[In, ?Yield] `)` Statement[?Yield, ?Return]
-        `for` `(` [lookahead != `let` ] LeftHandSideExpression[?Yield] `of` AssignmentExpression[In, ?Yield] `)` Statement[?Yield, ?Return]
-        `for` `(` `var` ForBinding[?Yield] `of` AssignmentExpression[In, ?Yield] `)` Statement[?Yield, ?Return]
-        `for` `(` ForDeclaration[?Yield] `of` AssignmentExpression[In, ?Yield] `)` Statement[?Yield, ?Return]
+        `do` Statement[?Yield, ?Return] `while` `(` Expression[+In, ?Yield] `)` `;`
+        `while` `(` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return]
+        `for` `(` [lookahead &lt;! {`let [`}] Expression[~In, ?Yield]? `;` Expression[+In, ?Yield]? `;` Expression[+In, ?Yield]? `)` Statement[?Yield, ?Return]
+        `for` `(` `var` VariableDeclarationList[~In, ?Yield] `;` Expression[+In, ?Yield]? `;` Expression[+In, ?Yield]? `)` Statement[?Yield, ?Return]
+        `for` `(` LexicalDeclaration[~In, ?Yield] Expression[+In, ?Yield]? `;` Expression[+In, ?Yield]? `)` Statement[?Yield, ?Return]
+        `for` `(` [lookahead &lt;! {`let [`}] LeftHandSideExpression[?Yield] `in` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return]
+        `for` `(` `var` ForBinding[?Yield] `in` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return]
+        `for` `(` ForDeclaration[?Yield] `in` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return]
+        `for` `(` [lookahead != `let` ] LeftHandSideExpression[?Yield] `of` AssignmentExpression[+In, ?Yield] `)` Statement[?Yield, ?Return]
+        `for` `(` `var` ForBinding[?Yield] `of` AssignmentExpression[+In, ?Yield] `)` Statement[?Yield, ?Return]
+        `for` `(` ForDeclaration[?Yield] `of` AssignmentExpression[+In, ?Yield] `)` Statement[?Yield, ?Return]
 
       ForDeclaration[Yield] :
         LetOrConst ForBinding[?Yield]
@@ -16294,7 +16306,7 @@
     <emu-grammar>
       ReturnStatement[Yield] :
         `return` `;`
-        `return` [no LineTerminator here] Expression[In, ?Yield] `;`
+        `return` [no LineTerminator here] Expression[+In, ?Yield] `;`
     </emu-grammar>
     <emu-note>
       <p>A `return` statement causes a function to cease execution and return a value to the caller. If |Expression| is omitted, the return value is *undefined*. Otherwise, the return value is the value of |Expression|.</p>
@@ -16322,7 +16334,7 @@
     <h2>Syntax</h2>
     <emu-grammar>
       WithStatement[Yield, Return] :
-        `with` `(` Expression[In, ?Yield] `)` Statement[?Yield, ?Return]
+        `with` `(` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return]
     </emu-grammar>
     <emu-note>
       <p>The `with` statement adds an object Environment Record for a computed object to the lexical environment of the running execution context. It then executes a statement using this augmented lexical environment. Finally, it restores the original lexical environment.</p>
@@ -16425,7 +16437,7 @@
     <h2>Syntax</h2>
     <emu-grammar>
       SwitchStatement[Yield, Return] :
-        `switch` `(` Expression[In, ?Yield] `)` CaseBlock[?Yield, ?Return]
+        `switch` `(` Expression[+In, ?Yield] `)` CaseBlock[?Yield, ?Return]
 
       CaseBlock[Yield, Return] :
         `{` CaseClauses[?Yield, ?Return]? `}`
@@ -16436,7 +16448,7 @@
         CaseClauses[?Yield, ?Return] CaseClause[?Yield, ?Return]
 
       CaseClause[Yield, Return] :
-        `case` Expression[In, ?Yield] `:` StatementList[?Yield, ?Return]?
+        `case` Expression[+In, ?Yield] `:` StatementList[?Yield, ?Return]?
 
       DefaultClause[Yield, Return] :
         `default` `:` StatementList[?Yield, ?Return]?
@@ -16845,7 +16857,7 @@
 
       LabelledItem[Yield, Return] :
         Statement[?Yield, ?Return]
-        FunctionDeclaration[?Yield]
+        FunctionDeclaration[?Yield, ~Default]
     </emu-grammar>
     <emu-note>
       <p>A |Statement| may be prefixed by a label. Labelled statements are only used in conjunction with labelled `break` and `continue` statements. ECMAScript has no `goto` statement. A |Statement| can be part of a |LabelledStatement|, which itself can be part of a |LabelledStatement|, and so on. The labels introduced this way are collectively referred to as the &ldquo;current label set&rdquo; when describing the semantics of individual statements.</p>
@@ -17096,7 +17108,7 @@
     <h2>Syntax</h2>
     <emu-grammar>
       ThrowStatement[Yield] :
-        `throw` [no LineTerminator here] Expression[In, ?Yield] `;`
+        `throw` [no LineTerminator here] Expression[+In, ?Yield] `;`
     </emu-grammar>
 
     <!-- es6num="13.14.1" -->
@@ -17401,11 +17413,11 @@
     <h2>Syntax</h2>
     <emu-grammar>
       FunctionDeclaration[Yield, Default] :
-        `function` BindingIdentifier[?Yield] `(` FormalParameters `)` `{` FunctionBody `}`
-        [+Default] `function` `(` FormalParameters `)` `{` FunctionBody `}`
+        `function` BindingIdentifier[?Yield] `(` FormalParameters[~Yield] `)` `{` FunctionBody[~Yield] `}`
+        [+Default] `function` `(` FormalParameters[~Yield] `)` `{` FunctionBody[~Yield] `}`
 
       FunctionExpression :
-        `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+        `function` BindingIdentifier[~Yield]? `(` FormalParameters[~Yield] `)` `{` FunctionBody[~Yield] `}`
 
       StrictFormalParameters[Yield] :
         FormalParameters[?Yield]
@@ -17433,7 +17445,7 @@
         FunctionStatementList[?Yield]
 
       FunctionStatementList[Yield] :
-        StatementList[?Yield, Return]?
+        StatementList[?Yield, +Return]?
     </emu-grammar>
 
     <!-- es6num="14.1.1" -->
@@ -17945,8 +17957,8 @@
         CoverParenthesizedExpressionAndArrowParameterList[?Yield] #parencover
 
       ConciseBody[In] :
-        [lookahead != `{` ] AssignmentExpression[?In]
-        `{` FunctionBody `}`
+        [lookahead != `{` ] AssignmentExpression[?In, ~Yield]
+        `{` FunctionBody[~Yield] `}`
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
     <p>When the production
@@ -17977,10 +17989,10 @@
       <emu-grammar>ArrowParameters[Yield] : CoverParenthesizedExpressionAndArrowParameterList[?Yield]</emu-grammar>
       <ul>
         <li>
-          If the <sub>[Yield]</sub> grammar parameter is present on |ArrowParameters|, it is a Syntax Error if the lexical token sequence matched by |CoverParenthesizedExpressionAndArrowParameterList[?Yield]| cannot be parsed with no tokens left over using |ArrowFormalParameters[Yield]| as the goal symbol.
+          If the <sub>[Yield]</sub> grammar parameter is present on |ArrowParameters|, it is a Syntax Error if the lexical token sequence matched by |CoverParenthesizedExpressionAndArrowParameterList[?Yield]| cannot be parsed with no tokens left over using |ArrowFormalParameters[+Yield]| as the goal symbol.
         </li>
         <li>
-          If the <sub>[Yield]</sub> grammar parameter is not present on |ArrowParameters|, it is a Syntax Error if the lexical token sequence matched by |CoverParenthesizedExpressionAndArrowParameterList[?Yield]| cannot be parsed with no tokens left over using |ArrowFormalParameters| as the goal symbol.
+          If the <sub>[Yield]</sub> grammar parameter is not present on |ArrowParameters|, it is a Syntax Error if the lexical token sequence matched by |CoverParenthesizedExpressionAndArrowParameterList[?Yield]| cannot be parsed with no tokens left over using |ArrowFormalParameters[~Yield]| as the goal symbol.
         </li>
         <li>
           All early errors rules for |ArrowFormalParameters| and its derived productions also apply to CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList[?Yield]|.
@@ -18091,8 +18103,8 @@
           `(` Expression `,` `...` BindingPattern `)`
       </emu-grammar>
       <emu-alg>
-        1. If the <sub>[Yield]</sub> grammar parameter is present for |CoverParenthesizedExpressionAndArrowParameterList[Yield]|, return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList[Yield]| using |ArrowFormalParameters[Yield]| as the goal symbol.
-        1. If the <sub>[Yield]</sub> grammar parameter is not present for |CoverParenthesizedExpressionAndArrowParameterList[Yield]|, return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList| using |ArrowFormalParameters| as the goal symbol.
+        1. If the <sub>[Yield]</sub> grammar parameter is present for |CoverParenthesizedExpressionAndArrowParameterList[Yield]|, return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList[Yield]| using |ArrowFormalParameters[+Yield]| as the goal symbol.
+        1. If the <sub>[Yield]</sub> grammar parameter is not present for |CoverParenthesizedExpressionAndArrowParameterList[Yield]|, return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList[Yield]| using |ArrowFormalParameters[~Yield]| as the goal symbol.
       </emu-alg>
     </emu-clause>
 
@@ -18196,13 +18208,13 @@
     <h2>Syntax</h2>
     <emu-grammar>
       MethodDefinition[Yield] :
-        PropertyName[?Yield] `(` StrictFormalParameters `)` `{` FunctionBody `}`
+        PropertyName[?Yield] `(` StrictFormalParameters[~Yield] `)` `{` FunctionBody[~Yield] `}`
         GeneratorMethod[?Yield]
-        `get` PropertyName[?Yield] `(` `)` `{` FunctionBody `}`
-        `set` PropertyName[?Yield] `(` PropertySetParameterList `)` `{` FunctionBody `}`
+        `get` PropertyName[?Yield] `(` `)` `{` FunctionBody[~Yield] `}`
+        `set` PropertyName[?Yield] `(` PropertySetParameterList `)` `{` FunctionBody[~Yield] `}`
 
       PropertySetParameterList :
-        FormalParameter
+        FormalParameter[~Yield]
     </emu-grammar>
 
     <!-- es6num="14.3.1" -->
@@ -18392,22 +18404,22 @@
     <h2>Syntax</h2>
     <emu-grammar>
       GeneratorMethod[Yield] :
-        `*` PropertyName[?Yield] `(` StrictFormalParameters[Yield] `)` `{` GeneratorBody `}`
+        `*` PropertyName[?Yield] `(` StrictFormalParameters[+Yield] `)` `{` GeneratorBody `}`
 
       GeneratorDeclaration[Yield, Default] :
-        `function` `*` BindingIdentifier[?Yield] `(` FormalParameters[Yield] `)` `{` GeneratorBody `}`
-        [+Default] `function` `*` `(` FormalParameters[Yield] `)` `{` GeneratorBody `}`
+        `function` `*` BindingIdentifier[?Yield] `(` FormalParameters[+Yield] `)` `{` GeneratorBody `}`
+        [+Default] `function` `*` `(` FormalParameters[+Yield] `)` `{` GeneratorBody `}`
 
       GeneratorExpression :
-        `function` `*` BindingIdentifier[Yield]? `(` FormalParameters[Yield] `)` `{` GeneratorBody `}`
+        `function` `*` BindingIdentifier[+Yield]? `(` FormalParameters[+Yield] `)` `{` GeneratorBody `}`
 
       GeneratorBody :
-        FunctionBody[Yield]
+        FunctionBody[+Yield]
 
       YieldExpression[In] :
         `yield`
-        `yield` [no LineTerminator here] AssignmentExpression[?In, Yield]
-        `yield` [no LineTerminator here] `*` AssignmentExpression[?In, Yield]
+        `yield` [no LineTerminator here] AssignmentExpression[?In, +Yield]
+        `yield` [no LineTerminator here] `*` AssignmentExpression[?In, +Yield]
     </emu-grammar>
     <emu-note>
       <p>The syntactic context immediately following `yield` requires use of the |InputElementRegExpOrTemplateTail| lexical goal.</p>
@@ -19031,11 +19043,11 @@
           1. If |ClassHeritage_opt| is present and _protoParent_ is not *null*, then
             1. Let _constructor_ be the result of parsing the source text
               <pre><code class="javascript">constructor(... args){ super (...args);}</code></pre>
-              using the syntactic grammar with the goal symbol |MethodDefinition|.
+              using the syntactic grammar with the goal symbol |MethodDefinition[~Yield]|.
           1. Else,
             1. Let _constructor_ be the result of parsing the source text
               <pre><code class="javascript">constructor( ){ }</code></pre>
-              using the syntactic grammar with the goal symbol |MethodDefinition|.
+              using the syntactic grammar with the goal symbol |MethodDefinition[~Yield]|.
         1. Set the running execution context's LexicalEnvironment to _classScope_.
         1. Let _constructorInfo_ be the result of performing DefineMethod for _constructor_ with arguments _proto_ and _constructorParent_ as the optional _functionPrototype_ argument.
         1. Assert: _constructorInfo_ is not an abrupt completion.
@@ -19446,7 +19458,7 @@
         ScriptBody?
 
       ScriptBody :
-        StatementList
+        StatementList[~Yield, ~Return]
     </emu-grammar>
 
     <!-- es6num="15.1.1" -->
@@ -19753,7 +19765,7 @@
       ModuleItem :
         ImportDeclaration
         ExportDeclaration
-        StatementListItem
+        StatementListItem[~Yield, ~Return]
     </emu-grammar>
 
     <!-- es6num="15.2.1" -->
@@ -21025,7 +21037,7 @@
           StringLiteral
 
         ImportedBinding :
-          BindingIdentifier
+          BindingIdentifier[~Yield]
       </emu-grammar>
 
       <!-- es6num="15.2.2.1" -->
@@ -21171,11 +21183,11 @@
           `export` `*` FromClause `;`
           `export` ExportClause FromClause `;`
           `export` ExportClause `;`
-          `export` VariableStatement
-          `export` Declaration
-          `export` `default` HoistableDeclaration[Default]
-          `export` `default` ClassDeclaration[Default]
-          `export` `default` [lookahead &lt;! {`function`, `class`}] AssignmentExpression[In] `;`
+          `export` VariableStatement[~Yield]
+          `export` Declaration[~Yield]
+          `export` `default` HoistableDeclaration[~Yield, +Default]
+          `export` `default` ClassDeclaration[~Yield, +Default]
+          `export` `default` [lookahead &lt;! {`function`, `class`}] AssignmentExpression[+In, ~Yield] `;`
 
         ExportClause :
           `{` `}`
@@ -21644,7 +21656,7 @@
         The behaviour of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, `%TypedArray%.prototype.toLocaleString`.
       </li>
       <li>
-        The RegExp pattern grammars in <emu-xref href="#sec-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[U]| when the U grammar parameter is present.
+        The RegExp pattern grammars in <emu-xref href="#sec-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[+U]| when the U grammar parameter is present.
       </li>
       <li>
         The Syntactic Grammar must not be extended in any manner that allows the token `:` to immediate follow source text that matches the |BindingIdentifier| nonterminal symbol.
@@ -23038,12 +23050,12 @@
           <emu-alg>
             1. If _newTarget_ is *undefined*, let _newTarget_ be _constructor_.
             1. If _kind_ is `"normal"`, then
-              1. Let _goal_ be the grammar symbol |FunctionBody|.
-              1. Let _parameterGoal_ be the grammar symbol |FormalParameters|.
+              1. Let _goal_ be the grammar symbol |FunctionBody[~Yield]|.
+              1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield]|.
               1. Let _fallbackProto_ be `"%FunctionPrototype%"`.
             1. Else,
               1. Let _goal_ be the grammar symbol |GeneratorBody|.
-              1. Let _parameterGoal_ be the grammar symbol |FormalParameters[Yield]|.
+              1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield]|.
               1. Let _fallbackProto_ be `"%Generator%"`.
             1. Let _argCount_ be the number of elements in _args_.
             1. Let _P_ be the empty String.
@@ -28820,10 +28832,10 @@ THH:mm:ss.sss
             1. If _F_ contains any code unit other than `"g"`, `"i"`, `"m"`, `"u"`, or `"y"` or if it contains the same code unit more than once, throw a *SyntaxError* exception.
             1. If _F_ contains `"u"`, let _BMP_ be *false*; else let _BMP_ be *true*.
             1. If _BMP_ is *true*, then
-              1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting each of its 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements. The goal symbol for the parse is |Pattern|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
+              1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting each of its 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements. The goal symbol for the parse is |Pattern[~U]|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code unit elements of _P_.
             1. Else,
-              1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting _P_ as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). The goal symbol for the parse is |Pattern[U]|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
+              1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting _P_ as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). The goal symbol for the parse is |Pattern[+U]|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code points resulting from applying UTF-16 decoding to _P_'s sequence of elements.
             1. Set _obj_.[[OriginalSource]] to _P_.
             1. Set _obj_.[[OriginalFlags]] to _F_.
@@ -28848,7 +28860,7 @@ THH:mm:ss.sss
           <h1>Runtime Semantics: EscapeRegExpPattern ( _P_, _F_ )</h1>
           <p>When the abstract operation EscapeRegExpPattern with arguments _P_ and _F_ is called, the following occurs:</p>
           <emu-alg>
-            1. Let _S_ be a String in the form of a |Pattern| (|Pattern[U]| if _F_ contains `"u"`) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the internal procedure that would result from evaluating _S_ as a |Pattern| (|Pattern[U]| if _F_ contains `"u"`) must behave identically to the internal procedure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
+            1. Let _S_ be a String in the form of a |Pattern[~U]| (|Pattern[+U]| if _F_ contains `"u"`) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the internal procedure that would result from evaluating _S_ as a |Pattern[~U]| (|Pattern[+U]| if _F_ contains `"u"`) must behave identically to the internal procedure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
             1. The code points `/` or any |LineTerminator| occurring in the pattern shall be escaped in _S_ as necessary to ensure that the String value formed by concatenating the Strings `"/"`, _S_, `"/"`, and _F_ can be parsed (in an appropriate lexical context) as a |RegularExpressionLiteral| that behaves identically to the constructed regular expression. For example, if _P_ is `"/"`, then _S_ could be `"\\/"` or `"\\u002F"`, among other possibilities, but not `"/"`, because `///` followed by _F_ would be parsed as a |SingleLineComment| rather than a |RegularExpressionLiteral|. If _P_ is the empty String, this specification can be met by letting _S_ be `"(?:)"`.
             1. Return _S_.
           </emu-alg>
@@ -35980,11 +35992,11 @@ THH:mm:ss.sss
       <h2>Syntax</h2>
       <emu-grammar>
         Term[U] ::
-          [+U] Assertion[U]
-          [+U] Atom[U]
-          [+U] Atom[U] Quantifier
+          [+U] Assertion[+U]
+          [+U] Atom[+U]
+          [+U] Atom[+U] Quantifier
           [~U] QuantifiableAssertion Quantifier
-          [~U] Assertion
+          [~U] Assertion[~U]
           [~U] ExtendedAtom Quantifier
           [~U] ExtendedAtom
 
@@ -35993,20 +36005,20 @@ THH:mm:ss.sss
           `$`
           `\` `b`
           `\` `B`
-          [+U] `(` `?` `=` Disjunction[U] `)`
-          [+U] `(` `?` `!` Disjunction[U] `)`
+          [+U] `(` `?` `=` Disjunction[+U] `)`
+          [+U] `(` `?` `!` Disjunction[+U] `)`
           [~U] QuantifiableAssertion
 
         QuantifiableAssertion ::
-          `(` `?` `=` Disjunction `)`
-          `(` `?` `!` Disjunction `)`
+          `(` `?` `=` Disjunction[~U] `)`
+          `(` `?` `!` Disjunction[~U] `)`
 
         ExtendedAtom ::
           `.`
-          `\` AtomEscape
-          CharacterClass
-          `(` Disjunction `)`
-          `(` `?` `:` Disjunction `)`
+          `\` AtomEscape[~U]
+          CharacterClass[~U]
+          `(` Disjunction[~U] `)`
+          `(` `?` `:` Disjunction[~U] `)`
           InvalidBracedQuantifier
           ExtendedPatternCharacter
 
@@ -36022,7 +36034,7 @@ THH:mm:ss.sss
           [+U] DecimalEscape
           [~U] DecimalEscape [> but only if the integer value of |DecimalEscape| is &lt;= _NcapturingParens_]
           CharacterClassEscape
-          CharacterEscape
+          CharacterEscape[~U]
 
         CharacterEscape[U] ::
           ControlEscape
@@ -36827,12 +36839,12 @@ THH:mm:ss.sss
       <p>The following augments the |IfStatement| production in <emu-xref href="#sec-if-statement"></emu-xref>:</p>
       <emu-grammar>
         IfStatement[Yield, Return] :
-          `if` `(` Expression[In, ?Yield] `)` FunctionDeclaration[?Yield] `else` Statement[?Yield, ?Return]
-          `if` `(` Expression[In, ?Yield] `)` Statement[?Yield, ?Return] `else` FunctionDeclaration[?Yield]
-          `if` `(` Expression[In, ?Yield] `)` FunctionDeclaration[?Yield] `else` FunctionDeclaration[?Yield]
-          `if` `(` Expression[In, ?Yield] `)` FunctionDeclaration[?Yield]
+          `if` `(` Expression[+In, ?Yield] `)` FunctionDeclaration[?Yield, ~Default] `else` Statement[?Yield, ?Return]
+          `if` `(` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return] `else` FunctionDeclaration[?Yield, ~Default]
+          `if` `(` Expression[+In, ?Yield] `)` FunctionDeclaration[?Yield, ~Default] `else` FunctionDeclaration[?Yield, ~Default]
+          `if` `(` Expression[+In, ?Yield] `)` FunctionDeclaration[?Yield, ~Default]
       </emu-grammar>
-      <p>This production only applies when parsing non-strict code. Code matching this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
+      <p>This production only applies when parsing non-strict code. Code matching this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
     </emu-annex>
 
     <!-- es6num="B.3.5" -->


### PR DESCRIPTION
(Make things more explicit, and establish a clearer parallel between rhs-guard syntax and rhs-nonterminal use syntax.)

Resolves Issue #374.