### PR TITLE
Editorial: use dot notation for internal methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6405,7 +6405,7 @@
             1. If _p_ is *null*, let _done_ be *true*.
             1. Else if SameValue(_p_, _O_) is *true*, return *false*.
             1. Else,
-              1. If the [[GetPrototypeOf]] internal method of _p_ is not the ordinary object internal method defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>, let _done_ be *true*.
+              1. If _p_.[[GetPrototypeOf]] is not the ordinary object internal method defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>, let _done_ be *true*.
               1. Else, let _p_ be _p_.[[Prototype]].
           1. Set _O_.[[Prototype]] to _V_.
           1. Return *true*.
@@ -6991,9 +6991,9 @@
         1. If _functionKind_ is `"non-constructor"`, let _functionKind_ be `"normal"`.
         1. Let _F_ be a newly created ECMAScript function object with the internal slots listed in <emu-xref href="#table-27"></emu-xref>. All of those internal slots are initialized to *undefined*.
         1. Set _F_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
-        1. Set _F_'s [[Call]] internal method to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
+        1. Set _F_.[[Call]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
         1. If _needsConstruct_ is *true*, then
-          1. Set _F_'s [[Construct]] internal method to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
+          1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
           1. Set _F_.[[ConstructorKind]] to `"base"`.
         1. Set _F_.[[Strict]] to _strict_.
         1. Set _F_.[[FunctionKind]] to _functionKind_.
@@ -7414,9 +7414,9 @@
           1. Let _proto_ be ? _targetFunction_.[[GetPrototypeOf]]().
           1. Let _obj_ be a newly created object.
           1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
-          1. Set the [[Call]] internal method of _obj_ as described in <emu-xref href="#sec-bound-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
+          1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-bound-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
           1. If _targetFunction_ has a [[Construct]] internal method, then
-            1. Set the [[Construct]] internal method of _obj_ as described in <emu-xref href="#sec-bound-function-exotic-objects-construct-argumentslist-newtarget"></emu-xref>.
+            1. Set _obj_.[[Construct]] as described in <emu-xref href="#sec-bound-function-exotic-objects-construct-argumentslist-newtarget"></emu-xref>.
           1. Set _obj_.[[Prototype]] to _proto_.
           1. Set _obj_.[[Extensible]] to *true*.
           1. Set _obj_.[[BoundTargetFunction]] to _targetFunction_.
@@ -7473,7 +7473,7 @@
           1. If the _proto_ argument was not passed, let _proto_ be the intrinsic object %ArrayPrototype%.
           1. Let _A_ be a newly created Array exotic object.
           1. Set _A_'s essential internal methods except for [[DefineOwnProperty]] to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
-          1. Set the [[DefineOwnProperty]] internal method of _A_ as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
+          1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _A_.[[Prototype]] to _proto_.
           1. Set _A_.[[Extensible]] to *true*.
           1. Perform ! OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor{[[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
@@ -7608,8 +7608,8 @@
           1. Let _S_ be a newly created String exotic object.
           1. Set _S_.[[StringData]] to _value_.
           1. Set _S_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
-          1. Set the [[GetOwnProperty]] internal method of _S_ as specified in <emu-xref href="#sec-string-exotic-objects-getownproperty-p"></emu-xref>.
-          1. Set the [[OwnPropertyKeys]] internal method of _S_ as specified in <emu-xref href="#sec-string-exotic-objects-ownpropertykeys"></emu-xref>.
+          1. Set _S_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-string-exotic-objects-getownproperty-p"></emu-xref>.
+          1. Set _S_.[[OwnPropertyKeys]] as specified in <emu-xref href="#sec-string-exotic-objects-ownpropertykeys"></emu-xref>.
           1. Set _S_.[[Prototype]] to _prototype_.
           1. Set _S_.[[Extensible]] to *true*.
           1. Let _length_ be the number of code unit elements in _value_.
@@ -7758,11 +7758,11 @@
           1. Assert: _formals_ does not contain a rest parameter, any binding patterns, or any initializers. It may contain duplicate identifiers.
           1. Let _len_ be the number of elements in _argumentsList_.
           1. Let _obj_ be a newly created arguments exotic object with a [[ParameterMap]] internal slot.
-          1. Set the [[GetOwnProperty]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-getownproperty-p"></emu-xref>.
-          1. Set the [[DefineOwnProperty]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-defineownproperty-p-desc"></emu-xref>.
-          1. Set the [[Get]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-get-p-receiver"></emu-xref>.
-          1. Set the [[Set]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-set-p-v-receiver"></emu-xref>.
-          1. Set the [[Delete]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
+          1. Set _obj_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-arguments-exotic-objects-getownproperty-p"></emu-xref>.
+          1. Set _obj_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-arguments-exotic-objects-defineownproperty-p-desc"></emu-xref>.
+          1. Set _obj_.[[Get]] as specified in <emu-xref href="#sec-arguments-exotic-objects-get-p-receiver"></emu-xref>.
+          1. Set _obj_.[[Set]] as specified in <emu-xref href="#sec-arguments-exotic-objects-set-p-v-receiver"></emu-xref>.
+          1. Set _obj_.[[Delete]] as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
           1. Set the remainder of _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _obj_.[[Prototype]] to %ObjectPrototype%.
           1. Set _obj_.[[Extensible]] to *true*.
@@ -7966,12 +7966,12 @@
           1. Assert: _internalSlotsList_ contains the names [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]].
           1. Let _A_ be a newly created object with an internal slot for each name in _internalSlotsList_.
           1. Set _A_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
-          1. Set the [[GetOwnProperty]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-getownproperty-p"></emu-xref>.
-          1. Set the [[HasProperty]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-hasproperty-p"></emu-xref>.
-          1. Set the [[DefineOwnProperty]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-defineownproperty-p-desc"></emu-xref>.
-          1. Set the [[Get]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-get-p-receiver"></emu-xref>.
-          1. Set the [[Set]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-set-p-v-receiver"></emu-xref>.
-          1. Set the [[OwnPropertyKeys]] internal method of _A_ as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-ownpropertykeys"></emu-xref>.
+          1. Set _A_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-getownproperty-p"></emu-xref>.
+          1. Set _A_.[[HasProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-hasproperty-p"></emu-xref>.
+          1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-defineownproperty-p-desc"></emu-xref>.
+          1. Set _A_.[[Get]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-get-p-receiver"></emu-xref>.
+          1. Set _A_.[[Set]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-set-p-v-receiver"></emu-xref>.
+          1. Set _A_.[[OwnPropertyKeys]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-ownpropertykeys"></emu-xref>.
           1. Set _A_.[[Prototype]] to _prototype_.
           1. Set _A_.[[Extensible]] to *true*.
           1. Return _A_.
@@ -8872,9 +8872,9 @@
         1. Let _P_ be a newly created object.
         1. Set _P_'s essential internal methods (except for [[Call]] and [[Construct]]) to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
         1. If IsCallable(_target_) is *true*, then
-          1. Set the [[Call]] internal method of _P_ as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
+          1. Set _P_.[[Call]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
           1. If _target_ has a [[Construct]] internal method, then
-            1. Set the [[Construct]] internal method of _P_ as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget"></emu-xref>.
+            1. Set _P_.[[Construct]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget"></emu-xref>.
         1. Set _P_.[[ProxyTarget]] to _target_.
         1. Set _P_.[[ProxyHandler]] to _handler_.
         1. Return _P_.
@@ -30845,7 +30845,7 @@ THH:mm:ss.sss
             Then for all nonnegative integers _j_ and _k_, each less than _len_, if <emu-eqn>SortCompare(old[_j_], old[_k_]) &lt; 0</emu-eqn> (see SortCompare below), then <emu-eqn>new[&pi;(_j_)] &lt; new[&pi;(_k_)]</emu-eqn>.
           </li>
         </ul>
-        <p>Here the notation <emu-eqn>old[_j_]</emu-eqn> is used to refer to the hypothetical result of calling the [[Get]] internal method of _obj_ with argument _j_ before this function is executed, and the notation <emu-eqn>new[_j_]</emu-eqn> to refer to the hypothetical result of calling the [[Get]] internal method of _obj_ with argument _j_ after this function has been executed.</p>
+        <p>Here the notation <emu-eqn>old[_j_]</emu-eqn> is used to refer to the hypothetical result of calling _obj_.[[Get]](_j_) before this function is executed, and the notation <emu-eqn>new[_j_]</emu-eqn> to refer to the hypothetical result of calling _obj_.[[Get]](_j_) after this function has been executed.</p>
         <p>A function _comparefn_ is a consistent comparison function for a set of values _S_ if all of the requirements below are met for all values _a_, _b_, and _c_ (possibly the same value) in the set _S_: The notation <emu-eqn>_a_ &lt;<sub>CF</sub> _b_</emu-eqn> means <emu-eqn>_comparefn_(_a_, _b_) &lt; 0</emu-eqn>; <emu-eqn>_a_ =<sub>CF</sub> _b_</emu-eqn> means <emu-eqn>_comparefn_(_a_, _b_) = 0</emu-eqn> (of either sign); and <emu-eqn>_a_ &gt;<sub>CF</sub> _b_</emu-eqn> means <emu-eqn>_comparefn_(_a_, _b_) &gt; 0</emu-eqn>.</p>
         <ul>
           <li>


### PR DESCRIPTION
Specifically, change 19 occurrences of

```
the [[Foo]] internal method of _O_
```

and 2 of

```
_O_'s [[Foo]] internal method
```

to

```
_O_.[[Foo]]
```

and 2 occurrences of

```
calling the [[Get]] internal method of _obj_ with argument _j_
```

to

```
calling _obj_.[[Get]](_j_)
```

(Split off from #591.)
