### PR TITLE
[editorial] Assert normal completion value

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2740,7 +2740,7 @@
           1. If IsPropertyReference(_V_) is *true*, then
             1. If HasPrimitiveBase(_V_) is *true*, then
               1. Assert: In this case, _base_ will never be *null* or *undefined*.
-              1. Let _base_ be ToObject(_base_).
+              1. Let _base_ be ! ToObject(_base_).
             1. Return ? _base_.[[Get]](GetReferencedName(_V_), GetThisValue(_V_)).
           1. Else _base_ must be an Environment Record,
             1. Return ? _base_.GetBindingValue(GetReferencedName(_V_), IsStrictReference(_V_)) (see <emu-xref href="#sec-environment-records"></emu-xref>).
@@ -2766,7 +2766,7 @@
           1. Else if IsPropertyReference(_V_) is *true*, then
             1. If HasPrimitiveBase(_V_) is *true*, then
               1. Assert: In this case, _base_ will never be *null* or *undefined*.
-              1. Set _base_ to ToObject(_base_).
+              1. Set _base_ to ! ToObject(_base_).
             1. Let _succeeded_ be ? _base_.[[Set]](GetReferencedName(_V_), _W_, GetThisValue(_V_)).
             1. If _succeeded_ is *false* and IsStrictReference(_V_) is *true*, throw a *TypeError* exception.
             1. Return.


### PR DESCRIPTION
As noted by the existing "Assert" clauses, the "base" value will never
be `undefined` or `null` in these cases, meaning ToObject will never
return an abrupt completion. Prefix the invocation with a `!` character
to document this.