### PR TITLE
Normative: `Object.getOwnPropertyDescriptors` should not create keys for undefined descriptors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22673,7 +22673,7 @@
           1. Repeat, for each element _key_ of _ownKeys_ in List order,
             1. Let _desc_ be ? _obj_.[[GetOwnProperty]](_key_).
             1. Let _descriptor_ be ! FromPropertyDescriptor(_desc_).
-            1. Perform ! CreateDataProperty(_descriptors_, _key_, _descriptor_).
+            1. If _descriptor_ is not *undefined*, perform ! CreateDataProperty(_descriptors_, _key_, _descriptor_).
           1. Return _descriptors_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Per discussion on https://github.com/tc39/ecma262/pull/582#issuecomment-223368443

This needs TC39 consensus.