### PR TITLE
Per May 2016 TC39 consensus, `String#{padStart,padEnd}` is now stage 4!

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26685,6 +26685,46 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
+      <emu-clause id="sec-string.prototype.padend">
+        <h1>String.prototype.padEnd( maxLength [ , fillString ] )</h1>
+        <p>When the `padEnd` method is called, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
+          1. Let _S_ be ? ToString(_O_).
+          1. Let _intMaxLength_ be ? ToLength(_maxLength_).
+          1. Let _stringLength_ be the number of elements in _S_.
+          1. If _intMaxLength_ is not greater than _stringLength_, return _S_.
+          1. If _fillString_ is *undefined*, let _filler_ be a String consisting solely of the code unit 0x0020 (SPACE).
+          1. Else, let _filler_ be ? ToString(_fillString_).
+          1. If _filler_ is the empty String, return _S_.
+          1. Let _fillLen_ be _intMaxLength_ - _stringLength_.
+          1. Let _truncatedStringFiller_ be a new String value consisting of repeated concatenations of _filler_ truncated to length _fillLen_.
+          1. Return a new String value computed by the concatenation of _S_ and _truncatedStringFiller_.
+        </emu-alg>
+        <emu-note>The first argument _maxLength_ will be clamped such that it can be no smaller than the length of the *this* value.</emu-note>
+        <emu-note>The optional second argument _fillString_ defaults to *" "* (a String consisting of 0x0020 SPACE).</emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-string.prototype.padstart">
+        <h1>String.prototype.padStart( maxLength [ , fillString ] )</h1>
+        <p>When the `padStart` method is called, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be ? RequireObjectCoercible(*this* value).
+          1. Let _S_ be ? ToString(_O_).
+          1. Let _intMaxLength_ be ? ToLength(_maxLength_).
+          1. Let _stringLength_ be the number of elements in _S_.
+          1. If _intMaxLength_ is not greater than _stringLength_, return _S_.
+          1. If _fillString_ is *undefined*, let _filler_ be a String consisting solely of the code unit 0x0020 (SPACE).
+          1. Else, let _filler_ be ? ToString(_fillString_).
+          1. If _filler_ is the empty String, return _S_.
+          1. Let _fillLen_ be _intMaxLength_ - _stringLength_.
+          1. Let _truncatedStringFiller_ be a new String value consisting of repeated concatenations of _filler_ truncated to length _fillLen_.
+          1. Return a new String value computed by the concatenation of _truncatedStringFiller_ and _S_.
+        </emu-alg>
+        <emu-note>The first argument _maxLength_ will be clamped such that it can be no smaller than the length of the *this* value.</emu-note>
+        <emu-note>The optional second argument _fillString_ defaults to *" "* (a String consisting of 0x0020 SPACE).</emu-note>
+      </emu-clause>
+
       <!-- es6num="21.1.3.13" -->
       <emu-clause id="sec-string.prototype.repeat">
         <h1>String.prototype.repeat ( _count_ )</h1>


### PR DESCRIPTION
(https://github.com/tc39/proposal-string-pad-start-end/issues/23)