### PR TITLE
Normative: DataView methods should throw for absent byteOffset

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33378,6 +33378,7 @@ THH:mm:ss.sss
         <p>When the `getFloat32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Float32"`).
         </emu-alg>
@@ -33389,6 +33390,7 @@ THH:mm:ss.sss
         <p>When the `getFloat64` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Float64"`).
         </emu-alg>
@@ -33400,6 +33402,7 @@ THH:mm:ss.sss
         <p>When the `getInt8` method is called with argument _byteOffset_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. Return ? GetViewValue(_v_, _byteOffset_, *true*, `"Int8"`).
         </emu-alg>
       </emu-clause>
@@ -33410,6 +33413,7 @@ THH:mm:ss.sss
         <p>When the `getInt16` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int16"`).
         </emu-alg>
@@ -33421,6 +33425,7 @@ THH:mm:ss.sss
         <p>When the `getInt32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *undefined*.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int32"`).
         </emu-alg>
@@ -33432,6 +33437,7 @@ THH:mm:ss.sss
         <p>When the `getUint8` method is called with argument _byteOffset_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. Return ? GetViewValue(_v_, _byteOffset_, *true*, `"Uint8"`).
         </emu-alg>
       </emu-clause>
@@ -33442,6 +33448,7 @@ THH:mm:ss.sss
         <p>When the `getUint16` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint16"`).
         </emu-alg>
@@ -33453,6 +33460,7 @@ THH:mm:ss.sss
         <p>When the `getUint32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint32"`).
         </emu-alg>
@@ -33464,6 +33472,7 @@ THH:mm:ss.sss
         <p>When the `setFloat32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Float32"`, _value_).
         </emu-alg>
@@ -33475,6 +33484,7 @@ THH:mm:ss.sss
         <p>When the `setFloat64` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Float64"`, _value_).
         </emu-alg>
@@ -33486,6 +33496,7 @@ THH:mm:ss.sss
         <p>When the `setInt8` method is called with arguments _byteOffset_ and _value_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. Return ? SetViewValue(_v_, _byteOffset_, *true*, `"Int8"`, _value_).
         </emu-alg>
       </emu-clause>
@@ -33496,6 +33507,7 @@ THH:mm:ss.sss
         <p>When the `setInt16` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int16"`, _value_).
         </emu-alg>
@@ -33507,6 +33519,7 @@ THH:mm:ss.sss
         <p>When the `setInt32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int32"`, _value_).
         </emu-alg>
@@ -33518,6 +33531,7 @@ THH:mm:ss.sss
         <p>When the `setUint8` method is called with arguments _byteOffset_ and _value_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. Return ? SetViewValue(_v_, _byteOffset_, *true*, `"Uint8"`, _value_).
         </emu-alg>
       </emu-clause>
@@ -33528,6 +33542,7 @@ THH:mm:ss.sss
         <p>When the `setUint16` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint16"`, _value_).
         </emu-alg>
@@ -33539,6 +33554,7 @@ THH:mm:ss.sss
         <p>When the `setUint32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
+          1. If _byteOffset_ is not present, throw a *TypeError* exception.
           1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint32"`, _value_).
         </emu-alg>


### PR DESCRIPTION
ES2016's [GetViewValue](https://tc39.github.io/ecma262/2016/#sec-getviewvalue) (and the SetViewValue) throws for undefined byteOffset arg, after #410, [it casts to 0 using ToIndex](https://tc39.github.io/ecma262/#sec-getviewvalue)

This change throws a TypeError only when the argument is absent. e.g.: `new DataView(buffer, 0).getFloat32()`

---

The alternative for this change is changing GetViewValue and SetViewValue, but that would also affect when the argument is present as `undefined` and the methods would become slightly different from the normalization introduced with ToIndex.