### PR TITLE
Editorial: create `EnqueuePromiseReactions` abstract operation.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35052,6 +35052,18 @@ THH:mm:ss.sss
               1. Let _onRejected_ be *undefined*.
             1. Let _fulfillReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
             1. Let _rejectReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
+            1. Return EnqueuePromiseReactions(_promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-enqueuepromisereactions" aoid="EnqueuePromiseReactions">
+          <h1>EnqueuePromiseReactions ( _promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_ )</h1>
+          <p>The abstract operation EnqueuePromiseReactions enqueues PromiseJobs with the provided PromiseReaction records on _promise_. The result is _resultCapability_'s promise.</p>
+          <emu-alg>
+            1. Assert: IsPromise(_promise_) is *true*.
+            1. Assert: _resultCapability_ is a PromiseCapability record.
+            1. Assert: _fulfillReaction_ is a PromiseReaction record.
+            1. Assert: _rejectReaction_ is a PromiseReaction record.
             1. If the value of _promise_'s [[PromiseState]] internal slot is `"pending"`, then
               1. Append _fulfillReaction_ as the last element of the List that is the value of _promise_'s [[PromiseFulfillReactions]] internal slot.
               1. Append _rejectReaction_ as the last element of the List that is the value of _promise_'s [[PromiseRejectReactions]] internal slot.


### PR DESCRIPTION
This unobservable spec refactor allows the `Promise#finally` proposal to make a much smaller change, so it can reuse some of the logic in PerformPromiseThen.

(following up on https://github.com/tc39/ecma262/pull/584)