### PR TITLE
Editorial: minor tidy-ups in the promise sections

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34457,7 +34457,7 @@ THH:mm:ss.sss
       <!-- es6num="25.4.1.1" -->
       <emu-clause id="sec-promisecapability-records">
         <h1>PromiseCapability Records</h1>
-        <p>A PromiseCapability is a Record value used to encapsulate a promise object along with the functions that are capable of resolving or rejecting that promise object. PromiseCapability records are produced by the NewPromiseCapability abstract operation.</p>
+        <p>A PromiseCapability is a Record value used to encapsulate a promise object along with the functions that are capable of resolving or rejecting that promise object. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
         <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-57"></emu-xref>.</p>
         <emu-table id="table-57" caption="PromiseCapability Record Fields">
           <table>
@@ -34513,7 +34513,7 @@ THH:mm:ss.sss
         <!-- es6num="25.4.1.1.1" -->
         <emu-clause id="sec-ifabruptrejectpromise" aoid="IfAbruptRejectPromise">
           <h1>IfAbruptRejectPromise ( _value_, _capability_ )</h1>
-          <p>IfAbruptRejectPromise is a short hand for a sequence of algorithm steps that use a PromiseCapability record. An algorithm step of the form:</p>
+          <p>IfAbruptRejectPromise is a short hand for a sequence of algorithm steps that use a PromiseCapability Record. An algorithm step of the form:</p>
           <emu-alg>
             1. IfAbruptRejectPromise(_value_, _capability_).
           </emu-alg>
@@ -34548,10 +34548,10 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                [[Capabilities]]
+                [[Capability]]
               </td>
               <td>
-                A PromiseCapability record
+                A PromiseCapability Record
               </td>
               <td>
                 The capabilities of the promise for which this record provides a reaction handler.
@@ -34662,12 +34662,12 @@ THH:mm:ss.sss
       <!-- es6num="25.4.1.5" -->
       <emu-clause id="sec-newpromisecapability" aoid="NewPromiseCapability">
         <h1>NewPromiseCapability ( _C_ )</h1>
-        <p>The abstract operation NewPromiseCapability takes a constructor function, and attempts to use that constructor function in the fashion of the built-in `Promise` constructor to create a Promise object and extract its resolve and reject functions. The promise plus the resolve and reject functions are used to initialize a new PromiseCapability record which is returned as the value of this abstract operation.</p>
+        <p>The abstract operation NewPromiseCapability takes a constructor function, and attempts to use that constructor function in the fashion of the built-in `Promise` constructor to create a Promise object and extract its resolve and reject functions. The promise plus the resolve and reject functions are used to initialize a new PromiseCapability Record which is returned as the value of this abstract operation.</p>
         <emu-alg>
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
           1. NOTE _C_ is assumed to be a constructor function that supports the parameter conventions of the `Promise` constructor (see <emu-xref href="#sec-promise-executor"></emu-xref>).
           1. Let _promiseCapability_ be a new PromiseCapability { [[Promise]]: *undefined*, [[Resolve]]: *undefined*, [[Reject]]: *undefined* }.
-          1. Let _executor_ be a new built-in function object as defined in GetCapabilitiesExecutor Functions (<emu-xref href="#sec-getcapabilitiesexecutor-functions"></emu-xref>).
+          1. Let _executor_ be a new built-in function object as defined in <emu-xref href="#sec-getcapabilitiesexecutor-functions" title></emu-xref>.
           1. Set _executor_.[[Capability]] to _promiseCapability_.
           1. Let _promise_ be ? Construct(_C_, &laquo; _executor_ &raquo;).
           1. If IsCallable(_promiseCapability_.[[Resolve]]) is *false*, throw a *TypeError* exception.
@@ -34769,7 +34769,7 @@ THH:mm:ss.sss
         <p>The job PromiseReactionJob with parameters _reaction_ and _argument_ applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler.</p>
         <emu-alg>
           1. Assert: _reaction_ is a PromiseReaction Record.
-          1. Let _promiseCapability_ be _reaction_.[[Capabilities]].
+          1. Let _promiseCapability_ be _reaction_.[[Capability]].
           1. Let _type_ be _reaction_.[[Type]].
           1. Let _handler_ be _reaction_.[[Handler]].
           1. If _handler_ is *undefined*, then
@@ -34851,7 +34851,7 @@ THH:mm:ss.sss
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _iterator_ be GetIterator(_iterable_).
           1. IfAbruptRejectPromise(_iterator_, _promiseCapability_).
-          1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
+          1. Let _iteratorRecord_ be Record { [[Iterator]]: _iterator_, [[Done]]: *false* }.
           1. Let _result_ be PerformPromiseAll(_iteratorRecord_, _C_, _promiseCapability_).
           1. If _result_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, let _result_ be IteratorClose(_iterator_, _result_).
@@ -34864,11 +34864,11 @@ THH:mm:ss.sss
 
         <!-- es6num="25.4.4.1.1" -->
         <emu-clause id="sec-performpromiseall" aoid="PerformPromiseAll">
-          <h1>Runtime Semantics: PerformPromiseAll( _iteratorRecord_, _constructor_, _resultCapability_)</h1>
+          <h1>Runtime Semantics: PerformPromiseAll( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
           <p>When the PerformPromiseAll abstract operation is called with arguments _iteratorRecord_, _constructor_, and _resultCapability_, the following steps are taken:</p>
           <emu-alg>
             1. Assert: _constructor_ is a constructor function.
-            1. Assert: _resultCapability_ is a PromiseCapability record.
+            1. Assert: _resultCapability_ is a PromiseCapability Record.
             1. Let _values_ be a new empty List.
             1. Let _remainingElementsCount_ be a new Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
@@ -34888,11 +34888,11 @@ THH:mm:ss.sss
               1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _values_.
               1. Let _nextPromise_ be ? Invoke(_constructor_, `"resolve"`, &laquo; _nextValue_ &raquo;).
-              1. Let _resolveElement_ be a new built-in function object as defined in Promise.all Resolve Element Functions.
-              1. Set _resolveElement_.[[AlreadyCalled]] to a new Record {[[Value]]: *false* }.
+              1. Let _resolveElement_ be a new built-in function object as defined in <emu-xref href="#sec-promise.all-resolve-element-functions" title></emu-xref>.
+              1. Set _resolveElement_.[[AlreadyCalled]] to a new Record { [[Value]]: *false* }.
               1. Set _resolveElement_.[[Index]] to _index_.
               1. Set _resolveElement_.[[Values]] to _values_.
-              1. Set _resolveElement_.[[Capabilities]] to _resultCapability_.
+              1. Set _resolveElement_.[[Capability]] to _resultCapability_.
               1. Set _resolveElement_.[[RemainingElements]] to _remainingElementsCount_.
               1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] + 1.
               1. Perform ? Invoke(_nextPromise_, `"then"`, &laquo; _resolveElement_, _resultCapability_.[[Reject]] &raquo;).
@@ -34902,16 +34902,16 @@ THH:mm:ss.sss
 
         <!-- es6num="25.4.4.1.2" -->
         <emu-clause id="sec-promise.all-resolve-element-functions">
-          <h1>Promise.all Resolve Element Functions</h1>
-          <p>A Promise.all resolve element function is an anonymous built-in function that is used to resolve a specific Promise.all element. Each Promise.all resolve element function has [[Index]], [[Values]], [[Capabilities]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
-          <p>When a Promise.all resolve element function _F_ is called with argument _x_, the following steps are taken:</p>
+          <h1>`Promise.all` Resolve Element Functions</h1>
+          <p>A `Promise.all` resolve element function is an anonymous built-in function that is used to resolve a specific `Promise.all` element. Each `Promise.all` resolve element function has [[Index]], [[Values]], [[Capability]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
+          <p>When a `Promise.all` resolve element function _F_ is called with argument _x_, the following steps are taken:</p>
           <emu-alg>
             1. Let _alreadyCalled_ be the value of _F_.[[AlreadyCalled]].
             1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
             1. Set _alreadyCalled_.[[Value]] to *true*.
             1. Let _index_ be the value of _F_.[[Index]].
             1. Let _values_ be the value of _F_.[[Values]].
-            1. Let _promiseCapability_ be the value of _F_.[[Capabilities]].
+            1. Let _promiseCapability_ be the value of _F_.[[Capability]].
             1. Let _remainingElementsCount_ be the value of _F_.[[RemainingElements]].
             1. Set _values_[_index_] to _x_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
@@ -34920,7 +34920,7 @@ THH:mm:ss.sss
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The `length` property of a Promise.all resolve element function is 1.</p>
+          <p>The `length` property of a `Promise.all` resolve element function is 1.</p>
         </emu-clause>
       </emu-clause>
 
@@ -34941,8 +34941,8 @@ THH:mm:ss.sss
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _iterator_ be GetIterator(_iterable_).
           1. IfAbruptRejectPromise(_iterator_, _promiseCapability_).
-          1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
-          1. Let _result_ be PerformPromiseRace(_iteratorRecord_, _promiseCapability_, _C_).
+          1. Let _iteratorRecord_ be Record { [[Iterator]]: _iterator_, [[Done]]: *false* }.
+          1. Let _result_ be PerformPromiseRace(_iteratorRecord_, _C_, _promiseCapability_).
           1. If _result_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, let _result_ be IteratorClose(_iterator_, _result_).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
@@ -34957,21 +34957,23 @@ THH:mm:ss.sss
 
         <!-- es6num="25.4.4.3.1" -->
         <emu-clause id="sec-performpromiserace" aoid="PerformPromiseRace">
-          <h1>Runtime Semantics: PerformPromiseRace ( _iteratorRecord_, _promiseCapability_, _C_ )</h1>
-          <p>When the PerformPromiseRace abstract operation is called with arguments _iteratorRecord_, _promiseCapability_, and _C_, the following steps are taken:</p>
+          <h1>Runtime Semantics: PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
+          <p>When the PerformPromiseRace abstract operation is called with arguments _iteratorRecord_, _constructor_, and _resultCapability_, the following steps are taken:</p>
           <emu-alg>
+            1. Assert: _constructor_ is a constructor function.
+            1. Assert: _resultCapability_ is a PromiseCapability Record.
             1. Repeat
               1. Let _next_ be IteratorStep(_iteratorRecord_.[[Iterator]]).
               1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_next_).
               1. If _next_ is *false*, then
                 1. Set _iteratorRecord_.[[Done]] to *true*.
-                1. Return _promiseCapability_.[[Promise]].
+                1. Return _resultCapability_.[[Promise]].
               1. Let _nextValue_ be IteratorValue(_next_).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
-              1. Let _nextPromise_ be ? Invoke(_C_, `"resolve"`, &laquo; _nextValue_ &raquo;).
-              1. Perform ? Invoke(_nextPromise_, `"then"`, &laquo; _promiseCapability_.[[Resolve]], _promiseCapability_.[[Reject]] &raquo;).
+              1. Let _nextPromise_ be ? Invoke(_constructor_, `"resolve"`, &laquo; _nextValue_ &raquo;).
+              1. Perform ? Invoke(_nextPromise_, `"then"`, &laquo; _resultCapability_.[[Resolve]], _resultCapability_.[[Reject]] &raquo;).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -35064,13 +35066,13 @@ THH:mm:ss.sss
           <p>The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. The result is _resultCapability_'s promise.</p>
           <emu-alg>
             1. Assert: IsPromise(_promise_) is *true*.
-            1. Assert: _resultCapability_ is a PromiseCapability record.
+            1. Assert: _resultCapability_ is a PromiseCapability Record.
             1. If IsCallable(_onFulfilled_) is *false*, then
               1. Let _onFulfilled_ be *undefined*.
             1. If IsCallable(_onRejected_) is *false*, then
               1. Let _onRejected_ be *undefined*.
-            1. Let _fulfillReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
-            1. Let _rejectReaction_ be the PromiseReaction { [[Capabilities]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
+            1. Let _fulfillReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
+            1. Let _rejectReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
             1. If the value of _promise_.[[PromiseState]] is `"pending"`, then
               1. Append _fulfillReaction_ as the last element of the List that is the value of _promise_.[[PromiseFulfillReactions]].
               1. Append _rejectReaction_ as the last element of the List that is the value of _promise_.[[PromiseRejectReactions]].


### PR DESCRIPTION
- Consistently use record fields named [[Capability]] to store PromiseCapability records, instead of [[Capabilities]].
- Consistently uppercase PromiseCapability *R*ecord
- Consistify PerformPromiseAll and PerformPromiseRace
- Cross-reference Promise.all resolve element functions correctly
- Add missing whitespace in a few places