### PR TITLE
Editorial: remove many occurrences of "the value of"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21733,7 +21733,8 @@
       <h1>eval (_x_)</h1>
       <p>The `eval` function is the <dfn>%eval%</dfn> intrinsic object. When the `eval` function is called with one argument _x_, the following steps are taken:</p>
       <emu-alg>
-        1. Let _evalRealm_ be the value of the active function object's [[Realm]] internal slot.
+        1. Let _f_ be the active function object.
+        1. Let _evalRealm_ be the value of _f_.[[Realm]].
         1. Perform ? HostEnsureCanCompileStrings(the current Realm Record, _evalRealm_).
         1. Return ? PerformEval(_x_, _evalRealm_, *false*, *false*).
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -3883,8 +3883,8 @@
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ is an Array exotic object, return *true*.
         1. If _argument_ is a Proxy exotic object, then
-          1. If the value of _argument_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
-          1. Let _target_ be the value of _argument_.[[ProxyTarget]].
+          1. If _argument_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
+          1. Let _target_ be _argument_.[[ProxyTarget]].
           1. Return ? IsArray(_target_).
         1. Return *false*.
       </emu-alg>
@@ -4373,7 +4373,7 @@
       <emu-alg>
         1. If IsCallable(_C_) is *false*, return *false*.
         1. If _C_ has a [[BoundTargetFunction]] internal slot, then
-          1. Let _BC_ be the value of _C_.[[BoundTargetFunction]].
+          1. Let _BC_ be _C_.[[BoundTargetFunction]].
           1. Return ? InstanceofOperator(_O_, _BC_).
         1. If Type(_O_) is not Object, return *false*.
         1. Let _P_ be ? Get(_C_, `"prototype"`).
@@ -4437,8 +4437,8 @@
           1. Let _target_ be _obj_.[[BoundTargetFunction]].
           1. Return ? GetFunctionRealm(_target_).
         1. If _obj_ is a Proxy exotic object, then
-          1. If the value of _obj_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
-          1. Let _proxyTarget_ be the value of _obj_.[[ProxyTarget]].
+          1. If _obj_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
+          1. Let _proxyTarget_ be _obj_.[[ProxyTarget]].
           1. Return ? GetFunctionRealm(_proxyTarget_).
         1. Return the current Realm Record.
       </emu-alg>
@@ -4564,15 +4564,15 @@
           1. Let _O_ be the *this* value.
           1. Let _f_ be the active function object.
           1. If _O_ does not have a [[IteratorNext]] internal slot, throw a *TypeError* exception.
-          1. Let _next_ be the value of _O_.[[IteratorNext]].
+          1. Let _next_ be _O_.[[IteratorNext]].
           1. If SameValue(_f_, _next_) is *false*, throw a *TypeError* exception.
           1. If _O_ does not have an [[IteratedList]] internal slot, throw a *TypeError* exception.
-          1. Let _list_ be the value of _O_.[[IteratedList]].
-          1. Let _index_ be the value of _O_.[[ListIteratorNextIndex]].
+          1. Let _list_ be _O_.[[IteratedList]].
+          1. Let _index_ be _O_.[[ListIteratorNextIndex]].
           1. Let _len_ be the number of elements of _list_.
           1. If _index_ &ge; _len_, then
             1. Return CreateIterResultObject(*undefined*, *true*).
-          1. Set the value of _O_.[[ListIteratorNextIndex]] to _index_+1.
+          1. Set _O_.[[ListIteratorNextIndex]] to _index_+1.
           1. Return CreateIterResultObject(_list_[_index_], *false*).
         </emu-alg>
         <emu-note>
@@ -5123,7 +5123,7 @@
           <h1>GetSuperBase ()</h1>
           <emu-alg>
             1. Let _envRec_ be the function Environment Record for which the method was invoked.
-            1. Let _home_ be the value of _envRec_.[[HomeObject]].
+            1. Let _home_ be _envRec_.[[HomeObject]].
             1. If _home_ has the value *undefined*, return *undefined*.
             1. Assert: Type(_home_) is Object.
             1. Return ? _home_.[[GetPrototypeOf]]().
@@ -5697,11 +5697,11 @@
           1. Set _envRec_.[[FunctionObject]] to _F_.
           1. If _F_.[[ThisMode]] is ~lexical~, set _envRec_.[[ThisBindingStatus]] to `"lexical"`.
           1. Else, set _envRec_.[[ThisBindingStatus]] to `"uninitialized"`.
-          1. Let _home_ be the value of _F_.[[HomeObject]].
+          1. Let _home_ be _F_.[[HomeObject]].
           1. Set _envRec_.[[HomeObject]] to _home_.
           1. Set _envRec_.[[NewTarget]] to _newTarget_.
           1. Set _env_'s EnvironmentRecord to _envRec_.
-          1. Set the outer lexical environment reference of _env_ to the value of _F_.[[Environment]].
+          1. Set the outer lexical environment reference of _env_ to _F_.[[Environment]].
           1. Return _env_.
         </emu-alg>
       </emu-clause>
@@ -6280,7 +6280,7 @@
         <h1>OrdinaryGetPrototypeOf (_O_)</h1>
         <p>When the abstract operation OrdinaryGetPrototypeOf is called with Object _O_, the following steps are taken:</p>
         <emu-alg>
-          1. Return the value of _O_.[[Prototype]].
+          1. Return _O_.[[Prototype]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -6298,8 +6298,8 @@
         <p>When the abstract operation OrdinarySetPrototypeOf is called with Object _O_ and value _V_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
-          1. Let _extensible_ be the value of _O_.[[Extensible]].
-          1. Let _current_ be the value of _O_.[[Prototype]].
+          1. Let _extensible_ be _O_.[[Extensible]].
+          1. Let _current_ be _O_.[[Prototype]].
           1. If SameValue(_V_, _current_) is *true*, return *true*.
           1. If _extensible_ is *false*, return *false*.
           1. Let _p_ be _V_.
@@ -6309,8 +6309,8 @@
             1. Else if SameValue(_p_, _O_) is *true*, return *false*.
             1. Else,
               1. If the [[GetPrototypeOf]] internal method of _p_ is not the ordinary object internal method defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>, let _done_ be *true*.
-              1. Else, let _p_ be the value of _p_.[[Prototype]].
-          1. Set the value of _O_.[[Prototype]] to _V_.
+              1. Else, let _p_ be _p_.[[Prototype]].
+          1. Set _O_.[[Prototype]] to _V_.
           1. Return *true*.
         </emu-alg>
         <emu-note>
@@ -6331,7 +6331,7 @@
         <h1>OrdinaryIsExtensible (_O_)</h1>
         <p>When the abstract operation OrdinaryIsExtensible is called with Object _O_, the following steps are taken:</p>
         <emu-alg>
-          1. Return the value of _O_.[[Extensible]].
+          1. Return _O_.[[Extensible]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -6348,7 +6348,7 @@
         <h1>OrdinaryPreventExtensions (_O_)</h1>
         <p>When the abstract operation OrdinaryPreventExtensions is called with Object _O_, the following steps are taken:</p>
         <emu-alg>
-          1. Set the value of _O_.[[Extensible]] to *false*.
+          1. Set _O_.[[Extensible]] to *false*.
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -6398,7 +6398,7 @@
         <p>When the abstract operation OrdinaryDefineOwnProperty is called with Object _O_, property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
         <emu-alg>
           1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
-          1. Let _extensible_ be the value of _O_.[[Extensible]].
+          1. Let _extensible_ be _O_.[[Extensible]].
           1. Return ValidateAndApplyPropertyDescriptor(_O_, _P_, _extensible_, _Desc_, _current_).
         </emu-alg>
       </emu-clause>
@@ -6812,9 +6812,9 @@
           1. Let _callerContext_ be the running execution context.
           1. Let _calleeContext_ be a new ECMAScript code execution context.
           1. Set the Function of _calleeContext_ to _F_.
-          1. Let _calleeRealm_ be the value of _F_.[[Realm]].
+          1. Let _calleeRealm_ be _F_.[[Realm]].
           1. Set the Realm of _calleeContext_ to _calleeRealm_.
-          1. Set the ScriptOrModule of _calleeContext_ to the value of _F_.[[ScriptOrModule]].
+          1. Set the ScriptOrModule of _calleeContext_ to _F_.[[ScriptOrModule]].
           1. Let _localEnv_ be NewFunctionEnvironment(_F_, _newTarget_).
           1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
           1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
@@ -6830,9 +6830,9 @@
         <h1>OrdinaryCallBindThis ( _F_, _calleeContext_, _thisArgument_ )</h1>
         <p>When the abstract operation OrdinaryCallBindThis is called with function object _F_, execution context _calleeContext_, and ECMAScript value _thisArgument_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _thisMode_ be the value of _F_.[[ThisMode]].
+          1. Let _thisMode_ be _F_.[[ThisMode]].
           1. If _thisMode_ is ~lexical~, return NormalCompletion(*undefined*).
-          1. Let _calleeRealm_ be the value of _F_.[[Realm]].
+          1. Let _calleeRealm_ be _F_.[[Realm]].
           1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
           1. If _thisMode_ is ~strict~, let _thisValue_ be _thisArgument_.
           1. Else,
@@ -6855,7 +6855,7 @@
         <p>When the abstract operation OrdinaryCallEvaluateBody is called with function object _F_ and List _argumentsList_, the following steps are taken:</p>
         <emu-alg>
           1. Perform ? FunctionDeclarationInstantiation(_F_, _argumentsList_).
-          1. Return the result of EvaluateBody of the parsed code that is the value of _F_.[[ECMAScriptCode]] passing _F_ as the argument.
+          1. Return the result of EvaluateBody of the parsed code that is _F_.[[ECMAScriptCode]] passing _F_ as the argument.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -6920,7 +6920,7 @@
         1. Assert: _F_ is an extensible object that does not have a `length` own property.
         1. Let _len_ be the ExpectedArgumentCount of _ParameterList_.
         1. Perform ! DefinePropertyOrThrow(_F_, `"length"`, PropertyDescriptor{[[Value]]: _len_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
-        1. Let _Strict_ be the value of _F_.[[Strict]].
+        1. Let _Strict_ be _F_.[[Strict]].
         1. Set _F_.[[Environment]] to the value of _Scope_.
         1. Set _F_.[[FormalParameters]] to _ParameterList_.
         1. Set _F_.[[ECMAScriptCode]] to _Body_.
@@ -7050,9 +7050,9 @@
         1. Let _calleeContext_ be the running execution context.
         1. Let _env_ be the LexicalEnvironment of _calleeContext_.
         1. Let _envRec_ be _env_'s EnvironmentRecord.
-        1. Let _code_ be the value of _func_.[[ECMAScriptCode]].
-        1. Let _strict_ be the value of _func_.[[Strict]].
-        1. Let _formals_ be the value of _func_.[[FormalParameters]].
+        1. Let _code_ be _func_.[[ECMAScriptCode]].
+        1. Let _strict_ be _func_.[[Strict]].
+        1. Let _formals_ be _func_.[[FormalParameters]].
         1. Let _parameterNames_ be the BoundNames of _formals_.
         1. If _parameterNames_ has any duplicate entries, let _hasDuplicates_ be *true*. Otherwise, let _hasDuplicates_ be *false*.
         1. Let _simpleParameterList_ be IsSimpleParameterList of _formals_.
@@ -7071,7 +7071,7 @@
               1. NOTE If there are multiple |FunctionDeclaration|s or |GeneratorDeclaration|s for the same name, the last declaration is used.
               1. Insert _d_ as the first element of _functionsToInitialize_.
         1. Let _argumentsObjectNeeded_ be *true*.
-        1. If the value of _func_.[[ThisMode]] is ~lexical~, then
+        1. If _func_.[[ThisMode]] is ~lexical~, then
           1. NOTE Arrow functions never have an arguments objects.
           1. Let _argumentsObjectNeeded_ be *false*.
         1. Else if `"arguments"` is an element of _parameterNames_, then
@@ -7178,9 +7178,9 @@
         1. If _callerContext_ is not already suspended, suspend _callerContext_.
         1. Let _calleeContext_ be a new ECMAScript code execution context.
         1. Set the Function of _calleeContext_ to _F_.
-        1. Let _calleeRealm_ be the value of _F_.[[Realm]].
+        1. Let _calleeRealm_ be _F_.[[Realm]].
         1. Set the Realm of _calleeContext_ to _calleeRealm_.
-        1. Set the ScriptOrModule of _calleeContext_ to the value of _F_.[[ScriptOrModule]].
+        1. Set the ScriptOrModule of _calleeContext_ to _F_.[[ScriptOrModule]].
         1. Perform any necessary implementation defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
         1. Let _result_ be the Completion Record that is the result of evaluating _F_ in an implementation defined manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
@@ -7286,9 +7286,9 @@
         <h1>[[Call]] ( _thisArgument_, _argumentsList_)</h1>
         <p>When the [[Call]] internal method of an exotic bound function object, _F_, which was created using the bind function is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values, the following steps are taken:</p>
         <emu-alg>
-          1. Let _target_ be the value of _F_.[[BoundTargetFunction]].
-          1. Let _boundThis_ be the value of _F_.[[BoundThis]].
-          1. Let _boundArgs_ be the value of _F_.[[BoundArguments]].
+          1. Let _target_ be _F_.[[BoundTargetFunction]].
+          1. Let _boundThis_ be _F_.[[BoundThis]].
+          1. Let _boundArgs_ be _F_.[[BoundArguments]].
           1. Let _args_ be a new list containing the same values as the list _boundArgs_ in the same order followed by the same values as the list _argumentsList_ in the same order.
           1. Return ? Call(_target_, _boundThis_, _args_).
         </emu-alg>
@@ -7299,9 +7299,9 @@
         <h1>[[Construct]] (_argumentsList_, _newTarget_)</h1>
         <p>When the [[Construct]] internal method of an exotic bound function object, _F_ that was created using the bind function is called with a list of arguments _argumentsList_ and _newTarget_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _target_ be the value of _F_.[[BoundTargetFunction]].
+          1. Let _target_ be _F_.[[BoundTargetFunction]].
           1. Assert: _target_ has a [[Construct]] internal method.
-          1. Let _boundArgs_ be the value of _F_.[[BoundArguments]].
+          1. Let _boundArgs_ be _F_.[[BoundArguments]].
           1. Let _args_ be a new list containing the same values as the list _boundArgs_ in the same order followed by the same values as the list _argumentsList_ in the same order.
           1. If SameValue(_F_, _newTarget_) is *true*, let _newTarget_ be _target_.
           1. Return ? Construct(_target_, _args_, _newTarget_).
@@ -7546,7 +7546,7 @@
           1. Let _args_ be the arguments object.
           1. Let _desc_ be OrdinaryGetOwnProperty(_args_, _P_).
           1. If _desc_ is *undefined*, return _desc_.
-          1. Let _map_ be the value of _args_.[[ParameterMap]].
+          1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If the value of _isMapped_ is *true*, then
             1. Set _desc_.[[Value]] to Get(_map_, _P_).
@@ -7562,7 +7562,7 @@
         <p>The [[DefineOwnProperty]] internal method of an arguments exotic object when called with a property key _P_ and Property Descriptor _Desc_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _map_ be the value of _args_.[[ParameterMap]].
+          1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be HasOwnProperty(_map_, _P_).
           1. Let _newArgDesc_ be _Desc_.
           1. If _isMapped_ is *true* and IsDataDescriptor(_Desc_) is *true*, then
@@ -7590,7 +7590,7 @@
         <p>The [[Get]] internal method of an arguments exotic object when called with a property key _P_ and ECMAScript language value _Receiver_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _map_ be the value of _args_.[[ParameterMap]].
+          1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If the value of _isMapped_ is *false*, then
             1. Return ? OrdinaryGet(_args_, _P_, _Receiver_).
@@ -7608,7 +7608,7 @@
           1. If SameValue(_args_, _Receiver_) is *false*, then
             1. Let _isMapped_ be *false*.
           1. Else,
-            1. Let _map_ be the value of _args_.[[ParameterMap]].
+            1. Let _map_ be _args_.[[ParameterMap]].
             1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If _isMapped_ is *true*, then
             1. Let _setStatus_ be Set(_map_, _P_, _V_, *false*).
@@ -7636,7 +7636,7 @@
         <p>The [[Delete]] internal method of an arguments exotic object when called with a property key _P_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _map_ be the value of _args_.[[ParameterMap]].
+          1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. Let _result_ be ? OrdinaryDelete(_args_, _P_).
           1. If _result_ is *true* and the value of _isMapped_ is *true*, then
@@ -7723,8 +7723,8 @@
           </emu-alg>
           <p>An ArgGetter function is an anonymous built-in function with [[Name]] and [[Env]] internal slots. When an ArgGetter function _f_ that expects no arguments is called it performs the following steps:</p>
           <emu-alg>
-            1. Let _name_ be the value of _f_.[[Name]].
-            1. Let _env_ be the value of _f_.[[Env]].
+            1. Let _name_ be _f_.[[Name]].
+            1. Let _env_ be _f_.[[Env]].
             1. Return _env_.GetBindingValue(_name_, *false*).
           </emu-alg>
           <emu-note>
@@ -7746,8 +7746,8 @@
           </emu-alg>
           <p>An ArgSetter function is an anonymous built-in function with [[Name]] and [[Env]] internal slots. When an ArgSetter function _f_ is called with argument _value_ it performs the following steps:</p>
           <emu-alg>
-            1. Let _name_ be the value of _f_.[[Name]].
-            1. Let _env_ be the value of _f_.[[Env]].
+            1. Let _name_ be _f_.[[Name]].
+            1. Let _env_ be _f_.[[Env]].
             1. Return _env_.SetMutableBinding(_name_, _value_, *false*).
           </emu-alg>
           <emu-note>
@@ -7791,12 +7791,12 @@
           1. If Type(_P_) is String, then
             1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+              1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
               1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
               1. If IsInteger(_numericIndex_) is *false*, return *false*.
               1. If _numericIndex_ = *-0*, return *false*.
               1. If _numericIndex_ &lt; 0, return *false*.
-              1. If _numericIndex_ &ge; the value of _O_.[[ArrayLength]], return *false*.
+              1. If _numericIndex_ &ge; _O_.[[ArrayLength]], return *false*.
               1. Return *true*.
           1. Return ? OrdinaryHasProperty(_O_, _P_).
         </emu-alg>
@@ -7815,7 +7815,7 @@
               1. If IsInteger(_numericIndex_) is *false*, return *false*.
               1. If _numericIndex_ = *-0*, return *false*.
               1. If _numericIndex_ &lt; 0, return *false*.
-              1. Let _length_ be the value of _O_.[[ArrayLength]].
+              1. Let _length_ be _O_.[[ArrayLength]].
               1. If _numericIndex_ &ge; _length_, return *false*.
               1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
               1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *true*, return *false*.
@@ -7864,7 +7864,7 @@
         <emu-alg>
           1. Let _keys_ be a new empty List.
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
-          1. Let _len_ be the value of _O_.[[ArrayLength]].
+          1. Let _len_ be _O_.[[ArrayLength]].
           1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order,
             1. Add ! ToString(_i_) as the last element of _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an integer index, in ascending chronological order of property creation
@@ -7902,13 +7902,13 @@
         <emu-alg>
           1. Assert: Type(_index_) is Number.
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If IsInteger(_index_) is *false*, return *undefined*.
           1. If _index_ = *-0*, return *undefined*.
-          1. Let _length_ be the value of _O_.[[ArrayLength]].
+          1. Let _length_ be _O_.[[ArrayLength]].
           1. If _index_ &lt; 0 or _index_ &ge; _length_, return *undefined*.
-          1. Let _offset_ be the value of _O_.[[ByteOffset]].
+          1. Let _offset_ be _O_.[[ByteOffset]].
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
@@ -7925,13 +7925,13 @@
           1. Assert: Type(_index_) is Number.
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
           1. Let _numValue_ be ? ToNumber(_value_).
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If IsInteger(_index_) is *false*, return *false*.
           1. If _index_ = *-0*, return *false*.
-          1. Let _length_ be the value of _O_.[[ArrayLength]].
+          1. Let _length_ be _O_.[[ArrayLength]].
           1. If _index_ &lt; 0 or _index_ &ge; _length_, return *false*.
-          1. Let _offset_ be the value of _O_.[[ByteOffset]].
+          1. Let _offset_ be _O_.[[ByteOffset]].
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
@@ -8031,7 +8031,7 @@
         <p>When the [[GetOwnProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryGetOwnProperty(_O_, _P_).
-          1. Let _exports_ be the value of _O_.[[Exports]].
+          1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _value_ be ? _O_.[[Get]](_P_, _O_).
           1. Return PropertyDescriptor{[[Value]]: _value_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
@@ -8053,7 +8053,7 @@
         <p>When the [[HasProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryHasProperty(_O_, _P_).
-          1. Let _exports_ be the value of _O_.[[Exports]].
+          1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is an element of _exports_, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -8067,9 +8067,9 @@
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is Symbol, then
             1. Return ? OrdinaryGet(_O_, _P_, _Receiver_).
-          1. Let _exports_ be the value of _O_.[[Exports]].
+          1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
-          1. Let _m_ be the value of _O_.[[Module]].
+          1. Let _m_ be _O_.[[Module]].
           1. Let _binding_ be ! _m_.ResolveExport(_P_, &laquo; &raquo;, &laquo; &raquo;).
           1. Assert: _binding_ is neither *null* nor `"ambiguous"`.
           1. Let _targetModule_ be _binding_.[[Module]].
@@ -8099,7 +8099,7 @@
         <p>When the [[Delete]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. Let _exports_ be the value of _O_.[[Exports]].
+          1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is an element of _exports_, return *false*.
           1. Return *true*.
         </emu-alg>
@@ -8110,7 +8110,7 @@
         <h1>[[OwnPropertyKeys]] ( )</h1>
         <p>When the [[OwnPropertyKeys]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
         <emu-alg>
-          1. Let _exports_ be a copy of the value of _O_.[[Exports]].
+          1. Let _exports_ be a copy of _O_.[[Exports]].
           1. Let _symbolKeys_ be ! OrdinaryOwnPropertyKeys(_O_).
           1. Append all the entries of _symbolKeys_ to the end of _exports_.
           1. Return _exports_.
@@ -8146,7 +8146,7 @@
         <p>When the [[SetPrototypeOf]] internal method of an immutable prototype exotic object _O_ is called with argument _V_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
-          1. Let _current_ be the value of _O_.[[Prototype]].
+          1. Let _current_ be _O_.[[Prototype]].
           1. If SameValue(_V_, _current_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -8286,10 +8286,10 @@
       <h1>[[GetPrototypeOf]] ( )</h1>
       <p>When the [[GetPrototypeOf]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"getPrototypeOf"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[GetPrototypeOf]]().
@@ -8320,10 +8320,10 @@
       <p>When the [[SetPrototypeOf]] internal method of a Proxy exotic object _O_ is called with argument _V_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"setPrototypeOf"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[SetPrototypeOf]](_V_).
@@ -8353,10 +8353,10 @@
       <h1>[[IsExtensible]] ( )</h1>
       <p>When the [[IsExtensible]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"isExtensible"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[IsExtensible]]().
@@ -8383,10 +8383,10 @@
       <h1>[[PreventExtensions]] ( )</h1>
       <p>When the [[PreventExtensions]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"preventExtensions"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[PreventExtensions]]().
@@ -8415,10 +8415,10 @@
       <p>When the [[GetOwnProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"getOwnPropertyDescriptor"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[GetOwnProperty]](_P_).
@@ -8470,10 +8470,10 @@
       <p>When the [[DefineOwnProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_ and Property Descriptor _Desc_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"defineProperty"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[DefineOwnProperty]](_P_, _Desc_).
@@ -8518,10 +8518,10 @@
       <p>When the [[HasProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"has"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[HasProperty]](_P_).
@@ -8556,10 +8556,10 @@
       <p>When the [[Get]] internal method of a Proxy exotic object _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"get"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Get]](_P_, _Receiver_).
@@ -8591,10 +8591,10 @@
       <p>When the [[Set]] internal method of a Proxy exotic object _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"set"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Set]](_P_, _V_, _Receiver_).
@@ -8630,10 +8630,10 @@
       <p>When the [[Delete]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"deleteProperty"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Delete]](_P_).
@@ -8662,10 +8662,10 @@
       <h1>[[OwnPropertyKeys]] ( )</h1>
       <p>When the [[OwnPropertyKeys]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"ownKeys"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[OwnPropertyKeys]]().
@@ -8719,10 +8719,10 @@
       <h1>[[Call]] (_thisArgument_, _argumentsList_)</h1>
       <p>The [[Call]] internal method of a Proxy exotic object _O_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"apply"`).
         1. If _trap_ is *undefined*, then
           1. Return ? Call(_target_, _thisArgument_, _argumentsList_).
@@ -8739,10 +8739,10 @@
       <h1>[[Construct]] ( _argumentsList_, _newTarget_)</h1>
       <p>The [[Construct]] internal method of a Proxy exotic object _O_ is called with parameters _argumentsList_ which is a possibly empty List of ECMAScript language values and _newTarget_. The following steps are taken:</p>
       <emu-alg>
-        1. Let _handler_ be the value of _O_.[[ProxyHandler]].
+        1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
-        1. Let _target_ be the value of _O_.[[ProxyTarget]].
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"construct"`).
         1. If _trap_ is *undefined*, then
           1. Assert: _target_ has a [[Construct]] internal method.
@@ -8771,9 +8771,9 @@
       <p>The abstract operation ProxyCreate with arguments _target_ and _handler_ is used to specify the creation of new Proxy exotic objects. It performs the following steps:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
-        1. If _target_ is a Proxy exotic object and the value of _target_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
+        1. If _target_ is a Proxy exotic object and _target_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
         1. If Type(_handler_) is not Object, throw a *TypeError* exception.
-        1. If _handler_ is a Proxy exotic object and the value of _handler_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
+        1. If _handler_ is a Proxy exotic object and _handler_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
         1. Let _P_ be a newly created object.
         1. Set _P_'s essential internal methods (except for [[Call]] and [[Construct]]) to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
         1. If IsCallable(_target_) is *true*, then
@@ -21734,7 +21734,7 @@
       <p>The `eval` function is the <dfn>%eval%</dfn> intrinsic object. When the `eval` function is called with one argument _x_, the following steps are taken:</p>
       <emu-alg>
         1. Let _f_ be the active function object.
-        1. Let _evalRealm_ be the value of _f_.[[Realm]].
+        1. Let _evalRealm_ be _f_.[[Realm]].
         1. Perform ? HostEnsureCanCompileStrings(the current Realm Record, _evalRealm_).
         1. Return ? PerformEval(_x_, _evalRealm_, *false*, *false*).
       </emu-alg>
@@ -22927,7 +22927,7 @@
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
           1. If _desc_ is *undefined*, return *false*.
-          1. Return the value of _desc_.[[Enumerable]].
+          1. Return _desc_.[[Enumerable]].
         </emu-alg>
         <emu-note>
           <p>This method does not consider objects in the prototype chain.</p>
@@ -23018,7 +23018,7 @@
         <p>When the `Function` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no &ldquo;_p_&rdquo; arguments, and where _body_ might also not be provided), the following steps are taken:</p>
         <emu-alg>
           1. Let _C_ be the active function object.
-          1. Let _calleeRealm_ be the value of _C_.[[Realm]].
+          1. Let _calleeRealm_ be _C_.[[Realm]].
           1. Perform ? HostEnsureCanCompileStrings(the current Realm Record, _calleeRealm_).
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
           1. Return ? CreateDynamicFunction(_C_, NewTarget, `"normal"`, _args_).
@@ -23077,7 +23077,7 @@
               1. If BoundNames of _parameters_ contains any duplicate elements, throw a *SyntaxError* exception.
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _fallbackProto_).
             1. Let _F_ be FunctionAllocate(_proto_, _strict_, _kind_).
-            1. Let _realmF_ be the value of _F_.[[Realm]].
+            1. Let _realmF_ be _F_.[[Realm]].
             1. Let _scope_ be _realmF_.[[GlobalEnv]].
             1. Perform FunctionInitialize(_F_, ~Normal~, _parameters_, _body_, _scope_).
             1. If _kind_ is `"generator"`, then
@@ -23306,7 +23306,7 @@
           1. Let _b_ be ToBoolean(_value_).
           1. If NewTarget is *undefined*, return _b_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%BooleanPrototype%"`, &laquo; [[BooleanData]] &raquo;).
-          1. Set the value of _O_.[[BooleanData]] to _b_.
+          1. Set _O_.[[BooleanData]] to _b_.
           1. Return _O_.
         </emu-alg>
       </emu-clause>
@@ -23338,7 +23338,7 @@
           1. If Type(_value_) is Boolean, return _value_.
           1. If Type(_value_) is Object and _value_ has a [[BooleanData]] internal slot, then
             1. Assert: _value_.[[BooleanData]] is a Boolean value.
-            1. Return the value of _value_.[[BooleanData]].
+            1. Return _value_.[[BooleanData]].
           1. Throw a *TypeError* exception.
         </emu-alg>
       </emu-clause>
@@ -23580,7 +23580,7 @@
           1. Else,
             1. If Type(_s_) is not Object, throw a *TypeError* exception.
             1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-            1. Let _sym_ be the value of _s_.[[SymbolData]].
+            1. Let _sym_ be _s_.[[SymbolData]].
           1. Return SymbolDescriptiveString(_sym_).
         </emu-alg>
 
@@ -23607,7 +23607,7 @@
           1. If Type(_s_) is Symbol, return _s_.
           1. If Type(_s_) is not Object, throw a *TypeError* exception.
           1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-          1. Return the value of _s_.[[SymbolData]].
+          1. Return _s_.[[SymbolData]].
         </emu-alg>
       </emu-clause>
 
@@ -23621,7 +23621,7 @@
           1. If Type(_s_) is Symbol, return _s_.
           1. If Type(_s_) is not Object, throw a *TypeError* exception.
           1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-          1. Return the value of _s_.[[SymbolData]].
+          1. Return _s_.[[SymbolData]].
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.toPrimitive]"`.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -23874,7 +23874,7 @@
           1. Else, let _n_ be ? ToNumber(_value_).
           1. If NewTarget is *undefined*, return _n_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%NumberPrototype%"`, &laquo; [[NumberData]] &raquo;).
-          1. Set the value of _O_.[[NumberData]] to _n_.
+          1. Set _O_.[[NumberData]] to _n_.
           1. Return _O_.
         </emu-alg>
       </emu-clause>
@@ -24032,7 +24032,7 @@
         1. If Type(_value_) is Number, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[NumberData]] internal slot, then
           1. Assert: _value_.[[NumberData]] is a Number value.
-          1. Return the value of _value_.[[NumberData]].
+          1. Return _value_.[[NumberData]].
         1. Throw a *TypeError* exception.
       </emu-alg>
       <p>The phrase &ldquo;this Number value&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisNumberValue with the *this* value of the method invocation passed as the argument.</p>
@@ -25709,7 +25709,7 @@ THH:mm:ss.sss
       <p>The abstract operation thisTimeValue(_value_) performs the following steps:</p>
       <emu-alg>
         1. If Type(_value_) is Object and _value_ has a [[DateValue]] internal slot, then
-          1. Return the value of _value_.[[DateValue]].
+          1. Return _value_.[[DateValue]].
         1. Throw a *TypeError* exception.
       </emu-alg>
       <p>In following descriptions of functions that are properties of the Date prototype object, the phrase &ldquo;this Date object&rdquo; refers to the object that is the *this* value for the invocation of the function. If the Type of the *this* value is not Object, a *TypeError* exception is thrown. The phrase &ldquo;<dfn>this time value</dfn>&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisTimeValue with the *this* value of the method invocation passed as the argument.</p>
@@ -26454,7 +26454,7 @@ THH:mm:ss.sss
         1. If Type(_value_) is String, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[StringData]] internal slot, then
           1. Assert: _value_.[[StringData]] is a String value.
-          1. Return the value of _value_.[[StringData]].
+          1. Return _value_.[[StringData]].
         1. Throw a *TypeError* exception.
       </emu-alg>
       <p>The phrase &ldquo;this String value&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisStringValue with the *this* value of the method invocation passed as the argument.</p>
@@ -27255,12 +27255,12 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of an String Iterator Instance (<emu-xref href="#sec-properties-of-string-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _s_ be the value of _O_.[[IteratedString]].
+            1. Let _s_ be _O_.[[IteratedString]].
             1. If _s_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
-            1. Let _position_ be the value of _O_.[[StringIteratorNextIndex]].
+            1. Let _position_ be _O_.[[StringIteratorNextIndex]].
             1. Let _len_ be the number of elements in _s_.
             1. If _position_ &ge; _len_, then
-              1. Set the value of _O_.[[IteratedString]] to *undefined*.
+              1. Set _O_.[[IteratedString]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
             1. Let _first_ be the code unit value at index _position_ in _s_.
             1. If _first_ &lt; 0xD800 or _first_ &gt; 0xDBFF or _position_+1 = _len_, let _resultString_ be the string consisting of the single code unit _first_.
@@ -27269,7 +27269,7 @@ THH:mm:ss.sss
               1. If _second_ &lt; 0xDC00 or _second_ &gt; 0xDFFF, let _resultString_ be the string consisting of the single code unit _first_.
               1. Else, let _resultString_ be the string consisting of the code unit _first_ followed by the code unit _second_.
             1. Let _resultSize_ be the number of code units in _resultString_.
-            1. Set the value of _O_.[[StringIteratorNextIndex]] to _position_ + _resultSize_.
+            1. Set _O_.[[StringIteratorNextIndex]] to _position_ + _resultSize_.
             1. Return CreateIterResultObject(_resultString_, *false*).
           </emu-alg>
         </emu-clause>
@@ -28775,8 +28775,8 @@ THH:mm:ss.sss
               1. Let _patternConstructor_ be ? Get(_pattern_, `"constructor"`).
               1. If SameValue(_newTarget_, _patternConstructor_) is *true*, return _pattern_.
           1. If Type(_pattern_) is Object and _pattern_ has a [[RegExpMatcher]] internal slot, then
-            1. Let _P_ be the value of _pattern_.[[OriginalSource]].
-            1. If _flags_ is *undefined*, let _F_ be the value of _pattern_.[[OriginalFlags]].
+            1. Let _P_ be _pattern_.[[OriginalSource]].
+            1. If _flags_ is *undefined*, let _F_ be _pattern_.[[OriginalFlags]].
             1. Else, let _F_ be _flags_.
           1. Else if _patternIsRegExp_ is *true*, then
             1. Let _P_ be ? Get(_pattern_, `"source"`).
@@ -28826,8 +28826,8 @@ THH:mm:ss.sss
             1. Else,
               1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting _P_ as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). The goal symbol for the parse is |Pattern[U]|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code points resulting from applying UTF-16 decoding to _P_'s sequence of elements.
-            1. Set the value of _obj_.[[OriginalSource]] to _P_.
-            1. Set the value of _obj_.[[OriginalFlags]] to _F_.
+            1. Set _obj_.[[OriginalSource]] to _P_.
+            1. Set _obj_.[[OriginalFlags]] to _F_.
             1. Set _obj_.[[RegExpMatcher]] to the internal procedure that evaluates the above parse of _P_ by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
             1. Perform ? Set(_obj_, `"lastIndex"`, 0, *true*).
             1. Return _obj_.
@@ -28941,11 +28941,11 @@ THH:mm:ss.sss
             1. Assert: Type(_S_) is String.
             1. Let _length_ be the number of code units in _S_.
             1. Let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
-            1. Let _flags_ be the value of _R_.[[OriginalFlags]].
+            1. Let _flags_ be _R_.[[OriginalFlags]].
             1. If _flags_ contains `"g"`, let _global_ be *true*, else let _global_ be *false*.
             1. If _flags_ contains `"y"`, let _sticky_ be *true*, else let _sticky_ be *false*.
             1. If _global_ is *false* and _sticky_ is *false*, let _lastIndex_ be 0.
-            1. Let _matcher_ be the value of _R_.[[RegExpMatcher]].
+            1. Let _matcher_ be _R_.[[RegExpMatcher]].
             1. If _flags_ contains `"u"`, let _fullUnicode_ be *true*, else let _fullUnicode_ be *false*.
             1. Let _matchSucceeded_ be *false*.
             1. Repeat, while _matchSucceeded_ is *false*
@@ -29041,7 +29041,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
+          1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"g"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -29057,7 +29057,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
+          1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"i"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -29110,7 +29110,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
+          1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"m"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -29213,8 +29213,8 @@ THH:mm:ss.sss
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return `"(?:)"`.
             1. Otherwise, throw a *TypeError* exception.
           1. Assert: _R_ has an [[OriginalFlags]] internal slot.
-          1. Let _src_ be the value of _R_.[[OriginalSource]].
-          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
+          1. Let _src_ be _R_.[[OriginalSource]].
+          1. Let _flags_ be _R_.[[OriginalFlags]].
           1. Return EscapeRegExpPattern(_src_, _flags_).
         </emu-alg>
       </emu-clause>
@@ -29300,7 +29300,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
+          1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"y"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -29345,7 +29345,7 @@ THH:mm:ss.sss
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
             1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
-          1. Let _flags_ be the value of _R_.[[OriginalFlags]].
+          1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit `"u"`, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -30724,18 +30724,18 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of an Array Iterator Instance (<emu-xref href="#sec-properties-of-array-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _a_ be the value of _O_.[[IteratedObject]].
+            1. Let _a_ be _O_.[[IteratedObject]].
             1. If _a_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
-            1. Let _index_ be the value of _O_.[[ArrayIteratorNextIndex]].
-            1. Let _itemKind_ be the value of _O_.[[ArrayIterationKind]].
+            1. Let _index_ be _O_.[[ArrayIteratorNextIndex]].
+            1. Let _itemKind_ be _O_.[[ArrayIterationKind]].
             1. If _a_ has a [[TypedArrayName]] internal slot, then
-              1. Let _len_ be the value of _a_.[[ArrayLength]].
+              1. Let _len_ be _a_.[[ArrayLength]].
             1. Else,
               1. Let _len_ be ? ToLength(? Get(_a_, `"length"`)).
             1. If _index_ &ge; _len_, then
-              1. Set the value of _O_.[[IteratedObject]] to *undefined*.
+              1. Set _O_.[[IteratedObject]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
-            1. Set the value of _O_.[[ArrayIteratorNextIndex]] to _index_+1.
+            1. Set _O_.[[ArrayIteratorNextIndex]] to _index_+1.
             1. If _itemKind_ is `"key"`, return CreateIterResultObject(_index_, *false*).
             1. Let _elementKey_ be ! ToString(_index_).
             1. Let _elementValue_ be ? Get(_a_, _elementKey_).
@@ -31173,7 +31173,7 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Return _buffer_.
         </emu-alg>
       </emu-clause>
@@ -31187,9 +31187,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
-          1. Let _size_ be the value of _O_.[[ByteLength]].
+          1. Let _size_ be _O_.[[ByteLength]].
           1. Return _size_.
         </emu-alg>
       </emu-clause>
@@ -31203,9 +31203,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
-          1. Let _offset_ be the value of _O_.[[ByteOffset]].
+          1. Let _offset_ be _O_.[[ByteOffset]].
           1. Return _offset_.
         </emu-alg>
       </emu-clause>
@@ -31231,7 +31231,7 @@ THH:mm:ss.sss
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
             1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-            1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+            1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. Return _buffer_.
           </emu-alg>
@@ -31271,7 +31271,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Let _len_ be the value of _O_.[[ArrayLength]].
+          1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _kept_ be a new empty List.
@@ -31363,9 +31363,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
-          1. Let _length_ be the value of _O_.[[ArrayLength]].
+          1. Let _length_ be _O_.[[ArrayLength]].
           1. Return _length_.
         </emu-alg>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
@@ -31379,7 +31379,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Let _len_ be the value of _O_.[[ArrayLength]].
+          1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _len_ &raquo;).
@@ -31434,13 +31434,13 @@ THH:mm:ss.sss
             1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
             1. Let _targetOffset_ be ? ToInteger(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
-            1. Let _targetBuffer_ be the value of _target_.[[ViewedArrayBuffer]].
+            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetLength_ be the value of _target_.[[ArrayLength]].
+            1. Let _targetLength_ be _target_.[[ArrayLength]].
             1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
             1. Let _targetElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
-            1. Let _targetByteOffset_ be the value of _target_.[[ByteOffset]].
+            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _src_ be ? ToObject(_array_).
             1. Let _srcLength_ be ? ToLength(? Get(_src_, `"length"`)).
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
@@ -31470,20 +31470,20 @@ THH:mm:ss.sss
             1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
             1. Let _targetOffset_ be ? ToInteger(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
-            1. Let _targetBuffer_ be the value of _target_.[[ViewedArrayBuffer]].
+            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetLength_ be the value of _target_.[[ArrayLength]].
-            1. Let _srcBuffer_ be the value of _typedArray_.[[ViewedArrayBuffer]].
+            1. Let _targetLength_ be _target_.[[ArrayLength]].
+            1. Let _srcBuffer_ be _typedArray_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
             1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
-            1. Let _targetByteOffset_ be the value of _target_.[[ByteOffset]].
+            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _srcName_ be the String value of _typedArray_.[[TypedArrayName]].
             1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
             1. Let _srcElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcName_.
-            1. Let _srcLength_ be the value of _typedArray_.[[ArrayLength]].
-            1. Let _srcByteOffset_ be the value of _typedArray_.[[ByteOffset]].
+            1. Let _srcLength_ be _typedArray_.[[ArrayLength]].
+            1. Let _srcByteOffset_ be _typedArray_.[[ByteOffset]].
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
             1. If SameValue(_srcBuffer_, _targetBuffer_) is *true*, then
               1. Let _srcBuffer_ be ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcLength_, %ArrayBuffer%).
@@ -31517,7 +31517,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Let _len_ be the value of _O_.[[ArrayLength]].
+          1. Let _len_ be _O_.[[ArrayLength]].
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
@@ -31537,12 +31537,12 @@ THH:mm:ss.sss
               1. Increase _k_ by 1.
               1. Increase _n_ by 1.
           1. Else if _count_ &gt; 0, then
-            1. Let _srcBuffer_ be the value of _O_.[[ViewedArrayBuffer]].
+            1. Let _srcBuffer_ be _O_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetBuffer_ be the value of _A_.[[ViewedArrayBuffer]].
+            1. Let _targetBuffer_ be _A_.[[ViewedArrayBuffer]].
             1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcType_.
             1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
-            1. Let _srcByteOffet_ be the value of _O_.[[ByteOffset]].
+            1. Let _srcByteOffet_ be _O_.[[ByteOffset]].
             1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
             1. Let _srcByteIndex_ be (_k_ &times; _elementSize_) + _srcByteOffet_.
             1. Let _limit_ be _targetByteIndex_ + _count_ &times; _elementSize_.
@@ -31572,7 +31572,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be the *this* value.
           1. Let _buffer_ be ? ValidateTypedArray(_obj_).
-          1. Let _len_ be the value of _obj_.[[ArrayLength]].
+          1. Let _len_ be _obj_.[[ArrayLength]].
         </emu-alg>
         <p>The implementation defined sort order condition for exotic objects is not applied by %TypedArray%`.prototype.sort`.</p>
         <p>The following version of SortCompare is used by %TypedArray%`.prototype.sort`. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. SortCompare has access to the _comparefn_ and _buffer_ values of the current invocation of the `sort` method.</p>
@@ -31607,8 +31607,8 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
-          1. Let _srcLength_ be the value of _O_.[[ArrayLength]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
+          1. Let _srcLength_ be _O_.[[ArrayLength]].
           1. Let _relativeBegin_ be ? ToInteger(_begin_).
           1. If _relativeBegin_ &lt; 0, let _beginIndex_ be max((_srcLength_ + _relativeBegin_), 0); else let _beginIndex_ be min(_relativeBegin_, _srcLength_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _srcLength_; else, let _relativeEnd_ be ? ToInteger(_end_).
@@ -31616,7 +31616,7 @@ THH:mm:ss.sss
           1. Let _newLength_ be max(_endIndex_ - _beginIndex_, 0).
           1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-          1. Let _srcByteOffset_ be the value of _O_.[[ByteOffset]].
+          1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
           1. Let _beginByteOffset_ be _srcByteOffset_ + _beginIndex_ &times; _elementSize_.
           1. Let _argumentsList_ be &laquo; _buffer_, _beginByteOffset_, _newLength_ &raquo;.
           1. Return ? TypedArraySpeciesCreate(_O_, _argumentsList_).
@@ -31665,7 +31665,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, return *undefined*.
           1. If _O_ does not have a [[TypedArrayName]] internal slot, return *undefined*.
-          1. Let _name_ be the value of _O_.[[TypedArrayName]].
+          1. Let _name_ be _O_.[[TypedArrayName]].
           1. Assert: _name_ is a String value.
           1. Return _name_.
         </emu-alg>
@@ -31757,19 +31757,19 @@ THH:mm:ss.sss
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
           1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
           1. Let _srcArray_ be _typedArray_.
-          1. Let _srcData_ be the value of _srcArray_.[[ViewedArrayBuffer]].
+          1. Let _srcData_ be _srcArray_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
-          1. Let _elementLength_ be the value of _srcArray_.[[ArrayLength]].
+          1. Let _elementLength_ be _srcArray_.[[ArrayLength]].
           1. Let _srcName_ be the String value of _srcArray_.[[TypedArrayName]].
           1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
           1. Let _srcElementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
-          1. Let _srcByteOffset_ be the value of _srcArray_.[[ByteOffset]].
+          1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
           1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
           1. If SameValue(_elementType_, _srcType_) is *true*, then
-            1. Let _srcLength_ be the value of _typedArray_.[[ByteLength]].
+            1. Let _srcLength_ be _typedArray_.[[ByteLength]].
             1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _srcLength_).
           1. Else,
             1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
@@ -31844,7 +31844,7 @@ THH:mm:ss.sss
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _bufferByteLength_ be the value of _buffer_.[[ArrayBufferByteLength]].
+          1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
           1. If _length_ is either not present or *undefined*, then
             1. If _bufferByteLength_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
             1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
@@ -31868,7 +31868,7 @@ THH:mm:ss.sss
           1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
           1. Perform ? ValidateTypedArray(_newTypedArray_).
           1. If _argumentList_ is a List of a single Number, then
-            1. If the value of _newTypedArray_.[[ArrayLength]] &lt; _argumentList_[0], throw a *TypeError* exception.
+            1. If _newTypedArray_.[[ArrayLength]] &lt; _argumentList_[0], throw a *TypeError* exception.
           1. Return _newTypedArray_.
         </emu-alg>
       </emu-clause>
@@ -31878,7 +31878,7 @@ THH:mm:ss.sss
         <p>The abstract operation TypedArraySpeciesCreate with arguments _exemplar_ and _argumentList_ is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps:</p>
         <emu-alg>
           1. Assert: _exemplar_ is an Object that has a [[TypedArrayName]] internal slot.
-          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for the value of _exemplar_.[[TypedArrayName]].
+          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for _exemplar_.[[TypedArrayName]].
           1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
           1. Return ? TypedArrayCreate(_constructor_, _argumentList_).
         </emu-alg>
@@ -32025,7 +32025,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
+          1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. Set _p_.[[Key]] to ~empty~.
             1. Set _p_.[[Value]] to ~empty~.
@@ -32050,7 +32050,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
+          1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Key]] to ~empty~.
@@ -32083,7 +32083,7 @@ THH:mm:ss.sss
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
-          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
+          1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _e_ that is an element of _entries_, in original key insertion order
             1. If _e_.[[Key]] is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _T_, &laquo; _e_.[[Value]], _e_.[[Key]], _M_ &raquo;).
@@ -32105,7 +32105,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
+          1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
           1. Return *undefined*.
@@ -32120,7 +32120,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
+          1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return *true*.
           1. Return *false*.
@@ -32145,7 +32145,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
+          1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Value]] to _value_.
@@ -32165,7 +32165,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[MapData]].
+          1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Let _count_ be 0.
           1. For each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_
             1. If _p_.[[Key]] is not ~empty~, set _count_ to _count_+1.
@@ -32235,12 +32235,12 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of a Map Iterator Instance (<emu-xref href="#sec-properties-of-map-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _m_ be the value of _O_.[[Map]].
-            1. Let _index_ be the value of _O_.[[MapNextIndex]].
-            1. Let _itemKind_ be the value of _O_.[[MapIterationKind]].
+            1. Let _m_ be _O_.[[Map]].
+            1. Let _index_ be _O_.[[MapNextIndex]].
+            1. Let _itemKind_ be _O_.[[MapIterationKind]].
             1. If _m_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
             1. Assert: _m_ has a [[MapData]] internal slot.
-            1. Let _entries_ be the List that is the value of _m_.[[MapData]].
+            1. Let _entries_ be the List that is _m_.[[MapData]].
             1. Repeat while _index_ is less than the total number of elements of _entries_. The number of elements must be redetermined each time this method is evaluated.
               1. Let _e_ be the Record {[[Key]], [[Value]]} that is the value of _entries_[_index_].
               1. Set _index_ to _index_+1.
@@ -32388,7 +32388,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
+          1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Return _S_.
@@ -32406,7 +32406,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
+          1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
           1. Return *undefined*.
@@ -32430,7 +32430,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
+          1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
@@ -32465,7 +32465,7 @@ THH:mm:ss.sss
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
-          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
+          1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_, in original insertion order
             1. If _e_ is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _T_, &laquo; _e_, _e_, _S_ &raquo;).
@@ -32489,7 +32489,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
+          1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, return *true*.
           1. Return *false*.
@@ -32513,7 +32513,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_.[[SetData]].
+          1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Let _count_ be 0.
           1. For each _e_ that is an element of _entries_
             1. If _e_ is not ~empty~, set _count_ to _count_+1.
@@ -32583,12 +32583,12 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of a Set Iterator Instance (<emu-xref href="#sec-properties-of-set-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _s_ be the value of _O_.[[IteratedSet]].
-            1. Let _index_ be the value of _O_.[[SetNextIndex]].
-            1. Let _itemKind_ be the value of _O_.[[SetIterationKind]].
+            1. Let _s_ be _O_.[[IteratedSet]].
+            1. Let _index_ be _O_.[[SetNextIndex]].
+            1. Let _itemKind_ be _O_.[[SetIterationKind]].
             1. If _s_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
             1. Assert: _s_ has a [[SetData]] internal slot.
-            1. Let _entries_ be the List that is the value of _s_.[[SetData]].
+            1. Let _entries_ be the List that is _s_.[[SetData]].
             1. Repeat while _index_ is less than the total number of elements of _entries_. The number of elements must be redetermined each time this method is evaluated.
               1. Let _e_ be _entries_[_index_].
               1. Set _index_ to _index_+1.
@@ -32742,7 +32742,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[WeakMapData]].
+          1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
@@ -32764,7 +32764,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[WeakMapData]].
+          1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *undefined*.
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
@@ -32780,7 +32780,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[WeakMapData]].
+          1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return *true*.
@@ -32796,7 +32796,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _M_.[[WeakMapData]].
+          1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, throw a *TypeError* exception.
           1. Repeat for each Record {[[Key]], [[Value]]} _p_ that is an element of _entries_,
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
@@ -32892,7 +32892,7 @@ THH:mm:ss.sss
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
           1. If Type(_value_) is not Object, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_.[[WeakSetData]].
+          1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Return _S_.
@@ -32916,7 +32916,7 @@ THH:mm:ss.sss
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
           1. If Type(_value_) is not Object, return *false*.
-          1. Let _entries_ be the List that is the value of _S_.[[WeakSetData]].
+          1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
@@ -32936,7 +32936,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is the value of _S_.[[WeakSetData]].
+          1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. If Type(_value_) is not Object, return *false*.
           1. Repeat for each _e_ that is an element of _entries_,
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, return *true*.
@@ -33022,10 +33022,10 @@ THH:mm:ss.sss
             1. Let _cloneConstructor_ be ? SpeciesConstructor(_srcBuffer_, %ArrayBuffer%).
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
           1. Else, Assert: IsConstructor(_cloneConstructor_) is *true*.
-          1. Let _srcBlock_ be the value of _srcBuffer_.[[ArrayBufferData]].
+          1. Let _srcBlock_ be _srcBuffer_.[[ArrayBufferData]].
           1. Let _targetBuffer_ be ? AllocateArrayBuffer(_cloneConstructor_, _srcLength_).
           1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-          1. Let _targetBlock_ be the value of _targetBuffer_.[[ArrayBufferData]].
+          1. Let _targetBlock_ be _targetBuffer_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _cloneLength_).
           1. Return _targetBuffer_.
         </emu-alg>
@@ -33160,7 +33160,7 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
-          1. Let _length_ be the value of _O_.[[ArrayBufferByteLength]].
+          1. Let _length_ be _O_.[[ArrayBufferByteLength]].
           1. Return _length_.
         </emu-alg>
       </emu-clause>
@@ -33180,7 +33180,7 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
-          1. Let _len_ be the value of _O_.[[ArrayBufferByteLength]].
+          1. Let _len_ be _O_.[[ArrayBufferByteLength]].
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _first_ be max((_len_ + _relativeStart_), 0); else let _first_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
@@ -33191,11 +33191,11 @@ THH:mm:ss.sss
           1. If _new_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If SameValue(_new_, _O_) is *true*, throw a *TypeError* exception.
-          1. If the value of _new_.[[ArrayBufferByteLength]] &lt; _newLen_, throw a *TypeError* exception.
+          1. If _new_.[[ArrayBufferByteLength]] &lt; _newLen_, throw a *TypeError* exception.
           1. NOTE: Side-effects of the above steps may have detached _O_.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
-          1. Let _fromBuf_ be the value of _O_.[[ArrayBufferData]].
-          1. Let _toBuf_ be the value of _new_.[[ArrayBufferData]].
+          1. Let _fromBuf_ be _O_.[[ArrayBufferData]].
+          1. Let _toBuf_ be _new_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_toBuf_, 0, _fromBuf_, _first_, _newLen_).
           1. Return _new_.
         </emu-alg>
@@ -33235,10 +33235,10 @@ THH:mm:ss.sss
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. Let _isLittleEndian_ be ToBoolean(_isLittleEndian_).
-          1. Let _buffer_ be the value of _view_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _viewOffset_ be the value of _view_.[[ByteOffset]].
-          1. Let _viewSize_ be the value of _view_.[[ByteLength]].
+          1. Let _viewOffset_ be _view_.[[ByteOffset]].
+          1. Let _viewSize_ be _view_.[[ByteLength]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
@@ -33257,10 +33257,10 @@ THH:mm:ss.sss
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. Let _numberValue_ be ? ToNumber(_value_).
           1. Let _isLittleEndian_ be ToBoolean(_isLittleEndian_).
-          1. Let _buffer_ be the value of _view_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _viewOffset_ be the value of _view_.[[ByteOffset]].
-          1. Let _viewSize_ be the value of _view_.[[ByteLength]].
+          1. Let _viewOffset_ be _view_.[[ByteOffset]].
+          1. Let _viewSize_ be _view_.[[ByteLength]].
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
@@ -33285,7 +33285,7 @@ THH:mm:ss.sss
           1. If _buffer_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _bufferByteLength_ be the value of _buffer_.[[ArrayBufferByteLength]].
+          1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
           1. If _offset_ &gt; _bufferByteLength_, throw a *RangeError* exception.
           1. If _byteLength_ is either not present or *undefined*, then
             1. Let _viewByteLength_ be _bufferByteLength_ - _offset_.
@@ -33330,7 +33330,7 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Return _buffer_.
         </emu-alg>
       </emu-clause>
@@ -33344,9 +33344,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _size_ be the value of _O_.[[ByteLength]].
+          1. Let _size_ be _O_.[[ByteLength]].
           1. Return _size_.
         </emu-alg>
       </emu-clause>
@@ -33360,9 +33360,9 @@ THH:mm:ss.sss
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _buffer_ be the value of _O_.[[ViewedArrayBuffer]].
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _offset_ be the value of _O_.[[ByteOffset]].
+          1. Let _offset_ be _O_.[[ByteOffset]].
           1. Return _offset_.
         </emu-alg>
       </emu-clause>
@@ -33748,7 +33748,7 @@ THH:mm:ss.sss
             1. Else if _value_ has a [[StringData]] internal slot, then
               1. Let _value_ be ? ToString(_value_).
             1. Else if _value_ has a [[BooleanData]] internal slot, then
-              1. Let _value_ be the value of _value_.[[BooleanData]].
+              1. Let _value_ be _value_.[[BooleanData]].
           1. If _value_ is *null*, return `"null"`.
           1. If _value_ is *true*, return `"true"`.
           1. If _value_ is *false*, return `"false"`.
@@ -34360,7 +34360,7 @@ THH:mm:ss.sss
           1. If Type(_generator_) is not Object, throw a *TypeError* exception.
           1. If _generator_ does not have a [[GeneratorState]] internal slot, throw a *TypeError* exception.
           1. Assert: _generator_ also has a [[GeneratorContext]] internal slot.
-          1. Let _state_ be the value of _generator_.[[GeneratorState]].
+          1. Let _state_ be _generator_.[[GeneratorState]].
           1. If _state_ is `"executing"`, throw a *TypeError* exception.
           1. Return _state_.
         </emu-alg>
@@ -34374,7 +34374,7 @@ THH:mm:ss.sss
           1. Let _state_ be ? GeneratorValidate(_generator_).
           1. If _state_ is `"completed"`, return CreateIterResultObject(*undefined*, *true*).
           1. Assert: _state_ is either `"suspendedStart"` or `"suspendedYield"`.
-          1. Let _genContext_ be the value of _generator_.[[GeneratorContext]].
+          1. Let _genContext_ be _generator_.[[GeneratorContext]].
           1. Let _methodContext_ be the running execution context.
           1. Suspend _methodContext_.
           1. Set _generator_.[[GeneratorState]] to `"executing"`.
@@ -34400,7 +34400,7 @@ THH:mm:ss.sss
               1. Return CreateIterResultObject(_abruptCompletion_.[[Value]], *true*).
             1. Return Completion(_abruptCompletion_).
           1. Assert: _state_ is `"suspendedYield"`.
-          1. Let _genContext_ be the value of _generator_.[[GeneratorContext]].
+          1. Let _genContext_ be _generator_.[[GeneratorContext]].
           1. Let _methodContext_ be the running execution context.
           1. Suspend _methodContext_.
           1. Set _generator_.[[GeneratorState]] to `"executing"`.
@@ -34420,7 +34420,7 @@ THH:mm:ss.sss
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
           1. Let _generator_ be the value of the Generator component of _genContext_.
-          1. Set the value of _generator_.[[GeneratorState]] to `"suspendedYield"`.
+          1. Set _generator_.[[GeneratorState]] to `"suspendedYield"`.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
             1. Return _resumptionValue_.
@@ -34607,8 +34607,8 @@ THH:mm:ss.sss
           <p>When a promise reject function _F_ is called with argument _reason_, the following steps are taken:</p>
           <emu-alg>
             1. Assert: _F_ has a [[Promise]] internal slot whose value is an Object.
-            1. Let _promise_ be the value of _F_.[[Promise]].
-            1. Let _alreadyResolved_ be the value of _F_.[[AlreadyResolved]].
+            1. Let _promise_ be _F_.[[Promise]].
+            1. Let _alreadyResolved_ be _F_.[[AlreadyResolved]].
             1. If _alreadyResolved_.[[Value]] is *true*, return *undefined*.
             1. Set _alreadyResolved_.[[Value]] to *true*.
             1. Return RejectPromise(_promise_, _reason_).
@@ -34623,8 +34623,8 @@ THH:mm:ss.sss
           <p>When a promise resolve function _F_ is called with argument _resolution_, the following steps are taken:</p>
           <emu-alg>
             1. Assert: _F_ has a [[Promise]] internal slot whose value is an Object.
-            1. Let _promise_ be the value of _F_.[[Promise]].
-            1. Let _alreadyResolved_ be the value of _F_.[[AlreadyResolved]].
+            1. Let _promise_ be _F_.[[Promise]].
+            1. Let _alreadyResolved_ be _F_.[[AlreadyResolved]].
             1. If _alreadyResolved_.[[Value]] is *true*, return *undefined*.
             1. Set _alreadyResolved_.[[Value]] to *true*.
             1. If SameValue(_resolution_, _promise_) is *true*, then
@@ -34651,11 +34651,11 @@ THH:mm:ss.sss
         <p>When the FulfillPromise abstract operation is called with arguments _promise_ and _value_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: The value of _promise_.[[PromiseState]] is `"pending"`.
-          1. Let _reactions_ be the value of _promise_.[[PromiseFulfillReactions]].
-          1. Set the value of _promise_.[[PromiseResult]] to _value_.
-          1. Set the value of _promise_.[[PromiseFulfillReactions]] to *undefined*.
-          1. Set the value of _promise_.[[PromiseRejectReactions]] to *undefined*.
-          1. Set the value of _promise_.[[PromiseState]] to `"fulfilled"`.
+          1. Let _reactions_ be _promise_.[[PromiseFulfillReactions]].
+          1. Set _promise_.[[PromiseResult]] to _value_.
+          1. Set _promise_.[[PromiseFulfillReactions]] to *undefined*.
+          1. Set _promise_.[[PromiseRejectReactions]] to *undefined*.
+          1. Set _promise_.[[PromiseState]] to `"fulfilled"`.
           1. Return TriggerPromiseReactions(_reactions_, _value_).
         </emu-alg>
       </emu-clause>
@@ -34687,7 +34687,7 @@ THH:mm:ss.sss
           <p>When a GetCapabilitiesExecutor function _F_ is called with arguments _resolve_ and _reject_, the following steps are taken:</p>
           <emu-alg>
             1. Assert: _F_ has a [[Capability]] internal slot whose value is a PromiseCapability Record.
-            1. Let _promiseCapability_ be the value of _F_.[[Capability]].
+            1. Let _promiseCapability_ be _F_.[[Capability]].
             1. If _promiseCapability_.[[Resolve]] is not *undefined*, throw a *TypeError* exception.
             1. If _promiseCapability_.[[Reject]] is not *undefined*, throw a *TypeError* exception.
             1. Set _promiseCapability_.[[Resolve]] to _resolve_.
@@ -34715,12 +34715,12 @@ THH:mm:ss.sss
         <p>When the RejectPromise abstract operation is called with arguments _promise_ and _reason_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: The value of _promise_.[[PromiseState]] is `"pending"`.
-          1. Let _reactions_ be the value of _promise_.[[PromiseRejectReactions]].
-          1. Set the value of _promise_.[[PromiseResult]] to _reason_.
-          1. Set the value of _promise_.[[PromiseFulfillReactions]] to *undefined*.
-          1. Set the value of _promise_.[[PromiseRejectReactions]] to *undefined*.
-          1. Set the value of _promise_.[[PromiseState]] to `"rejected"`.
-          1. If the value of _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
+          1. Let _reactions_ be _promise_.[[PromiseRejectReactions]].
+          1. Set _promise_.[[PromiseResult]] to _reason_.
+          1. Set _promise_.[[PromiseFulfillReactions]] to *undefined*.
+          1. Set _promise_.[[PromiseRejectReactions]] to *undefined*.
+          1. Set _promise_.[[PromiseState]] to `"rejected"`.
+          1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
           1. Return TriggerPromiseReactions(_reactions_, _reason_).
         </emu-alg>
       </emu-clause>
@@ -34907,13 +34907,13 @@ THH:mm:ss.sss
           <p>A Promise.all resolve element function is an anonymous built-in function that is used to resolve a specific Promise.all element. Each Promise.all resolve element function has [[Index]], [[Values]], [[Capabilities]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
           <p>When a Promise.all resolve element function _F_ is called with argument _x_, the following steps are taken:</p>
           <emu-alg>
-            1. Let _alreadyCalled_ be the value of _F_.[[AlreadyCalled]].
+            1. Let _alreadyCalled_ be _F_.[[AlreadyCalled]].
             1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
             1. Set _alreadyCalled_.[[Value]] to *true*.
-            1. Let _index_ be the value of _F_.[[Index]].
-            1. Let _values_ be the value of _F_.[[Values]].
-            1. Let _promiseCapability_ be the value of _F_.[[Capabilities]].
-            1. Let _remainingElementsCount_ be the value of _F_.[[RemainingElements]].
+            1. Let _index_ be _F_.[[Index]].
+            1. Let _values_ be _F_.[[Values]].
+            1. Let _promiseCapability_ be _F_.[[Capabilities]].
+            1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Set _values_[_index_] to _x_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
@@ -35072,16 +35072,16 @@ THH:mm:ss.sss
               1. Let _onRejected_ be *undefined*.
             1. Let _fulfillReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
             1. Let _rejectReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
-            1. If the value of _promise_.[[PromiseState]] is `"pending"`, then
-              1. Append _fulfillReaction_ as the last element of the List that is the value of _promise_.[[PromiseFulfillReactions]].
-              1. Append _rejectReaction_ as the last element of the List that is the value of _promise_.[[PromiseRejectReactions]].
-            1. Else if the value of _promise_.[[PromiseState]] is `"fulfilled"`, then
-              1. Let _value_ be the value of _promise_.[[PromiseResult]].
+            1. If _promise_.[[PromiseState]] is `"pending"`, then
+              1. Append _fulfillReaction_ as the last element of the List that is _promise_.[[PromiseFulfillReactions]].
+              1. Append _rejectReaction_ as the last element of the List that is _promise_.[[PromiseRejectReactions]].
+            1. Else if _promise_.[[PromiseState]] is `"fulfilled"`, then
+              1. Let _value_ be _promise_.[[PromiseResult]].
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _fulfillReaction_, _value_ &raquo;).
             1. Else,
               1. Assert: The value of _promise_.[[PromiseState]] is `"rejected"`.
-              1. Let _reason_ be the value of _promise_.[[PromiseResult]].
-              1. If the value of _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
+              1. Let _reason_ be _promise_.[[PromiseResult]].
+              1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _rejectReaction_, _reason_ &raquo;).
             1. Set _promise_.[[PromiseIsHandled]] to *true*.
             1. Return _resultCapability_.[[Promise]].
@@ -35368,9 +35368,9 @@ THH:mm:ss.sss
           <p>Each Proxy revocation function has a [[RevocableProxy]] internal slot.</p>
           <p>When a Proxy revocation function, _F_, is called, the following steps are taken:</p>
           <emu-alg>
-            1. Let _p_ be the value of _F_.[[RevocableProxy]].
+            1. Let _p_ be _F_.[[RevocableProxy]].
             1. If _p_ is *null*, return *undefined*.
-            1. Set the value of _F_.[[RevocableProxy]] to *null*.
+            1. Set _F_.[[RevocableProxy]] to *null*.
             1. Assert: _p_ is a Proxy object.
             1. Set _p_.[[ProxyTarget]] to *null*.
             1. Set _p_.[[ProxyHandler]] to *null*.
@@ -35402,7 +35402,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _N_ be the *this* value.
         1. If _N_ is not a module namespace exotic object, throw a *TypeError* exception.
-        1. Let _exports_ be the value of _N_.[[Exports]].
+        1. Let _exports_ be _N_.[[Exports]].
         1. Return ! CreateListIterator(_exports_).
       </emu-alg>
       <p>The value of the `name` property of this function is `"[Symbol.iterator]"`.</p>
@@ -36568,8 +36568,8 @@ THH:mm:ss.sss
             1. Throw a *TypeError* exception.
           1. If Type(_pattern_) is Object and _pattern_ has a [[RegExpMatcher]] internal slot, then
             1. If _flags_ is not *undefined*, throw a *TypeError* exception.
-            1. Let _P_ be the value of _pattern_.[[OriginalSource]].
-            1. Let _F_ be the value of _pattern_.[[OriginalFlags]].
+            1. Let _P_ be _pattern_.[[OriginalSource]].
+            1. Let _F_ be _pattern_.[[OriginalFlags]].
           1. Else,
             1. Let _P_ be _pattern_.
             1. Let _F_ be _flags_.

--- a/spec.html
+++ b/spec.html
@@ -3700,7 +3700,7 @@
               Boolean
             </td>
             <td>
-              Return a new Boolean object whose [[BooleanData]] internal slot is set to the value of _argument_. See <emu-xref href="#sec-boolean-objects"></emu-xref> for a description of Boolean objects.
+              Return a new Boolean object whose [[BooleanData]] internal slot is set to _argument_. See <emu-xref href="#sec-boolean-objects"></emu-xref> for a description of Boolean objects.
             </td>
           </tr>
           <tr>
@@ -3708,7 +3708,7 @@
               Number
             </td>
             <td>
-              Return a new Number object whose [[NumberData]] internal slot is set to the value of _argument_. See <emu-xref href="#sec-number-objects"></emu-xref> for a description of Number objects.
+              Return a new Number object whose [[NumberData]] internal slot is set to _argument_. See <emu-xref href="#sec-number-objects"></emu-xref> for a description of Number objects.
             </td>
           </tr>
           <tr>
@@ -3716,7 +3716,7 @@
               String
             </td>
             <td>
-              Return a new String object whose [[StringData]] internal slot is set to the value of _argument_. See <emu-xref href="#sec-string-objects"></emu-xref> for a description of String objects.
+              Return a new String object whose [[StringData]] internal slot is set to _argument_. See <emu-xref href="#sec-string-objects"></emu-xref> for a description of String objects.
             </td>
           </tr>
           <tr>
@@ -3724,7 +3724,7 @@
               Symbol
             </td>
             <td>
-              Return a new Symbol object whose [[SymbolData]] internal slot is set to the value of _argument_. See <emu-xref href="#sec-symbol-objects"></emu-xref> for a description of Symbol objects.
+              Return a new Symbol object whose [[SymbolData]] internal slot is set to _argument_. See <emu-xref href="#sec-symbol-objects"></emu-xref> for a description of Symbol objects.
             </td>
           </tr>
           <tr>
@@ -5422,7 +5422,7 @@
           <emu-alg>
             1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
-            1. If _varDeclaredNames_ contains the value of _N_, return *true*.
+            1. If _varDeclaredNames_ contains _N_, return *true*.
             1. Return *false*.
           </emu-alg>
         </emu-clause>
@@ -5500,7 +5500,7 @@
               1. Perform ? _ObjRec_.CreateMutableBinding(_N_, _D_).
               1. Perform ? _ObjRec_.InitializeBinding(_N_, *undefined*).
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
-            1. If _varDeclaredNames_ does not contain the value of _N_, then
+            1. If _varDeclaredNames_ does not contain _N_, then
               1. Append _N_ to _varDeclaredNames_.
             1. Return NormalCompletion(~empty~).
           </emu-alg>
@@ -5523,7 +5523,7 @@
             1. Record that the binding for _N_ in _ObjRec_ has been initialized.
             1. Perform ? Set(_globalObject_, _N_, _V_, *false*).
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
-            1. If _varDeclaredNames_ does not contain the value of _N_, then
+            1. If _varDeclaredNames_ does not contain _N_, then
               1. Append _N_ to _varDeclaredNames_.
             1. Return NormalCompletion(~empty~).
           </emu-alg>
@@ -6921,7 +6921,7 @@
         1. Let _len_ be the ExpectedArgumentCount of _ParameterList_.
         1. Perform ! DefinePropertyOrThrow(_F_, `"length"`, PropertyDescriptor{[[Value]]: _len_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
         1. Let _Strict_ be _F_.[[Strict]].
-        1. Set _F_.[[Environment]] to the value of _Scope_.
+        1. Set _F_.[[Environment]] to _Scope_.
         1. Set _F_.[[FormalParameters]] to _ParameterList_.
         1. Set _F_.[[ECMAScriptCode]] to _Body_.
         1. Set _F_.[[ScriptOrModule]] to GetActiveScriptOrModule().
@@ -7323,7 +7323,7 @@
           1. Set _obj_.[[Prototype]] to _proto_.
           1. Set _obj_.[[Extensible]] to *true*.
           1. Set _obj_.[[BoundTargetFunction]] to _targetFunction_.
-          1. Set _obj_.[[BoundThis]] to the value of _boundThis_.
+          1. Set _obj_.[[BoundThis]] to _boundThis_.
           1. Set _obj_.[[BoundArguments]] to _boundArgs_.
           1. Return _obj_.
         </emu-alg>
@@ -7548,7 +7548,7 @@
           1. If _desc_ is *undefined*, return _desc_.
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
-          1. If the value of _isMapped_ is *true*, then
+          1. If _isMapped_ is *true*, then
             1. Set _desc_.[[Value]] to Get(_map_, _P_).
           1. If IsDataDescriptor(_desc_) is *true* and _P_ is `"caller"` and _desc_.[[Value]] is a strict mode Function object, throw a *TypeError* exception.
           1. Return _desc_.
@@ -7571,7 +7571,7 @@
               1. Set _newArgDesc_.[[Value]] to Get(_map_, _P_).
           1. Let _allowed_ be ? OrdinaryDefineOwnProperty(_args_, _P_, _newArgDesc_).
           1. If _allowed_ is *false*, return *false*.
-          1. If the value of _isMapped_ is *true*, then
+          1. If _isMapped_ is *true*, then
             1. If IsAccessorDescriptor(_Desc_) is *true*, then
               1. Call _map_.[[Delete]](_P_).
             1. Else,
@@ -7592,7 +7592,7 @@
           1. Let _args_ be the arguments object.
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
-          1. If the value of _isMapped_ is *false*, then
+          1. If _isMapped_ is *false*, then
             1. Return ? OrdinaryGet(_args_, _P_, _Receiver_).
           1. Else _map_ contains a formal parameter mapping for _P_,
             1. Return Get(_map_, _P_).
@@ -7639,7 +7639,7 @@
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. Let _result_ be ? OrdinaryDelete(_args_, _P_).
-          1. If _result_ is *true* and the value of _isMapped_ is *true*, then
+          1. If _result_ is *true* and _isMapped_ is *true*, then
             1. Call _map_.[[Delete]](_P_).
           1. Return _result_.
         </emu-alg>
@@ -22040,7 +22040,7 @@
                 1. Let _j_ be 0.
                 1. Repeat, while _j_ &lt; _L_
                   1. Let _jOctet_ be the value at index _j_ within _Octets_.
-                  1. Let _S_ be a String containing three code units <code>"%<var>XY</var>"</code> where _XY_ are two uppercase hexadecimal digits encoding the value of _jOctet_.
+                  1. Let _S_ be a String containing three code units <code>"%<var>XY</var>"</code> where _XY_ are two uppercase hexadecimal digits encoding _jOctet_.
                   1. Let _R_ be a new String value computed by concatenating the previous value of _R_ and _S_.
                   1. Increase _j_ by 1.
               1. Increase _k_ by 1.
@@ -36193,9 +36193,9 @@ THH:mm:ss.sss
             1. If _char_ is one of the code units in `"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@*_+-./"`, then
               1. Let _S_ be a String containing the single code unit _char_.
             1. Else if _char_ &ge; 256, then
-              1. Let _S_ be a String containing six code units <code>"%u<var>wxyz</var>"</code> where _wxyz_ are the code units of the four uppercase hexadecimal digits encoding the value of _char_.
+              1. Let _S_ be a String containing six code units <code>"%u<var>wxyz</var>"</code> where _wxyz_ are the code units of the four uppercase hexadecimal digits encoding _char_.
             1. Else _char_ &lt; 256,
-              1. Let _S_ be a String containing three code units <code>"%<var>xy</var>"</code> where _xy_ are the code units of two uppercase hexadecimal digits encoding the value of _char_.
+              1. Let _S_ be a String containing three code units <code>"%<var>xy</var>"</code> where _xy_ are the code units of two uppercase hexadecimal digits encoding _char_.
             1. Let _R_ be a new String value computed by concatenating the previous value of _R_ and _S_.
             1. Increase _k_ by 1.
           1. Return _R_.


### PR DESCRIPTION
I removed it from _every_ phrase of the form
```
the value of _V_.[[Foo]]
```
and some (16) phrases of the form
```
the value of _V_
```

There are still some occurrences of the latter form, and also a few others (about 30 in total). I left them in...
- when it's talking about the value of a property, or a binding, or an attribute of a property; or
- when taking it out left a sentence that seemed odd or possibly misleading to me. YMMV.