### PR TITLE
[editorial] Remove unused "HasComputedPropertyKey"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11075,25 +11075,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.6.4" -->
-      <emu-clause id="sec-object-initializer-static-semantics-hascomputedpropertykey">
-        <h1>Static Semantics: HasComputedPropertyKey</h1>
-        <emu-see-also-para op="HasComputedPropertyKey"></emu-see-also-para>
-        <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
-        <emu-alg>
-          1. If HasComputedPropertyKey of |PropertyDefinitionList| is *true*, return *true*.
-          1. Return HasComputedPropertyKey of |PropertyDefinition|.
-        </emu-alg>
-        <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
-        <emu-alg>
-          1. Return IsComputedPropertyKey of |PropertyName|.
-        </emu-alg>
-      </emu-clause>
-
       <!-- es6num="12.2.6.5" -->
       <emu-clause id="sec-static-semantics-iscomputedpropertykey">
         <h1>Static Semantics: IsComputedPropertyKey</h1>
@@ -18259,21 +18240,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.3.4" -->
-    <emu-clause id="sec-method-definitions-static-semantics-hascomputedpropertykey">
-      <h1>Static Semantics: HasComputedPropertyKey</h1>
-      <emu-see-also-para op="HasComputedPropertyKey"></emu-see-also-para>
-      <emu-grammar>
-        MethodDefinition :
-          PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`
-          `get` PropertyName `(` `)` `{` FunctionBody `}`
-          `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return IsComputedPropertyKey of |PropertyName|.
-      </emu-alg>
-    </emu-clause>
-
     <!-- es6num="14.3.5" -->
     <emu-clause id="sec-method-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
@@ -18522,16 +18488,6 @@
       <emu-note>
         <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
       </emu-note>
-    </emu-clause>
-
-    <!-- es6num="14.4.5" -->
-    <emu-clause id="sec-generator-function-definitions-static-semantics-hascomputedpropertykey">
-      <h1>Static Semantics: HasComputedPropertyKey</h1>
-      <emu-see-also-para op="HasComputedPropertyKey"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` StrictFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return IsComputedPropertyKey of |PropertyName|.
-      </emu-alg>
     </emu-clause>
 
     <!-- es6num="14.4.6" -->


### PR DESCRIPTION
HasComputedPropertyKey was introduced in revision 20 of 2015 [1], but in
that draft, it was not referenced from any other algorithm (nor mentioned
in the accompanying change log [2]). The latest revision of ECMA
maintains the abstract operation in this state.

Remove HasComputedPropertyKey due to its being superfluous to the
specification.

[1] http://wiki.ecmascript.org/lib/exe/fetch.php?id=harmony%3Aspecification_drafts&cache=cache&media=harmony:working_draft_ecma-262_edition_6_10-28-13-rev20markup.pdf
[2] http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts&s=es6#october_28_2013_draft_rev_20