### PR TITLE
Editorial: Use the canonical category name `Space_Separator`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9113,7 +9113,7 @@
             Other category &ldquo;Zs&rdquo;
           </td>
           <td>
-            Any other Unicode &ldquo;Separator, space&rdquo; code point
+            Any other Unicode &ldquo;Space_Separator&rdquo; code point
           </td>
           <td>
             &lt;USP&gt;
@@ -9122,9 +9122,9 @@
         </tbody>
       </table>
     </emu-table>
-    <p>ECMAScript implementations must recognize as |WhiteSpace| code points listed in the &ldquo;Separator, space&rdquo; (Zs) category.</p>
+    <p>ECMAScript implementations must recognize as |WhiteSpace| code points listed in the &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;) category.</p>
     <emu-note>
-      <p>Other than for the code points listed in <emu-xref href="#table-32"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Zs&rdquo;.</p>
+      <p>Other than for the code points listed in <emu-xref href="#table-32"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
     </emu-note>
     <h2>Syntax</h2>
     <emu-grammar>
@@ -27148,7 +27148,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _T_ be a String value that is a copy of _S_ with both leading and trailing white space removed. The definition of white space is the union of |WhiteSpace| and |LineTerminator|. When determining whether a Unicode code point is in Unicode general category &ldquo;Zs&rdquo;, code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.
+          1. Let _T_ be a String value that is a copy of _S_ with both leading and trailing white space removed. The definition of white space is the union of |WhiteSpace| and |LineTerminator|. When determining whether a Unicode code point is in Unicode general category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;), code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.
           1. Return _T_.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
Rather than “Separator, Space” and other variations, consistently use the canonical Unicode category name `Space_Separator` along with its alias `Zs`.