### PR TITLE
Editorial: Use hexadecimal notation for code points and bytes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8796,9 +8796,9 @@
       <p>The UTF16Encoding of a numeric code point value, _cp_, is determined as follows:</p>
       <emu-alg>
         1. Assert: 0 &le; _cp_ &le; 0x10FFFF.
-        1. If _cp_ &le; 65535, return _cp_.
-        1. Let _cu1_ be floor((_cp_ - 65536) / 1024) + 0xD800.
-        1. Let _cu2_ be ((_cp_ - 65536) modulo 1024) + 0xDC00.
+        1. If _cp_ &le; 0xFFFF, return _cp_.
+        1. Let _cu1_ be floor((_cp_ - 0x10000) / 0x400) + 0xD800.
+        1. Let _cu2_ be ((_cp_ - 0x10000) modulo 0x400) + 0xDC00.
         1. Return the code unit sequence consisting of _cu1_ followed by _cu2_.
       </emu-alg>
     </emu-clause>
@@ -8809,7 +8809,7 @@
       <p>Two code units, _lead_ and _trail_, that form a UTF-16 surrogate pair are converted to a code point by performing the following steps:</p>
       <emu-alg>
         1. Assert: 0xD800 &le; _lead_ &le; 0xDBFF and 0xDC00 &le; _trail_ &le; 0xDFFF.
-        1. Let _cp_ be (_lead_ - 0xD800) &times; 1024 + (_trail_ - 0xDC00) + 0x10000.
+        1. Let _cp_ be (_lead_ - 0xD800) &times; 0x400 + (_trail_ - 0xDC00) + 0x10000.
         1. Return the code point _cp_.
       </emu-alg>
     </emu-clause>
@@ -9773,7 +9773,7 @@
         <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the MV of |HexDigits| &gt; 1114111.
+            It is a Syntax Error if the MV of |HexDigits| &gt; 0x10FFFF.
           </li>
         </ul>
       </emu-clause>
@@ -10015,7 +10015,7 @@
             The SV of <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the SV of |Hex4Digits|.
           </li>
           <li>
-            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit value that is (4096 times the MV of the first |HexDigit|) plus (256 times the MV of the second |HexDigit|) plus (16 times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
+            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit value that is (0x1000 times the MV of the first |HexDigit|) plus (0x100 times the MV of the second |HexDigit|) plus (0x10 times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
           </li>
           <li>
             The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the UTF16Encoding of the MV of |HexDigits|.
@@ -26471,7 +26471,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.codepointat">
         <h1>String.prototype.codePointAt ( _pos_ )</h1>
         <emu-note>
-          <p>Returns a nonnegative integer Number less than 1114112 (0x110000) that is the code point value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ in the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 surrogate pair does not begin at _pos_, the result is the code unit at _pos_.</p>
+          <p>Returns a nonnegative integer Number less than 0x110000 that is the code point value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ in the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 surrogate pair does not begin at _pos_, the result is the code unit at _pos_.</p>
         </emu-note>
         <p>When the `codePointAt` method is called with one argument _pos_, the following steps are taken:</p>
         <emu-alg>
@@ -27432,7 +27432,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the MV of |HexDigits| &gt; 1114111.
+            It is a Syntax Error if the MV of |HexDigits| &gt; 0x10FFFF.
           </li>
         </ul>
       </emu-clause>


### PR DESCRIPTION
Previously this wasn’t being done consistently.

In the context of code points, e.g. `0x10FFFF` is more readable than `1114111`.