### PR TITLE
Editorial: Remove impossible condition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17865,14 +17865,13 @@
       </emu-alg>
       <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. If the function code for |FunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
-        1. Let _F_ be FunctionCreate(~Normal~, |FormalParameters|, |FunctionBody|, _scope_, _strict_).
+        1. Let _F_ be FunctionCreate(~Normal~, |FormalParameters|, |FunctionBody|, _scope_, *true*).
         1. Perform MakeConstructor(_F_).
         1. Perform SetFunctionName(_F_, `"default"`).
         1. Return _F_.
       </emu-alg>
       <emu-note>
-        <p>An anonymous |FunctionDeclaration| can only occur as part of an `export default` declaration.</p>
+        <p>An anonymous |FunctionDeclaration| can only occur as part of an `export default` declaration, and its function code is therefore always strict mode code.</p>
       </emu-note>
     </emu-clause>
 
@@ -18590,15 +18589,14 @@
       </emu-alg>
       <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. If the function code for |GeneratorDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
-        1. Let _F_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_, _strict_).
+        1. Let _F_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_, *true*).
         1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
         1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
         1. Perform SetFunctionName(_F_, `"default"`).
         1. Return _F_.
       </emu-alg>
       <emu-note>
-        <p>An anonymous |GeneratorDeclaration| can only occur as part of an `export default` declaration.</p>
+        <p>An anonymous |GeneratorDeclaration| can only occur as part of an `export default` declaration, and its function code is therefore always strict mode code.</p>
       </emu-note>
     </emu-clause>
 


### PR DESCRIPTION
Because an anonymous FunctionDeclaration can only occur as part of an
`export default` declaration, an `export` declaration can only occur in
in module code, and module code is always strict mode code, the function
code of an anonymous FunctionDeclaration is always strict mode code.

Remove the condition that allows for non-strict anonymous function
declarations, and update the accompanying informative note to explain
this detail.