### PR TITLE
Proposed changes to inferred Function.name

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11204,7 +11204,11 @@
           1. Let _propValue_ be ? GetValue(_exprValueRef_).
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
             1. Let _hasNameProperty_ be ? HasOwnProperty(_propValue_, `"name"`).
-            1. If _hasNameProperty_ is *false*, perform SetFunctionName(_propValue_, _propKey_).
+            1. If _hasNameProperty_ is *false*, then
+              1. Let _name_ be _propKey_.
+              1. If _name_ is not an |Identifier|, let _name_ be `""`.
+              1. If _name_ is a |ReservedWord|, let _name_ be `""`.
+              1. Perform SetFunctionName(_propValue_, _name_).
           1. Assert: _enumerable_ is *true*.
           1. Return CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
         </emu-alg>
@@ -36539,7 +36543,11 @@ THH:mm:ss.sss
           1. Return NormalCompletion(~empty~).
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
           1. Let _hasNameProperty_ be ? HasOwnProperty(_propValue_, `"name"`).
-          1. If _hasNameProperty_ is *false*, perform SetFunctionName(_propValue_, _propKey_).
+          1. If _hasNameProperty_ is *false*, then
+            1. Let _name_ be _propKey_.
+            1. If _name_ is not an |Identifier|, let _name_ be `""`.
+            1. If _name_ is a |ReservedWord|, let _name_ be `""`.
+            1. Perform SetFunctionName(_propValue_, _name_).
         1. Assert: _enumerable_ is *true*.
         1. Return CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
       </emu-alg>


### PR DESCRIPTION
Currently the spec allows for creating an inferred Function.name that is not a valid _Identifier_.  This causes a problem with the library mathjs (see http://mathjs.org and https://github.com/josdejong/mathjs).  It uses an an idiom where it created literal objects with property names with the library's type information encoded in them, e.g.: `number | BigNumber | Unit`.  See WebKit bug [ES6 Function.name inferred from property names of literal objects can break some websites](https://bugs.webkit.org/show_bug.cgi?id=157246) for more details.

We propose that we revert to the ES5 behavior of creating a name with an empty string if the inferred name is not a valid _Identifier_ or _ReservedWord_.

We have confirmed that this is not only a web compatibility issue for WebKit, but also for Chrome.
