### PR TITLE
Editorial: Remove inline style attributes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -979,57 +979,57 @@
           <table>
             <tbody>
             <tr>
-              <th style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <th>
                 Attribute Name
               </th>
-              <th style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <th>
                 Value Domain
               </th>
-              <th style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <th>
                 Description
               </th>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid black">
+              <td>
                 [[Value]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 Any ECMAScript language type
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 The value retrieved by a get access of the property.
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid black">
+              <td>
                 [[Writable]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 Boolean
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 If *false*, attempts by ECMAScript code to change the property's [[Value]] attribute using [[Set]] will not succeed.
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid black">
+              <td>
                 [[Enumerable]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 Boolean
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 If *true*, the property will be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid black">
+              <td>
                 [[Configurable]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 Boolean
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 If *false*, attempts to delete the property, change the property to be an accessor property, or change its attributes (other than [[Value]], or changing [[Writable]] to *false*) will fail.
               </td>
             </tr>
@@ -1041,57 +1041,57 @@
           <table>
             <tbody>
             <tr>
-              <th style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <th>
                 Attribute Name
               </th>
-              <th style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <th>
                 Value Domain
               </th>
-              <th style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <th>
                 Description
               </th>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000">
+              <td>
                 [[Get]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 Object | Undefined
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-6"></emu-xref>) is called with an empty arguments list to retrieve the property value each time a get access of the property is performed.
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 [[Set]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 Object | Undefined
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-6"></emu-xref>) is called with an arguments list containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 [[Enumerable]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 Boolean
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 If *true*, the property is to be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 [[Configurable]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 Boolean
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 If *false*, attempts to delete the property, change the property to be a data property, or change its attributes will fail.
               </td>
             </tr>
@@ -1103,58 +1103,58 @@
           <table>
             <tbody>
             <tr>
-              <th style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <th>
                 Attribute Name
               </th>
-              <th style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <th>
                 Default Value
               </th>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 [[Value]]
               </td>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 *undefined*
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000">
+              <td>
                 [[Get]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 *undefined*
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 [[Set]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 *undefined*
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 [[Writable]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 *false*
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 [[Enumerable]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 *false*
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid #000000; border-top: 1px solid black">
+              <td>
                 [[Configurable]]
               </td>
-              <td style="border-bottom: 1px solid black; border-right: 1px solid black">
+              <td>
                 *false*
               </td>
             </tr>
@@ -20181,26 +20181,26 @@
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black">
+              <td>
                 ResolveExport(exportName, resolveSet, exportStarSet)
               </td>
-              <td style="border-bottom: 1px solid black">
+              <td>
                 Return the binding of a name exported by this module. Bindings are represented by a Record of the form {[[Module]]: Module Record, [[BindingName]]: String}
               </td>
             </tr>
             <tr>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid black; border-top: 1px solid black">
+              <td>
                 ModuleDeclarationInstantiation()
               </td>
-              <td style="border-bottom: 1px solid black; border-left: 1px solid black; border-right: 1px solid black; border-top: 1px solid black">
+              <td>
                 Transitively resolve all module dependencies and create a module Environment Record for the module.
               </td>
             </tr>
             <tr>
-              <td style="border-top: 1px solid black">
+              <td>
                 ModuleEvaluation()
               </td>
-              <td style="border-top: 1px solid black">
+              <td>
                 <p>Do nothing if this module has already been evaluated. Otherwise, transitively evaluate all module dependences of this module and then evaluate this module.</p>
                 <p>ModuleDeclarationInstantiation must be completed prior to invoking this method.</p>
               </td>
@@ -30768,22 +30768,22 @@ THH:mm:ss.sss
       <table>
         <tbody>
         <tr>
-          <th style="background-color: #BFBFBF">
+          <th>
             Constructor Name and Intrinsic
           </th>
-          <th style="background-color: #BFBFBF">
+          <th>
             Element Type
           </th>
-          <th style="background-color: #BFBFBF">
+          <th>
             Element Size
           </th>
-          <th style="background-color: #BFBFBF">
+          <th>
             Conversion Operation
           </th>
-          <th style="background-color: #BFBFBF">
+          <th>
             Description
           </th>
-          <th style="background-color: #BFBFBF">
+          <th>
             Equivalent C Type
           </th>
         </tr>
@@ -32582,10 +32582,10 @@ THH:mm:ss.sss
           <table>
             <tbody>
             <tr>
-              <th style="background-color: #BFBFBF">
+              <th>
                 Internal Slot
               </th>
-              <th style="background-color: #BFBFBF">
+              <th>
                 Description
               </th>
             </tr>
@@ -33914,13 +33914,13 @@ THH:mm:ss.sss
           <table>
             <tbody>
             <tr>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Property
               </th>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Value
               </th>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Requirements
               </th>
             </tr>
@@ -33948,13 +33948,13 @@ THH:mm:ss.sss
           <table>
             <tbody>
             <tr>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Property
               </th>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Value
               </th>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Requirements
               </th>
             </tr>
@@ -33979,13 +33979,13 @@ THH:mm:ss.sss
           <table>
             <tbody>
             <tr>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Property
               </th>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Value
               </th>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Requirements
               </th>
             </tr>
@@ -34027,13 +34027,13 @@ THH:mm:ss.sss
           <table>
             <tbody>
             <tr>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Property
               </th>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Value
               </th>
-              <th style="background-color: #A6A6A6">
+              <th>
                 Requirements
               </th>
             </tr>


### PR DESCRIPTION
Most of them (i.e. the ones adding a black 1px border) didn’t have any visual effect in the first place, and the others made the table headers look inconsistent. With this change, table headers get the same background color rather than using fifty shades of gray.