### PR TITLE
Editorial: (markup) add namespace to algorithm-conventions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -669,7 +669,7 @@
   </emu-clause>
 
   <!-- es6num="5.2" -->
-  <emu-clause id="sec-algorithm-conventions">
+  <emu-clause id="sec-algorithm-conventions" namespace=algorithm-conventions>
     <h1>Algorithm Conventions</h1>
     <p>The specification often uses a numbered list to specify steps in an algorithm. These algorithms are used to precisely specify the required semantics of ECMAScript language constructs. The algorithms are not intended to imply the use of any specific implementation technique. In practice, there may be more efficient algorithms available to implement a given feature.</p>
     <p>Algorithms may be explicitly parameterized, in which case the names and usage of the parameters must be provided as part of the algorithm's definition. In order to facilitate their use in multiple parts of this specification, some algorithms, called <em>abstract operations</em>, are named and written in parameterized functional form so that they may be referenced by name from within other algorithms. Abstract operations are typically referenced using a functional application style such as operationName(_arg1_, _arg2_). Some abstract operations are treated as polymorphically dispatched methods of class-like specification abstractions. Such method-like abstract operations are typically referenced using a method application style such as _someValue_.operationName(_arg1_, _arg2_).</p>


### PR DESCRIPTION
Currently clicking on `Block` anywhere in the main document, e.g. [here](https://tc39.github.io/ecma262/#sec-block), links to [the preface](https://tc39.github.io/ecma262/#prod-Block). This is particularly annoying since the runtime semantics given in that section are not in fact the semantics for `Block`.

This PR corrects this.