### PR TITLE
Editorial: use dot notation for accessing internal slots

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3883,8 +3883,8 @@
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ is an Array exotic object, return *true*.
         1. If _argument_ is a Proxy exotic object, then
-          1. If the value of the [[ProxyHandler]] internal slot of _argument_ is *null*, throw a *TypeError* exception.
-          1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _argument_.
+          1. If the value of _argument_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
+          1. Let _target_ be the value of _argument_.[[ProxyTarget]].
           1. Return ? IsArray(_target_).
         1. Return *false*.
       </emu-alg>
@@ -4373,7 +4373,7 @@
       <emu-alg>
         1. If IsCallable(_C_) is *false*, return *false*.
         1. If _C_ has a [[BoundTargetFunction]] internal slot, then
-          1. Let _BC_ be the value of _C_'s [[BoundTargetFunction]] internal slot.
+          1. Let _BC_ be the value of _C_.[[BoundTargetFunction]].
           1. Return ? InstanceofOperator(_O_, _BC_).
         1. If Type(_O_) is not Object, return *false*.
         1. Let _P_ be ? Get(_C_, `"prototype"`).
@@ -4432,13 +4432,13 @@
       <emu-alg>
         1. Assert: _obj_ is a callable object.
         1. If _obj_ has a [[Realm]] internal slot, then
-          1. Return _obj_'s [[Realm]] internal slot.
+          1. Return _obj_.[[Realm]].
         1. If _obj_ is a Bound Function exotic object, then
-          1. Let _target_ be _obj_'s [[BoundTargetFunction]] internal slot.
+          1. Let _target_ be _obj_.[[BoundTargetFunction]].
           1. Return ? GetFunctionRealm(_target_).
         1. If _obj_ is a Proxy exotic object, then
-          1. If the value of the [[ProxyHandler]] internal slot of _obj_ is *null*, throw a *TypeError* exception.
-          1. Let _proxyTarget_ be the value of _obj_'s [[ProxyTarget]] internal slot.
+          1. If the value of _obj_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
+          1. Let _proxyTarget_ be the value of _obj_.[[ProxyTarget]].
           1. Return ? GetFunctionRealm(_proxyTarget_).
         1. Return the current Realm Record.
       </emu-alg>
@@ -4548,10 +4548,10 @@
       <p>The abstract operation CreateListIterator with argument _list_ creates an Iterator (<emu-xref href="#sec-iterator-interface"></emu-xref>) object whose next method returns the successive elements of _list_. It performs the following steps:</p>
       <emu-alg>
         1. Let _iterator_ be ObjectCreate(%IteratorPrototype%, &laquo; [[IteratorNext]], [[IteratedList]], [[ListIteratorNextIndex]] &raquo;).
-        1. Set _iterator_'s [[IteratedList]] internal slot to _list_.
-        1. Set _iterator_'s [[ListIteratorNextIndex]] internal slot to 0.
+        1. Set _iterator_.[[IteratedList]] to _list_.
+        1. Set _iterator_.[[ListIteratorNextIndex]] to 0.
         1. Let _next_ be a new built-in function object as defined in ListIterator `next` (<emu-xref href="#sec-listiterator-next"></emu-xref>).
-        1. Set _iterator_'s [[IteratorNext]] internal slot to _next_.
+        1. Set _iterator_.[[IteratorNext]] to _next_.
         1. Perform CreateMethodProperty(_iterator_, `"next"`, _next_).
         1. Return _iterator_.
       </emu-alg>
@@ -4564,15 +4564,15 @@
           1. Let _O_ be the *this* value.
           1. Let _f_ be the active function object.
           1. If _O_ does not have a [[IteratorNext]] internal slot, throw a *TypeError* exception.
-          1. Let _next_ be the value of the [[IteratorNext]] internal slot of _O_.
+          1. Let _next_ be the value of _O_.[[IteratorNext]].
           1. If SameValue(_f_, _next_) is *false*, throw a *TypeError* exception.
           1. If _O_ does not have an [[IteratedList]] internal slot, throw a *TypeError* exception.
-          1. Let _list_ be the value of the [[IteratedList]] internal slot of _O_.
-          1. Let _index_ be the value of the [[ListIteratorNextIndex]] internal slot of _O_.
+          1. Let _list_ be the value of _O_.[[IteratedList]].
+          1. Let _index_ be the value of _O_.[[ListIteratorNextIndex]].
           1. Let _len_ be the number of elements of _list_.
           1. If _index_ &ge; _len_, then
             1. Return CreateIterResultObject(*undefined*, *true*).
-          1. Set the value of the [[ListIteratorNextIndex]] internal slot of _O_ to _index_+1.
+          1. Set the value of _O_.[[ListIteratorNextIndex]] to _index_+1.
           1. Return CreateIterResultObject(_list_[_index_], *false*).
         </emu-alg>
         <emu-note>
@@ -5695,13 +5695,13 @@
           1. Let _env_ be a new Lexical Environment.
           1. Let _envRec_ be a new function Environment Record containing no bindings.
           1. Set _envRec_.[[FunctionObject]] to _F_.
-          1. If _F_'s [[ThisMode]] internal slot is ~lexical~, set _envRec_.[[ThisBindingStatus]] to `"lexical"`.
+          1. If _F_.[[ThisMode]] is ~lexical~, set _envRec_.[[ThisBindingStatus]] to `"lexical"`.
           1. Else, set _envRec_.[[ThisBindingStatus]] to `"uninitialized"`.
-          1. Let _home_ be the value of _F_'s [[HomeObject]] internal slot.
+          1. Let _home_ be the value of _F_.[[HomeObject]].
           1. Set _envRec_.[[HomeObject]] to _home_.
           1. Set _envRec_.[[NewTarget]] to _newTarget_.
           1. Set _env_'s EnvironmentRecord to _envRec_.
-          1. Set the outer lexical environment reference of _env_ to the value of _F_'s [[Environment]] internal slot.
+          1. Set the outer lexical environment reference of _env_ to the value of _F_.[[Environment]].
           1. Return _env_.
         </emu-alg>
       </emu-clause>
@@ -6280,7 +6280,7 @@
         <h1>OrdinaryGetPrototypeOf (_O_)</h1>
         <p>When the abstract operation OrdinaryGetPrototypeOf is called with Object _O_, the following steps are taken:</p>
         <emu-alg>
-          1. Return the value of the [[Prototype]] internal slot of _O_.
+          1. Return the value of _O_.[[Prototype]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -6298,8 +6298,8 @@
         <p>When the abstract operation OrdinarySetPrototypeOf is called with Object _O_ and value _V_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
-          1. Let _extensible_ be the value of the [[Extensible]] internal slot of _O_.
-          1. Let _current_ be the value of the [[Prototype]] internal slot of _O_.
+          1. Let _extensible_ be the value of _O_.[[Extensible]].
+          1. Let _current_ be the value of _O_.[[Prototype]].
           1. If SameValue(_V_, _current_) is *true*, return *true*.
           1. If _extensible_ is *false*, return *false*.
           1. Let _p_ be _V_.
@@ -6309,8 +6309,8 @@
             1. Else if SameValue(_p_, _O_) is *true*, return *false*.
             1. Else,
               1. If the [[GetPrototypeOf]] internal method of _p_ is not the ordinary object internal method defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>, let _done_ be *true*.
-              1. Else, let _p_ be the value of _p_'s [[Prototype]] internal slot.
-          1. Set the value of the [[Prototype]] internal slot of _O_ to _V_.
+              1. Else, let _p_ be the value of _p_.[[Prototype]].
+          1. Set the value of _O_.[[Prototype]] to _V_.
           1. Return *true*.
         </emu-alg>
         <emu-note>
@@ -6331,7 +6331,7 @@
         <h1>OrdinaryIsExtensible (_O_)</h1>
         <p>When the abstract operation OrdinaryIsExtensible is called with Object _O_, the following steps are taken:</p>
         <emu-alg>
-          1. Return the value of the [[Extensible]] internal slot of _O_.
+          1. Return the value of _O_.[[Extensible]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -6348,7 +6348,7 @@
         <h1>OrdinaryPreventExtensions (_O_)</h1>
         <p>When the abstract operation OrdinaryPreventExtensions is called with Object _O_, the following steps are taken:</p>
         <emu-alg>
-          1. Set the value of the [[Extensible]] internal slot of _O_ to *false*.
+          1. Set the value of _O_.[[Extensible]] to *false*.
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -6398,7 +6398,7 @@
         <p>When the abstract operation OrdinaryDefineOwnProperty is called with Object _O_, property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
         <emu-alg>
           1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
-          1. Let _extensible_ be the value of the [[Extensible]] internal slot of _O_.
+          1. Let _extensible_ be the value of _O_.[[Extensible]].
           1. Return ValidateAndApplyPropertyDescriptor(_O_, _P_, _extensible_, _Desc_, _current_).
         </emu-alg>
       </emu-clause>
@@ -6612,8 +6612,8 @@
         1. If _internalSlotsList_ was not provided, let _internalSlotsList_ be a new empty List.
         1. Let _obj_ be a newly created object with an internal slot for each name in _internalSlotsList_.
         1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
-        1. Set the [[Prototype]] internal slot of _obj_ to _proto_.
-        1. Set the [[Extensible]] internal slot of _obj_ to *true*.
+        1. Set _obj_.[[Prototype]] to _proto_.
+        1. Set _obj_.[[Extensible]] to *true*.
         1. Return _obj_.
       </emu-alg>
     </emu-clause>
@@ -6788,7 +6788,7 @@
       <p>The [[Call]] internal method for an ECMAScript function object _F_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. If _F_'s [[FunctionKind]] internal slot is `"classConstructor"`, throw a *TypeError* exception.
+        1. If _F_.[[FunctionKind]] is `"classConstructor"`, throw a *TypeError* exception.
         1. Let _callerContext_ be the running execution context.
         1. Let _calleeContext_ be PrepareForOrdinaryCall(_F_, *undefined*).
         1. Assert: _calleeContext_ is now the running execution context.
@@ -6812,9 +6812,9 @@
           1. Let _callerContext_ be the running execution context.
           1. Let _calleeContext_ be a new ECMAScript code execution context.
           1. Set the Function of _calleeContext_ to _F_.
-          1. Let _calleeRealm_ be the value of _F_'s [[Realm]] internal slot.
+          1. Let _calleeRealm_ be the value of _F_.[[Realm]].
           1. Set the Realm of _calleeContext_ to _calleeRealm_.
-          1. Set the ScriptOrModule of _calleeContext_ to the value of _F_'s [[ScriptOrModule]] internal slot.
+          1. Set the ScriptOrModule of _calleeContext_ to the value of _F_.[[ScriptOrModule]].
           1. Let _localEnv_ be NewFunctionEnvironment(_F_, _newTarget_).
           1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
           1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
@@ -6830,9 +6830,9 @@
         <h1>OrdinaryCallBindThis ( _F_, _calleeContext_, _thisArgument_ )</h1>
         <p>When the abstract operation OrdinaryCallBindThis is called with function object _F_, execution context _calleeContext_, and ECMAScript value _thisArgument_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _thisMode_ be the value of _F_'s [[ThisMode]] internal slot.
+          1. Let _thisMode_ be the value of _F_.[[ThisMode]].
           1. If _thisMode_ is ~lexical~, return NormalCompletion(*undefined*).
-          1. Let _calleeRealm_ be the value of _F_'s [[Realm]] internal slot.
+          1. Let _calleeRealm_ be the value of _F_.[[Realm]].
           1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
           1. If _thisMode_ is ~strict~, let _thisValue_ be _thisArgument_.
           1. Else,
@@ -6855,7 +6855,7 @@
         <p>When the abstract operation OrdinaryCallEvaluateBody is called with function object _F_ and List _argumentsList_, the following steps are taken:</p>
         <emu-alg>
           1. Perform ? FunctionDeclarationInstantiation(_F_, _argumentsList_).
-          1. Return the result of EvaluateBody of the parsed code that is the value of _F_'s [[ECMAScriptCode]] internal slot passing _F_ as the argument.
+          1. Return the result of EvaluateBody of the parsed code that is the value of _F_.[[ECMAScriptCode]] passing _F_ as the argument.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -6868,7 +6868,7 @@
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: Type(_newTarget_) is Object.
         1. Let _callerContext_ be the running execution context.
-        1. Let _kind_ be _F_'s [[ConstructorKind]] internal slot.
+        1. Let _kind_ be _F_.[[ConstructorKind]].
         1. If _kind_ is `"base"`, then
           1. Let _thisArgument_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%ObjectPrototype%"`).
         1. Let _calleeContext_ be PrepareForOrdinaryCall(_F_, _newTarget_).
@@ -6902,12 +6902,12 @@
         1. Set _F_'s [[Call]] internal method to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
         1. If _needsConstruct_ is *true*, then
           1. Set _F_'s [[Construct]] internal method to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
-          1. Set the [[ConstructorKind]] internal slot of _F_ to `"base"`.
-        1. Set the [[Strict]] internal slot of _F_ to _strict_.
-        1. Set the [[FunctionKind]] internal slot of _F_ to _functionKind_.
-        1. Set the [[Prototype]] internal slot of _F_ to _functionPrototype_.
-        1. Set the [[Extensible]] internal slot of _F_ to *true*.
-        1. Set the [[Realm]] internal slot of _F_ to the current Realm Record.
+          1. Set _F_.[[ConstructorKind]] to `"base"`.
+        1. Set _F_.[[Strict]] to _strict_.
+        1. Set _F_.[[FunctionKind]] to _functionKind_.
+        1. Set _F_.[[Prototype]] to _functionPrototype_.
+        1. Set _F_.[[Extensible]] to *true*.
+        1. Set _F_.[[Realm]] to the current Realm Record.
         1. Return _F_.
       </emu-alg>
     </emu-clause>
@@ -6920,14 +6920,14 @@
         1. Assert: _F_ is an extensible object that does not have a `length` own property.
         1. Let _len_ be the ExpectedArgumentCount of _ParameterList_.
         1. Perform ! DefinePropertyOrThrow(_F_, `"length"`, PropertyDescriptor{[[Value]]: _len_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
-        1. Let _Strict_ be the value of the [[Strict]] internal slot of _F_.
-        1. Set the [[Environment]] internal slot of _F_ to the value of _Scope_.
-        1. Set the [[FormalParameters]] internal slot of _F_ to _ParameterList_.
-        1. Set the [[ECMAScriptCode]] internal slot of _F_ to _Body_.
-        1. Set the [[ScriptOrModule]] internal slot of _F_ to GetActiveScriptOrModule().
-        1. If _kind_ is ~Arrow~, set the [[ThisMode]] internal slot of _F_ to ~lexical~.
-        1. Else if _Strict_ is *true*, set the [[ThisMode]] internal slot of _F_ to ~strict~.
-        1. Else, set the [[ThisMode]] internal slot of _F_ to ~global~.
+        1. Let _Strict_ be the value of _F_.[[Strict]].
+        1. Set _F_.[[Environment]] to the value of _Scope_.
+        1. Set _F_.[[FormalParameters]] to _ParameterList_.
+        1. Set _F_.[[ECMAScriptCode]] to _Body_.
+        1. Set _F_.[[ScriptOrModule]] to GetActiveScriptOrModule().
+        1. If _kind_ is ~Arrow~, set _F_.[[ThisMode]] to ~lexical~.
+        1. Else if _Strict_ is *true*, set _F_.[[ThisMode]] to ~strict~.
+        1. Else, set _F_.[[ThisMode]] to ~global~.
         1. Return _F_.
       </emu-alg>
     </emu-clause>
@@ -7003,8 +7003,8 @@
       <p>The abstract operation MakeClassConstructor with argument _F_ performs the following steps:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. Assert: _F_'s [[FunctionKind]] internal slot is `"normal"`.
-        1. Set _F_'s [[FunctionKind]] internal slot to `"classConstructor"`.
+        1. Assert: _F_.[[FunctionKind]] is `"normal"`.
+        1. Set _F_.[[FunctionKind]] to `"classConstructor"`.
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
     </emu-clause>
@@ -7016,7 +7016,7 @@
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: Type(_homeObject_) is Object.
-        1. Set the [[HomeObject]] internal slot of _F_ to _homeObject_.
+        1. Set _F_.[[HomeObject]] to _homeObject_.
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
     </emu-clause>
@@ -7050,9 +7050,9 @@
         1. Let _calleeContext_ be the running execution context.
         1. Let _env_ be the LexicalEnvironment of _calleeContext_.
         1. Let _envRec_ be _env_'s EnvironmentRecord.
-        1. Let _code_ be the value of the [[ECMAScriptCode]] internal slot of _func_.
-        1. Let _strict_ be the value of the [[Strict]] internal slot of _func_.
-        1. Let _formals_ be the value of the [[FormalParameters]] internal slot of _func_.
+        1. Let _code_ be the value of _func_.[[ECMAScriptCode]].
+        1. Let _strict_ be the value of _func_.[[Strict]].
+        1. Let _formals_ be the value of _func_.[[FormalParameters]].
         1. Let _parameterNames_ be the BoundNames of _formals_.
         1. If _parameterNames_ has any duplicate entries, let _hasDuplicates_ be *true*. Otherwise, let _hasDuplicates_ be *false*.
         1. Let _simpleParameterList_ be IsSimpleParameterList of _formals_.
@@ -7071,7 +7071,7 @@
               1. NOTE If there are multiple |FunctionDeclaration|s or |GeneratorDeclaration|s for the same name, the last declaration is used.
               1. Insert _d_ as the first element of _functionsToInitialize_.
         1. Let _argumentsObjectNeeded_ be *true*.
-        1. If the value of the [[ThisMode]] internal slot of _func_ is ~lexical~, then
+        1. If the value of _func_.[[ThisMode]] is ~lexical~, then
           1. NOTE Arrow functions never have an arguments objects.
           1. Let _argumentsObjectNeeded_ be *false*.
         1. Else if `"arguments"` is an element of _parameterNames_, then
@@ -7178,9 +7178,9 @@
         1. If _callerContext_ is not already suspended, suspend _callerContext_.
         1. Let _calleeContext_ be a new ECMAScript code execution context.
         1. Set the Function of _calleeContext_ to _F_.
-        1. Let _calleeRealm_ be the value of _F_'s [[Realm]] internal slot.
+        1. Let _calleeRealm_ be the value of _F_.[[Realm]].
         1. Set the Realm of _calleeContext_ to _calleeRealm_.
-        1. Set the ScriptOrModule of _calleeContext_ to the value of _F_'s [[ScriptOrModule]] internal slot.
+        1. Set the ScriptOrModule of _calleeContext_ to the value of _F_.[[ScriptOrModule]].
         1. Perform any necessary implementation defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
         1. Let _result_ be the Completion Record that is the result of evaluating _F_ in an implementation defined manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
@@ -7209,10 +7209,10 @@
         1. Assert: _realm_ is a Realm Record.
         1. Assert: _steps_ is either a set of algorithm steps or other definition of a function's behaviour provided in this specification.
         1. Let _func_ be a new built-in function object that when called performs the action described by _steps_. The new function object has internal slots whose names are the elements of _internalSlotsList_. The initial value of each of those internal slots is *undefined*.
-        1. Set the [[Realm]] internal slot of _func_ to _realm_.
-        1. Set the [[Prototype]] internal slot of _func_ to _prototype_.
-        1. Set the [[Extensible]] internal slot of _func_ to *true*.
-        1. Set the [[ScriptOrModule]] internal slot of _func_ to *null*.
+        1. Set _func_.[[Realm]] to _realm_.
+        1. Set _func_.[[Prototype]] to _prototype_.
+        1. Set _func_.[[Extensible]] to *true*.
+        1. Set _func_.[[ScriptOrModule]] to *null*.
         1. Return _func_.
       </emu-alg>
       <p>Each built-in function defined in this specification is created as if by calling the CreateBuiltinFunction abstract operation, unless otherwise specified.</p>
@@ -7286,9 +7286,9 @@
         <h1>[[Call]] ( _thisArgument_, _argumentsList_)</h1>
         <p>When the [[Call]] internal method of an exotic bound function object, _F_, which was created using the bind function is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values, the following steps are taken:</p>
         <emu-alg>
-          1. Let _target_ be the value of _F_'s [[BoundTargetFunction]] internal slot.
-          1. Let _boundThis_ be the value of _F_'s [[BoundThis]] internal slot.
-          1. Let _boundArgs_ be the value of _F_'s [[BoundArguments]] internal slot.
+          1. Let _target_ be the value of _F_.[[BoundTargetFunction]].
+          1. Let _boundThis_ be the value of _F_.[[BoundThis]].
+          1. Let _boundArgs_ be the value of _F_.[[BoundArguments]].
           1. Let _args_ be a new list containing the same values as the list _boundArgs_ in the same order followed by the same values as the list _argumentsList_ in the same order.
           1. Return ? Call(_target_, _boundThis_, _args_).
         </emu-alg>
@@ -7299,9 +7299,9 @@
         <h1>[[Construct]] (_argumentsList_, _newTarget_)</h1>
         <p>When the [[Construct]] internal method of an exotic bound function object, _F_ that was created using the bind function is called with a list of arguments _argumentsList_ and _newTarget_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _target_ be the value of _F_'s [[BoundTargetFunction]] internal slot.
+          1. Let _target_ be the value of _F_.[[BoundTargetFunction]].
           1. Assert: _target_ has a [[Construct]] internal method.
-          1. Let _boundArgs_ be the value of _F_'s [[BoundArguments]] internal slot.
+          1. Let _boundArgs_ be the value of _F_.[[BoundArguments]].
           1. Let _args_ be a new list containing the same values as the list _boundArgs_ in the same order followed by the same values as the list _argumentsList_ in the same order.
           1. If SameValue(_F_, _newTarget_) is *true*, let _newTarget_ be _target_.
           1. Return ? Construct(_target_, _args_, _newTarget_).
@@ -7320,11 +7320,11 @@
           1. Set the [[Call]] internal method of _obj_ as described in <emu-xref href="#sec-bound-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
           1. If _targetFunction_ has a [[Construct]] internal method, then
             1. Set the [[Construct]] internal method of _obj_ as described in <emu-xref href="#sec-bound-function-exotic-objects-construct-argumentslist-newtarget"></emu-xref>.
-          1. Set the [[Prototype]] internal slot of _obj_ to _proto_.
-          1. Set the [[Extensible]] internal slot of _obj_ to *true*.
-          1. Set the [[BoundTargetFunction]] internal slot of _obj_ to _targetFunction_.
-          1. Set the [[BoundThis]] internal slot of _obj_ to the value of _boundThis_.
-          1. Set the [[BoundArguments]] internal slot of _obj_ to _boundArgs_.
+          1. Set _obj_.[[Prototype]] to _proto_.
+          1. Set _obj_.[[Extensible]] to *true*.
+          1. Set _obj_.[[BoundTargetFunction]] to _targetFunction_.
+          1. Set _obj_.[[BoundThis]] to the value of _boundThis_.
+          1. Set _obj_.[[BoundArguments]] to _boundArgs_.
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -7377,8 +7377,8 @@
           1. Let _A_ be a newly created Array exotic object.
           1. Set _A_'s essential internal methods except for [[DefineOwnProperty]] to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set the [[DefineOwnProperty]] internal method of _A_ as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
-          1. Set the [[Prototype]] internal slot of _A_ to _proto_.
-          1. Set the [[Extensible]] internal slot of _A_ to *true*.
+          1. Set _A_.[[Prototype]] to _proto_.
+          1. Set _A_.[[Extensible]] to *true*.
           1. Perform ! OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor{[[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
           1. Return _A_.
         </emu-alg>
@@ -7474,7 +7474,7 @@
           1. If _index_ is *undefined*, return *undefined*.
           1. If IsInteger(_index_) is *false*, return *undefined*.
           1. If _index_ = *-0*, return *undefined*.
-          1. Let _str_ be the String value of the [[StringData]] internal slot of _S_.
+          1. Let _str_ be the String value of _S_.[[StringData]].
           1. Let _len_ be the number of elements in _str_.
           1. If _index_ &lt; 0 or _len_ &le; _index_, return *undefined*.
           1. Let _resultStr_ be a String value of length 1, containing one code unit from _str_, specifically the code unit at index _index_.
@@ -7488,7 +7488,7 @@
         <p>When the [[OwnPropertyKeys]] internal method of a String exotic object _O_ is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _keys_ be a new empty List.
-          1. Let _str_ be the String value of the [[StringData]] internal slot of _O_.
+          1. Let _str_ be the String value of _O_.[[StringData]].
           1. Let _len_ be the number of elements in _str_.
           1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order,
             1. Add ! ToString(_i_) as the last element of _keys_.
@@ -7509,12 +7509,12 @@
         <emu-alg>
           1. Assert: Type(_value_) is String.
           1. Let _S_ be a newly created String exotic object.
-          1. Set the [[StringData]] internal slot of _S_ to _value_.
+          1. Set _S_.[[StringData]] to _value_.
           1. Set _S_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set the [[GetOwnProperty]] internal method of _S_ as specified in <emu-xref href="#sec-string-exotic-objects-getownproperty-p"></emu-xref>.
           1. Set the [[OwnPropertyKeys]] internal method of _S_ as specified in <emu-xref href="#sec-string-exotic-objects-ownpropertykeys"></emu-xref>.
-          1. Set the [[Prototype]] internal slot of _S_ to _prototype_.
-          1. Set the [[Extensible]] internal slot of _S_ to *true*.
+          1. Set _S_.[[Prototype]] to _prototype_.
+          1. Set _S_.[[Extensible]] to *true*.
           1. Let _length_ be the number of code unit elements in _value_.
           1. Perform ! DefinePropertyOrThrow(_S_, `"length"`, PropertyDescriptor{[[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _S_.
@@ -7546,7 +7546,7 @@
           1. Let _args_ be the arguments object.
           1. Let _desc_ be OrdinaryGetOwnProperty(_args_, _P_).
           1. If _desc_ is *undefined*, return _desc_.
-          1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
+          1. Let _map_ be the value of _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If the value of _isMapped_ is *true*, then
             1. Set _desc_.[[Value]] to Get(_map_, _P_).
@@ -7562,7 +7562,7 @@
         <p>The [[DefineOwnProperty]] internal method of an arguments exotic object when called with a property key _P_ and Property Descriptor _Desc_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
+          1. Let _map_ be the value of _args_.[[ParameterMap]].
           1. Let _isMapped_ be HasOwnProperty(_map_, _P_).
           1. Let _newArgDesc_ be _Desc_.
           1. If _isMapped_ is *true* and IsDataDescriptor(_Desc_) is *true*, then
@@ -7590,7 +7590,7 @@
         <p>The [[Get]] internal method of an arguments exotic object when called with a property key _P_ and ECMAScript language value _Receiver_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
+          1. Let _map_ be the value of _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If the value of _isMapped_ is *false*, then
             1. Return ? OrdinaryGet(_args_, _P_, _Receiver_).
@@ -7608,7 +7608,7 @@
           1. If SameValue(_args_, _Receiver_) is *false*, then
             1. Let _isMapped_ be *false*.
           1. Else,
-            1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
+            1. Let _map_ be the value of _args_.[[ParameterMap]].
             1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If _isMapped_ is *true*, then
             1. Let _setStatus_ be Set(_map_, _P_, _V_, *false*).
@@ -7636,7 +7636,7 @@
         <p>The [[Delete]] internal method of an arguments exotic object when called with a property key _P_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
+          1. Let _map_ be the value of _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. Let _result_ be ? OrdinaryDelete(_args_, _P_).
           1. If _result_ is *true* and the value of _isMapped_ is *true*, then
@@ -7652,7 +7652,7 @@
         <emu-alg>
           1. Let _len_ be the number of elements in _argumentsList_.
           1. Let _obj_ be ObjectCreate(%ObjectPrototype%, &laquo; [[ParameterMap]] &raquo;).
-          1. Set _obj_'s [[ParameterMap]] internal slot to *undefined*.
+          1. Set _obj_.[[ParameterMap]] to *undefined*.
           1. Perform DefinePropertyOrThrow(_obj_, `"length"`, PropertyDescriptor{[[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
           1. Let _index_ be 0.
           1. Repeat while _index_ &lt; _len_,
@@ -7681,10 +7681,10 @@
           1. Set the [[HasProperty]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-hasproperty"></emu-xref>.
           1. Set the [[Delete]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
           1. Set the remainder of _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
-          1. Set the [[Prototype]] internal slot of _obj_ to %ObjectPrototype%.
-          1. Set the [[Extensible]] internal slot of _obj_ to *true*.
+          1. Set _obj_.[[Prototype]] to %ObjectPrototype%.
+          1. Set _obj_.[[Extensible]] to *true*.
           1. Let _map_ be ObjectCreate(*null*).
-          1. Set the [[ParameterMap]] internal slot of _obj_ to _map_.
+          1. Set _obj_.[[ParameterMap]] to _map_.
           1. Let _parameterNames_ be the BoundNames of _formals_.
           1. Let _numberOfParameters_ be the number of elements in _parameterNames_.
           1. Let _index_ be 0.
@@ -7717,14 +7717,14 @@
             1. Let _realm_ be the current Realm Record.
             1. Let _steps_ be the steps of an ArgGetter function as specified below.
             1. Let _getter_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[Name]], [[Env]] &raquo;).
-            1. Set _getter_'s [[Name]] internal slot to _name_.
-            1. Set _getter_'s [[Env]] internal slot to _env_.
+            1. Set _getter_.[[Name]] to _name_.
+            1. Set _getter_.[[Env]] to _env_.
             1. Return _getter_.
           </emu-alg>
           <p>An ArgGetter function is an anonymous built-in function with [[Name]] and [[Env]] internal slots. When an ArgGetter function _f_ that expects no arguments is called it performs the following steps:</p>
           <emu-alg>
-            1. Let _name_ be the value of _f_'s [[Name]] internal slot.
-            1. Let _env_ be the value of _f_'s [[Env]] internal slot.
+            1. Let _name_ be the value of _f_.[[Name]].
+            1. Let _env_ be the value of _f_.[[Env]].
             1. Return _env_.GetBindingValue(_name_, *false*).
           </emu-alg>
           <emu-note>
@@ -7740,14 +7740,14 @@
             1. Let _realm_ be the current Realm Record.
             1. Let _steps_ be the steps of an ArgSetter function as specified below.
             1. Let _setter_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[Name]], [[Env]] &raquo;).
-            1. Set _setter_'s [[Name]] internal slot to _name_.
-            1. Set _setter_'s [[Env]] internal slot to _env_.
+            1. Set _setter_.[[Name]] to _name_.
+            1. Set _setter_.[[Env]] to _env_.
             1. Return _setter_.
           </emu-alg>
           <p>An ArgSetter function is an anonymous built-in function with [[Name]] and [[Env]] internal slots. When an ArgSetter function _f_ is called with argument _value_ it performs the following steps:</p>
           <emu-alg>
-            1. Let _name_ be the value of _f_'s [[Name]] internal slot.
-            1. Let _env_ be the value of _f_'s [[Env]] internal slot.
+            1. Let _name_ be the value of _f_.[[Name]].
+            1. Let _env_ be the value of _f_.[[Env]].
             1. Return _env_.SetMutableBinding(_name_, _value_, *false*).
           </emu-alg>
           <emu-note>
@@ -7791,12 +7791,12 @@
           1. If Type(_P_) is String, then
             1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+              1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
               1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
               1. If IsInteger(_numericIndex_) is *false*, return *false*.
               1. If _numericIndex_ = *-0*, return *false*.
               1. If _numericIndex_ &lt; 0, return *false*.
-              1. If _numericIndex_ &ge; the value of _O_'s [[ArrayLength]] internal slot, return *false*.
+              1. If _numericIndex_ &ge; the value of _O_.[[ArrayLength]], return *false*.
               1. Return *true*.
           1. Return ? OrdinaryHasProperty(_O_, _P_).
         </emu-alg>
@@ -7815,7 +7815,7 @@
               1. If IsInteger(_numericIndex_) is *false*, return *false*.
               1. If _numericIndex_ = *-0*, return *false*.
               1. If _numericIndex_ &lt; 0, return *false*.
-              1. Let _length_ be the value of _O_'s [[ArrayLength]] internal slot.
+              1. Let _length_ be the value of _O_.[[ArrayLength]].
               1. If _numericIndex_ &ge; _length_, return *false*.
               1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
               1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *true*, return *false*.
@@ -7864,7 +7864,7 @@
         <emu-alg>
           1. Let _keys_ be a new empty List.
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
-          1. Let _len_ be the value of _O_'s [[ArrayLength]] internal slot.
+          1. Let _len_ be the value of _O_.[[ArrayLength]].
           1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order,
             1. Add ! ToString(_i_) as the last element of _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an integer index, in ascending chronological order of property creation
@@ -7889,8 +7889,8 @@
           1. Set the [[Get]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-get-p-receiver"></emu-xref>.
           1. Set the [[Set]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-set-p-v-receiver"></emu-xref>.
           1. Set the [[OwnPropertyKeys]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-ownpropertykeys"></emu-xref>.
-          1. Set the [[Prototype]] internal slot of _A_ to _prototype_.
-          1. Set the [[Extensible]] internal slot of _A_ to *true*.
+          1. Set _A_.[[Prototype]] to _prototype_.
+          1. Set _A_.[[Extensible]] to *true*.
           1. Return _A_.
         </emu-alg>
       </emu-clause>
@@ -7902,14 +7902,14 @@
         <emu-alg>
           1. Assert: Type(_index_) is Number.
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If IsInteger(_index_) is *false*, return *undefined*.
           1. If _index_ = *-0*, return *undefined*.
-          1. Let _length_ be the value of _O_'s [[ArrayLength]] internal slot.
+          1. Let _length_ be the value of _O_.[[ArrayLength]].
           1. If _index_ &lt; 0 or _index_ &ge; _length_, return *undefined*.
-          1. Let _offset_ be the value of _O_'s [[ByteOffset]] internal slot.
-          1. Let _arrayTypeName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _offset_ be the value of _O_.[[ByteOffset]].
+          1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
@@ -7925,14 +7925,14 @@
           1. Assert: Type(_index_) is Number.
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
           1. Let _numValue_ be ? ToNumber(_value_).
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If IsInteger(_index_) is *false*, return *false*.
           1. If _index_ = *-0*, return *false*.
-          1. Let _length_ be the value of _O_'s [[ArrayLength]] internal slot.
+          1. Let _length_ be the value of _O_.[[ArrayLength]].
           1. If _index_ &lt; 0 or _index_ &ge; _length_, return *false*.
-          1. Let _offset_ be the value of _O_'s [[ByteOffset]] internal slot.
-          1. Let _arrayTypeName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _offset_ be the value of _O_.[[ByteOffset]].
+          1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
@@ -8031,7 +8031,7 @@
         <p>When the [[GetOwnProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryGetOwnProperty(_O_, _P_).
-          1. Let _exports_ be the value of _O_'s [[Exports]] internal slot.
+          1. Let _exports_ be the value of _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _value_ be ? _O_.[[Get]](_P_, _O_).
           1. Return PropertyDescriptor{[[Value]]: _value_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
@@ -8053,7 +8053,7 @@
         <p>When the [[HasProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryHasProperty(_O_, _P_).
-          1. Let _exports_ be the value of _O_'s [[Exports]] internal slot.
+          1. Let _exports_ be the value of _O_.[[Exports]].
           1. If _P_ is an element of _exports_, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -8067,9 +8067,9 @@
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is Symbol, then
             1. Return ? OrdinaryGet(_O_, _P_, _Receiver_).
-          1. Let _exports_ be the value of _O_'s [[Exports]] internal slot.
+          1. Let _exports_ be the value of _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
-          1. Let _m_ be the value of _O_'s [[Module]] internal slot.
+          1. Let _m_ be the value of _O_.[[Module]].
           1. Let _binding_ be ! _m_.ResolveExport(_P_, &laquo; &raquo;, &laquo; &raquo;).
           1. Assert: _binding_ is neither *null* nor `"ambiguous"`.
           1. Let _targetModule_ be _binding_.[[Module]].
@@ -8099,7 +8099,7 @@
         <p>When the [[Delete]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. Let _exports_ be the value of _O_'s [[Exports]] internal slot.
+          1. Let _exports_ be the value of _O_.[[Exports]].
           1. If _P_ is an element of _exports_, return *false*.
           1. Return *true*.
         </emu-alg>
@@ -8110,7 +8110,7 @@
         <h1>[[OwnPropertyKeys]] ( )</h1>
         <p>When the [[OwnPropertyKeys]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
         <emu-alg>
-          1. Let _exports_ be a copy of the value of _O_'s [[Exports]] internal slot.
+          1. Let _exports_ be a copy of the value of _O_.[[Exports]].
           1. Let _symbolKeys_ be ! OrdinaryOwnPropertyKeys(_O_).
           1. Append all the entries of _symbolKeys_ to the end of _exports_.
           1. Return _exports_.
@@ -8127,9 +8127,9 @@
           1. Assert: _exports_ is a List of String values.
           1. Let _M_ be a newly created object.
           1. Set _M_'s essential internal methods to the definitions specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref>.
-          1. Set _M_'s [[Module]] internal slot to _module_.
+          1. Set _M_.[[Module]] to _module_.
           1. Let _sortedExports_ be a new List containing the same values as the list _exports_ where the values are ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using SortCompare as _comparefn_.
-          1. Set _M_'s [[Exports]] internal slot to _sortedExports_.
+          1. Set _M_.[[Exports]] to _sortedExports_.
           1. Create own properties of _M_ corresponding to the definitions in <emu-xref href="#sec-module-namespace-objects"></emu-xref>.
           1. Set _module_.[[Namespace]] to _M_.
           1. Return _M_.
@@ -8146,7 +8146,7 @@
         <p>When the [[SetPrototypeOf]] internal method of an immutable prototype exotic object _O_ is called with argument _V_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
-          1. Let _current_ be the value of the [[Prototype]] internal slot of _O_.
+          1. Let _current_ be the value of _O_.[[Prototype]].
           1. If SameValue(_V_, _current_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -8286,10 +8286,10 @@
       <h1>[[GetPrototypeOf]] ( )</h1>
       <p>When the [[GetPrototypeOf]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"getPrototypeOf"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[GetPrototypeOf]]().
@@ -8320,10 +8320,10 @@
       <p>When the [[SetPrototypeOf]] internal method of a Proxy exotic object _O_ is called with argument _V_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"setPrototypeOf"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[SetPrototypeOf]](_V_).
@@ -8353,10 +8353,10 @@
       <h1>[[IsExtensible]] ( )</h1>
       <p>When the [[IsExtensible]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"isExtensible"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[IsExtensible]]().
@@ -8383,10 +8383,10 @@
       <h1>[[PreventExtensions]] ( )</h1>
       <p>When the [[PreventExtensions]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"preventExtensions"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[PreventExtensions]]().
@@ -8415,10 +8415,10 @@
       <p>When the [[GetOwnProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"getOwnPropertyDescriptor"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[GetOwnProperty]](_P_).
@@ -8470,10 +8470,10 @@
       <p>When the [[DefineOwnProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_ and Property Descriptor _Desc_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"defineProperty"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[DefineOwnProperty]](_P_, _Desc_).
@@ -8518,10 +8518,10 @@
       <p>When the [[HasProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"has"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[HasProperty]](_P_).
@@ -8556,10 +8556,10 @@
       <p>When the [[Get]] internal method of a Proxy exotic object _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"get"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Get]](_P_, _Receiver_).
@@ -8591,10 +8591,10 @@
       <p>When the [[Set]] internal method of a Proxy exotic object _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"set"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Set]](_P_, _V_, _Receiver_).
@@ -8630,10 +8630,10 @@
       <p>When the [[Delete]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"deleteProperty"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Delete]](_P_).
@@ -8662,10 +8662,10 @@
       <h1>[[OwnPropertyKeys]] ( )</h1>
       <p>When the [[OwnPropertyKeys]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"ownKeys"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[OwnPropertyKeys]]().
@@ -8719,10 +8719,10 @@
       <h1>[[Call]] (_thisArgument_, _argumentsList_)</h1>
       <p>The [[Call]] internal method of a Proxy exotic object _O_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"apply"`).
         1. If _trap_ is *undefined*, then
           1. Return ? Call(_target_, _thisArgument_, _argumentsList_).
@@ -8739,10 +8739,10 @@
       <h1>[[Construct]] ( _argumentsList_, _newTarget_)</h1>
       <p>The [[Construct]] internal method of a Proxy exotic object _O_ is called with parameters _argumentsList_ which is a possibly empty List of ECMAScript language values and _newTarget_. The following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of the [[ProxyHandler]] internal slot of _O_.
+        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of the [[ProxyTarget]] internal slot of _O_.
+        1. Let _target_ be the value of _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"construct"`).
         1. If _trap_ is *undefined*, then
           1. Assert: _target_ has a [[Construct]] internal method.
@@ -8771,17 +8771,17 @@
       <p>The abstract operation ProxyCreate with arguments _target_ and _handler_ is used to specify the creation of new Proxy exotic objects. It performs the following steps:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
-        1. If _target_ is a Proxy exotic object and the value of the [[ProxyHandler]] internal slot of _target_ is *null*, throw a *TypeError* exception.
+        1. If _target_ is a Proxy exotic object and the value of _target_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
         1. If Type(_handler_) is not Object, throw a *TypeError* exception.
-        1. If _handler_ is a Proxy exotic object and the value of the [[ProxyHandler]] internal slot of _handler_ is *null*, throw a *TypeError* exception.
+        1. If _handler_ is a Proxy exotic object and the value of _handler_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
         1. Let _P_ be a newly created object.
         1. Set _P_'s essential internal methods (except for [[Call]] and [[Construct]]) to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
         1. If IsCallable(_target_) is *true*, then
           1. Set the [[Call]] internal method of _P_ as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
           1. If _target_ has a [[Construct]] internal method, then
             1. Set the [[Construct]] internal method of _P_ as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget"></emu-xref>.
-        1. Set the [[ProxyTarget]] internal slot of _P_ to _target_.
-        1. Set the [[ProxyHandler]] internal slot of _P_ to _handler_.
+        1. Set _P_.[[ProxyTarget]] to _target_.
+        1. Set _P_.[[ProxyHandler]] to _handler_.
         1. Return _P_.
       </emu-alg>
     </emu-clause>
@@ -19041,7 +19041,7 @@
         1. Let _constructorInfo_ be the result of performing DefineMethod for _constructor_ with arguments _proto_ and _constructorParent_ as the optional _functionPrototype_ argument.
         1. Assert: _constructorInfo_ is not an abrupt completion.
         1. Let _F_ be _constructorInfo_.[[Closure]].
-        1. If |ClassHeritage_opt| is present and _protoParent_ is not *null*, then set _F_'s [[ConstructorKind]] internal slot to `"derived"`.
+        1. If |ClassHeritage_opt| is present and _protoParent_ is not *null*, then set _F_.[[ConstructorKind]] to `"derived"`.
         1. Perform MakeConstructor(_F_, *false*, _proto_).
         1. Perform MakeClassConstructor(_F_).
         1. Perform CreateMethodProperty(_proto_, `"constructor"`, _F_).
@@ -23017,7 +23017,7 @@
         <p>When the `Function` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no &ldquo;_p_&rdquo; arguments, and where _body_ might also not be provided), the following steps are taken:</p>
         <emu-alg>
           1. Let _C_ be the active function object.
-          1. Let _calleeRealm_ be the value of _C_'s [[Realm]] internal slot.
+          1. Let _calleeRealm_ be the value of _C_.[[Realm]].
           1. Perform ? HostEnsureCanCompileStrings(the current Realm Record, _calleeRealm_).
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
           1. Return ? CreateDynamicFunction(_C_, NewTarget, `"normal"`, _args_).
@@ -23076,7 +23076,7 @@
               1. If BoundNames of _parameters_ contains any duplicate elements, throw a *SyntaxError* exception.
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _fallbackProto_).
             1. Let _F_ be FunctionAllocate(_proto_, _strict_, _kind_).
-            1. Let _realmF_ be the value of _F_'s [[Realm]] internal slot.
+            1. Let _realmF_ be the value of _F_.[[Realm]].
             1. Let _scope_ be _realmF_.[[GlobalEnv]].
             1. Perform FunctionInitialize(_F_, ~Normal~, _parameters_, _body_, _scope_).
             1. If _kind_ is `"generator"`, then
@@ -23305,7 +23305,7 @@
           1. Let _b_ be ToBoolean(_value_).
           1. If NewTarget is *undefined*, return _b_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%BooleanPrototype%"`, &laquo; [[BooleanData]] &raquo;).
-          1. Set the value of _O_'s [[BooleanData]] internal slot to _b_.
+          1. Set the value of _O_.[[BooleanData]] to _b_.
           1. Return _O_.
         </emu-alg>
       </emu-clause>
@@ -23336,8 +23336,8 @@
         <emu-alg>
           1. If Type(_value_) is Boolean, return _value_.
           1. If Type(_value_) is Object and _value_ has a [[BooleanData]] internal slot, then
-            1. Assert: _value_'s [[BooleanData]] internal slot is a Boolean value.
-            1. Return the value of _value_'s [[BooleanData]] internal slot.
+            1. Assert: _value_.[[BooleanData]] is a Boolean value.
+            1. Return the value of _value_.[[BooleanData]].
           1. Throw a *TypeError* exception.
         </emu-alg>
       </emu-clause>
@@ -23579,7 +23579,7 @@
           1. Else,
             1. If Type(_s_) is not Object, throw a *TypeError* exception.
             1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-            1. Let _sym_ be the value of _s_'s [[SymbolData]] internal slot.
+            1. Let _sym_ be the value of _s_.[[SymbolData]].
           1. Return SymbolDescriptiveString(_sym_).
         </emu-alg>
 
@@ -23606,7 +23606,7 @@
           1. If Type(_s_) is Symbol, return _s_.
           1. If Type(_s_) is not Object, throw a *TypeError* exception.
           1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-          1. Return the value of _s_'s [[SymbolData]] internal slot.
+          1. Return the value of _s_.[[SymbolData]].
         </emu-alg>
       </emu-clause>
 
@@ -23620,7 +23620,7 @@
           1. If Type(_s_) is Symbol, return _s_.
           1. If Type(_s_) is not Object, throw a *TypeError* exception.
           1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-          1. Return the value of _s_'s [[SymbolData]] internal slot.
+          1. Return the value of _s_.[[SymbolData]].
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.toPrimitive]"`.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -23873,7 +23873,7 @@
           1. Else, let _n_ be ? ToNumber(_value_).
           1. If NewTarget is *undefined*, return _n_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%NumberPrototype%"`, &laquo; [[NumberData]] &raquo;).
-          1. Set the value of _O_'s [[NumberData]] internal slot to _n_.
+          1. Set the value of _O_.[[NumberData]] to _n_.
           1. Return _O_.
         </emu-alg>
       </emu-clause>
@@ -24030,8 +24030,8 @@
       <emu-alg>
         1. If Type(_value_) is Number, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[NumberData]] internal slot, then
-          1. Assert: _value_'s [[NumberData]] internal slot is a Number value.
-          1. Return the value of _value_'s [[NumberData]] internal slot.
+          1. Assert: _value_.[[NumberData]] is a Number value.
+          1. Return the value of _value_.[[NumberData]].
         1. Throw a *TypeError* exception.
       </emu-alg>
       <p>The phrase &ldquo;this Number value&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisNumberValue with the *this* value of the method invocation passed as the argument.</p>
@@ -25586,7 +25586,7 @@ THH:mm:ss.sss
             1. If _y_ is not *NaN* and 0 &le; ToInteger(_y_) &le; 99, let _yr_ be 1900+ToInteger(_y_); otherwise, let _yr_ be _y_.
             1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
             1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DatePrototype%"`, &laquo; [[DateValue]] &raquo;).
-            1. Set the [[DateValue]] internal slot of _O_ to TimeClip(UTC(_finalDate_)).
+            1. Set _O_.[[DateValue]] to TimeClip(UTC(_finalDate_)).
             1. Return _O_.
           1. Else,
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
@@ -25613,7 +25613,7 @@ THH:mm:ss.sss
               1. Else,
                 1. Let _tv_ be ? ToNumber(_v_).
             1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DatePrototype%"`, &laquo; [[DateValue]] &raquo;).
-            1. Set the [[DateValue]] internal slot of _O_ to TimeClip(_tv_).
+            1. Set _O_.[[DateValue]] to TimeClip(_tv_).
             1. Return _O_.
           1. Else,
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
@@ -25631,7 +25631,7 @@ THH:mm:ss.sss
           1. Assert: _numberOfArgs_ = 0.
           1. If NewTarget is not *undefined*, then
             1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DatePrototype%"`, &laquo; [[DateValue]] &raquo;).
-            1. Set the [[DateValue]] internal slot of _O_ to the time value (UTC) identifying the current time.
+            1. Set _O_.[[DateValue]] to the time value (UTC) identifying the current time.
             1. Return _O_.
           1. Else,
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
@@ -25708,7 +25708,7 @@ THH:mm:ss.sss
       <p>The abstract operation thisTimeValue(_value_) performs the following steps:</p>
       <emu-alg>
         1. If Type(_value_) is Object and _value_ has a [[DateValue]] internal slot, then
-          1. Return the value of _value_'s [[DateValue]] internal slot.
+          1. Return the value of _value_.[[DateValue]].
         1. Throw a *TypeError* exception.
       </emu-alg>
       <p>In following descriptions of functions that are properties of the Date prototype object, the phrase &ldquo;this Date object&rdquo; refers to the object that is the *this* value for the invocation of the function. If the Type of the *this* value is not Object, a *TypeError* exception is thrown. The phrase &ldquo;<dfn>this time value</dfn>&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisTimeValue with the *this* value of the method invocation passed as the argument.</p>
@@ -26452,8 +26452,8 @@ THH:mm:ss.sss
       <emu-alg>
         1. If Type(_value_) is String, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[StringData]] internal slot, then
-          1. Assert: _value_'s [[StringData]] internal slot is a String value.
-          1. Return the value of _value_'s [[StringData]] internal slot.
+          1. Assert: _value_.[[StringData]] is a String value.
+          1. Return the value of _value_.[[StringData]].
         1. Throw a *TypeError* exception.
       </emu-alg>
       <p>The phrase &ldquo;this String value&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisStringValue with the *this* value of the method invocation passed as the argument.</p>
@@ -27236,8 +27236,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: Type(_string_) is String.
           1. Let _iterator_ be ObjectCreate(%StringIteratorPrototype%, &laquo; [[IteratedString]], [[StringIteratorNextIndex]] &raquo;).
-          1. Set _iterator_'s [[IteratedString]] internal slot to _string_.
-          1. Set _iterator_'s [[StringIteratorNextIndex]] internal slot to 0.
+          1. Set _iterator_.[[IteratedString]] to _string_.
+          1. Set _iterator_.[[StringIteratorNextIndex]] to 0.
           1. Return _iterator_.
         </emu-alg>
       </emu-clause>
@@ -27254,12 +27254,12 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of an String Iterator Instance (<emu-xref href="#sec-properties-of-string-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _s_ be the value of the [[IteratedString]] internal slot of _O_.
+            1. Let _s_ be the value of _O_.[[IteratedString]].
             1. If _s_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
-            1. Let _position_ be the value of the [[StringIteratorNextIndex]] internal slot of _O_.
+            1. Let _position_ be the value of _O_.[[StringIteratorNextIndex]].
             1. Let _len_ be the number of elements in _s_.
             1. If _position_ &ge; _len_, then
-              1. Set the value of the [[IteratedString]] internal slot of _O_ to *undefined*.
+              1. Set the value of _O_.[[IteratedString]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
             1. Let _first_ be the code unit value at index _position_ in _s_.
             1. If _first_ &lt; 0xD800 or _first_ &gt; 0xDBFF or _position_+1 = _len_, let _resultString_ be the string consisting of the single code unit _first_.
@@ -27268,7 +27268,7 @@ THH:mm:ss.sss
               1. If _second_ &lt; 0xDC00 or _second_ &gt; 0xDFFF, let _resultString_ be the string consisting of the single code unit _first_.
               1. Else, let _resultString_ be the string consisting of the code unit _first_ followed by the code unit _second_.
             1. Let _resultSize_ be the number of code units in _resultString_.
-            1. Set the value of the [[StringIteratorNextIndex]] internal slot of _O_ to _position_ + _resultSize_.
+            1. Set the value of _O_.[[StringIteratorNextIndex]] to _position_ + _resultSize_.
             1. Return CreateIterResultObject(_resultString_, *false*).
           </emu-alg>
         </emu-clause>
@@ -28774,8 +28774,8 @@ THH:mm:ss.sss
               1. Let _patternConstructor_ be ? Get(_pattern_, `"constructor"`).
               1. If SameValue(_newTarget_, _patternConstructor_) is *true*, return _pattern_.
           1. If Type(_pattern_) is Object and _pattern_ has a [[RegExpMatcher]] internal slot, then
-            1. Let _P_ be the value of _pattern_'s [[OriginalSource]] internal slot.
-            1. If _flags_ is *undefined*, let _F_ be the value of _pattern_'s [[OriginalFlags]] internal slot.
+            1. Let _P_ be the value of _pattern_.[[OriginalSource]].
+            1. If _flags_ is *undefined*, let _F_ be the value of _pattern_.[[OriginalFlags]].
             1. Else, let _F_ be _flags_.
           1. Else if _patternIsRegExp_ is *true*, then
             1. Let _P_ be ? Get(_pattern_, `"source"`).
@@ -28825,9 +28825,9 @@ THH:mm:ss.sss
             1. Else,
               1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting _P_ as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). The goal symbol for the parse is |Pattern[U]|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code points resulting from applying UTF-16 decoding to _P_'s sequence of elements.
-            1. Set the value of _obj_'s [[OriginalSource]] internal slot to _P_.
-            1. Set the value of _obj_'s [[OriginalFlags]] internal slot to _F_.
-            1. Set _obj_'s [[RegExpMatcher]] internal slot to the internal procedure that evaluates the above parse of _P_ by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
+            1. Set the value of _obj_.[[OriginalSource]] to _P_.
+            1. Set the value of _obj_.[[OriginalFlags]] to _F_.
+            1. Set _obj_.[[RegExpMatcher]] to the internal procedure that evaluates the above parse of _P_ by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
             1. Perform ? Set(_obj_, `"lastIndex"`, 0, *true*).
             1. Return _obj_.
           </emu-alg>
@@ -28940,11 +28940,11 @@ THH:mm:ss.sss
             1. Assert: Type(_S_) is String.
             1. Let _length_ be the number of code units in _S_.
             1. Let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
-            1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
+            1. Let _flags_ be the value of _R_.[[OriginalFlags]].
             1. If _flags_ contains `"g"`, let _global_ be *true*, else let _global_ be *false*.
             1. If _flags_ contains `"y"`, let _sticky_ be *true*, else let _sticky_ be *false*.
             1. If _global_ is *false* and _sticky_ is *false*, let _lastIndex_ be 0.
-            1. Let _matcher_ be the value of _R_'s [[RegExpMatcher]] internal slot.
+            1. Let _matcher_ be the value of _R_.[[RegExpMatcher]].
             1. If _flags_ contains `"u"`, let _fullUnicode_ be *true*, else let _fullUnicode_ be *false*.
             1. Let _matchSucceeded_ be *false*.
             1. Repeat, while _matchSucceeded_ is *false*
@@ -29040,7 +29040,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
+          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"g"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -29056,7 +29056,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
+          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"i"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -29109,7 +29109,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
+          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"m"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -29212,8 +29212,8 @@ THH:mm:ss.sss
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return `"(?:)"`.
             1. Otherwise, throw a *TypeError* exception.
           1. Assert: _R_ has an [[OriginalFlags]] internal slot.
-          1. Let _src_ be the value of _R_'s [[OriginalSource]] internal slot.
-          1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
+          1. Let _src_ be the value of _R_.[[OriginalSource]].
+          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
           1. Return EscapeRegExpPattern(_src_, _flags_).
         </emu-alg>
       </emu-clause>
@@ -29299,7 +29299,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
+          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"y"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -29344,7 +29344,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_'s [[OriginalFlags]] internal slot.
+          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"u"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -30704,9 +30704,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: Type(_array_) is Object.
           1. Let _iterator_ be ObjectCreate(%ArrayIteratorPrototype%, &laquo; [[IteratedObject]], [[ArrayIteratorNextIndex]], [[ArrayIterationKind]] &raquo;).
-          1. Set _iterator_'s [[IteratedObject]] internal slot to _array_.
-          1. Set _iterator_'s [[ArrayIteratorNextIndex]] internal slot to 0.
-          1. Set _iterator_'s [[ArrayIterationKind]] internal slot to _kind_.
+          1. Set _iterator_.[[IteratedObject]] to _array_.
+          1. Set _iterator_.[[ArrayIteratorNextIndex]] to 0.
+          1. Set _iterator_.[[ArrayIterationKind]] to _kind_.
           1. Return _iterator_.
         </emu-alg>
       </emu-clause>
@@ -30723,18 +30723,18 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of an Array Iterator Instance (<emu-xref href="#sec-properties-of-array-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _a_ be the value of the [[IteratedObject]] internal slot of _O_.
+            1. Let _a_ be the value of _O_.[[IteratedObject]].
             1. If _a_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
-            1. Let _index_ be the value of the [[ArrayIteratorNextIndex]] internal slot of _O_.
-            1. Let _itemKind_ be the value of the [[ArrayIterationKind]] internal slot of _O_.
+            1. Let _index_ be the value of _O_.[[ArrayIteratorNextIndex]].
+            1. Let _itemKind_ be the value of _O_.[[ArrayIterationKind]].
             1. If _a_ has a [[TypedArrayName]] internal slot, then
-              1. Let _len_ be the value of _a_'s [[ArrayLength]] internal slot.
+              1. Let _len_ be the value of _a_.[[ArrayLength]].
             1. Else,
               1. Let _len_ be ? ToLength(? Get(_a_, `"length"`)).
             1. If _index_ &ge; _len_, then
-              1. Set the value of the [[IteratedObject]] internal slot of _O_ to *undefined*.
+              1. Set the value of _O_.[[IteratedObject]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
-            1. Set the value of the [[ArrayIteratorNextIndex]] internal slot of _O_ to _index_+1.
+            1. Set the value of _O_.[[ArrayIteratorNextIndex]] to _index_+1.
             1. If _itemKind_ is `"key"`, return CreateIterResultObject(_index_, *false*).
             1. Let _elementKey_ be ! ToString(_index_).
             1. Let _elementValue_ be ? Get(_a_, _elementKey_).
@@ -31172,7 +31172,7 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. Return _buffer_.
         </emu-alg>
       </emu-clause>
@@ -31186,9 +31186,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
-          1. Let _size_ be the value of _O_'s [[ByteLength]] internal slot.
+          1. Let _size_ be the value of _O_.[[ByteLength]].
           1. Return _size_.
         </emu-alg>
       </emu-clause>
@@ -31202,9 +31202,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
-          1. Let _offset_ be the value of _O_'s [[ByteOffset]] internal slot.
+          1. Let _offset_ be the value of _O_.[[ByteOffset]].
           1. Return _offset_.
         </emu-alg>
       </emu-clause>
@@ -31230,7 +31230,7 @@ THH:mm:ss.sss
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
             1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-            1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+            1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. Return _buffer_.
           </emu-alg>
@@ -31270,7 +31270,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Let _len_ be the value of _O_'s [[ArrayLength]] internal slot.
+          1. Let _len_ be the value of _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _kept_ be a new empty List.
@@ -31362,9 +31362,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
-          1. Let _length_ be the value of _O_'s [[ArrayLength]] internal slot.
+          1. Let _length_ be the value of _O_.[[ArrayLength]].
           1. Return _length_.
         </emu-alg>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
@@ -31378,7 +31378,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Let _len_ be the value of _O_'s [[ArrayLength]] internal slot.
+          1. Let _len_ be the value of _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _len_ &raquo;).
@@ -31433,13 +31433,13 @@ THH:mm:ss.sss
             1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
             1. Let _targetOffset_ be ? ToInteger(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
-            1. Let _targetBuffer_ be the value of _target_'s [[ViewedArrayBuffer]] internal slot.
+            1. Let _targetBuffer_ be the value of _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetLength_ be the value of _target_'s [[ArrayLength]] internal slot.
-            1. Let _targetName_ be the String value of _target_'s [[TypedArrayName]] internal slot.
+            1. Let _targetLength_ be the value of _target_.[[ArrayLength]].
+            1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
             1. Let _targetElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
-            1. Let _targetByteOffset_ be the value of _target_'s [[ByteOffset]] internal slot.
+            1. Let _targetByteOffset_ be the value of _target_.[[ByteOffset]].
             1. Let _src_ be ? ToObject(_array_).
             1. Let _srcLength_ be ? ToLength(? Get(_src_, `"length"`)).
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
@@ -31469,20 +31469,20 @@ THH:mm:ss.sss
             1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
             1. Let _targetOffset_ be ? ToInteger(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
-            1. Let _targetBuffer_ be the value of _target_'s [[ViewedArrayBuffer]] internal slot.
+            1. Let _targetBuffer_ be the value of _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetLength_ be the value of _target_'s [[ArrayLength]] internal slot.
-            1. Let _srcBuffer_ be the value of _typedArray_'s [[ViewedArrayBuffer]] internal slot.
+            1. Let _targetLength_ be the value of _target_.[[ArrayLength]].
+            1. Let _srcBuffer_ be the value of _typedArray_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetName_ be the String value of _target_'s [[TypedArrayName]] internal slot.
+            1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
             1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
-            1. Let _targetByteOffset_ be the value of _target_'s [[ByteOffset]] internal slot.
-            1. Let _srcName_ be the String value of _typedArray_'s [[TypedArrayName]] internal slot.
+            1. Let _targetByteOffset_ be the value of _target_.[[ByteOffset]].
+            1. Let _srcName_ be the String value of _typedArray_.[[TypedArrayName]].
             1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
             1. Let _srcElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcName_.
-            1. Let _srcLength_ be the value of _typedArray_'s [[ArrayLength]] internal slot.
-            1. Let _srcByteOffset_ be the value of _typedArray_'s [[ByteOffset]] internal slot.
+            1. Let _srcLength_ be the value of _typedArray_.[[ArrayLength]].
+            1. Let _srcByteOffset_ be the value of _typedArray_.[[ByteOffset]].
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
             1. If SameValue(_srcBuffer_, _targetBuffer_) is *true*, then
               1. Let _srcBuffer_ be ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcLength_, %ArrayBuffer%).
@@ -31516,16 +31516,16 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Let _len_ be the value of _O_'s [[ArrayLength]] internal slot.
+          1. Let _len_ be the value of _O_.[[ArrayLength]].
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
           1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be max(_final_ - _k_, 0).
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _count_ &raquo;).
-          1. Let _srcName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _srcName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
-          1. Let _targetName_ be the String value of _A_'s [[TypedArrayName]] internal slot.
+          1. Let _targetName_ be the String value of _A_.[[TypedArrayName]].
           1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
           1. If SameValue(_srcType_, _targetType_) is *false*, then
             1. Let _n_ be 0.
@@ -31536,13 +31536,13 @@ THH:mm:ss.sss
               1. Increase _k_ by 1.
               1. Increase _n_ by 1.
           1. Else if _count_ &gt; 0, then
-            1. Let _srcBuffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+            1. Let _srcBuffer_ be the value of _O_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetBuffer_ be the value of _A_'s [[ViewedArrayBuffer]] internal slot.
+            1. Let _targetBuffer_ be the value of _A_.[[ViewedArrayBuffer]].
             1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcType_.
             1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
-            1. Let _srcByteOffet_ be the value of _O_'s [[ByteOffset]] internal slot.
-            1. Let _targetByteIndex_ be _A_'s [[ByteOffset]] internal slot.
+            1. Let _srcByteOffet_ be the value of _O_.[[ByteOffset]].
+            1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
             1. Let _srcByteIndex_ be (_k_ &times; _elementSize_) + _srcByteOffet_.
             1. Let _limit_ be _targetByteIndex_ + _count_ &times; _elementSize_.
             1. Repeat, while _targetByteIndex_ &lt; _limit_
@@ -31571,7 +31571,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be the *this* value.
           1. Let _buffer_ be ? ValidateTypedArray(_obj_).
-          1. Let _len_ be the value of _obj_'s [[ArrayLength]] internal slot.
+          1. Let _len_ be the value of _obj_.[[ArrayLength]].
         </emu-alg>
         <p>The implementation defined sort order condition for exotic objects is not applied by %TypedArray%`.prototype.sort`.</p>
         <p>The following version of SortCompare is used by %TypedArray%`.prototype.sort`. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. SortCompare has access to the _comparefn_ and _buffer_ values of the current invocation of the `sort` method.</p>
@@ -31606,16 +31606,16 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
-          1. Let _srcLength_ be the value of _O_'s [[ArrayLength]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _srcLength_ be the value of _O_.[[ArrayLength]].
           1. Let _relativeBegin_ be ? ToInteger(_begin_).
           1. If _relativeBegin_ &lt; 0, let _beginIndex_ be max((_srcLength_ + _relativeBegin_), 0); else let _beginIndex_ be min(_relativeBegin_, _srcLength_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _srcLength_; else, let _relativeEnd_ be ? ToInteger(_end_).
           1. If _relativeEnd_ &lt; 0, let _endIndex_ be max((_srcLength_ + _relativeEnd_), 0); else let _endIndex_ be min(_relativeEnd_, _srcLength_).
           1. Let _newLength_ be max(_endIndex_ - _beginIndex_, 0).
-          1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-          1. Let _srcByteOffset_ be the value of _O_'s [[ByteOffset]] internal slot.
+          1. Let _srcByteOffset_ be the value of _O_.[[ByteOffset]].
           1. Let _beginByteOffset_ be _srcByteOffset_ + _beginIndex_ &times; _elementSize_.
           1. Let _argumentsList_ be &laquo; _buffer_, _beginByteOffset_, _newLength_ &raquo;.
           1. Return ? TypedArraySpeciesCreate(_O_, _argumentsList_).
@@ -31664,7 +31664,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, return *undefined*.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, return *undefined*.
-          1. Let _name_ be the value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _name_ be the value of _O_.[[TypedArrayName]].
           1. Assert: _name_ is a String value.
           1. Return _name_.
         </emu-alg>
@@ -31713,12 +31713,12 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
             1. Let _obj_ be IntegerIndexedObjectCreate(_proto_, &laquo; [[ViewedArrayBuffer]], [[TypedArrayName]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;).
-            1. Assert: The [[ViewedArrayBuffer]] internal slot of _obj_ is *undefined*.
-            1. Set _obj_'s [[TypedArrayName]] internal slot to _constructorName_.
+            1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
+            1. Set _obj_.[[TypedArrayName]] to _constructorName_.
             1. If _length_ was not passed, then
-              1. Set _obj_'s [[ByteLength]] internal slot to 0.
-              1. Set _obj_'s [[ByteOffset]] internal slot to 0.
-              1. Set _obj_'s [[ArrayLength]] internal slot to 0.
+              1. Set _obj_.[[ByteLength]] to 0.
+              1. Set _obj_.[[ByteOffset]] to 0.
+              1. Set _obj_.[[ArrayLength]] to 0.
             1. Else,
               1. Perform ? AllocateTypedArrayBuffer(_obj_, _length_).
             1. Return _obj_.
@@ -31730,16 +31730,16 @@ THH:mm:ss.sss
           <p>The abstract operation AllocateTypedArrayBuffer with arguments _O_ and _length_ allocates and associates an ArrayBuffer with the TypedArray instance _O_. It performs the following steps:</p>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
-            1. Assert: The [[ViewedArrayBuffer]] internal slot of _O_ is *undefined*.
+            1. Assert: _O_.[[ViewedArrayBuffer]] is *undefined*.
             1. Assert: _length_ &ge; 0.
-            1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+            1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
             1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
             1. Let _byteLength_ be _elementSize_ &times; _length_.
             1. Let _data_ be ? AllocateArrayBuffer(%ArrayBuffer%, _byteLength_).
-            1. Set _O_'s [[ViewedArrayBuffer]] internal slot to _data_.
-            1. Set _O_'s [[ByteLength]] internal slot to _byteLength_.
-            1. Set _O_'s [[ByteOffset]] internal slot to 0.
-            1. Set _O_'s [[ArrayLength]] internal slot to _length_.
+            1. Set _O_.[[ViewedArrayBuffer]] to _data_.
+            1. Set _O_.[[ByteLength]] to _byteLength_.
+            1. Set _O_.[[ByteOffset]] to 0.
+            1. Set _O_.[[ArrayLength]] to _length_.
             1. Return _O_.
           </emu-alg>
         </emu-clause>
@@ -31756,19 +31756,19 @@ THH:mm:ss.sss
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
           1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
           1. Let _srcArray_ be _typedArray_.
-          1. Let _srcData_ be the value of _srcArray_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _srcData_ be the value of _srcArray_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-          1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-          1. Let _elementLength_ be the value of _srcArray_'s [[ArrayLength]] internal slot.
-          1. Let _srcName_ be the String value of _srcArray_'s [[TypedArrayName]] internal slot.
+          1. Let _elementLength_ be the value of _srcArray_.[[ArrayLength]].
+          1. Let _srcName_ be the String value of _srcArray_.[[TypedArrayName]].
           1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
           1. Let _srcElementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
-          1. Let _srcByteOffset_ be the value of _srcArray_'s [[ByteOffset]] internal slot.
+          1. Let _srcByteOffset_ be the value of _srcArray_.[[ByteOffset]].
           1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
           1. If SameValue(_elementType_, _srcType_) is *true*, then
-            1. Let _srcLength_ be the value of _typedArray_'s [[ByteLength]] internal slot.
+            1. Let _srcLength_ be the value of _typedArray_.[[ByteLength]].
             1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _srcLength_).
           1. Else,
             1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
@@ -31783,10 +31783,10 @@ THH:mm:ss.sss
               1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
               1. Set _targetByteIndex_ to _targetByteIndex_ + _elementSize_.
               1. Decrement _count_ by 1.
-          1. Set _O_'s [[ViewedArrayBuffer]] internal slot to _data_.
-          1. Set _O_'s [[ByteLength]] internal slot to _byteLength_.
-          1. Set _O_'s [[ByteOffset]] internal slot to 0.
-          1. Set _O_'s [[ArrayLength]] internal slot to _elementLength_.
+          1. Set _O_.[[ViewedArrayBuffer]] to _data_.
+          1. Set _O_.[[ByteLength]] to _byteLength_.
+          1. Set _O_.[[ByteOffset]] to 0.
+          1. Set _O_.[[ArrayLength]] to _elementLength_.
           1. Return _O_.
         </emu-alg>
       </emu-clause>
@@ -31838,12 +31838,12 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
           1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
-          1. Let _constructorName_ be the String value of _O_'s [[TypedArrayName]] internal slot.
+          1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Number value of the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _bufferByteLength_ be the value of _buffer_'s [[ArrayBufferByteLength]] internal slot.
+          1. Let _bufferByteLength_ be the value of _buffer_.[[ArrayBufferByteLength]].
           1. If _length_ is either not present or *undefined*, then
             1. If _bufferByteLength_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
             1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
@@ -31852,10 +31852,10 @@ THH:mm:ss.sss
             1. Let _newLength_ be ? ToIndex(_length_).
             1. Let _newByteLength_ be _newLength_ &times; _elementSize_.
             1. If _offset_+_newByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
-          1. Set _O_'s [[ViewedArrayBuffer]] internal slot to _buffer_.
-          1. Set _O_'s [[ByteLength]] internal slot to _newByteLength_.
-          1. Set _O_'s [[ByteOffset]] internal slot to _offset_.
-          1. Set _O_'s [[ArrayLength]] internal slot to _newByteLength_ / _elementSize_.
+          1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
+          1. Set _O_.[[ByteLength]] to _newByteLength_.
+          1. Set _O_.[[ByteOffset]] to _offset_.
+          1. Set _O_.[[ArrayLength]] to _newByteLength_ / _elementSize_.
           1. Return _O_.
         </emu-alg>
       </emu-clause>
@@ -31867,7 +31867,7 @@ THH:mm:ss.sss
           1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
           1. Perform ? ValidateTypedArray(_newTypedArray_).
           1. If _argumentList_ is a List of a single Number, then
-            1. If the value of _newTypedArray_'s [[ArrayLength]] internal slot &lt; _argumentList_[0], throw a *TypeError* exception.
+            1. If the value of _newTypedArray_.[[ArrayLength]] &lt; _argumentList_[0], throw a *TypeError* exception.
           1. Return _newTypedArray_.
         </emu-alg>
       </emu-clause>
@@ -31877,7 +31877,7 @@ THH:mm:ss.sss
         <p>The abstract operation TypedArraySpeciesCreate with arguments _exemplar_ and _argumentList_ is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps:</p>
         <emu-alg>
           1. Assert: _exemplar_ is an Object that has a [[TypedArrayName]] internal slot.
-          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for the value of _exemplar_'s [[TypedArrayName]] internal slot.
+          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for the value of _exemplar_.[[TypedArrayName]].
           1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
           1. Return ? TypedArrayCreate(_constructor_, _argumentList_).
         </emu-alg>
@@ -31956,7 +31956,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%MapPrototype%"`, &laquo; [[MapData]] &raquo;).
-          1. Set _map_'s [[MapData]] internal slot to a new empty List.
+          1. Set _map_.[[MapData]] to a new empty List.
           1. If _iterable_ is not present, let _iterable_ be *undefined*.
           1. If _iterable_ is either *undefined* or *null*, let _iter_ be *undefined*.
           1. Else,
@@ -32024,7 +32024,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[MapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. Set _p_.[[Key]] to ~empty~.
             1. Set _p_.[[Value]] to ~empty~.
@@ -32049,7 +32049,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[MapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Key]] to ~empty~.
@@ -32082,7 +32082,7 @@ THH:mm:ss.sss
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
-          1. Let _entries_ be the List that is the value of _M_'s [[MapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _e_ that is an element of _entries_, in original key insertion order
             1. If _e_.[[Key]] is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _T_, &laquo; _e_.[[Value]], _e_.[[Key]], _M_ &raquo;).
@@ -32104,7 +32104,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[MapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
           1. Return *undefined*.
@@ -32119,7 +32119,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[MapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return *true*.
           1. Return *false*.
@@ -32144,7 +32144,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[MapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Value]] to _value_.
@@ -32164,7 +32164,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[MapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
           1. Let _count_ be 0.
           1. For each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_
             1. If _p_.[[Key]] is not ~empty~, set _count_ to _count_+1.
@@ -32215,9 +32215,9 @@ THH:mm:ss.sss
           1. If Type(_map_) is not Object, throw a *TypeError* exception.
           1. If _map_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
           1. Let _iterator_ be ObjectCreate(%MapIteratorPrototype%, &laquo; [[Map]], [[MapNextIndex]], [[MapIterationKind]] &raquo;).
-          1. Set _iterator_'s [[Map]] internal slot to _map_.
-          1. Set _iterator_'s [[MapNextIndex]] internal slot to 0.
-          1. Set _iterator_'s [[MapIterationKind]] internal slot to _kind_.
+          1. Set _iterator_.[[Map]] to _map_.
+          1. Set _iterator_.[[MapNextIndex]] to 0.
+          1. Set _iterator_.[[MapIterationKind]] to _kind_.
           1. Return _iterator_.
         </emu-alg>
       </emu-clause>
@@ -32234,16 +32234,16 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of a Map Iterator Instance (<emu-xref href="#sec-properties-of-map-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _m_ be the value of the [[Map]] internal slot of _O_.
-            1. Let _index_ be the value of the [[MapNextIndex]] internal slot of _O_.
-            1. Let _itemKind_ be the value of the [[MapIterationKind]] internal slot of _O_.
+            1. Let _m_ be the value of _O_.[[Map]].
+            1. Let _index_ be the value of _O_.[[MapNextIndex]].
+            1. Let _itemKind_ be the value of _O_.[[MapIterationKind]].
             1. If _m_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
             1. Assert: _m_ has a [[MapData]] internal slot.
-            1. Let _entries_ be the List that is the value of the [[MapData]] internal slot of _m_.
+            1. Let _entries_ be the List that is the value of _m_.[[MapData]].
             1. Repeat while _index_ is less than the total number of elements of _entries_. The number of elements must be redetermined each time this method is evaluated.
               1. Let _e_ be the Record {[[Key]], [[Value]]} that is the value of _entries_[_index_].
               1. Set _index_ to _index_+1.
-              1. Set the [[MapNextIndex]] internal slot of _O_ to _index_.
+              1. Set _O_.[[MapNextIndex]] to _index_.
               1. If _e_.[[Key]] is not ~empty~, then
                 1. If _itemKind_ is `"key"`, let _result_ be _e_.[[Key]].
                 1. Else if _itemKind_ is `"value"`, let _result_ be _e_.[[Value]].
@@ -32251,7 +32251,7 @@ THH:mm:ss.sss
                   1. Assert: _itemKind_ is `"key+value"`.
                   1. Let _result_ be CreateArrayFromList(&laquo; _e_.[[Key]], _e_.[[Value]] &raquo;).
                 1. Return CreateIterResultObject(_result_, *false*).
-            1. Set the [[Map]] internal slot of _O_ to *undefined*.
+            1. Set _O_.[[Map]] to *undefined*.
             1. Return CreateIterResultObject(*undefined*, *true*).
           </emu-alg>
         </emu-clause>
@@ -32329,7 +32329,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%SetPrototype%"`, &laquo; [[SetData]] &raquo;).
-          1. Set _set_'s [[SetData]] internal slot to a new empty List.
+          1. Set _set_.[[SetData]] to a new empty List.
           1. If _iterable_ is not present, let _iterable_ be *undefined*.
           1. If _iterable_ is either *undefined* or *null*, let _iter_ be *undefined*.
           1. Else,
@@ -32387,7 +32387,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_'s [[SetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Return _S_.
@@ -32405,7 +32405,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_'s [[SetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
           1. Return *undefined*.
@@ -32429,7 +32429,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_'s [[SetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
@@ -32464,7 +32464,7 @@ THH:mm:ss.sss
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
-          1. Let _entries_ be the List that is the value of _S_'s [[SetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_, in original insertion order
             1. If _e_ is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _T_, &laquo; _e_, _e_, _S_ &raquo;).
@@ -32488,7 +32488,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_'s [[SetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, return *true*.
           1. Return *false*.
@@ -32512,7 +32512,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_'s [[SetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
           1. Let _count_ be 0.
           1. For each _e_ that is an element of _entries_
             1. If _e_ is not ~empty~, set _count_ to _count_+1.
@@ -32563,9 +32563,9 @@ THH:mm:ss.sss
           1. If Type(_set_) is not Object, throw a *TypeError* exception.
           1. If _set_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
           1. Let _iterator_ be ObjectCreate(%SetIteratorPrototype%, &laquo; [[IteratedSet]], [[SetNextIndex]], [[SetIterationKind]] &raquo;).
-          1. Set _iterator_'s [[IteratedSet]] internal slot to _set_.
-          1. Set _iterator_'s [[SetNextIndex]] internal slot to 0.
-          1. Set _iterator_'s [[SetIterationKind]] internal slot to _kind_.
+          1. Set _iterator_.[[IteratedSet]] to _set_.
+          1. Set _iterator_.[[SetNextIndex]] to 0.
+          1. Set _iterator_.[[SetIterationKind]] to _kind_.
           1. Return _iterator_.
         </emu-alg>
       </emu-clause>
@@ -32582,21 +32582,21 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of a Set Iterator Instance (<emu-xref href="#sec-properties-of-set-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _s_ be the value of the [[IteratedSet]] internal slot of _O_.
-            1. Let _index_ be the value of the [[SetNextIndex]] internal slot of _O_.
-            1. Let _itemKind_ be the value of the [[SetIterationKind]] internal slot of _O_.
+            1. Let _s_ be the value of _O_.[[IteratedSet]].
+            1. Let _index_ be the value of _O_.[[SetNextIndex]].
+            1. Let _itemKind_ be the value of _O_.[[SetIterationKind]].
             1. If _s_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
             1. Assert: _s_ has a [[SetData]] internal slot.
-            1. Let _entries_ be the List that is the value of the [[SetData]] internal slot of _s_.
+            1. Let _entries_ be the List that is the value of _s_.[[SetData]].
             1. Repeat while _index_ is less than the total number of elements of _entries_. The number of elements must be redetermined each time this method is evaluated.
               1. Let _e_ be _entries_[_index_].
               1. Set _index_ to _index_+1.
-              1. Set the [[SetNextIndex]] internal slot of _O_ to _index_.
+              1. Set _O_.[[SetNextIndex]] to _index_.
               1. If _e_ is not ~empty~, then
                 1. If _itemKind_ is `"key+value"`, then
                   1. Return CreateIterResultObject(CreateArrayFromList(&laquo; _e_, _e_ &raquo;), *false*).
                 1. Return CreateIterResultObject(_e_, *false*).
-            1. Set the [[IteratedSet]] internal slot of _O_ to *undefined*.
+            1. Set _O_.[[IteratedSet]] to *undefined*.
             1. Return CreateIterResultObject(*undefined*, *true*).
           </emu-alg>
         </emu-clause>
@@ -32680,7 +32680,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakMapPrototype%"`, &laquo; [[WeakMapData]] &raquo;).
-          1. Set _map_'s [[WeakMapData]] internal slot to a new empty List.
+          1. Set _map_.[[WeakMapData]] to a new empty List.
           1. If _iterable_ is not present, let _iterable_ be *undefined*.
           1. If _iterable_ is either *undefined* or *null*, let _iter_ be *undefined*.
           1. Else,
@@ -32741,7 +32741,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[WeakMapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
@@ -32763,7 +32763,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[WeakMapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *undefined*.
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
@@ -32779,7 +32779,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[WeakMapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return *true*.
@@ -32795,7 +32795,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_'s [[WeakMapData]] internal slot.
+          1. Let _entries_ be the List that is the value of _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, throw a *TypeError* exception.
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
@@ -32845,7 +32845,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakSetPrototype%"`, &laquo; [[WeakSetData]] &raquo;).
-          1. Set _set_'s [[WeakSetData]] internal slot to a new empty List.
+          1. Set _set_.[[WeakSetData]] to a new empty List.
           1. If _iterable_ is not present, let _iterable_ be *undefined*.
           1. If _iterable_ is either *undefined* or *null*, let _iter_ be *undefined*.
           1. Else,
@@ -32891,7 +32891,7 @@ THH:mm:ss.sss
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
           1. If Type(_value_) is not Object, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_'s [[WeakSetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[WeakSetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Return _S_.
@@ -32915,7 +32915,7 @@ THH:mm:ss.sss
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
           1. If Type(_value_) is not Object, return *false*.
-          1. Let _entries_ be the List that is the value of _S_'s [[WeakSetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[WeakSetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
@@ -32935,7 +32935,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_'s [[WeakSetData]] internal slot.
+          1. Let _entries_ be the List that is the value of _S_.[[WeakSetData]].
           1. If Type(_value_) is not Object, return *false*.
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, return *true*.
@@ -32979,8 +32979,8 @@ THH:mm:ss.sss
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, `"%ArrayBufferPrototype%"`, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
           1. Assert: _byteLength_ is an integer value &ge; 0.
           1. Let _block_ be ? CreateByteDataBlock(_byteLength_).
-          1. Set _obj_'s [[ArrayBufferData]] internal slot to _block_.
-          1. Set _obj_'s [[ArrayBufferByteLength]] internal slot to _byteLength_.
+          1. Set _obj_.[[ArrayBufferData]] to _block_.
+          1. Set _obj_.[[ArrayBufferByteLength]] to _byteLength_.
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -32991,7 +32991,7 @@ THH:mm:ss.sss
         <p>The abstract operation IsDetachedBuffer with argument _arrayBuffer_ performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_arrayBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
-          1. If _arrayBuffer_'s [[ArrayBufferData]] internal slot is *null*, return *true*.
+          1. If _arrayBuffer_.[[ArrayBufferData]] is *null*, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -33002,8 +33002,8 @@ THH:mm:ss.sss
         <p>The abstract operation DetachArrayBuffer with argument _arrayBuffer_ performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_arrayBuffer_) is Object and it has [[ArrayBufferData]] and [[ArrayBufferByteLength]] internal slots.
-          1. Set _arrayBuffer_'s [[ArrayBufferData]] internal slot to *null*.
-          1. Set _arrayBuffer_'s [[ArrayBufferByteLength]] internal slot to 0.
+          1. Set _arrayBuffer_.[[ArrayBufferData]] to *null*.
+          1. Set _arrayBuffer_.[[ArrayBufferByteLength]] to 0.
           1. Return NormalCompletion(*null*).
         </emu-alg>
         <emu-note>
@@ -33021,10 +33021,10 @@ THH:mm:ss.sss
             1. Let _cloneConstructor_ be ? SpeciesConstructor(_srcBuffer_, %ArrayBuffer%).
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
           1. Else, Assert: IsConstructor(_cloneConstructor_) is *true*.
-          1. Let _srcBlock_ be the value of _srcBuffer_'s [[ArrayBufferData]] internal slot.
+          1. Let _srcBlock_ be the value of _srcBuffer_.[[ArrayBufferData]].
           1. Let _targetBuffer_ be ? AllocateArrayBuffer(_cloneConstructor_, _srcLength_).
           1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-          1. Let _targetBlock_ be the value of _targetBuffer_'s [[ArrayBufferData]] internal slot.
+          1. Let _targetBlock_ be the value of _targetBuffer_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _cloneLength_).
           1. Return _targetBuffer_.
         </emu-alg>
@@ -33038,7 +33038,7 @@ THH:mm:ss.sss
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
           1. Assert: _byteIndex_ is an integer value &ge; 0.
-          1. Let _block_ be _arrayBuffer_'s [[ArrayBufferData]] internal slot.
+          1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. Let _rawValue_ be a List of _elementSize_ containing, in order, the _elementSize_ sequence of bytes starting with _block_[_byteIndex_].
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to either *true* or *false*. The choice is implementation dependent and should be the alternative that is most efficient for the implementation. An implementation must use the same value each time this step is executed and the same value must be used for the corresponding step in the SetValueInBuffer abstract operation.
@@ -33068,7 +33068,7 @@ THH:mm:ss.sss
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
           1. Assert: _byteIndex_ is an integer value &ge; 0.
           1. Assert: Type(_value_) is Number.
-          1. Let _block_ be _arrayBuffer_'s [[ArrayBufferData]] internal slot.
+          1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Assert: _block_ is not *undefined*.
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to either *true* or *false*. The choice is implementation dependent and should be the alternative that is most efficient for the implementation. An implementation must use the same value each time this step is executed and the same value must be used for the corresponding step in the GetValueFromBuffer abstract operation.
           1. If _type_ is `"Float32"`, then
@@ -33159,7 +33159,7 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
-          1. Let _length_ be the value of _O_'s [[ArrayBufferByteLength]] internal slot.
+          1. Let _length_ be the value of _O_.[[ArrayBufferByteLength]].
           1. Return _length_.
         </emu-alg>
       </emu-clause>
@@ -33179,7 +33179,7 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
-          1. Let _len_ be the value of _O_'s [[ArrayBufferByteLength]] internal slot.
+          1. Let _len_ be the value of _O_.[[ArrayBufferByteLength]].
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _first_ be max((_len_ + _relativeStart_), 0); else let _first_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
@@ -33190,11 +33190,11 @@ THH:mm:ss.sss
           1. If _new_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If SameValue(_new_, _O_) is *true*, throw a *TypeError* exception.
-          1. If the value of _new_'s [[ArrayBufferByteLength]] internal slot &lt; _newLen_, throw a *TypeError* exception.
+          1. If the value of _new_.[[ArrayBufferByteLength]] &lt; _newLen_, throw a *TypeError* exception.
           1. NOTE: Side-effects of the above steps may have detached _O_.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
-          1. Let _fromBuf_ be the value of _O_'s [[ArrayBufferData]] internal slot.
-          1. Let _toBuf_ be the value of _new_'s [[ArrayBufferData]] internal slot.
+          1. Let _fromBuf_ be the value of _O_.[[ArrayBufferData]].
+          1. Let _toBuf_ be the value of _new_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_toBuf_, 0, _fromBuf_, _first_, _newLen_).
           1. Return _new_.
         </emu-alg>
@@ -33234,10 +33234,10 @@ THH:mm:ss.sss
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. Let _isLittleEndian_ be ToBoolean(_isLittleEndian_).
-          1. Let _buffer_ be the value of _view_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _viewOffset_ be the value of _view_'s [[ByteOffset]] internal slot.
-          1. Let _viewSize_ be the value of _view_'s [[ByteLength]] internal slot.
+          1. Let _viewOffset_ be the value of _view_.[[ByteOffset]].
+          1. Let _viewSize_ be the value of _view_.[[ByteLength]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
@@ -33256,10 +33256,10 @@ THH:mm:ss.sss
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. Let _numberValue_ be ? ToNumber(_value_).
           1. Let _isLittleEndian_ be ToBoolean(_isLittleEndian_).
-          1. Let _buffer_ be the value of _view_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _viewOffset_ be the value of _view_'s [[ByteOffset]] internal slot.
-          1. Let _viewSize_ be the value of _view_'s [[ByteLength]] internal slot.
+          1. Let _viewOffset_ be the value of _view_.[[ByteOffset]].
+          1. Let _viewSize_ be the value of _view_.[[ByteLength]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
@@ -33284,7 +33284,7 @@ THH:mm:ss.sss
           1. If _buffer_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _bufferByteLength_ be the value of _buffer_'s [[ArrayBufferByteLength]] internal slot.
+          1. Let _bufferByteLength_ be the value of _buffer_.[[ArrayBufferByteLength]].
           1. If _offset_ &gt; _bufferByteLength_, throw a *RangeError* exception.
           1. If _byteLength_ is either not present or *undefined*, then
             1. Let _viewByteLength_ be _bufferByteLength_ - _offset_.
@@ -33292,10 +33292,10 @@ THH:mm:ss.sss
             1. Let _viewByteLength_ be ? ToIndex(_byteLength_).
             1. If _offset_+_viewByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DataViewPrototype%"`, &laquo; [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] &raquo;).
-          1. Set _O_'s [[DataView]] internal slot to *true*.
-          1. Set _O_'s [[ViewedArrayBuffer]] internal slot to _buffer_.
-          1. Set _O_'s [[ByteLength]] internal slot to _viewByteLength_.
-          1. Set _O_'s [[ByteOffset]] internal slot to _offset_.
+          1. Set _O_.[[DataView]] to *true*.
+          1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
+          1. Set _O_.[[ByteLength]] to _viewByteLength_.
+          1. Set _O_.[[ByteOffset]] to _offset_.
           1. Return _O_.
         </emu-alg>
       </emu-clause>
@@ -33329,7 +33329,7 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. Return _buffer_.
         </emu-alg>
       </emu-clause>
@@ -33343,9 +33343,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _size_ be the value of _O_'s [[ByteLength]] internal slot.
+          1. Let _size_ be the value of _O_.[[ByteLength]].
           1. Return _size_.
         </emu-alg>
       </emu-clause>
@@ -33359,9 +33359,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_'s [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _offset_ be the value of _O_'s [[ByteOffset]] internal slot.
+          1. Let _offset_ be the value of _O_.[[ByteOffset]].
           1. Return _offset_.
         </emu-alg>
       </emu-clause>
@@ -33747,7 +33747,7 @@ THH:mm:ss.sss
             1. Else if _value_ has a [[StringData]] internal slot, then
               1. Let _value_ be ? ToString(_value_).
             1. Else if _value_ has a [[BooleanData]] internal slot, then
-              1. Let _value_ be the value of the [[BooleanData]] internal slot of _value_.
+              1. Let _value_ be the value of _value_.[[BooleanData]].
           1. If _value_ is *null*, return `"null"`.
           1. If _value_ is *true*, return `"true"`.
           1. If _value_ is *false*, return `"false"`.
@@ -34331,22 +34331,22 @@ THH:mm:ss.sss
         <h1>GeneratorStart (_generator_, _generatorBody_)</h1>
         <p>The abstract operation GeneratorStart with arguments _generator_ and _generatorBody_ performs the following steps:</p>
         <emu-alg>
-          1. Assert: The value of _generator_'s [[GeneratorState]] internal slot is *undefined*.
+          1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. Let _result_ be the result of evaluating _generatorBody_.
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set _generator_'s [[GeneratorState]] internal slot to `"completed"`.
+            1. Set _generator_.[[GeneratorState]] to `"completed"`.
             1. Once a generator enters the `"completed"` state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
             1. If _result_ is a normal completion, let _resultValue_ be *undefined*.
             1. Else,
               1. If _result_.[[Type]] is ~return~, let _resultValue_ be _result_.[[Value]].
               1. Else, return Completion(_result_).
             1. Return CreateIterResultObject(_resultValue_, *true*).
-          1. Set _generator_'s [[GeneratorContext]] internal slot to _genContext_.
-          1. Set _generator_'s [[GeneratorState]] internal slot to `"suspendedStart"`.
+          1. Set _generator_.[[GeneratorContext]] to _genContext_.
+          1. Set _generator_.[[GeneratorState]] to `"suspendedStart"`.
           1. Return NormalCompletion(*undefined*).
         </emu-alg>
       </emu-clause>
@@ -34359,7 +34359,7 @@ THH:mm:ss.sss
           1. If Type(_generator_) is not Object, throw a *TypeError* exception.
           1. If _generator_ does not have a [[GeneratorState]] internal slot, throw a *TypeError* exception.
           1. Assert: _generator_ also has a [[GeneratorContext]] internal slot.
-          1. Let _state_ be the value of _generator_'s [[GeneratorState]] internal slot.
+          1. Let _state_ be the value of _generator_.[[GeneratorState]].
           1. If _state_ is `"executing"`, throw a *TypeError* exception.
           1. Return _state_.
         </emu-alg>
@@ -34373,10 +34373,10 @@ THH:mm:ss.sss
           1. Let _state_ be ? GeneratorValidate(_generator_).
           1. If _state_ is `"completed"`, return CreateIterResultObject(*undefined*, *true*).
           1. Assert: _state_ is either `"suspendedStart"` or `"suspendedYield"`.
-          1. Let _genContext_ be the value of _generator_'s [[GeneratorContext]] internal slot.
+          1. Let _genContext_ be the value of _generator_.[[GeneratorContext]].
           1. Let _methodContext_ be the running execution context.
           1. Suspend _methodContext_.
-          1. Set _generator_'s [[GeneratorState]] internal slot to `"executing"`.
+          1. Set _generator_.[[GeneratorState]] to `"executing"`.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
           1. Resume the suspended evaluation of _genContext_ using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
@@ -34391,7 +34391,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _state_ be ? GeneratorValidate(_generator_).
           1. If _state_ is `"suspendedStart"`, then
-            1. Set _generator_'s [[GeneratorState]] internal slot to `"completed"`.
+            1. Set _generator_.[[GeneratorState]] to `"completed"`.
             1. Once a generator enters the `"completed"` state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
             1. Let _state_ be `"completed"`.
           1. If _state_ is `"completed"`, then
@@ -34399,10 +34399,10 @@ THH:mm:ss.sss
               1. Return CreateIterResultObject(_abruptCompletion_.[[Value]], *true*).
             1. Return Completion(_abruptCompletion_).
           1. Assert: _state_ is `"suspendedYield"`.
-          1. Let _genContext_ be the value of _generator_'s [[GeneratorContext]] internal slot.
+          1. Let _genContext_ be the value of _generator_.[[GeneratorContext]].
           1. Let _methodContext_ be the running execution context.
           1. Suspend _methodContext_.
-          1. Set _generator_'s [[GeneratorState]] internal slot to `"executing"`.
+          1. Set _generator_.[[GeneratorState]] to `"executing"`.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
           1. Resume the suspended evaluation of _genContext_ using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
@@ -34419,7 +34419,7 @@ THH:mm:ss.sss
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
           1. Let _generator_ be the value of the Generator component of _genContext_.
-          1. Set the value of _generator_'s [[GeneratorState]] internal slot to `"suspendedYield"`.
+          1. Set the value of _generator_.[[GeneratorState]] to `"suspendedYield"`.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
             1. Return _resumptionValue_.
@@ -34591,11 +34591,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _alreadyResolved_ be a new Record { [[Value]]: *false* }.
           1. Let _resolve_ be a new built-in function object as defined in Promise Resolve Functions (<emu-xref href="#sec-promise-resolve-functions"></emu-xref>).
-          1. Set the [[Promise]] internal slot of _resolve_ to _promise_.
-          1. Set the [[AlreadyResolved]] internal slot of _resolve_ to _alreadyResolved_.
+          1. Set _resolve_.[[Promise]] to _promise_.
+          1. Set _resolve_.[[AlreadyResolved]] to _alreadyResolved_.
           1. Let _reject_ be a new built-in function object as defined in Promise Reject Functions (<emu-xref href="#sec-promise-reject-functions"></emu-xref>).
-          1. Set the [[Promise]] internal slot of _reject_ to _promise_.
-          1. Set the [[AlreadyResolved]] internal slot of _reject_ to _alreadyResolved_.
+          1. Set _reject_.[[Promise]] to _promise_.
+          1. Set _reject_.[[AlreadyResolved]] to _alreadyResolved_.
           1. Return a new Record { [[Resolve]]: _resolve_, [[Reject]]: _reject_ }.
         </emu-alg>
 
@@ -34606,8 +34606,8 @@ THH:mm:ss.sss
           <p>When a promise reject function _F_ is called with argument _reason_, the following steps are taken:</p>
           <emu-alg>
             1. Assert: _F_ has a [[Promise]] internal slot whose value is an Object.
-            1. Let _promise_ be the value of _F_'s [[Promise]] internal slot.
-            1. Let _alreadyResolved_ be the value of _F_'s [[AlreadyResolved]] internal slot.
+            1. Let _promise_ be the value of _F_.[[Promise]].
+            1. Let _alreadyResolved_ be the value of _F_.[[AlreadyResolved]].
             1. If _alreadyResolved_.[[Value]] is *true*, return *undefined*.
             1. Set _alreadyResolved_.[[Value]] to *true*.
             1. Return RejectPromise(_promise_, _reason_).
@@ -34622,8 +34622,8 @@ THH:mm:ss.sss
           <p>When a promise resolve function _F_ is called with argument _resolution_, the following steps are taken:</p>
           <emu-alg>
             1. Assert: _F_ has a [[Promise]] internal slot whose value is an Object.
-            1. Let _promise_ be the value of _F_'s [[Promise]] internal slot.
-            1. Let _alreadyResolved_ be the value of _F_'s [[AlreadyResolved]] internal slot.
+            1. Let _promise_ be the value of _F_.[[Promise]].
+            1. Let _alreadyResolved_ be the value of _F_.[[AlreadyResolved]].
             1. If _alreadyResolved_.[[Value]] is *true*, return *undefined*.
             1. Set _alreadyResolved_.[[Value]] to *true*.
             1. If SameValue(_resolution_, _promise_) is *true*, then
@@ -34649,12 +34649,12 @@ THH:mm:ss.sss
         <h1>FulfillPromise ( _promise_, _value_)</h1>
         <p>When the FulfillPromise abstract operation is called with arguments _promise_ and _value_, the following steps are taken:</p>
         <emu-alg>
-          1. Assert: The value of _promise_'s [[PromiseState]] internal slot is `"pending"`.
-          1. Let _reactions_ be the value of _promise_'s [[PromiseFulfillReactions]] internal slot.
-          1. Set the value of _promise_'s [[PromiseResult]] internal slot to _value_.
-          1. Set the value of _promise_'s [[PromiseFulfillReactions]] internal slot to *undefined*.
-          1. Set the value of _promise_'s [[PromiseRejectReactions]] internal slot to *undefined*.
-          1. Set the value of _promise_'s [[PromiseState]] internal slot to `"fulfilled"`.
+          1. Assert: The value of _promise_.[[PromiseState]] is `"pending"`.
+          1. Let _reactions_ be the value of _promise_.[[PromiseFulfillReactions]].
+          1. Set the value of _promise_.[[PromiseResult]] to _value_.
+          1. Set the value of _promise_.[[PromiseFulfillReactions]] to *undefined*.
+          1. Set the value of _promise_.[[PromiseRejectReactions]] to *undefined*.
+          1. Set the value of _promise_.[[PromiseState]] to `"fulfilled"`.
           1. Return TriggerPromiseReactions(_reactions_, _value_).
         </emu-alg>
       </emu-clause>
@@ -34668,7 +34668,7 @@ THH:mm:ss.sss
           1. NOTE _C_ is assumed to be a constructor function that supports the parameter conventions of the `Promise` constructor (see <emu-xref href="#sec-promise-executor"></emu-xref>).
           1. Let _promiseCapability_ be a new PromiseCapability { [[Promise]]: *undefined*, [[Resolve]]: *undefined*, [[Reject]]: *undefined* }.
           1. Let _executor_ be a new built-in function object as defined in GetCapabilitiesExecutor Functions (<emu-xref href="#sec-getcapabilitiesexecutor-functions"></emu-xref>).
-          1. Set the [[Capability]] internal slot of _executor_ to _promiseCapability_.
+          1. Set _executor_.[[Capability]] to _promiseCapability_.
           1. Let _promise_ be ? Construct(_C_, &laquo; _executor_ &raquo;).
           1. If IsCallable(_promiseCapability_.[[Resolve]]) is *false*, throw a *TypeError* exception.
           1. If IsCallable(_promiseCapability_.[[Reject]]) is *false*, throw a *TypeError* exception.
@@ -34686,7 +34686,7 @@ THH:mm:ss.sss
           <p>When a GetCapabilitiesExecutor function _F_ is called with arguments _resolve_ and _reject_, the following steps are taken:</p>
           <emu-alg>
             1. Assert: _F_ has a [[Capability]] internal slot whose value is a PromiseCapability Record.
-            1. Let _promiseCapability_ be the value of _F_'s [[Capability]] internal slot.
+            1. Let _promiseCapability_ be the value of _F_.[[Capability]].
             1. If _promiseCapability_.[[Resolve]] is not *undefined*, throw a *TypeError* exception.
             1. If _promiseCapability_.[[Reject]] is not *undefined*, throw a *TypeError* exception.
             1. Set _promiseCapability_.[[Resolve]] to _resolve_.
@@ -34713,13 +34713,13 @@ THH:mm:ss.sss
         <h1>RejectPromise ( _promise_, _reason_ )</h1>
         <p>When the RejectPromise abstract operation is called with arguments _promise_ and _reason_, the following steps are taken:</p>
         <emu-alg>
-          1. Assert: The value of _promise_'s [[PromiseState]] internal slot is `"pending"`.
-          1. Let _reactions_ be the value of _promise_'s [[PromiseRejectReactions]] internal slot.
-          1. Set the value of _promise_'s [[PromiseResult]] internal slot to _reason_.
-          1. Set the value of _promise_'s [[PromiseFulfillReactions]] internal slot to *undefined*.
-          1. Set the value of _promise_'s [[PromiseRejectReactions]] internal slot to *undefined*.
-          1. Set the value of _promise_'s [[PromiseState]] internal slot to `"rejected"`.
-          1. If the value of _promise_'s [[PromiseIsHandled]] internal slot is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
+          1. Assert: The value of _promise_.[[PromiseState]] is `"pending"`.
+          1. Let _reactions_ be the value of _promise_.[[PromiseRejectReactions]].
+          1. Set the value of _promise_.[[PromiseResult]] to _reason_.
+          1. Set the value of _promise_.[[PromiseFulfillReactions]] to *undefined*.
+          1. Set the value of _promise_.[[PromiseRejectReactions]] to *undefined*.
+          1. Set the value of _promise_.[[PromiseState]] to `"rejected"`.
+          1. If the value of _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
           1. Return TriggerPromiseReactions(_reactions_, _reason_).
         </emu-alg>
       </emu-clause>
@@ -34816,10 +34816,10 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
           1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%PromisePrototype%"`, &laquo; [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] &raquo;).
-          1. Set _promise_'s [[PromiseState]] internal slot to `"pending"`.
-          1. Set _promise_'s [[PromiseFulfillReactions]] internal slot to a new empty List.
-          1. Set _promise_'s [[PromiseRejectReactions]] internal slot to a new empty List.
-          1. Set _promise_'s [[PromiseIsHandled]] internal slot to *false*.
+          1. Set _promise_.[[PromiseState]] to `"pending"`.
+          1. Set _promise_.[[PromiseFulfillReactions]] to a new empty List.
+          1. Set _promise_.[[PromiseRejectReactions]] to a new empty List.
+          1. Set _promise_.[[PromiseIsHandled]] to *false*.
           1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promise_).
           1. Let _completion_ be Call(_executor_, *undefined*, &laquo; _resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]] &raquo;).
           1. If _completion_ is an abrupt completion, then
@@ -34889,11 +34889,11 @@ THH:mm:ss.sss
               1. Append *undefined* to _values_.
               1. Let _nextPromise_ be ? Invoke(_constructor_, `"resolve"`, &laquo; _nextValue_ &raquo;).
               1. Let _resolveElement_ be a new built-in function object as defined in Promise.all Resolve Element Functions.
-              1. Set the [[AlreadyCalled]] internal slot of _resolveElement_ to a new Record {[[Value]]: *false* }.
-              1. Set the [[Index]] internal slot of _resolveElement_ to _index_.
-              1. Set the [[Values]] internal slot of _resolveElement_ to _values_.
-              1. Set the [[Capabilities]] internal slot of _resolveElement_ to _resultCapability_.
-              1. Set the [[RemainingElements]] internal slot of _resolveElement_ to _remainingElementsCount_.
+              1. Set _resolveElement_.[[AlreadyCalled]] to a new Record {[[Value]]: *false* }.
+              1. Set _resolveElement_.[[Index]] to _index_.
+              1. Set _resolveElement_.[[Values]] to _values_.
+              1. Set _resolveElement_.[[Capabilities]] to _resultCapability_.
+              1. Set _resolveElement_.[[RemainingElements]] to _remainingElementsCount_.
               1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] + 1.
               1. Perform ? Invoke(_nextPromise_, `"then"`, &laquo; _resolveElement_, _resultCapability_.[[Reject]] &raquo;).
               1. Set _index_ to _index_ + 1.
@@ -34906,13 +34906,13 @@ THH:mm:ss.sss
           <p>A Promise.all resolve element function is an anonymous built-in function that is used to resolve a specific Promise.all element. Each Promise.all resolve element function has [[Index]], [[Values]], [[Capabilities]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
           <p>When a Promise.all resolve element function _F_ is called with argument _x_, the following steps are taken:</p>
           <emu-alg>
-            1. Let _alreadyCalled_ be the value of _F_'s [[AlreadyCalled]] internal slot.
+            1. Let _alreadyCalled_ be the value of _F_.[[AlreadyCalled]].
             1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
             1. Set _alreadyCalled_.[[Value]] to *true*.
-            1. Let _index_ be the value of _F_'s [[Index]] internal slot.
-            1. Let _values_ be the value of _F_'s [[Values]] internal slot.
-            1. Let _promiseCapability_ be the value of _F_'s [[Capabilities]] internal slot.
-            1. Let _remainingElementsCount_ be the value of _F_'s [[RemainingElements]] internal slot.
+            1. Let _index_ be the value of _F_.[[Index]].
+            1. Let _values_ be the value of _F_.[[Values]].
+            1. Let _promiseCapability_ be the value of _F_.[[Capabilities]].
+            1. Let _remainingElementsCount_ be the value of _F_.[[RemainingElements]].
             1. Set _values_[_index_] to _x_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
@@ -35071,18 +35071,18 @@ THH:mm:ss.sss
               1. Let _onRejected_ be *undefined*.
             1. Let _fulfillReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
             1. Let _rejectReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
-            1. If the value of _promise_'s [[PromiseState]] internal slot is `"pending"`, then
-              1. Append _fulfillReaction_ as the last element of the List that is the value of _promise_'s [[PromiseFulfillReactions]] internal slot.
-              1. Append _rejectReaction_ as the last element of the List that is the value of _promise_'s [[PromiseRejectReactions]] internal slot.
-            1. Else if the value of _promise_'s [[PromiseState]] internal slot is `"fulfilled"`, then
-              1. Let _value_ be the value of _promise_'s [[PromiseResult]] internal slot.
+            1. If the value of _promise_.[[PromiseState]] is `"pending"`, then
+              1. Append _fulfillReaction_ as the last element of the List that is the value of _promise_.[[PromiseFulfillReactions]].
+              1. Append _rejectReaction_ as the last element of the List that is the value of _promise_.[[PromiseRejectReactions]].
+            1. Else if the value of _promise_.[[PromiseState]] is `"fulfilled"`, then
+              1. Let _value_ be the value of _promise_.[[PromiseResult]].
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _fulfillReaction_, _value_ &raquo;).
             1. Else,
-              1. Assert: The value of _promise_'s [[PromiseState]] internal slot is `"rejected"`.
-              1. Let _reason_ be the value of _promise_'s [[PromiseResult]] internal slot.
-              1. If the value of _promise_'s [[PromiseIsHandled]] internal slot is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
+              1. Assert: The value of _promise_.[[PromiseState]] is `"rejected"`.
+              1. Let _reason_ be the value of _promise_.[[PromiseResult]].
+              1. If the value of _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _rejectReaction_, _reason_ &raquo;).
-            1. Set _promise_'s [[PromiseIsHandled]] internal slot to *true*.
+            1. Set _promise_.[[PromiseIsHandled]] to *true*.
             1. Return _resultCapability_.[[Promise]].
           </emu-alg>
         </emu-clause>
@@ -35353,7 +35353,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _p_ be ? ProxyCreate(_target_, _handler_).
           1. Let _revoker_ be a new built-in function object as defined in <emu-xref href="#sec-proxy-revocation-functions"></emu-xref>.
-          1. Set the [[RevocableProxy]] internal slot of _revoker_ to _p_.
+          1. Set _revoker_.[[RevocableProxy]] to _p_.
           1. Let _result_ be ObjectCreate(%ObjectPrototype%).
           1. Perform CreateDataProperty(_result_, `"proxy"`, _p_).
           1. Perform CreateDataProperty(_result_, `"revoke"`, _revoker_).
@@ -35367,12 +35367,12 @@ THH:mm:ss.sss
           <p>Each Proxy revocation function has a [[RevocableProxy]] internal slot.</p>
           <p>When a Proxy revocation function, _F_, is called, the following steps are taken:</p>
           <emu-alg>
-            1. Let _p_ be the value of _F_'s [[RevocableProxy]] internal slot.
+            1. Let _p_ be the value of _F_.[[RevocableProxy]].
             1. If _p_ is *null*, return *undefined*.
-            1. Set the value of _F_'s [[RevocableProxy]] internal slot to *null*.
+            1. Set the value of _F_.[[RevocableProxy]] to *null*.
             1. Assert: _p_ is a Proxy object.
-            1. Set the [[ProxyTarget]] internal slot of _p_ to *null*.
-            1. Set the [[ProxyHandler]] internal slot of _p_ to *null*.
+            1. Set _p_.[[ProxyTarget]] to *null*.
+            1. Set _p_.[[ProxyHandler]] to *null*.
             1. Return *undefined*.
           </emu-alg>
           <p>The `length` property of a Proxy revocation function is 0.</p>
@@ -35401,7 +35401,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _N_ be the *this* value.
         1. If _N_ is not a module namespace exotic object, throw a *TypeError* exception.
-        1. Let _exports_ be the value of _N_'s [[Exports]] internal slot.
+        1. Let _exports_ be the value of _N_.[[Exports]].
         1. Return ! CreateListIterator(_exports_).
       </emu-alg>
       <p>The value of the `name` property of this function is `"[Symbol.iterator]"`.</p>
@@ -36567,8 +36567,8 @@ THH:mm:ss.sss
             1. Throw a *TypeError* exception.
           1. If Type(_pattern_) is Object and _pattern_ has a [[RegExpMatcher]] internal slot, then
             1. If _flags_ is not *undefined*, throw a *TypeError* exception.
-            1. Let _P_ be the value of _pattern_'s [[OriginalSource]] internal slot.
-            1. Let _F_ be the value of _pattern_'s [[OriginalFlags]] internal slot.
+            1. Let _P_ be the value of _pattern_.[[OriginalSource]].
+            1. Let _F_ be the value of _pattern_.[[OriginalFlags]].
           1. Else,
             1. Let _P_ be _pattern_.
             1. Let _F_ be _flags_.

--- a/spec.html
+++ b/spec.html
@@ -7546,7 +7546,7 @@
           1. Let _args_ be the arguments object.
           1. Let _desc_ be OrdinaryGetOwnProperty(_args_, _P_).
           1. If _desc_ is *undefined*, return _desc_.
-          1. Let _map_ be the value of the [[ParameterMap]] internal slot of the arguments object.
+          1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If the value of _isMapped_ is *true*, then
             1. Set _desc_.[[Value]] to Get(_map_, _P_).
@@ -7562,7 +7562,7 @@
         <p>The [[DefineOwnProperty]] internal method of an arguments exotic object when called with a property key _P_ and Property Descriptor _Desc_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _map_ be the value of the [[ParameterMap]] internal slot of the arguments object.
+          1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
           1. Let _isMapped_ be HasOwnProperty(_map_, _P_).
           1. Let _newArgDesc_ be _Desc_.
           1. If _isMapped_ is *true* and IsDataDescriptor(_Desc_) is *true*, then
@@ -7590,7 +7590,7 @@
         <p>The [[Get]] internal method of an arguments exotic object when called with a property key _P_ and ECMAScript language value _Receiver_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _map_ be the value of the [[ParameterMap]] internal slot of the arguments object.
+          1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If the value of _isMapped_ is *false*, then
             1. Return ? OrdinaryGet(_args_, _P_, _Receiver_).
@@ -7608,7 +7608,7 @@
           1. If SameValue(_args_, _Receiver_) is *false*, then
             1. Let _isMapped_ be *false*.
           1. Else,
-            1. Let _map_ be the value of the [[ParameterMap]] internal slot of the arguments object.
+            1. Let _map_ be the value of the [[ParameterMap]] internal slot of _args_.
             1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If _isMapped_ is *true*, then
             1. Let _setStatus_ be Set(_map_, _P_, _V_, *false*).


### PR DESCRIPTION
Specifically, change:
```
   the [[Foo]] internal slot of _O_  (132 occurrences)
```
and
```
   _O_'s [[Foo]] internal slot (265 occurrences)
```
to
```
   _O_.[[Foo]]
```

(Resolves issue #574)