### PR TITLE
Editorial: tweak String.prototype.pad{End,Start}

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26686,7 +26686,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.padend">
-        <h1>String.prototype.padEnd( maxLength [ , fillString ] )</h1>
+        <h1>String.prototype.padEnd( _maxLength_ [ , _fillString_ ] )</h1>
         <p>When the `padEnd` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
@@ -26701,12 +26701,16 @@ THH:mm:ss.sss
           1. Let _truncatedStringFiller_ be a new String value consisting of repeated concatenations of _filler_ truncated to length _fillLen_.
           1. Return a new String value computed by the concatenation of _S_ and _truncatedStringFiller_.
         </emu-alg>
-        <emu-note>The first argument _maxLength_ will be clamped such that it can be no smaller than the length of the *this* value.</emu-note>
-        <emu-note>The optional second argument _fillString_ defaults to *" "* (a String consisting of 0x0020 SPACE).</emu-note>
+        <emu-note>
+          <p>The first argument _maxLength_ will be clamped such that it can be no smaller than the length of the *this* value.</p>
+        </emu-note>
+        <emu-note>
+          <p>The optional second argument _fillString_ defaults to *" "* (a String consisting of 0x0020 SPACE).</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.padstart">
-        <h1>String.prototype.padStart( maxLength [ , fillString ] )</h1>
+        <h1>String.prototype.padStart( _maxLength_ [ , _fillString_ ] )</h1>
         <p>When the `padStart` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
@@ -26721,8 +26725,12 @@ THH:mm:ss.sss
           1. Let _truncatedStringFiller_ be a new String value consisting of repeated concatenations of _filler_ truncated to length _fillLen_.
           1. Return a new String value computed by the concatenation of _truncatedStringFiller_ and _S_.
         </emu-alg>
-        <emu-note>The first argument _maxLength_ will be clamped such that it can be no smaller than the length of the *this* value.</emu-note>
-        <emu-note>The optional second argument _fillString_ defaults to *" "* (a String consisting of 0x0020 SPACE).</emu-note>
+        <emu-note>
+          <p>The first argument _maxLength_ will be clamped such that it can be no smaller than the length of the *this* value.</p>
+        </emu-note>
+        <emu-note>
+          <p>The optional second argument _fillString_ defaults to *" "* (a String consisting of 0x0020 SPACE).</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="21.1.3.13" -->


### PR DESCRIPTION
- Add underscores to parameter names in clause header.
- Add `<p>..</p>` to `<emu-note>`s.