### PR TITLE
Normative: Resolve template argument references

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11353,8 +11353,8 @@
         <emu-alg>
           1. Let _templateLiteral_ be this |TemplateLiteral|.
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
-          1. Let _firstSub_ be the result of evaluating |Expression|.
-          1. ReturnIfAbrupt(_firstSub_).
+          1. Let _firstSubRef_ be the result of evaluating |Expression|.
+          1. Let _firstSub_ be ? GetValue(_firstSubRef_).
           1. Let _restSub_ be SubstitutionEvaluation of |TemplateSpans|.
           1. ReturnIfAbrupt(_restSub_).
           1. Assert: _restSub_ is a List.
@@ -11415,16 +11415,16 @@
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _sub_ be the result of evaluating |Expression|.
-          1. ReturnIfAbrupt(_sub_).
+          1. Let _subRef_ be the result of evaluating |Expression|.
+          1. Let _sub_ be ? GetValue(_subRef_).
           1. Return a List containing only _sub_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _preceding_ be the result of SubstitutionEvaluation of |TemplateMiddleList|.
           1. ReturnIfAbrupt(_preceding_).
-          1. Let _next_ be the result of evaluating |Expression|.
-          1. ReturnIfAbrupt(_next_).
+          1. Let _nextRef_ be the result of evaluating |Expression|.
+          1. Let _next_ be ? GetValue(_nextRef_).
           1. Append _next_ as the last element of the List _preceding_.
           1. Return _preceding_.
         </emu-alg>


### PR DESCRIPTION
Previously, when performing ArgumentListEvaluation for tagged templates,
the result of evaluating each substitution expression was not passed to
GetValue. This meant that unresolvable references would not interrupt
ArgumentListEvaluation, and that Reference values would eventually be
assigned to function parameter bindings in
FunctionDeclarationInstantiation.

Update ArgumentListEvaluation (and the related SubstitutionEvaluation)
to avoid this situation and increase parity with the abstract
operation's behavior when applied to the Arguments production.