### PR TITLE
[normative] Handle abrupt cmpltn in SuperProperty

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11947,7 +11947,7 @@
         <emu-grammar>SuperProperty : `super` `[` Expression `]`</emu-grammar>
         <emu-alg>
           1. Let _propertyNameReference_ be the result of evaluating |Expression|.
-          1. Let _propertyNameValue_ be GetValue(_propertyNameReference_).
+          1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
           1. Let _propertyKey_ be ? ToPropertyKey(_propertyNameValue_).
           1. If the code matched by the syntactic production that is being evaluated is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? MakeSuperPropertyReference(_propertyKey_, _strict_).


### PR DESCRIPTION
During evaluation of SuperProperty, the result of evaluating Expression
may be an abrupt completion. GetValue is designed to immediately return
such completion values, through it may also return a new abrupt
completion if a valid Reference value is provided but cannot be
resolved. In either case, the result of GetValue will be an abrupt
completion, which ToPropertyKey is not designed to handle.

Update the algorithm to immediately return abrupt completions produced
by the invocation of GetValue.