### PR TITLE
Normative: Remove proxy OwnPropertyKeys error with duplicate keys

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8670,11 +8670,11 @@
         1. Let _uncheckedResultKeys_ be a new List which is a copy of _trapResult_.
         1. Repeat, for each _key_ that is an element of _targetNonconfigurableKeys_,
           1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
-          1. Remove _key_ from _uncheckedResultKeys_.
+          1. Remove all occurrences of _key_ from _uncheckedResultKeys_.
         1. If _extensibleTarget_ is *true*, return _trapResult_.
         1. Repeat, for each _key_ that is an element of _targetConfigurableKeys_,
           1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
-          1. Remove _key_ from _uncheckedResultKeys_.
+          1. Remove all occurrences of _key_ from _uncheckedResultKeys_.
         1. If _uncheckedResultKeys_ is not empty, throw a *TypeError* exception.
         1. Return _trapResult_.
       </emu-alg>


### PR DESCRIPTION
Previously, proxy OwnPropertyKeys returning duplicate keys would cause an error when the target object was non-extensible. The error does not seem deliberate but rather a result of not considering the possibility of duplicate keys. This PR handles that possibility and removes the error.

I think this is just a bug fix but if anyone thinks this needs consensus let me know. Also note that this is a breaking change for spidermonkey and chakra. V8 already implements these semantics. cc @efaust.