### PR TITLE
Editorial: Assert normal completion value

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11979,7 +11979,8 @@
           1. Let _envRec_ be GetThisEnvironment( ).
           1. Assert: _envRec_ is a function Environment Record.
           1. Let _activeFunction_ be _envRec_.[[FunctionObject]].
-          1. Let _superConstructor_ be ? _activeFunction_.[[GetPrototypeOf]]().
+          1. Assert: _activeFunction_ is an ECMAScript function object.
+          1. Let _superConstructor_ be ! _activeFunction_.[[GetPrototypeOf]]().
           1. If IsConstructor(_superConstructor_) is *false*, throw a *TypeError* exception.
           1. Return _superConstructor_.
         </emu-alg>


### PR DESCRIPTION
The GetSuperConstructor abstract operation invokes the
[[GetPrototypeOf]] method of a [[FunctionObject]] value. This is
currently guarded by "ReturnIfAbrupt." That is unnecessary because
[[FunctionObject]] is always an ECMAScript function object and therefore
implements the [[GetPrototypeOf]] method of ordinary objects (which
never returns abruptly).

The [[FunctionObject]] internal slot is set by one internal operation
only: NewFunctionEnvironment. This is itself only invoked by one
operation: PrepareForOrdinaryCall. PrepareForOrdinaryCall is invoked by
exactly two abstract operations: [[Call]] for ECMAScript function
objects and [[Construct]] for ECMAScript function objects. Both of these
operations include the following assertion:

> 1. Assert: F is an ECMAScript function object.

Remove the unnecessary guard for abrupt completions and insert an
"Assert" step documenting the invariant which makes this possible.