### PR TITLE
Editorial: Remove unnecessary step from ValidateAndApplyPropertyDescriptor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6466,9 +6466,6 @@
             1. For each field of _Desc_ that is present, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
           1. Return *true*.
         </emu-alg>
-        <emu-note>
-          <p>Step 7.b allows any field of _Desc_ to be different from the corresponding field of _current_ if _current_'s [[Configurable]] field is *true*. This even permits changing the [[Value]] of a property whose [[Writable]] attribute is *false*. This is allowed because a *true* [[Configurable]] attribute would permit an equivalent sequence of calls where [[Writable]] is first set to *true*, a new [[Value]] is set, and then [[Writable]] is set to *false*.</p>
-        </emu-note>
       </emu-clause>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -6457,7 +6457,6 @@
                 1. Return *false*, if the [[Writable]] field of _Desc_ is present and the [[Writable]] field of _Desc_ is *true*.
                 1. Return *false*, if the [[Value]] field of _Desc_ is present and SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*.
                 1. Return *true*.
-            1. Else the [[Configurable]] field of _current_ is *true*, so any change is acceptable.
           1. Else IsAccessorDescriptor(_current_) and IsAccessorDescriptor(_Desc_) are both *true*,
             1. If the [[Configurable]] field of _current_ is *false*, then
               1. Return *false*, if the [[Set]] field of _Desc_ is present and SameValue(_Desc_.[[Set]], _current_.[[Set]]) is *false*.


### PR DESCRIPTION
I first thought on prefixing that step with a Note, but that information does not add much as there's no ambiguous or complex thing to explain there. It actually took me a few seconds to see it is not doing anything, just informing the changes will be applied in a further step.