### PR TITLE
Editorial: Remove extraneous spaces

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11234,9 +11234,9 @@
     <!-- es6num="12.2.7" -->
     <emu-clause id="sec-function-defining-expressions">
       <h1>Function Defining Expressions</h1>
-      <p>See <emu-xref href="#sec-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : FunctionExpression</emu-grammar> .</p>
-      <p>See <emu-xref href="#sec-generator-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : GeneratorExpression</emu-grammar> .</p>
-      <p>See <emu-xref href="#sec-class-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : ClassExpression</emu-grammar> .</p>
+      <p>See <emu-xref href="#sec-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : FunctionExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-generator-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : GeneratorExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-class-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : ClassExpression</emu-grammar>.</p>
     </emu-clause>
 
     <!-- es6num="12.2.8" -->
@@ -28388,9 +28388,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-characterclassescape">
         <h1>CharacterClassEscape</h1>
         <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates by returning the ten-element set of characters containing the characters `0` through `9` inclusive.</p>
-        <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> .</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar>.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates by returning the set of characters containing the characters that are on the right-hand side of the |WhiteSpace| or |LineTerminator| productions.</p>
-        <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> .</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar>.</p>
         <p>The production <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> evaluates by returning the set of characters containing the sixty-three characters:</p>
         <figure>
           <table class="lightweight-table">
@@ -28623,7 +28623,7 @@ THH:mm:ss.sss
             </tbody>
           </table>
         </figure>
-        <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> .</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates by returning the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar>.</p>
       </emu-clause>
 
       <!-- es6num="21.2.2.13" -->
@@ -36596,7 +36596,7 @@ THH:mm:ss.sss
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for `"__proto__"` and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar> .
+          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for `"__proto__"` and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
         </li>
       </ul>
       <emu-note>


### PR DESCRIPTION
Replace `</emu-grammar> .` with `</emu-grammar>.`.