### PR TITLE
Normative: Allow initializers in ForInStatement heads

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15388,6 +15388,9 @@
         BindingIdentifier[?Yield]
         BindingPattern[?Yield]
     </emu-grammar>
+    <emu-note>
+      <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+    </emu-note>
 
     <!-- es6num="13.7.1" -->
     <emu-clause id="sec-iteration-statements-semantics">
@@ -15852,6 +15855,9 @@
         <emu-alg>
           1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
         </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="13.7.5.4" -->
@@ -15871,6 +15877,9 @@
         <emu-alg>
           1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
         </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="13.7.5.5" -->
@@ -15890,6 +15899,9 @@
         <emu-alg>
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="13.7.5.6" -->
@@ -15908,6 +15920,9 @@
         <emu-alg>
           1. Return *true*.
         </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="13.7.5.7" -->
@@ -15942,6 +15957,9 @@
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="13.7.5.8" -->
@@ -15976,6 +15994,9 @@
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="13.7.5.9" -->
@@ -16043,6 +16064,9 @@
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~lexicalBinding~, _labelSet_).
         </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="13.7.5.12" -->
@@ -36616,6 +36640,69 @@ THH:mm:ss.sss
         1. If _thisEnvRec_ is not the Environment Record for a |Catch| clause, let _bindingExists_ be *true*.
       </emu-alg>
     </emu-annex>
+
+    <!-- es6num="B.3.6" -->
+    <emu-annex id="sec-initializers-in-forin-statement-heads">
+      <h1>Initializers in ForIn Statement Heads</h1>
+      <p>The following augments the |IterationStatement| production in <emu-xref href="#sec-iteration-statements"></emu-xref>:</p>
+      <emu-grammar>
+      IterationStatement[Yield, Return]:
+        `for` `(` `var` BindingIdentifier[?Yield] Initializer[~In, ?Yield] `in` Expression[+In, ?Yield] `)` Statement[?Yield, ?Return]
+      </emu-grammar>
+      <p>This production only applies when parsing non-strict code.</p>
+      <p>The static semantics of ContainsDuplicateLabels in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels"></emu-xref> are augmented with the following:</p>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <p>The static semantics of ContainsUndefinedBreakTarget in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget"></emu-xref> are augmented with the following:</p>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <p>The static semantics of ContainsUndefinedContinueTarget in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget"></emu-xref> are augmented with the following:</p>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <p>The static semantics of IsDestructuring in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-isdestructuring"></emu-xref> are augmented with the following:</p>
+      <emu-grammar>
+        BindingIdentifier :
+          Identifier
+          `yield`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <p>The static semantics of VarDeclaredNames in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-vardeclarednames"></emu-xref> are augmented with the following:</p>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be the BoundNames of |BindingIdentifier|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
+        1. Return _names_.
+      </emu-alg>
+      <p>The static semantics of VarScopedDeclarations in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations"></emu-xref> are augmented with the following:</p>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be a List containing |BindingIdentifier|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
+        1. Return _declarations_.
+      </emu-alg>
+      <p>The runtime semantics of LabelledEvaluation in <emu-xref href="#sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation"></emu-xref> are augmented with the following:</p>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _bindingId_ be StringValue of |BindingIdentifier|.
+        1. Let _lhs_ be ? ResolveBinding(_bindingId_).
+        1. Let _rhs_ be the result of evaluating |Initializer|.
+        1. Let _value_ be ? GetValue(_rhs_).
+        1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
+          1. Let _hasNameProperty_ be ? HasOwnProperty(_value_, `"name"`).
+          1. If _hasNameProperty_ is *false*, perform SetFunctionName(_value_, _bindingId_).
+        1. Perform ? PutValue(_lhs_, _value_).
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
+        1. Return ? ForIn/OfBodyEvaluation(|BindingIdentifier|, |Statement|, _keyResult_, ~varBinding~, _labelSet_).
+      </emu-alg>
+    </emu-annex>
   </emu-annex>
 </emu-annex>
 
@@ -36706,7 +36793,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-if-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the normal completion value of an |IfStatement| is never the value ~empty~. If no |Statement| part is evaluated or if the evaluated |Statement| part produces a normal completion whose value is ~empty~, the completion value of the |IfStatement| is *undefined*.</p>
   <p><emu-xref href="#sec-iteration-statements"></emu-xref>: In ECMAScript 2015, if the `(` token of a for statement is immediately followed by the token sequence `let [` then the `let` is treated as the start of a |LexicalDeclaration|. In previous editions such a token sequence would be the start of an |Expression|.</p>
   <p><emu-xref href="#sec-iteration-statements"></emu-xref>: In ECMAScript 2015, if the ( token of a for-in statement is immediately followed by the token sequence `let [` then the `let` is treated as the start of a |ForDeclaration|. In previous editions such a token sequence would be the start of an |LeftHandSideExpression|.</p>
-  <p><emu-xref href="#sec-iteration-statements"></emu-xref>: Prior to ECMAScript 2015, an initialization expression could appear as part of the |VariableDeclaration| that precedes the `in` keyword. The value of that expression was always discarded. In ECMAScript 2015, the _ForBinding_ in that same position does not allow the occurrence of such an initializer.</p>
+  <p><emu-xref href="#sec-iteration-statements"></emu-xref>: Prior to ECMAScript 2015, an initialization expression could appear as part of the |VariableDeclaration| that precedes the `in` keyword. In ECMAScript 2015, the |ForBinding| in that same position does not allow the occurrence of such an initializer. In ECMAScript 2017, such an initializer is permitted only in non-strict code.</p>
   <p><emu-xref href="#sec-iteration-statements"></emu-xref>: In ECMAScript 2015, the completion value of an |IterationStatement| is never the value ~empty~. If the |Statement| part of an |IterationStatement| is not evaluated or if the final evaluation of the |Statement| part produces a completion whose value is ~empty~, the completion value of the |IterationStatement| is *undefined*.</p>
   <p><emu-xref href="#sec-with-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the normal completion value of a |WithStatement| is never the value ~empty~. If evaluation of the |Statement| part of a |WithStatement| produces a normal completion whose value is ~empty~, the completion value of the |WithStatement| is *undefined*.</p>
   <p><emu-xref href="#sec-switch-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the completion value of a |SwitchStatement| is never the value ~empty~. If the |CaseBlock| part of a |SwitchStatement| produces a completion whose value is ~empty~, the completion value of the |SwitchStatement| is *undefined*.</p>


### PR DESCRIPTION
Fixes #260.

Per [discussion](https://github.com/rwaldron/tc39-notes/blob/aad8937063ab32eb33ec2a5b40325b1d9f171180/es6/2014-04/apr-10.md#revisiting-initializer-in-for-in), this adds a section in Annex B with a production for `for ( var BindingIdentifier Initializer in Expression) Statement` with its original semantics, in light of the [usage statistics collected by V8](https://github.com/tc39/ecma262/issues/260#issuecomment-220823926) and the fact that implementers have had to allow this production.

--

Edit (July 27, 2016): This comment was slightly wrong; it was only added to non-strict code.