### PR TITLE
Editorial: spec refactor of PromiseReaction records/PromiseReactionJob

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34540,13 +34540,24 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
+                [[Type]]
+              </td>
+              <td>
+                Either `"Fulfill"` or `"Reject"`.
+              </td>
+              <td>
+                The [[Type]] is used when [[Handler]] is *undefined* to allow for behavior specific to the settlement type.
+              </td>
+            </tr>
+            <tr>
+              <td>
                 [[Handler]]
               </td>
               <td>
-                A function object or a String
+                A function object or *undefined*.
               </td>
               <td>
-                The function that should be applied to the incoming value, and whose return value will govern what happens to the derived promise. If [[Handler]] is `"Identity"` it is equivalent to a function that simply returns its first argument. If [[Handler]] is `"Thrower"` it is equivalent to a function that throws its first argument as an exception.
+                The function that should be applied to the incoming value, and whose return value will govern what happens to the derived promise. If [[Handler]] is *undefined*, a function that depends on the value of [[Type]] will be used instead.
               </td>
             </tr>
             </tbody>
@@ -34697,7 +34708,7 @@ THH:mm:ss.sss
       <!-- es6num="25.4.1.8" -->
       <emu-clause id="sec-triggerpromisereactions" aoid="TriggerPromiseReactions">
         <h1>TriggerPromiseReactions ( _reactions_, _argument_ )</h1>
-        <p>The abstract operation TriggerPromiseReactions takes a collection of PromiseReactionRecords and enqueues a new Job for each record. Each such Job processes the [[Handler]] of the PromiseReactionRecord, and if the [[Handler]] is a function, calls it passing the given argument.</p>
+        <p>The abstract operation TriggerPromiseReactions takes a collection of PromiseReactionRecords and enqueues a new Job for each record. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReactionRecord, and if the [[Handler]] is a function, calls it passing the given argument. If the [[Handler]] is *undefined*, the behavior is determined by the [[Type]].</p>
         <emu-alg>
           1. Repeat for each _reaction_ in _reactions_, in original insertion order
             1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _reaction_, _argument_ &raquo;).
@@ -34740,14 +34751,16 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _reaction_ is a PromiseReaction Record.
           1. Let _promiseCapability_ be _reaction_.[[Capabilities]].
+          1. Let _type_ be _reaction_.[[Type]].
           1. Let _handler_ be _reaction_.[[Handler]].
-          1. If _handler_ is `"Identity"`, let _handlerResult_ be NormalCompletion(_argument_).
-          1. Else if _handler_ is `"Thrower"`, let _handlerResult_ be Completion{[[Type]]: ~throw~, [[Value]]: _argument_, [[Target]]: ~empty~}.
+          1. If _handler_ is *undefined*, then
+            1. If _type_ is `"Fulfill"`, let _handlerResult_ be NormalCompletion(_argument_).
+            1. Otherwise, _type_ is `"Reject"`. Let _handlerResult_ be Completion {[[Type]]: ~throw~, [[Value]]: _argument_, [[Target]]: ~empty~}.
           1. Else, let _handlerResult_ be Call(_handler_, *undefined*, &laquo; _argument_ &raquo;).
           1. If _handlerResult_ is an abrupt completion, then
             1. Let _status_ be Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
-            1. Return Completion(_status_).
-          1. Let _status_ be Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
+          1. Else,
+            1. Let _status_ be Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
           1. Return Completion(_status_).
         </emu-alg>
       </emu-clause>
@@ -35034,11 +35047,11 @@ THH:mm:ss.sss
             1. Assert: IsPromise(_promise_) is *true*.
             1. Assert: _resultCapability_ is a PromiseCapability record.
             1. If IsCallable(_onFulfilled_) is *false*, then
-              1. Let _onFulfilled_ be `"Identity"`.
+              1. Let _onFulfilled_ be *undefined*.
             1. If IsCallable(_onRejected_) is *false*, then
-              1. Let _onRejected_ be `"Thrower"`.
-            1. Let _fulfillReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Handler]]: _onFulfilled_ }.
-            1. Let _rejectReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Handler]]: _onRejected_}.
+              1. Let _onRejected_ be *undefined*.
+            1. Let _fulfillReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
+            1. Let _rejectReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
             1. If the value of _promise_'s [[PromiseState]] internal slot is `"pending"`, then
               1. Append _fulfillReaction_ as the last element of the List that is the value of _promise_'s [[PromiseFulfillReactions]] internal slot.
               1. Append _rejectReaction_ as the last element of the List that is the value of _promise_'s [[PromiseRejectReactions]] internal slot.


### PR DESCRIPTION
The current spec creates fictional “equivalent functions” called “Identity” and “Thrower”, and passes these around with `PromiseReaction` records.

Instead, this change adds a string “Type” field to `PromiseReaction` records, and sets the “Handler” field to `undefined` when none is provided, so that the behavior can be determined solely inside `PromiseReactionJob`.

This change should be non-observable, hopefully adds a bit more clarity, and helps [future Promise proposals](https://github.com/ljharb/proposal-promise-finally) have smaller diffs against the spec.