### PR TITLE
Normative: Require the latest available Unicode version instead of a fixed version number

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48,7 +48,7 @@
 <emu-clause id="sec-conformance">
   <h1>Conformance</h1>
   <p>A conforming implementation of ECMAScript must provide and support all the types, values, objects, properties, functions, and program syntax and semantics described in this specification.</p>
-  <p>A conforming implementation of ECMAScript must interpret source text input in conformance with the Unicode Standard, Version 8.0.0 or later and ISO/IEC 10646.</p>
+  <p>A conforming implementation of ECMAScript must interpret source text input in conformance with the latest version of the Unicode Standard and ISO/IEC 10646.</p>
   <p>A conforming implementation of ECMAScript that provides an application programming interface that supports programs that need to adapt to the linguistic and cultural conventions used by different human languages and countries must implement the interface defined by the most recent edition of ECMA-402 that is compatible with this specification.</p>
   <p>A conforming implementation of ECMAScript may provide additional types, values, objects, properties, and functions beyond those described in this specification. In particular, a conforming implementation of ECMAScript may provide properties not described in this specification, and values for those properties, for objects that are described in this specification.</p>
   <p>A conforming implementation of ECMAScript may support program and regular expression syntax not described in this specification. In particular, a conforming implementation of ECMAScript may support program syntax that makes use of the &ldquo;future reserved words&rdquo; listed in subclause <emu-xref href="#sec-future-reserved-words"></emu-xref> of this specification.</p>
@@ -8811,7 +8811,7 @@
       SourceCharacter ::
         &gt; any Unicode code point
     </emu-grammar>
-    <p>ECMAScript code is expressed using Unicode, version 8.0.0 or later. ECMAScript source text is a sequence of code points. All Unicode code point values from U+0000 to U+10FFFF, including surrogate code points, may occur in source text where permitted by the ECMAScript grammars. The actual encodings used to store and interchange ECMAScript source text is not relevant to this specification. Regardless of the external source text encoding, a conforming ECMAScript implementation processes the source text as if it was an equivalent sequence of |SourceCharacter| values, each |SourceCharacter| being a Unicode code point. Conforming ECMAScript implementations are not required to perform any normalization of source text, or behave as though they were performing normalization of source text.</p>
+    <p>ECMAScript code is expressed using Unicode. ECMAScript source text is a sequence of code points. All Unicode code point values from U+0000 to U+10FFFF, including surrogate code points, may occur in source text where permitted by the ECMAScript grammars. The actual encodings used to store and interchange ECMAScript source text is not relevant to this specification. Regardless of the external source text encoding, a conforming ECMAScript implementation processes the source text as if it was an equivalent sequence of |SourceCharacter| values, each |SourceCharacter| being a Unicode code point. Conforming ECMAScript implementations are not required to perform any normalization of source text, or behave as though they were performing normalization of source text.</p>
     <p>The components of a combining character sequence are treated as individual Unicode code points even though a user might think of the whole sequence as a single character.</p>
     <emu-note>
       <p>In string literals, regular expression literals, template literals and identifiers, any Unicode code point may also be expressed using Unicode escape sequences that explicitly express a code point's numeric value. Within a comment, such an escape sequence is effectively ignored as part of the comment.</p>
@@ -9285,7 +9285,7 @@
   <!-- es6num="11.6" -->
   <emu-clause id="sec-names-and-keywords">
     <h1>Names and Keywords</h1>
-    <p>|IdentifierName| and |ReservedWord| are tokens that are interpreted according to the Default Identifier Syntax given in Unicode Standard Annex #31, Identifier and Pattern Syntax, with some small modifications. |ReservedWord| is an enumerated subset of |IdentifierName|. The syntactic grammar defines |Identifier| as an |IdentifierName| that is not a |ReservedWord|. The Unicode identifier grammar is based on character properties specified by the Unicode Standard. The Unicode code points in the specified categories in version 8.0.0 of the Unicode standard must be treated as in those categories by all conforming ECMAScript implementations. ECMAScript implementations may recognize identifier code points defined in later editions of the Unicode Standard.</p>
+    <p>|IdentifierName| and |ReservedWord| are tokens that are interpreted according to the Default Identifier Syntax given in Unicode Standard Annex #31, Identifier and Pattern Syntax, with some small modifications. |ReservedWord| is an enumerated subset of |IdentifierName|. The syntactic grammar defines |Identifier| as an |IdentifierName| that is not a |ReservedWord|. The Unicode identifier grammar is based on character properties specified by the Unicode Standard. The Unicode code points in the specified categories in the latest version of the Unicode standard must be treated as in those categories by all conforming ECMAScript implementations. ECMAScript implementations may recognize identifier code points defined in later editions of the Unicode Standard.</p>
     <emu-note>
       <p>This standard specifies specific code point additions: U+0024 (DOLLAR SIGN) and U+005F (LOW LINE) are permitted anywhere in an |IdentifierName|, and the code points U+200C (ZERO WIDTH NON-JOINER) and U+200D (ZERO WIDTH JOINER) are permitted anywhere after the first code point of an |IdentifierName|.</p>
     </emu-note>
@@ -36743,38 +36743,34 @@ THH:mm:ss.sss
       IEEE Std 754-2008: <i>IEEE Standard for Floating-Point Arithmetic</i>. Institute of Electrical and Electronic Engineers, New York (2008)
     </li>
     <li>
-      <i>The Unicode Standard, Version 8.0.0</i> or successor.
-      <br>
-      &lt;<a href="http://www.unicode.org/versions/latest">http://www.unicode.org/versions/latest</a>&gt;
+      <i>The Unicode Standard</i>, available at &lt;<a href="http://www.unicode.org/versions/latest">http://www.unicode.org/versions/latest</a>&gt;
     </li>
     <li>
-      <i>Unicode Standard Annex #15, Unicode Normalization Forms, version Unicode 8.0.0</i>, or successor.
-      <br>
-      &lt;<a href="http://www.unicode.org/reports/tr15/">http://www.unicode.org/reports/tr15/</a>&gt;
+      <i>Unicode Standard Annex #15, Unicode Normalization Forms</i>, available at &lt;<a href="http://www.unicode.org/reports/tr15/">http://www.unicode.org/reports/tr15/</a>&gt;
     </li>
     <li>
-      <i>Unicode Standard Annex #31, Unicode Identifiers and Pattern Syntax, version Unicode 8.0.0</i>, or successor. &lt;<a href="http://www.unicode.org/reports/tr31/">http://www.unicode.org/reports/tr31/</a>&gt;
+      <i>Unicode Standard Annex #31, Unicode Identifiers and Pattern Syntax</i>, available at &lt;<a href="http://www.unicode.org/reports/tr31/">http://www.unicode.org/reports/tr31/</a>&gt;
     </li>
     <li>
-      Unicode Technical Note #5: Canonical Equivalence in Applications, available at &lt;<a href="http://www.unicode.org/notes/tn5/">http://www.unicode.org/notes/tn5/</a>&gt;
+      <i>Unicode Technical Note #5: Canonical Equivalence in Applications</i>, available at &lt;<a href="http://www.unicode.org/notes/tn5/">http://www.unicode.org/notes/tn5/</a>&gt;
     </li>
     <li>
-      Unicode Technical Standard #10: Unicode Collation Algorithm version 8.0.0, or successor, available at &lt;<a href="http://www.unicode.org/reports/tr10/">http://www.unicode.org/reports/tr10/</a>&gt;
+      <i>Unicode Technical Standard #10: Unicode Collation Algorithm</i>, available at &lt;<a href="http://www.unicode.org/reports/tr10/">http://www.unicode.org/reports/tr10/</a>&gt;
     </li>
     <li>
-      <i>IANA Time Zone Database</i> at &lt;<a href="http://www.iana.org/time-zones">http://www.iana.org/time-zones</a>&gt;
+      <i>IANA Time Zone Database</i>, available at &lt;<a href="http://www.iana.org/time-zones">http://www.iana.org/time-zones</a>&gt;
     </li>
     <li>
       ISO 8601:2004(E) <i>Data elements and interchange formats &ndash; Information interchange</i> &mdash; <i>Representation of dates and times</i>
     </li>
     <li>
-      RFC 1738 &ldquo;Uniform Resource Locators (URL)&rdquo;, available at &lt;<a href="http://tools.ietf.org/html/rfc1738">http://tools.ietf.org/html/rfc1738</a>&gt;
+      <i>RFC 1738 &ldquo;Uniform Resource Locators (URL)&rdquo;</i>, available at &lt;<a href="http://tools.ietf.org/html/rfc1738">http://tools.ietf.org/html/rfc1738</a>&gt;
     </li>
     <li>
-      RFC 2396 &ldquo;Uniform Resource Identifiers (URI): Generic Syntax&rdquo;, available at &lt;<a href="http://tools.ietf.org/html/rfc2396">http://tools.ietf.org/html/rfc2396</a>&gt;
+      <i>RFC 2396 &ldquo;Uniform Resource Identifiers (URI): Generic Syntax&rdquo;</i>, available at &lt;<a href="http://tools.ietf.org/html/rfc2396">http://tools.ietf.org/html/rfc2396</a>&gt;
     </li>
     <li>
-      RFC 3629 &ldquo;UTF-8, a transformation format of ISO 10646&rdquo;, available at &lt;<a href="http://tools.ietf.org/html/rfc3629">http://tools.ietf.org/html/rfc3629</a>&gt;
+      <i>RFC 3629 &ldquo;UTF-8, a transformation format of ISO 10646&rdquo;</i>, available at &lt;<a href="http://tools.ietf.org/html/rfc3629">http://tools.ietf.org/html/rfc3629</a>&gt;
     </li>
   </ol>
 </emu-annex>


### PR DESCRIPTION
As of June 21st, Unicode 9.0.0 is the latest version.

**Update July 27:** This PR has been updated to refer to the latest available Unicode version rather than v9.0.0 specifically, as per the July 27 meeting.