### PR TITLE
Editorial: Remove reference for 'this String value'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26424,7 +26424,6 @@ THH:mm:ss.sss
           1. Return _value_.[[StringData]].
         1. Throw a *TypeError* exception.
       </emu-alg>
-      <p>The phrase &ldquo;this String value&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisStringValue with the *this* value of the method invocation passed as the argument.</p>
 
       <!-- es6num="21.1.3.1" -->
       <emu-clause id="sec-string.prototype.charat">


### PR DESCRIPTION
This phrase was last used in ES5 for String#toString and String#valueOf
and it seems this paragraph can be safely removed now.