### PR TITLE
Disregard lastIndex for non-global non-sticky regexps

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28687,17 +28687,18 @@ THH:mm:ss.sss
             1. Assert: _R_ is an initialized RegExp instance.
             1. Assert: Type(_S_) is String.
             1. Let _length_ be the number of code units in _S_.
-            1. Let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
             1. Let _flags_ be _R_.[[OriginalFlags]].
             1. If _flags_ contains `"g"`, let _global_ be *true*, else let _global_ be *false*.
             1. If _flags_ contains `"y"`, let _sticky_ be *true*, else let _sticky_ be *false*.
             1. If _global_ is *false* and _sticky_ is *false*, let _lastIndex_ be 0.
+            1. Else, let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
             1. Let _matcher_ be _R_.[[RegExpMatcher]].
             1. If _flags_ contains `"u"`, let _fullUnicode_ be *true*, else let _fullUnicode_ be *false*.
             1. Let _matchSucceeded_ be *false*.
             1. Repeat, while _matchSucceeded_ is *false*
               1. If _lastIndex_ &gt; _length_, then
-                1. Perform ? Set(_R_, `"lastIndex"`, 0, *true*).
+                1. If _global_ is *true* or _sticky_ is *true*, then
+                  1. Perform ? Set(_R_, `"lastIndex"`, 0, *true*).
                 1. Return *null*.
               1. Let _r_ be _matcher_(_S_, _lastIndex_).
               1. If _r_ is ~failure~, then
@@ -28937,9 +28938,12 @@ THH:mm:ss.sss
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
           1. Let _previousLastIndex_ be ? Get(_rx_, `"lastIndex"`).
-          1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
+          1. If SameValue(_previousLastIndex_, 0) is *false*, then
+            1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
           1. Let _result_ be ? RegExpExec(_rx_, _S_).
-          1. Perform ? Set(_rx_, `"lastIndex"`, _previousLastIndex_, *true*).
+          1. Let _currentLastIndex_ be ? Get(_rx_, `"lastIndex"`).
+          1. If SameValue(_currentLastIndex_, _previousLastIndex_) is *false*, then
+            1. Perform ? Set(_rx_, `"lastIndex"`, _previousLastIndex_, *true*).
           1. If _result_ is *null*, return -1.
           1. Return ? Get(_result_, `"index"`).
         </emu-alg>


### PR DESCRIPTION
With these changes , non-global non-sticky regexps with nonwritable
lastIndex property should just work:
- In RegExpBuiltinExec, remove any access to the lastIndex property for
  non-global, non-sticky regexp.
- In RegExp.prototype.@@search, avoid to to set the lastIndex property
  when not necessary.
