### PR TITLE
Editorial: Remove ambiguous statement from Date.UTC

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -72,7 +72,7 @@
 <emu-clause id="sec-overview">
   <h1>Overview</h1>
   <p>This section contains a non-normative overview of the ECMAScript language.</p>
-  <p>ECMAScript is an object-oriented programming language for performing computations and manipulating computational objects within a host environment. ECMAScript as defined here is not intended to be computationally self-sufficient; indeed, there are no provisions in this specification for input of external data or output of computed results. Instead, it is expected that the computational environment of an ECMAScript program will provide not only the objects and other facilities described in this specification but also certain environment-specific objects, whose description and behavior are beyond the scope of this specification except to indicate that they may provide certain properties that can be accessed and certain functions that can be called from an ECMAScript program.</p>
+  <p>ECMAScript is an object-oriented programming language for performing computations and manipulating computational objects within a host environment. ECMAScript as defined here is not intended to be computationally self-sufficient; indeed, there are no provisions in this specification for input of external data or output of computed results. Instead, it is expected that the computational environment of an ECMAScript program will provide not only the objects and other facilities described in this specification but also certain environment-specific objects, whose description and behaviour are beyond the scope of this specification except to indicate that they may provide certain properties that can be accessed and certain functions that can be called from an ECMAScript program.</p>
   <p>ECMAScript was originally designed to be used as a scripting language, but has become widely used as a general-purpose programming language. A <em>scripting language</em> is a programming language that is used to manipulate, customize, and automate the facilities of an existing system. In such systems, useful functionality is already available through a user interface, and the scripting language is a mechanism for exposing that functionality to program control. In this way, the existing system is said to provide a host environment of objects and facilities, which completes the capabilities of the scripting language. A scripting language is intended for use by both professional and non-professional programmers.</p>
   <p>ECMAScript was originally designed to be a <em>Web scripting language</em>, providing a mechanism to enliven Web pages in browsers and to perform server computation as part of a Web-based client-server architecture. ECMAScript is now used to provide core scripting capabilities for a variety of host environments. Therefore the core language is specified in this document apart from any particular host environment.</p>
   <p>ECMAScript usage has moved beyond simple scripting and it is now used for the full spectrum of programming tasks in many different environments and scales. As the usage of ECMAScript has expanded, so has the features and facilities it provides. ECMAScript is now a fully featured general-purpose programming language.</p>
@@ -108,7 +108,7 @@
       <emu-figure id="figure-1" caption="Object/Prototype Relationships">
         <object data="img/figure-1.svg" height="354" type="image/svg+xml" width="719"> <img alt="An image of lots of boxes and arrows." height="354" src="img/figure-1.png" width="719"> </object>
       </emu-figure>
-      <p>In a class-based object-oriented language, in general, state is carried by instances, methods are carried by classes, and inheritance is only of structure and behavior. In ECMAScript, the state and methods are carried by objects, while structure, behavior, and state are all inherited.</p>
+      <p>In a class-based object-oriented language, in general, state is carried by instances, methods are carried by classes, and inheritance is only of structure and behaviour. In ECMAScript, the state and methods are carried by objects, while structure, behaviour, and state are all inherited.</p>
       <p>All objects that do not directly contain a particular property that their prototype contains share that property and its value. Figure 1 illustrates this:</p>
       <p><b>CF</b> is a constructor (and also an object). Five objects have been created by using `new` expressions: <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b>. Each of these objects contains properties named `q1` and `q2`. The dashed lines represent the implicit prototype relationship; so, for example, <b>cf<sub>3</sub></b>'s prototype is <b>CF<sub>p</sub></b>. The constructor, <b>CF</b>, has two properties itself, named `P1` and `P2`, which are not visible to <b>CF<sub>p</sub></b>, <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, or <b>cf<sub>5</sub></b>. The property named `CFP1` in <b>CF<sub>p</sub></b> is shared by <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> (but not by <b>CF</b>), as are any properties found in <b>CF<sub>p</sub></b>'s implicit prototype chain that are not named `q1`, `q2`, or `CFP1`. Notice that there is no implicit prototype link between <b>CF</b> and <b>CF<sub>p</sub></b>.</p>
       <p>Unlike most class-based object languages, properties can be added to objects dynamically by assigning values to them. That is, constructors are not required to name or assign values to all or any of the constructed object's properties. In the above diagram, one could add a new shared property for <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> by assigning a new value to the property in <b>CF<sub>p</sub></b>.</p>
@@ -174,13 +174,13 @@
     <!-- es6num="4.3.6" -->
     <emu-clause id="sec-ordinary-object">
       <h1>ordinary object</h1>
-      <p>object that has the default behavior for the essential internal methods that must be supported by all objects</p>
+      <p>object that has the default behaviour for the essential internal methods that must be supported by all objects</p>
     </emu-clause>
 
     <!-- es6num="4.3.7" -->
     <emu-clause id="sec-exotic-object">
       <h1>exotic object</h1>
-      <p>object that does not have the default behavior for one or more of the essential internal methods</p>
+      <p>object that does not have the default behaviour for one or more of the essential internal methods</p>
       <emu-note>
         <p>Any object that is not an ordinary object is an exotic object.</p>
       </emu-note>
@@ -942,7 +942,7 @@
     <!-- es6num="6.1.6" -->
     <emu-clause id="sec-ecmascript-language-types-number-type">
       <h1>The Number Type</h1>
-      <p>The Number type has exactly 18437736874454810627 (that is, <emu-eqn>2<sup>64</sup>-2<sup>53</sup>+3</emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2008 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990 (that is, <emu-eqn>2<sup>53</sup>-2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behavior is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+      <p>The Number type has exactly 18437736874454810627 (that is, <emu-eqn>2<sup>64</sup>-2<sup>53</sup>+3</emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2008 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990 (that is, <emu-eqn>2<sup>53</sup>-2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
       <emu-note>
         <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
       </emu-note>
@@ -962,7 +962,7 @@
       <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>52</sup>, and _e_ is -1074.</p>
       <p>Note that all the positive and negative integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the integer 0 has two representations, *+0* and *-0*).</p>
       <p>A finite number has an <em>odd significand</em> if it is nonzero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
-      <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact nonzero real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behavior of the IEEE 754-2008 &ldquo;round to nearest, ties to even&rdquo; mode.)</p>
+      <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact nonzero real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 &ldquo;round to nearest, ties to even&rdquo; mode.)</p>
       <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup>-1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup>-1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
     </emu-clause>
 
@@ -1178,7 +1178,7 @@
       <!-- es6num="6.1.7.2" -->
       <emu-clause id="sec-object-internal-methods-and-internal-slots">
         <h1>Object Internal Methods and Internal Slots</h1>
-        <p>The actual semantics of objects, in ECMAScript, are specified via algorithms called <em>internal methods</em>. Each object in an ECMAScript engine is associated with a set of internal methods that defines its runtime behavior. These internal methods are not part of the ECMAScript language. They are defined by this specification purely for expository purposes. However, each object within an implementation of ECMAScript must behave as specified by the internal methods associated with it. The exact manner in which this is accomplished is determined by the implementation.</p>
+        <p>The actual semantics of objects, in ECMAScript, are specified via algorithms called <em>internal methods</em>. Each object in an ECMAScript engine is associated with a set of internal methods that defines its runtime behaviour. These internal methods are not part of the ECMAScript language. They are defined by this specification purely for expository purposes. However, each object within an implementation of ECMAScript must behave as specified by the internal methods associated with it. The exact manner in which this is accomplished is determined by the implementation.</p>
         <p>Internal method names are polymorphic. This means that different object values may perform different algorithms when a common internal method name is invoked upon them. That actual object upon which an internal method is invoked is the &ldquo;target&rdquo; of the invocation. If, at runtime, the implementation of an algorithm attempts to use an internal method of an object that the object does not support, a *TypeError* exception is thrown.</p>
         <p>Internal slots correspond to internal state that is associated with objects and used by various ECMAScript specification algorithms. Internal slots are not object properties and they are not inherited. Depending upon the specific internal slot specification, such state may consist of values of any ECMAScript language type or of specific ECMAScript specification type values. Unless explicitly specified otherwise, internal slots are allocated as part of the process of creating an object and may not be dynamically added to an object. Unless specified otherwise, the initial value of an internal slot is the value *undefined*. Various algorithms within this specification create objects that have internal slots. However, the ECMAScript language provides no direct way to associate internal slots with an object.</p>
         <p>Internal methods and internal slots are identified within this specification using names enclosed in double square brackets [[ ]].</p>
@@ -1362,14 +1362,14 @@
             </tbody>
           </table>
         </emu-table>
-        <p>The semantics of the essential internal methods for ordinary objects and standard exotic objects are specified in clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviors"></emu-xref>. If any specified use of an internal method of an exotic object is not supported by an implementation, that usage must throw a *TypeError* exception when attempted.</p>
+        <p>The semantics of the essential internal methods for ordinary objects and standard exotic objects are specified in clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>. If any specified use of an internal method of an exotic object is not supported by an implementation, that usage must throw a *TypeError* exception when attempted.</p>
       </emu-clause>
 
       <!-- es6num="6.1.7.3" -->
       <emu-clause id="sec-invariants-of-the-essential-internal-methods">
         <h1>Invariants of the Essential Internal Methods</h1>
         <p>The Internal Methods of Objects of an ECMAScript engine must conform to the list of invariants specified below. Ordinary ECMAScript Objects as well as all standard exotic objects in this specification maintain these invariants. ECMAScript Proxy objects maintain these invariants by means of runtime checks on the result of traps invoked on the [[ProxyHandler]] object.</p>
-        <p>Any implementation provided exotic objects must also maintain these invariants for those objects. Violation of these invariants may cause ECMAScript code to have unpredictable behavior and create security issues. However, violation of these invariants must never compromise the memory safety of an implementation.</p>
+        <p>Any implementation provided exotic objects must also maintain these invariants for those objects. Violation of these invariants may cause ECMAScript code to have unpredictable behaviour and create security issues. However, violation of these invariants must never compromise the memory safety of an implementation.</p>
         <p>An implementation must not allow these invariants to be circumvented in any manner such as by providing alternative interfaces that implement the functionality of the essential internal methods without enforcing their invariants.</p>
         <h2>Definitions:</h2>
         <ul>
@@ -2566,7 +2566,7 @@
     <!-- es6num="6.2.2" -->
     <emu-clause id="sec-completion-record-specification-type" aoid="Completion">
       <h1>The Completion Record Specification Type</h1>
-      <p>The Completion type is a Record used to explain the runtime propagation of values and control flow such as the behavior of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
+      <p>The Completion type is a Record used to explain the runtime propagation of values and control flow such as the behaviour of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
       <p>Values of the Completion type are Record values whose fields are defined as by <emu-xref href="#table-8"></emu-xref>. Such values are referred to as <dfn>Completion Record</dfn>s.</p>
       <emu-table id="table-8" caption="Completion Record Fields">
         <table>
@@ -2711,7 +2711,7 @@
     <emu-clause id="sec-reference-specification-type">
       <h1>The Reference Specification Type</h1>
       <emu-note>
-        <p>The Reference type is used to explain the behavior of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a reference.</p>
+        <p>The Reference type is used to explain the behaviour of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a reference.</p>
       </emu-note>
       <p>A <dfn>Reference</dfn> is a resolved name or property binding. A Reference consists of three components, the base value component, the referenced name component, and the Boolean-valued strict reference flag. The base value component is either *undefined*, an Object, a Boolean, a String, a Symbol, a Number, or an Environment Record. A base value component of *undefined* indicates that the Reference could not be resolved to a binding. The referenced name component is a String or Symbol value.</p>
       <p>A <dfn id="super-reference">Super Reference</dfn> is a Reference that is used to represents a name binding that was expressed using the super keyword. A Super Reference has an additional thisValue component, and its base value component will never be an Environment Record.</p>
@@ -2943,7 +2943,7 @@
     <!-- es6num="6.2.5" -->
     <emu-clause id="sec-lexical-environment-and-environment-record-specification-types">
       <h1>The Lexical Environment and Environment Record Specification Types</h1>
-      <p>The Lexical Environment and Environment Record types are used to explain the behavior of name resolution in nested functions and blocks. These types and the operations upon them are defined in <emu-xref href="#sec-lexical-environments"></emu-xref>.</p>
+      <p>The Lexical Environment and Environment Record types are used to explain the behaviour of name resolution in nested functions and blocks. These types and the operations upon them are defined in <emu-xref href="#sec-lexical-environments"></emu-xref>.</p>
     </emu-clause>
 
     <!-- es6num="6.2.6" -->
@@ -3085,7 +3085,7 @@
         1. Return ? OrdinaryToPrimitive(_input_, _hint_).
       </emu-alg>
       <emu-note>
-        <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were Number. However, objects may over-ride this behavior by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behavior. Date objects treat no hint as if the hint were String.</p>
+        <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were Number. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Date objects treat no hint as if the hint were String.</p>
       </emu-note>
 
       <emu-clause id="sec-ordinarytoprimitive" aoid="OrdinaryToPrimitive">
@@ -4713,7 +4713,7 @@
       <emu-clause id="sec-declarative-environment-records">
         <h1>Declarative Environment Records</h1>
         <p>Each declarative Environment Record is associated with an ECMAScript program scope containing variable, constant, let, class, module, import, and/or function declarations. A declarative Environment Record binds the set of identifiers defined by the declarations contained within its scope.</p>
-        <p>The behavior of the concrete specification methods for declarative Environment Records is defined by the following algorithms.</p>
+        <p>The behaviour of the concrete specification methods for declarative Environment Records is defined by the following algorithms.</p>
 
         <!-- es6num="8.1.1.1.1" -->
         <emu-clause id="sec-declarative-environment-records-hasbinding-n">
@@ -4846,7 +4846,7 @@
         <h1>Object Environment Records</h1>
         <p>Each object Environment Record is associated with an object called its <em>binding object</em>. An object Environment Record binds the set of string identifier names that directly correspond to the property names of its binding object. Property keys that are not strings in the form of an |IdentifierName| are not included in the set of bound identifiers. Both own and inherited properties are included in the set regardless of the setting of their [[Enumerable]] attribute. Because properties can be dynamically added and deleted from objects, the set of identifiers bound by an object Environment Record may potentially change as a side-effect of any operation that adds or deletes properties. Any bindings that are created as a result of such a side-effect are considered to be a mutable binding even if the Writable attribute of the corresponding property has the value *false*. Immutable bindings do not exist for object Environment Records.</p>
         <p>Object Environment Records created for `with` statements (<emu-xref href="#sec-with-statement"></emu-xref>) can provide their binding object as an implicit *this* value for use in function calls. The capability is controlled by a _withEnvironment_ Boolean value that is associated with each object Environment Record. By default, the value of _withEnvironment_ is *false* for any object Environment Record.</p>
-        <p>The behavior of the concrete specification methods for object Environment Records is defined by the following algorithms.</p>
+        <p>The behaviour of the concrete specification methods for object Environment Records is defined by the following algorithms.</p>
 
         <!-- es6num="8.1.1.2.1" -->
         <emu-clause id="sec-object-environment-records-hasbinding-n">
@@ -5084,7 +5084,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p>The behavior of the additional concrete specification methods for function Environment Records is defined by the following algorithms:</p>
+        <p>The behaviour of the additional concrete specification methods for function Environment Records is defined by the following algorithms:</p>
 
         <!-- es6num="8.1.1.3.1" -->
         <emu-clause id="sec-bindthisvalue">
@@ -5288,7 +5288,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p>The behavior of the concrete specification methods for global Environment Records is defined by the following algorithms.</p>
+        <p>The behaviour of the concrete specification methods for global Environment Records is defined by the following algorithms.</p>
 
         <!-- es6num="8.1.1.4.1" -->
         <emu-clause id="sec-global-environment-records-hasbinding-n">
@@ -5579,7 +5579,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p>The behavior of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
+        <p>The behaviour of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
 
         <!-- es6num="8.1.1.5.1" -->
         <emu-clause id="sec-module-environment-records-getbindingvalue-n-s">
@@ -6268,8 +6268,8 @@
 </emu-clause>
 
 <!-- es6num="9" -->
-<emu-clause id="sec-ordinary-and-exotic-objects-behaviors">
-  <h1>Ordinary and Exotic Objects Behaviors</h1>
+<emu-clause id="sec-ordinary-and-exotic-objects-behaviours">
+  <h1>Ordinary and Exotic Objects Behaviours</h1>
 
   <!-- es6num="9.1" -->
   <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots">
@@ -7172,10 +7172,10 @@
   <!-- es6num="9.3" -->
   <emu-clause id="sec-built-in-function-objects">
     <h1>Built-in Function Objects</h1>
-    <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behavior is provided using ECMAScript code or as implementation provided exotic function objects whose behavior is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
-    <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behavior specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such exotic function objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
+    <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided exotic function objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
+    <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such exotic function objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
     <p>Unless otherwise specified every built-in function object has the %FunctionPrototype% object as the initial value of its [[Prototype]] internal slot.</p>
-    <p>The behavior specified for each built-in function via algorithm steps or other means is the specification of the function body behavior for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behavior must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behavior other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value `"classConstructor"`.</p>
+    <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value `"classConstructor"`.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
     <p>Built-in functions that are not constructors do not have a `prototype` property unless otherwise specified in the description of a particular function.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
@@ -7218,7 +7218,7 @@
       <p>The abstract operation CreateBuiltinFunction takes arguments _realm_, _steps_, and _prototype_. The optional argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. CreateBuiltinFunction returns a built-in function object created by the following steps:</p>
       <emu-alg>
         1. Assert: _realm_ is a Realm Record.
-        1. Assert: _steps_ is either a set of algorithm steps or other definition of a function's behavior provided in this specification.
+        1. Assert: _steps_ is either a set of algorithm steps or other definition of a function's behaviour provided in this specification.
         1. Let _func_ be a new built-in function object that when called performs the action described by _steps_. The new function object has internal slots whose names are the elements of _internalSlotsList_. The initial value of each of those internal slots is *undefined*.
         1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[Prototype]] to _prototype_.
@@ -7418,7 +7418,7 @@
           1. Return ? Construct(_C_, &laquo; _length_ &raquo;).
         </emu-alg>
         <emu-note>
-          <p>If _originalArray_ was created using the standard built-in Array constructor for a realm that is not the realm of the running execution context, then a new Array is created using the realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behavior for the Array.prototype methods that now are defined using ArraySpeciesCreate.</p>
+          <p>If _originalArray_ was created using the standard built-in Array constructor for a realm that is not the realm of the running execution context, then a new Array is created using the realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behaviour for the Array.prototype methods that now are defined using ArraySpeciesCreate.</p>
         </emu-note>
       </emu-clause>
 
@@ -7460,7 +7460,7 @@
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>In steps 3 and 4, if _Desc_.[[Value]] is an object then its `valueOf` method is called twice. This is legacy behavior that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
+          <p>In steps 3 and 4, if _Desc_.[[Value]] is an object then its `valueOf` method is called twice. This is legacy behaviour that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -8815,7 +8815,7 @@
     <p>The components of a combining character sequence are treated as individual Unicode code points even though a user might think of the whole sequence as a single character.</p>
     <emu-note>
       <p>In string literals, regular expression literals, template literals and identifiers, any Unicode code point may also be expressed using Unicode escape sequences that explicitly express a code point's numeric value. Within a comment, such an escape sequence is effectively ignored as part of the comment.</p>
-      <p>ECMAScript differs from the Java programming language in the behavior of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a string literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a string literal&mdash;one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the String value of a string literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a string literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the string literal.</p>
+      <p>ECMAScript differs from the Java programming language in the behaviour of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a string literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a string literal&mdash;one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the String value of a string literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a string literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the string literal.</p>
     </emu-note>
 
     <!-- es6num="10.1.1" -->
@@ -8895,7 +8895,7 @@
     <!-- es6num="10.2.2" -->
     <emu-clause id="sec-non-ecmascript-functions">
       <h1>Non-ECMAScript Functions</h1>
-      <p>An ECMAScript implementation may support the evaluation of exotic function objects whose evaluative behavior is expressed in some implementation defined form of executable code other than via ECMAScript code. Whether a function object is an ECMAScript code function or a non-ECMAScript function is not semantically observable from the perspective of an ECMAScript code function that calls or is called by such a non-ECMAScript function.</p>
+      <p>An ECMAScript implementation may support the evaluation of exotic function objects whose evaluative behaviour is expressed in some implementation defined form of executable code other than via ECMAScript code. Whether a function object is an ECMAScript code function or a non-ECMAScript function is not semantically observable from the perspective of an ECMAScript code function that calls or is called by such a non-ECMAScript function.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>
@@ -9142,7 +9142,7 @@
   <!-- es6num="11.3" -->
   <emu-clause id="sec-line-terminators">
     <h1>Line Terminators</h1>
-    <p>Like white space code points, line terminator code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other. However, unlike white space code points, line terminators have some influence over the behavior of the syntactic grammar. In general, line terminators may occur between any two tokens, but there are a few places where they are forbidden by the syntactic grammar. Line terminators also affect the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A line terminator cannot occur within any token except a |StringLiteral|, |Template|, or |TemplateSubstitutionTail|. Line terminators may only occur within a |StringLiteral| token as part of a |LineContinuation|.</p>
+    <p>Like white space code points, line terminator code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other. However, unlike white space code points, line terminators have some influence over the behaviour of the syntactic grammar. In general, line terminators may occur between any two tokens, but there are a few places where they are forbidden by the syntactic grammar. Line terminators also affect the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A line terminator cannot occur within any token except a |StringLiteral|, |Template|, or |TemplateSubstitutionTail|. Line terminators may only occur within a |StringLiteral| token as part of a |LineContinuation|.</p>
     <p>A line terminator can occur within a |MultiLineComment| but cannot occur within a |SingleLineComment|.</p>
     <p>Line terminators are included in the set of white space code points that are matched by the `\\s` class in regular expressions.</p>
     <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-33"></emu-xref>.</p>
@@ -11779,7 +11779,7 @@
         <div class="rhs">
           |MemberExpression| `.` |IdentifierName|
         </div>
-        <p>is identical in its behavior to</p>
+        <p>is identical in its behaviour to</p>
         <div class="rhs">
           |MemberExpression| `[` &lt;<i>identifier-name-string</i>&gt; `]`
         </div>
@@ -11787,7 +11787,7 @@
         <div class="rhs">
           |CallExpression| `.` |IdentifierName|
         </div>
-        <p>is identical in its behavior to</p>
+        <p>is identical in its behaviour to</p>
         <div class="rhs">
           |CallExpression| `[` &lt;<i>identifier-name-string</i>&gt; `]`
         </div>
@@ -12725,7 +12725,7 @@
         <emu-note>
           <p>In C and C++, the remainder operator accepts only integral operands; in ECMAScript, it also accepts floating-point operands.</p>
         </emu-note>
-        <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2008. The IEEE 754-2008 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behavior is not analogous to that of the usual integer remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java integer remainder operator; this may be compared with the C library function fmod.</p>
+        <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2008. The IEEE 754-2008 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual integer remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java integer remainder operator; this may be compared with the C library function fmod.</p>
         <p>The result of an ECMAScript floating-point remainder operation is determined by the rules of IEEE arithmetic:</p>
         <ul>
           <li>
@@ -12779,7 +12779,7 @@
           <li>If _base_ &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integer, the result is *NaN*.</li>
         </ul>
         <emu-note>
-          <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity* differs from IEEE 754-2008. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2008 specified *1*. The historical ECMAScript behavior is preserved for compatibility reasons.</p>
+          <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity* differs from IEEE 754-2008. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2008 specified *1*. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -19661,7 +19661,7 @@
                 1. If _vnDefinable_ is *false*, throw a *TypeError* exception.
                 1. If _vn_ is not an element of _declaredVarNames_, then
                   1. Append _vn_ to _declaredVarNames_.
-        1. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviors that cause abnormal terminations in some of the following steps.
+        1. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviours that cause abnormal terminations in some of the following steps.
         1. NOTE: Annex <emu-xref href="#sec-web-compat-globaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
         1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _script_.
         1. For each element _d_ in _lexDeclarations_ do
@@ -21576,13 +21576,13 @@
   <p>An implementation shall report all errors as specified, except for the following:</p>
   <ul>
     <li>
-      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may extend |Script| syntax, |Module| syntax, and regular expression pattern or flag syntax. To permit this, all operations (such as calling `eval`, using a regular expression literal, or using the `Function` or `RegExp` constructor) that are allowed to throw *SyntaxError* are permitted to exhibit implementation-defined behavior instead of throwing *SyntaxError* when they encounter an implementation-defined extension to the script syntax or regular expression pattern or flag syntax.
+      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may extend |Script| syntax, |Module| syntax, and regular expression pattern or flag syntax. To permit this, all operations (such as calling `eval`, using a regular expression literal, or using the `Function` or `RegExp` constructor) that are allowed to throw *SyntaxError* are permitted to exhibit implementation-defined behaviour instead of throwing *SyntaxError* when they encounter an implementation-defined extension to the script syntax or regular expression pattern or flag syntax.
     </li>
     <li>
-      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may provide additional types, values, objects, properties, and functions beyond those described in this specification. This may cause constructs (such as looking up a variable in the global scope) to have implementation-defined behavior instead of throwing an error (such as *ReferenceError*).
+      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may provide additional types, values, objects, properties, and functions beyond those described in this specification. This may cause constructs (such as looking up a variable in the global scope) to have implementation-defined behaviour instead of throwing an error (such as *ReferenceError*).
     </li>
   </ul>
-  <p>An implementation may define behavior other than throwing *RangeError* for `toFixed`, `toExponential`, and `toPrecision` when the _fractionDigits_ or _precision_ argument is outside the specified range.</p>
+  <p>An implementation may define behaviour other than throwing *RangeError* for `toFixed`, `toExponential`, and `toPrecision` when the _fractionDigits_ or _precision_ argument is outside the specified range.</p>
 
   <emu-clause id="sec-host-report-errors" aoid="HostReportErrors">
     <h1>HostReportErrors ( _errorList_ )</h1>
@@ -21608,7 +21608,7 @@
         If an implementation extends non-strict or built-in function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
       </li>
       <li>
-        The behavior of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, `%TypedArray%.prototype.toLocaleString`.
+        The behaviour of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, `%TypedArray%.prototype.toLocaleString`.
       </li>
       <li>
         The RegExp pattern grammars in <emu-xref href="#sec-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[+U]| when the U grammar parameter is present.
@@ -21639,7 +21639,7 @@
   <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in Function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in Function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;`this` value&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
-  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behavior relating to such arguments as long as the behavior is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>
+  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>
   <emu-note>
     <p>Implementations that add additional capabilities to the set of built-in functions are encouraged to do so by adding new functions rather than adding new parameters to existing functions.</p>
   </emu-note>
@@ -22880,7 +22880,7 @@
             1. If SameValue(_O_, _V_) is *true*, return *true*.
         </emu-alg>
         <emu-note>
-          <p>The ordering of steps 1 and 2 preserves the behavior specified by previous editions of this specification for the case where _V_ is not an object and the *this* value is *undefined* or *null*.</p>
+          <p>The ordering of steps 1 and 2 preserves the behaviour specified by previous editions of this specification for the case where _V_ is not an object and the *this* value is *undefined* or *null*.</p>
         </emu-note>
       </emu-clause>
 
@@ -22913,7 +22913,7 @@
         </emu-alg>
         <p>The optional parameters to this function are not used but are intended to correspond to the parameter pattern used by ECMA-402 `toLocalString` functions. Implementations that do not include ECMA-402 support must not use those parameter positions for other purposes.</p>
         <emu-note>
-          <p>This function provides a generic `toLocaleString` implementation for objects that have no locale-specific `toString` behavior. `Array`, `Number`, `Date`, and `Typed Arrays` provide their own locale-sensitive `toLocaleString` methods.</p>
+          <p>This function provides a generic `toLocaleString` implementation for objects that have no locale-specific `toString` behaviour. `Array`, `Number`, `Date`, and `Typed Arrays` provide their own locale-sensitive `toLocaleString` methods.</p>
         </emu-note>
         <emu-note>
           <p>ECMA-402 intentionally does not provide an alternative to this default implementation.</p>
@@ -22975,7 +22975,7 @@
     <emu-clause id="sec-function-constructor">
       <h1>The Function Constructor</h1>
       <p>The Function constructor is the <dfn>%Function%</dfn> intrinsic object and the initial value of the `Function` property of the global object. When `Function` is called as a function rather than as a constructor, it creates and initializes a new Function object. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</p>
-      <p>The `Function` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behavior must include a `super` call to the `Function` constructor to create and initialize a subclass instances with the internal slots necessary for built-in function behavior. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction` subclass.</p>
+      <p>The `Function` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instances with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction` subclass.</p>
 
       <!-- es6num="19.2.1.1" -->
       <emu-clause id="sec-function-p1-p2-pn-body">
@@ -23232,7 +23232,7 @@
       <!-- es6num="19.2.4.1" -->
       <emu-clause id="sec-function-instances-length">
         <h1>length</h1>
-        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behavior of a function when invoked on a number of arguments other than the number specified by its `length` property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a function when invoked on a number of arguments other than the number specified by its `length` property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <!-- es6num="19.2.4.2" -->
@@ -23262,7 +23262,7 @@
     <emu-clause id="sec-boolean-constructor">
       <h1>The Boolean Constructor</h1>
       <p>The Boolean constructor is the <dfn>%Boolean%</dfn> intrinsic object and the initial value of the `Boolean` property of the global object. When called as a constructor it creates and initializes a new Boolean object. When `Boolean` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `Boolean` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behavior must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</p>
+      <p>The `Boolean` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behaviour must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</p>
 
       <!-- es6num="19.3.1.1" -->
       <emu-clause id="sec-boolean-constructor-boolean-value">
@@ -23617,7 +23617,7 @@
     <emu-clause id="sec-error-constructor">
       <h1>The Error Constructor</h1>
       <p>The Error constructor is the <dfn>%Error%</dfn> intrinsic object and the initial value of the `Error` property of the global object. When `Error` is called as a function rather than as a constructor, it creates and initializes a new Error object. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</p>
-      <p>The `Error` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behavior must include a `super` call to the `Error` constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
+      <p>The `Error` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
 
       <!-- es6num="19.5.1.1" -->
       <emu-clause id="sec-error-message">
@@ -23749,7 +23749,7 @@
       <emu-clause id="sec-nativeerror-constructors">
         <h1>_NativeError_ Constructors</h1>
         <p>When a _NativeError_ constructor is called as a function rather than as a constructor, it creates and initializes a new _NativeError_ object. A call of the object as a function is equivalent to calling it as a constructor with the same arguments. Thus the function call <code><var>NativeError</var>(&hellip;)</code> is equivalent to the object creation expression <code>new <var>NativeError</var>(&hellip;)</code> with the same arguments.</p>
-        <p>Each _NativeError_ constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behavior must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
+        <p>Each _NativeError_ constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
 
         <!-- es6num="19.5.6.1.1" -->
         <emu-clause id="sec-nativeerror">
@@ -23829,7 +23829,7 @@
     <emu-clause id="sec-number-constructor">
       <h1>The Number Constructor</h1>
       <p>The Number constructor is the <dfn>%Number%</dfn> intrinsic object and the initial value of the `Number` property of the global object. When called as a constructor, it creates and initializes a new Number object. When `Number` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `Number` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behavior must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</p>
+      <p>The `Number` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behaviour must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</p>
 
       <!-- es6num="20.1.1.1" -->
       <emu-clause id="sec-number-constructor-number-value">
@@ -24024,7 +24024,7 @@
             1. Let _x_ be -_x_.
           1. If _x_ = *+&infin;*, then
             1. Return the concatenation of the Strings _s_ and `"Infinity"`.
-          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behavior of `toExponential` for values of _f_ less than 0 or greater than 20. In this case `toExponential` would not necessarily throw *RangeError* for such values.
+          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toExponential` for values of _f_ less than 0 or greater than 20. In this case `toExponential` would not necessarily throw *RangeError* for such values.
           1. If _x_ = 0, then
             1. Let _m_ be the String consisting of _f_+1 occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.
@@ -24049,7 +24049,7 @@
           1. Let _m_ be the concatenation of the four Strings _m_, `"e"`, _c_, and _d_.
           1. Return the concatenation of the Strings _s_ and _m_.
         </emu-alg>
-        <p>If the `toExponential` method is called with more than one argument, then the behavior is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
+        <p>If the `toExponential` method is called with more than one argument, then the behaviour is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
         <emu-note>
           <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 10.b.i be used as a guideline:</p>
           <emu-alg type="i">
@@ -24068,7 +24068,7 @@
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToInteger(_fractionDigits_). (If _fractionDigits_ is *undefined*, this step produces the value 0.)
-          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behavior of `toFixed` for values of _f_ less than 0 or greater than 20. In this case `toFixed` would not necessarily throw *RangeError* for such values.
+          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toFixed` for values of _f_ less than 0 or greater than 20. In this case `toFixed` would not necessarily throw *RangeError* for such values.
           1. If _x_ is *NaN*, return the String `"NaN"`.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
@@ -24089,7 +24089,7 @@
               1. Let _m_ be the concatenation of the three Strings _a_, `"."`, and _b_.
           1. Return the concatenation of the Strings _s_ and _m_.
         </emu-alg>
-        <p>If the `toFixed` method is called with more than one argument, then the behavior is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
+        <p>If the `toFixed` method is called with more than one argument, then the behaviour is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
         <emu-note>
           <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent number values. For example,</p>
           <p>`(1000000000000000128).toString()` returns `"1000000000000000100"`, while
@@ -24121,7 +24121,7 @@
             1. Let _x_ be -_x_.
           1. If _x_ = *+&infin;*, then
             1. Return the String that is the concatenation of _s_ and `"Infinity"`.
-          1. If _p_ &lt; 1 or _p_ &gt; 21, throw a *RangeError* exception. However, an implementation is permitted to extend the behavior of `toPrecision` for values of _p_ less than 1 or greater than 21. In this case `toPrecision` would not necessarily throw *RangeError* for such values.
+          1. If _p_ &lt; 1 or _p_ &gt; 21, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toPrecision` for values of _p_ less than 1 or greater than 21. In this case `toPrecision` would not necessarily throw *RangeError* for such values.
           1. If _x_ = 0, then
             1. Let _m_ be the String consisting of _p_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.
@@ -24146,7 +24146,7 @@
             1. Let _m_ be the String formed by the concatenation of code unit 0x0030 (DIGIT ZERO), code unit 0x002E (FULL STOP), -(_e_+1) occurrences of code unit 0x0030 (DIGIT ZERO), and the String _m_.
           1. Return the String that is the concatenation of _s_ and _m_.
         </emu-alg>
-        <p>If the `toPrecision` method is called with more than one argument, then the behavior is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
+        <p>If the `toPrecision` method is called with more than one argument, then the behaviour is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
       </emu-clause>
 
       <!-- es6num="20.1.3.6" -->
@@ -24278,7 +24278,7 @@
       <p>Each of the following `Math` object functions applies the ToNumber abstract operation to each of its arguments (in left-to-right order if there is more than one). If ToNumber returns an abrupt completion, that Completion Record is immediately returned. Otherwise, the function performs a computation on the resulting Number value(s). The value returned by each function is a Number.</p>
       <p>In the function descriptions below, the symbols *NaN*, *-0*, *+0*, *-&infin;* and *+&infin;* refer to the Number values described in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>.</p>
       <emu-note>
-        <p>The behavior of the functions `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `atan2`, `cbrt`, `cos`, `cosh`, `exp`, `expm1`, `hypot`, `log`,`log1p`, `log2`, `log10`, `pow`, `random`, `sin`, `sinh`, `sqrt`, `tan`, and `tanh` is not precisely specified here except to require specific results for certain argument values that represent boundary cases of interest. For other argument values, these functions are intended to compute approximations to the results of familiar mathematical functions, but some latitude is allowed in the choice of approximation algorithms. The general intent is that an implementer should be able to use the same mathematical library for ECMAScript on a given hardware platform that is available to C programmers on that platform.</p>
+        <p>The behaviour of the functions `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `atan2`, `cbrt`, `cos`, `cosh`, `exp`, `expm1`, `hypot`, `log`,`log1p`, `log2`, `log10`, `pow`, `random`, `sin`, `sinh`, `sqrt`, `tan`, and `tanh` is not precisely specified here except to require specific results for certain argument values that represent boundary cases of interest. For other argument values, these functions are intended to compute approximations to the results of familiar mathematical functions, but some latitude is allowed in the choice of approximation algorithms. The general intent is that an implementer should be able to use the same mathematical library for ECMAScript on a given hardware platform that is available to C programmers on that platform.</p>
         <p>Although the choice of algorithms is left to the implementation, it is recommended (but not specified by this standard) that implementations use the approximation algorithms for IEEE 754-2008 arithmetic contained in `fdlibm`, the freely distributable mathematical library from Sun Microsystems (<a href="http://www.netlib.org/fdlibm">http://www.netlib.org/fdlibm</a>).</p>
       </emu-note>
 
@@ -25530,8 +25530,8 @@ THH:mm:ss.sss
     <emu-clause id="sec-date-constructor">
       <h1>The Date Constructor</h1>
       <p>The Date constructor is the <dfn>%Date%</dfn> intrinsic object and the initial value of the `Date` property of the global object. When called as a constructor it creates and initializes a new Date object. When `Date` is called as a function rather than as a constructor, it returns a String representing the current time (UTC).</p>
-      <p>The `Date` constructor is a single function whose behavior is overloaded based upon the number and types of its arguments.</p>
-      <p>The `Date` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behavior must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</p>
+      <p>The `Date` constructor is a single function whose behaviour is overloaded based upon the number and types of its arguments.</p>
+      <p>The `Date` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behaviour must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</p>
       <p>The `length` property of the `Date` constructor function is 7.</p>
 
       <!-- es6num="20.3.2.1" -->
@@ -26308,7 +26308,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-string-constructor">
       <h1>The String Constructor</h1>
       <p>The String constructor is the <dfn>%String%</dfn> intrinsic object and the initial value of the `String` property of the global object. When called as a constructor it creates and initializes a new String object. When `String` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `String` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behavior must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</p>
+      <p>The `String` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behaviour must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</p>
 
       <!-- es6num="21.1.1.1" -->
       <emu-clause id="sec-string-constructor-string-value">
@@ -27109,7 +27109,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The result must be derived according to the locale-insensitive case mappings in the Unicode Character Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive mappings in the SpecialCasings.txt file that accompanies it).</p>
         <emu-note>
-          <p>The case mapping of some code points may produce multiple code points. In this case the result String may not be the same length as the source String. Because both `toUpperCase` and `toLowerCase` have context-sensitive behavior, the functions are not symmetrical. In other words, `s.toUpperCase().toLowerCase()` is not necessarily equal to `s.toLowerCase()`.</p>
+          <p>The case mapping of some code points may produce multiple code points. In this case the result String may not be the same length as the source String. Because both `toUpperCase` and `toLowerCase` have context-sensitive behaviour, the functions are not symmetrical. In other words, `s.toUpperCase().toLowerCase()` is not necessarily equal to `s.toLowerCase()`.</p>
         </emu-note>
         <emu-note>
           <p>The `toLowerCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -27448,7 +27448,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-pattern-semantics">
       <h1>Pattern Semantics</h1>
       <p>A regular expression pattern is converted into an internal procedure using the process described below. An implementation is encouraged to use more efficient algorithms than the ones listed below, as long as the results are the same. The internal procedure is used as the value of a RegExp object's [[RegExpMatcher]] internal slot.</p>
-      <p>A |Pattern| is either a BMP pattern or a Unicode pattern depending upon whether or not its associated flags contain a `"u"`. A BMP pattern matches against a String interpreted as consisting of a sequence of 16-bit values that are Unicode code points in the range of the Basic Multilingual Plane. A Unicode pattern matches against a String interpreted as consisting of Unicode code points encoded using UTF-16. In the context of describing the behavior of a BMP pattern &ldquo;character&rdquo; means a single 16-bit Unicode BMP code point. In the context of describing the behavior of a Unicode pattern &ldquo;character&rdquo; means a UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). In either context, &ldquo;character value&rdquo; means the numeric value of the corresponding non-encoded code point.</p>
+      <p>A |Pattern| is either a BMP pattern or a Unicode pattern depending upon whether or not its associated flags contain a `"u"`. A BMP pattern matches against a String interpreted as consisting of a sequence of 16-bit values that are Unicode code points in the range of the Basic Multilingual Plane. A Unicode pattern matches against a String interpreted as consisting of Unicode code points encoded using UTF-16. In the context of describing the behaviour of a BMP pattern &ldquo;character&rdquo; means a single 16-bit Unicode BMP code point. In the context of describing the behaviour of a Unicode pattern &ldquo;character&rdquo; means a UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). In either context, &ldquo;character value&rdquo; means the numeric value of the corresponding non-encoded code point.</p>
       <p>The syntax and semantics of |Pattern| is defined as if the source code for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>
       <emu-note>
         <p>For example, consider a pattern expressed in source text as the single non-BMP character U+1D11E (MUSICAL SYMBOL G CLEF). Interpreted as a Unicode pattern, it would be a single element (character) List consisting of the single code point 0x1D11E. However, interpreted as a BMP pattern, it is first UTF-16 encoded to produce a two element List consisting of the code units 0xD834 and 0xDD1E.</p>
@@ -27639,7 +27639,7 @@ THH:mm:ss.sss
             <p>which returns the gcd in unary notation `"aaaaa"`.</p>
           </emu-note>
           <emu-note>
-            <p>Step 4 of the RepeatMatcher clears |Atom|'s captures each time |Atom| is repeated. We can see its behavior in the regular expression</p>
+            <p>Step 4 of the RepeatMatcher clears |Atom|'s captures each time |Atom| is repeated. We can see its behaviour in the regular expression</p>
             <pre><code class="javascript">/(z)((a+)?(b+)?(c))*/.exec("zaacbbbcac")</code></pre>
             <p>which returns the array</p>
             <pre><code class="javascript">["zaacbbbcac", "z", "ac", "a", undefined, "c"]</code></pre>
@@ -28104,10 +28104,10 @@ THH:mm:ss.sss
               1. Return _cu_.
           </emu-alg>
           <emu-note>
-            <p>Parentheses of the form `(` |Disjunction| `)` serve both to group the components of the |Disjunction| pattern together and to save the result of the match. The result can be used either in a backreference (`\\` followed by a nonzero decimal number), referenced in a replace String, or returned as part of an array from the regular expression matching internal procedure. To inhibit the capturing behavior of parentheses, use the form `(?:` |Disjunction| `)` instead.</p>
+            <p>Parentheses of the form `(` |Disjunction| `)` serve both to group the components of the |Disjunction| pattern together and to save the result of the match. The result can be used either in a backreference (`\\` followed by a nonzero decimal number), referenced in a replace String, or returned as part of an array from the regular expression matching internal procedure. To inhibit the capturing behaviour of parentheses, use the form `(?:` |Disjunction| `)` instead.</p>
           </emu-note>
           <emu-note>
-            <p>The form `(?=` |Disjunction| `)` specifies a zero-width positive lookahead. In order for it to succeed, the pattern inside |Disjunction| must match at the current position, but the current position is not advanced before matching the sequel. If |Disjunction| can match at the current position in several ways, only the first one is tried. Unlike other regular expression operators, there is no backtracking into a `(?=` form (this unusual behavior is inherited from Perl). This only matters when the |Disjunction| contains capturing parentheses and the sequel of the pattern contains backreferences to those captures.</p>
+            <p>The form `(?=` |Disjunction| `)` specifies a zero-width positive lookahead. In order for it to succeed, the pattern inside |Disjunction| must match at the current position, but the current position is not advanced before matching the sequel. If |Disjunction| can match at the current position in several ways, only the first one is tried. Unlike other regular expression operators, there is no backtracking into a `(?=` form (this unusual behaviour is inherited from Perl). This only matters when the |Disjunction| contains capturing parentheses and the sequel of the pattern contains backreferences to those captures.</p>
             <p>For example,</p>
             <pre><code class="javascript">/(?=(a+))/.exec("baaabac")</code></pre>
             <p>matches the empty String immediately after the first `b` and therefore returns the array:</p>
@@ -28507,7 +28507,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-regexp-constructor">
       <h1>The RegExp Constructor</h1>
       <p>The RegExp constructor is the <dfn>%RegExp%</dfn> intrinsic object and the initial value of the `RegExp` property of the global object. When `RegExp` is called as a function rather than as a constructor, it creates and initializes a new RegExp object. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</p>
-      <p>The `RegExp` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behavior must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</p>
+      <p>The `RegExp` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behaviour must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</p>
 
       <!-- es6num="21.2.3.1" -->
       <emu-clause id="sec-regexp-pattern-flags">
@@ -28626,7 +28626,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>RegExp prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
+          <p>RegExp prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -28675,7 +28675,7 @@ THH:mm:ss.sss
             1. Return ? RegExpBuiltinExec(_R_, _S_).
           </emu-alg>
           <emu-note>
-            <p>If a callable `exec` property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behavior for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of `exec`.</p>
+            <p>If a callable `exec` property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behaviour for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of `exec`.</p>
           </emu-note>
         </emu-clause>
 
@@ -28843,7 +28843,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.match]"`.</p>
         <emu-note>
-          <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behavior of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
+          <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behaviour of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
         </emu-note>
       </emu-clause>
 
@@ -29078,7 +29078,7 @@ THH:mm:ss.sss
           1. Return _result_.
         </emu-alg>
         <emu-note>
-          <p>The returned String has the form of a |RegularExpressionLiteral| that evaluates to another RegExp object with the same behavior as this object.</p>
+          <p>The returned String has the form of a |RegularExpressionLiteral| that evaluates to another RegExp object with the same behaviour as this object.</p>
         </emu-note>
       </emu-clause>
 
@@ -29130,8 +29130,8 @@ THH:mm:ss.sss
     <emu-clause id="sec-array-constructor">
       <h1>The Array Constructor</h1>
       <p>The Array constructor is the <dfn>%Array%</dfn> intrinsic object and the initial value of the `Array` property of the global object. When called as a constructor it creates and initializes a new exotic Array object. When `Array` is called as a function rather than as a constructor, it also creates and initializes a new Array object. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</p>
-      <p>The `Array` constructor is a single function whose behavior is overloaded based upon the number and types of its arguments.</p>
-      <p>The `Array` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behavior must include a `super` call to the `Array` constructor to initialize subclass instances that are exotic Array objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their `this` value being an exotic Array object.</p>
+      <p>The `Array` constructor is a single function whose behaviour is overloaded based upon the number and types of its arguments.</p>
+      <p>The `Array` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behaviour must include a `super` call to the `Array` constructor to initialize subclass instances that are exotic Array objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their `this` value being an exotic Array object.</p>
       <p>The `length` property of the `Array` constructor function is 1.</p>
 
       <!-- es6num="22.1.1.1" -->
@@ -29315,7 +29315,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>Array prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
+          <p>Array prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -30118,7 +30118,7 @@ THH:mm:ss.sss
         <p>The sort order is also implementation defined if any of the following conditions are true:</p>
         <ul>
           <li>
-            If _obj_ is an exotic object (including Proxy exotic objects) whose behavior for [[Get]], [[Set]], [[Delete]], and [[GetOwnProperty]] is not the ordinary object implementation of these internal methods.
+            If _obj_ is an exotic object (including Proxy exotic objects) whose behaviour for [[Get]], [[Set]], [[Delete]], and [[GetOwnProperty]] is not the ordinary object implementation of these internal methods.
           </li>
           <li>
             If any index property of _obj_ whose name is a nonnegative integer less than _len_ is an accessor property or is a data property whose [[Writable]] attribute is *false*.
@@ -30418,7 +30418,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         <emu-note>
-          <p>The own property names of this object are property names that were not included as standard properties of `Array.prototype` prior to the ECMAScript 2015 specification. These names are ignored for `with` statement binding purposes in order to preserve the behavior of existing code that might use one of these names as a binding in an outer scope that is shadowed by a `with` statement whose binding object is an Array object.</p>
+          <p>The own property names of this object are property names that were not included as standard properties of `Array.prototype` prior to the ECMAScript 2015 specification. These names are ignored for `with` statement binding purposes in order to preserve the behaviour of existing code that might use one of these names as a binding in an outer scope that is shadowed by a `with` statement whose binding object is an Array object.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -30901,7 +30901,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>%TypedArrayPrototype% methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
+          <p>%TypedArrayPrototype% methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -30967,7 +30967,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.copywithin">
         <h1>%TypedArray%.prototype.copyWithin (_target_, _start_ [ , _end_ ] )</h1>
         <p>%TypedArray%`.prototype.copyWithin` is a distinct function that implements the same algorithm as `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"` and the actual copying of values in step 12 must be performed in a manner that preserves the bit-level encoding of the source data</p>
-        <p>The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
+        <p>The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
 
         <!-- es6num="22.2.3.5.1" -->
@@ -30999,14 +30999,14 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.7" -->
       <emu-clause id="sec-%typedarray%.prototype.every">
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.8" -->
       <emu-clause id="sec-%typedarray%.prototype.fill">
         <h1>%TypedArray%.prototype.fill (_value_ [ , _start_ [ , _end_ ] ] )</h1>
-        <p>%TypedArray%`.prototype.fill` is a distinct function that implements the same algorithm as `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
+        <p>%TypedArray%`.prototype.fill` is a distinct function that implements the same algorithm as `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -31045,41 +31045,41 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.10" -->
       <emu-clause id="sec-%typedarray%.prototype.find">
         <h1>%TypedArray%.prototype.find (_predicate_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.11" -->
       <emu-clause id="sec-%typedarray%.prototype.findindex">
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.12" -->
       <emu-clause id="sec-%typedarray%.prototype.foreach">
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.includes">
         <h1>%TypedArray%.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>`%TypedArray%.prototype.includes` is a distinct function that implements the same algorithm as `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
+        <p>`%TypedArray%.prototype.includes` is a distinct function that implements the same algorithm as `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.13" -->
       <emu-clause id="sec-%typedarray%.prototype.indexof">
         <h1>%TypedArray%.prototype.indexOf (_searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
+        <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.14" -->
       <emu-clause id="sec-%typedarray%.prototype.join">
         <h1>%TypedArray%.prototype.join ( _separator_ )</h1>
-        <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
+        <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -31097,7 +31097,7 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.16" -->
       <emu-clause id="sec-%typedarray%.prototype.lastindexof">
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
+        <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -31145,28 +31145,28 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.19" -->
       <emu-clause id="sec-%typedarray%.prototype.reduce">
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.20" -->
       <emu-clause id="sec-%typedarray%.prototype.reduceright">
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.21" -->
       <emu-clause id="sec-%typedarray%.prototype.reverse">
         <h1>%TypedArray%.prototype.reverse ( )</h1>
-        <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
+        <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.22" -->
       <emu-clause id="sec-%typedarray%.prototype.set-overloaded-offset">
         <h1>%TypedArray%.prototype.set ( _overloaded_ [ , _offset_ ])</h1>
-        <p>%TypedArray%`.prototype.set` is a single function whose behavior is overloaded based upon the type of its first argument.</p>
+        <p>%TypedArray%`.prototype.set` is a single function whose behaviour is overloaded based upon the type of its first argument.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
 
         <!-- es6num="22.2.3.22.1" -->
@@ -31306,7 +31306,7 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.24" -->
       <emu-clause id="sec-%typedarray%.prototype.some">
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -31374,7 +31374,7 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.27" -->
       <emu-clause id="sec-%typedarray%.prototype.tolocalestring">
         <h1>%TypedArray%.prototype.toLocaleString ([ _reserved1_ [ , _reserved2_ ] ])</h1>
-        <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
+        <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
         <emu-note>
           <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this function is based upon the algorithm for `Array.prototype.toLocaleString` that is in the ECMA-402 specification.</p>
@@ -31425,9 +31425,9 @@ THH:mm:ss.sss
     <emu-clause id="sec-typedarray-constructors">
       <h1>The _TypedArray_ Constructors</h1>
       <p>Each of the _TypedArray_ constructor objects is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-49"></emu-xref>.</p>
-      <p>The _TypedArray_ intrinsic constructor functions are single functions whose behavior is overloaded based upon the number and types of its arguments. The actual behavior of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</p>
+      <p>The _TypedArray_ intrinsic constructor functions are single functions whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</p>
       <p>The _TypedArray_ constructors are not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behavior must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray`%.prototype` built-in methods.</p>
+      <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray`%.prototype` built-in methods.</p>
       <p>The `length` property of the _TypedArray_ constructor function is 3.</p>
 
       <!-- es6num="22.2.4.1" -->
@@ -31695,7 +31695,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-map-constructor">
       <h1>The Map Constructor</h1>
       <p>The Map constructor is the <dfn>%Map%</dfn> intrinsic object and the initial value of the `Map` property of the global object. When called as a constructor it creates and initializes a new Map object. `Map` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Map` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behavior must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</p>
+      <p>The `Map` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behaviour must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</p>
 
       <!-- es6num="23.1.1.1" -->
       <emu-clause id="sec-map-iterable">
@@ -32068,7 +32068,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-set-constructor">
       <h1>The Set Constructor</h1>
       <p>The Set constructor is the <dfn>%Set%</dfn> intrinsic object and the initial value of the `Set` property of the global object. When called as a constructor it creates and initializes a new Set object. `Set` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Set` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behavior must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</p>
+      <p>The `Set` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behaviour must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</p>
 
       <!-- es6num="23.2.1.1" -->
       <emu-clause id="sec-set-iterable">
@@ -32419,7 +32419,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-weakmap-constructor">
       <h1>The WeakMap Constructor</h1>
       <p>The WeakMap constructor is the <dfn>%WeakMap%</dfn> intrinsic object and the initial value of the `WeakMap` property of the global object. When called as a constructor it creates and initializes a new WeakMap object. `WeakMap` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `WeakMap` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behavior must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</p>
+      <p>The `WeakMap` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behaviour must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</p>
 
       <!-- es6num="23.3.1.1" -->
       <emu-clause id="sec-weakmap-iterable">
@@ -32584,7 +32584,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-weakset-constructor">
       <h1>The WeakSet Constructor</h1>
       <p>The WeakSet constructor is the <dfn>%WeakSet%</dfn> intrinsic object and the initial value of the `WeakSet` property of the global object. When called as a constructor it creates and initializes a new WeakSet object. `WeakSet` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `WeakSet` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behavior must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</p>
+      <p>The `WeakSet` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behaviour must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</p>
 
       <!-- es6num="23.4.1.1" -->
       <emu-clause id="sec-weakset-iterable">
@@ -32841,7 +32841,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-arraybuffer-constructor">
       <h1>The ArrayBuffer Constructor</h1>
       <p>The ArrayBuffer constructor is the <dfn>%ArrayBuffer%</dfn> intrinsic object and the initial value of the `ArrayBuffer` property of the global object. When called as a constructor it creates and initializes a new ArrayBuffer object. `ArrayBuffer` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `ArrayBuffer` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behavior must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</p>
+      <p>The `ArrayBuffer` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behaviour must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</p>
 
       <!-- es6num="24.1.2.1" -->
       <emu-clause id="sec-arraybuffer-length">
@@ -32888,7 +32888,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>ArrayBuffer prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
+          <p>ArrayBuffer prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -33020,7 +33020,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-dataview-constructor">
       <h1>The DataView Constructor</h1>
       <p>The DataView constructor is the <dfn>%DataView%</dfn> intrinsic object and the initial value of the `DataView` property of the global object. When called as a constructor it creates and initializes a new DataView object. `DataView` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `DataView` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behavior must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</p>
+      <p>The `DataView` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behaviour must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</p>
 
       <!-- es6num="24.2.2.1" -->
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
@@ -33874,7 +33874,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-generatorfunction-constructor">
       <h1>The GeneratorFunction Constructor</h1>
       <p>The `GeneratorFunction` constructor is the <dfn>%GeneratorFunction%</dfn> intrinsic. When `GeneratorFunction` is called as a function rather than as a constructor, it creates and initializes a new GeneratorFunction object. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</p>
-      <p>`GeneratorFunction` is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `GeneratorFunction` behavior must include a `super` call to the `GeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behavior. All ECMAScript syntactic forms for defining generator function objects create direct instances of `GeneratorFunction`. There is no syntactic means to create instances of `GeneratorFunction` subclasses.</p>
+      <p>`GeneratorFunction` is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `GeneratorFunction` behaviour must include a `super` call to the `GeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of `GeneratorFunction`. There is no syntactic means to create instances of `GeneratorFunction` subclasses.</p>
 
       <!-- es6num="25.2.1.1" -->
       <emu-clause id="sec-generatorfunction">
@@ -33951,7 +33951,7 @@ THH:mm:ss.sss
       <!-- es6num="25.2.4.1" -->
       <emu-clause id="sec-generatorfunction-instances-length">
         <h1>length</h1>
-        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the GeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behavior of a GeneratorFunction when invoked on a number of arguments other than the number specified by its `length` property depends on the function.</p>
+        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the GeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a GeneratorFunction when invoked on a number of arguments other than the number specified by its `length` property depends on the function.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -34554,7 +34554,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-promise-constructor">
       <h1>The Promise Constructor</h1>
       <p>The Promise constructor is the <dfn>%Promise%</dfn> intrinsic object and the initial value of the `Promise` property of the global object. When called as a constructor it creates and initializes a new Promise object. `Promise` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Promise` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behavior must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</p>
+      <p>The `Promise` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behaviour must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</p>
 
       <!-- es6num="25.4.3.1" -->
       <emu-clause id="sec-promise-executor">
@@ -34578,7 +34578,7 @@ THH:mm:ss.sss
           <p>The _executor_ argument must be a function object. It is called for initiating and reporting completion of the possibly deferred action represented by this Promise object. The executor is called with two arguments: _resolve_ and _reject_. These are functions that may be used by the _executor_ function to report eventual completion or failure of the deferred computation. Returning from the executor function does not mean that the deferred action has been completed but only that the request to eventually perform the deferred action has been accepted.</p>
           <p>The _resolve_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _resolve_ function to indicate that it wishes to resolve the associated Promise object. The argument passed to the _resolve_ function represents the eventual value of the deferred action and can be either the actual fulfillment value or another Promise object which will provide the value if it is fulfilled.</p>
           <p>The _reject_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _reject_ function to indicate that the associated Promise is rejected and will never be fulfilled. The argument passed to the _reject_ function is used as the rejection value of the promise. Typically it will be an `Error` object.</p>
-          <p>The resolve and reject functions passed to an _executor_ function by the Promise constructor have the capability to actually resolve and reject the associated promise. Subclasses may have different constructor behavior that passes in customized values for resolve and reject.</p>
+          <p>The resolve and reject functions passed to an _executor_ function by the Promise constructor have the capability to actually resolve and reject the associated promise. Subclasses may have different constructor behaviour that passes in customized values for resolve and reject.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -34770,7 +34770,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>Promise prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
+          <p>Promise prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -35512,8 +35512,8 @@ THH:mm:ss.sss
   <h1>Additional ECMAScript Features for Web Browsers</h1>
   <p>The ECMAScript language syntax and semantics defined in this annex are required when the ECMAScript host is a web browser. The content of this annex is normative but optional if the ECMAScript host is not a web browser.</p>
   <emu-note>
-    <p>This annex describes various legacy features and other characteristics of web browser based ECMAScript implementations. All of the language features and behaviors specified in this annex have one or more undesirable characteristics and in the absence of legacy usage would be removed from this specification. However, the usage of these features by large numbers of existing web pages means that web browsers must continue to support them. The specifications in this annex define the requirements for interoperable implementations of these legacy features.</p>
-    <p>These features are not considered part of the core ECMAScript language. Programmers should not use or assume the existence of these features and behaviors when writing new ECMAScript code. ECMAScript implementations are discouraged from implementing these features unless the implementation is part of a web browser or is required to run the same legacy ECMAScript code that web browsers encounter.</p>
+    <p>This annex describes various legacy features and other characteristics of web browser based ECMAScript implementations. All of the language features and behaviours specified in this annex have one or more undesirable characteristics and in the absence of legacy usage would be removed from this specification. However, the usage of these features by large numbers of existing web pages means that web browsers must continue to support them. The specifications in this annex define the requirements for interoperable implementations of these legacy features.</p>
+    <p>These features are not considered part of the core ECMAScript language. Programmers should not use or assume the existence of these features and behaviours when writing new ECMAScript code. ECMAScript implementations are discouraged from implementing these features unless the implementation is part of a web browser or is required to run the same legacy ECMAScript code that web browsers encounter.</p>
   </emu-note>
 
   <!-- es6num="B.1" -->
@@ -36448,7 +36448,7 @@ THH:mm:ss.sss
         </li>
       </ol>
       <p>The first use case is interoperable with the semantics of |Block| level function declarations provided by ECMAScript 2015. Any pre-existing ECMAScript code that employs that use case will operate using the Block level function declarations semantics defined by clauses 9, 13, and 14 of this specification.</p>
-      <p>ECMAScript 2015 interoperability for the second and third use cases requires the following extensions to the clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviors"></emu-xref>, clause <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>, clause <emu-xref href="#sec-eval-x"></emu-xref> and clause <emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref> semantics.</p>
+      <p>ECMAScript 2015 interoperability for the second and third use cases requires the following extensions to the clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, clause <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>, clause <emu-xref href="#sec-eval-x"></emu-xref> and clause <emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref> semantics.</p>
       <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatibility semantics are applied and introduce observable differences from non-compatibility semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
       <emu-annex id="sec-web-compat-functiondeclarationinstantiation">
         <h1>Changes to FunctionDeclarationInstantiation</h1>
@@ -36605,7 +36605,7 @@ THH:mm:ss.sss
       <emu-note>
         <p>The |Block| of a |Catch| clause may contain `var` declarations that bind a name that is also bound by the |CatchParameter|. At runtime, such bindings are instantiated in the VariableDeclarationEnvironment. They do not shadow the same-named bindings introduced by the |CatchParameter| and hence the |Initializer| for such `var` declarations will assign to the corresponding catch parameter rather than the `var` binding. The relaxation of the normal static semantic rule does not apply to names only bound by for-of statements.</p>
       </emu-note>
-      <p>This modified behavior also applies to `var` and `function` declarations introduced by direct eval calls contained within the |Block| of a |Catch| clause. This change is accomplished by modify the algorithm of <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref> as follows:</p>
+      <p>This modified behaviour also applies to `var` and `function` declarations introduced by direct eval calls contained within the |Block| of a |Catch| clause. This change is accomplished by modify the algorithm of <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref> as follows:</p>
       <p>Step 5.d.ii.2.a.i is replaced by:</p>
       <emu-alg type="i">
         1. If _thisEnvRec_ is not the Environment Record for a |Catch| clause, throw a *SyntaxError* exception.
@@ -36685,10 +36685,10 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>: The 5<sup>th</sup> Edition moved the capture of the current array length prior to the integer conversion of the array index or new length value. However, the captured length value could become invalid if the conversion process has the side-effect of changing the array length. ECMAScript 2015 specifies that the current array length must be captured after the possible occurrence of such side-effects.</p>
   <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0* or *-0* as the representation of a 0 time value. ECMAScript 2015 specifies that *+0* always returned. This means that for ECMAScript 2015 the time value of a Date object is never observably *-0* and methods that return time values never return *-0*.</p>
   <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a time zone offset is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as `"z"`.</p>
-  <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behavior for that case.</p>
+  <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by Date.prototype.toString when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value is `"Invalid Date"`.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the `source` property of an RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `"/"`.</p>
-  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` is flag set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behavior is that `lastIndex` should be incremented by one only if the pattern matched the empty string.</p>
+  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` is flag set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by one only if the pattern matched the empty string.</p>
   <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>, <emu-xref href="#sec-sortcompare"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0* was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation dependent. In practice, implementations call ToNumber.</p>
 </emu-annex>
 
@@ -36698,7 +36698,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>: In ECMAScript 2015, ToNumber applied to a String value now recognizes and converts |BinaryIntegerLiteral| and |OctalIntegerLiteral| numeric strings. In previous editions such strings were converted to *NaN*.</p>
   <p><emu-xref href="#sec-reference-specification-type"></emu-xref>: In ECMAScript 2015, Function calls are not allowed to return a Reference value.</p>
   <p><emu-xref href="#sec-names-and-keywords"></emu-xref>: In ECMAScript 2015, the valid code points for an |IdentifierName| are specified in terms of the Unicode properties &ldquo;ID_Start&rdquo; and &ldquo;ID_Continue&rdquo;. In previous editions, the valid |IdentifierName| or |Identifier| code points were specified by enumerating various Unicode code point categories.</p>
-  <p><emu-xref href="#sec-rules-of-automatic-semicolon-insertion"></emu-xref>: In ECMAScript 2015, Automatic Semicolon Insertion adds a semicolon at the end of a do-while statement if the semicolon is missing. This change aligns the specification with the actual behavior of most existing implementations.</p>
+  <p><emu-xref href="#sec-rules-of-automatic-semicolon-insertion"></emu-xref>: In ECMAScript 2015, Automatic Semicolon Insertion adds a semicolon at the end of a do-while statement if the semicolon is missing. This change aligns the specification with the actual behaviour of most existing implementations.</p>
   <p><emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>: In ECMAScript 2015, it is no longer an early error to have duplicate property names in Object Initializers.</p>
   <p><emu-xref href="#sec-assignment-operators-static-semantics-early-errors"></emu-xref>: In ECMAScript 2015, strict mode code containing an assignment to an immutable binding such as the function name of a |FunctionExpression| does not produce an early error. Instead it produces a runtime error.</p>
   <p><emu-xref href="#sec-block"></emu-xref>: In ECMAScript 2015, a |StatementList| beginning with the token let followed by the input elements |LineTerminator| then |Identifier| is the start of a |LexicalDeclaration|. In previous editions, automatic semicolon insertion would always insert a semicolon before the |Identifier| input element.</p>

--- a/spec.html
+++ b/spec.html
@@ -25647,7 +25647,7 @@ THH:mm:ss.sss
       <!-- es6num="20.3.3.4" -->
       <emu-clause id="sec-date.utc">
         <h1>Date.UTC ( _year_, _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] )</h1>
-        <p>When the `UTC` function is called with fewer than two arguments, the behaviour is implementation-dependent. When the `UTC` function is called with two to seven arguments, it computes the date from _year_, _month_ and (optionally) _date_, _hours_, _minutes_, _seconds_ and _ms_. The following steps are taken:</p>
+        <p>When the `UTC` function is called with fewer than two arguments, the behaviour is implementation-dependent. When the `UTC` function is called with two to seven arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _y_ be ? ToNumber(_year_).
           1. Let _m_ be ? ToNumber(_month_).

--- a/spec.html
+++ b/spec.html
@@ -25647,7 +25647,7 @@ THH:mm:ss.sss
       <!-- es6num="20.3.3.4" -->
       <emu-clause id="sec-date.utc">
         <h1>Date.UTC ( _year_, _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] )</h1>
-        <p>When the `UTC` function is called with fewer than two arguments, the behaviour is implementation-dependent. When the `UTC` function is called with two to seven arguments, the following steps are taken:</p>
+        <p>When the `UTC` function is called with fewer than two arguments, the behavior is implementation-dependent. When the `UTC` function is called with two to seven arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _y_ be ? ToNumber(_year_).
           1. Let _m_ be ? ToNumber(_month_).

--- a/spec.html
+++ b/spec.html
@@ -25647,7 +25647,7 @@ THH:mm:ss.sss
       <!-- es6num="20.3.3.4" -->
       <emu-clause id="sec-date.utc">
         <h1>Date.UTC ( _year_, _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] )</h1>
-        <p>When the `UTC` function is called with fewer than two arguments, the behavior is implementation-dependent. When the `UTC` function is called with two to seven arguments, the following steps are taken:</p>
+        <p>When the `UTC` function is called with fewer than two arguments, the behaviour is implementation-dependent. When the `UTC` function is called with two to seven arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _y_ be ? ToNumber(_year_).
           1. Let _m_ be ? ToNumber(_month_).

--- a/spec.html
+++ b/spec.html
@@ -72,7 +72,7 @@
 <emu-clause id="sec-overview">
   <h1>Overview</h1>
   <p>This section contains a non-normative overview of the ECMAScript language.</p>
-  <p>ECMAScript is an object-oriented programming language for performing computations and manipulating computational objects within a host environment. ECMAScript as defined here is not intended to be computationally self-sufficient; indeed, there are no provisions in this specification for input of external data or output of computed results. Instead, it is expected that the computational environment of an ECMAScript program will provide not only the objects and other facilities described in this specification but also certain environment-specific objects, whose description and behaviour are beyond the scope of this specification except to indicate that they may provide certain properties that can be accessed and certain functions that can be called from an ECMAScript program.</p>
+  <p>ECMAScript is an object-oriented programming language for performing computations and manipulating computational objects within a host environment. ECMAScript as defined here is not intended to be computationally self-sufficient; indeed, there are no provisions in this specification for input of external data or output of computed results. Instead, it is expected that the computational environment of an ECMAScript program will provide not only the objects and other facilities described in this specification but also certain environment-specific objects, whose description and behavior are beyond the scope of this specification except to indicate that they may provide certain properties that can be accessed and certain functions that can be called from an ECMAScript program.</p>
   <p>ECMAScript was originally designed to be used as a scripting language, but has become widely used as a general-purpose programming language. A <em>scripting language</em> is a programming language that is used to manipulate, customize, and automate the facilities of an existing system. In such systems, useful functionality is already available through a user interface, and the scripting language is a mechanism for exposing that functionality to program control. In this way, the existing system is said to provide a host environment of objects and facilities, which completes the capabilities of the scripting language. A scripting language is intended for use by both professional and non-professional programmers.</p>
   <p>ECMAScript was originally designed to be a <em>Web scripting language</em>, providing a mechanism to enliven Web pages in browsers and to perform server computation as part of a Web-based client-server architecture. ECMAScript is now used to provide core scripting capabilities for a variety of host environments. Therefore the core language is specified in this document apart from any particular host environment.</p>
   <p>ECMAScript usage has moved beyond simple scripting and it is now used for the full spectrum of programming tasks in many different environments and scales. As the usage of ECMAScript has expanded, so has the features and facilities it provides. ECMAScript is now a fully featured general-purpose programming language.</p>
@@ -108,7 +108,7 @@
       <emu-figure id="figure-1" caption="Object/Prototype Relationships">
         <object data="img/figure-1.svg" height="354" type="image/svg+xml" width="719"> <img alt="An image of lots of boxes and arrows." height="354" src="img/figure-1.png" width="719"> </object>
       </emu-figure>
-      <p>In a class-based object-oriented language, in general, state is carried by instances, methods are carried by classes, and inheritance is only of structure and behaviour. In ECMAScript, the state and methods are carried by objects, while structure, behaviour, and state are all inherited.</p>
+      <p>In a class-based object-oriented language, in general, state is carried by instances, methods are carried by classes, and inheritance is only of structure and behavior. In ECMAScript, the state and methods are carried by objects, while structure, behavior, and state are all inherited.</p>
       <p>All objects that do not directly contain a particular property that their prototype contains share that property and its value. Figure 1 illustrates this:</p>
       <p><b>CF</b> is a constructor (and also an object). Five objects have been created by using `new` expressions: <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b>. Each of these objects contains properties named `q1` and `q2`. The dashed lines represent the implicit prototype relationship; so, for example, <b>cf<sub>3</sub></b>'s prototype is <b>CF<sub>p</sub></b>. The constructor, <b>CF</b>, has two properties itself, named `P1` and `P2`, which are not visible to <b>CF<sub>p</sub></b>, <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, or <b>cf<sub>5</sub></b>. The property named `CFP1` in <b>CF<sub>p</sub></b> is shared by <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> (but not by <b>CF</b>), as are any properties found in <b>CF<sub>p</sub></b>'s implicit prototype chain that are not named `q1`, `q2`, or `CFP1`. Notice that there is no implicit prototype link between <b>CF</b> and <b>CF<sub>p</sub></b>.</p>
       <p>Unlike most class-based object languages, properties can be added to objects dynamically by assigning values to them. That is, constructors are not required to name or assign values to all or any of the constructed object's properties. In the above diagram, one could add a new shared property for <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> by assigning a new value to the property in <b>CF<sub>p</sub></b>.</p>
@@ -174,13 +174,13 @@
     <!-- es6num="4.3.6" -->
     <emu-clause id="sec-ordinary-object">
       <h1>ordinary object</h1>
-      <p>object that has the default behaviour for the essential internal methods that must be supported by all objects</p>
+      <p>object that has the default behavior for the essential internal methods that must be supported by all objects</p>
     </emu-clause>
 
     <!-- es6num="4.3.7" -->
     <emu-clause id="sec-exotic-object">
       <h1>exotic object</h1>
-      <p>object that does not have the default behaviour for one or more of the essential internal methods</p>
+      <p>object that does not have the default behavior for one or more of the essential internal methods</p>
       <emu-note>
         <p>Any object that is not an ordinary object is an exotic object.</p>
       </emu-note>
@@ -942,7 +942,7 @@
     <!-- es6num="6.1.6" -->
     <emu-clause id="sec-ecmascript-language-types-number-type">
       <h1>The Number Type</h1>
-      <p>The Number type has exactly 18437736874454810627 (that is, <emu-eqn>2<sup>64</sup>-2<sup>53</sup>+3</emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2008 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990 (that is, <emu-eqn>2<sup>53</sup>-2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+      <p>The Number type has exactly 18437736874454810627 (that is, <emu-eqn>2<sup>64</sup>-2<sup>53</sup>+3</emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2008 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990 (that is, <emu-eqn>2<sup>53</sup>-2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behavior is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
       <emu-note>
         <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
       </emu-note>
@@ -962,7 +962,7 @@
       <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>52</sup>, and _e_ is -1074.</p>
       <p>Note that all the positive and negative integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the integer 0 has two representations, *+0* and *-0*).</p>
       <p>A finite number has an <em>odd significand</em> if it is nonzero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
-      <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact nonzero real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 &ldquo;round to nearest, ties to even&rdquo; mode.)</p>
+      <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact nonzero real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behavior of the IEEE 754-2008 &ldquo;round to nearest, ties to even&rdquo; mode.)</p>
       <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup>-1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup>-1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
     </emu-clause>
 
@@ -1178,7 +1178,7 @@
       <!-- es6num="6.1.7.2" -->
       <emu-clause id="sec-object-internal-methods-and-internal-slots">
         <h1>Object Internal Methods and Internal Slots</h1>
-        <p>The actual semantics of objects, in ECMAScript, are specified via algorithms called <em>internal methods</em>. Each object in an ECMAScript engine is associated with a set of internal methods that defines its runtime behaviour. These internal methods are not part of the ECMAScript language. They are defined by this specification purely for expository purposes. However, each object within an implementation of ECMAScript must behave as specified by the internal methods associated with it. The exact manner in which this is accomplished is determined by the implementation.</p>
+        <p>The actual semantics of objects, in ECMAScript, are specified via algorithms called <em>internal methods</em>. Each object in an ECMAScript engine is associated with a set of internal methods that defines its runtime behavior. These internal methods are not part of the ECMAScript language. They are defined by this specification purely for expository purposes. However, each object within an implementation of ECMAScript must behave as specified by the internal methods associated with it. The exact manner in which this is accomplished is determined by the implementation.</p>
         <p>Internal method names are polymorphic. This means that different object values may perform different algorithms when a common internal method name is invoked upon them. That actual object upon which an internal method is invoked is the &ldquo;target&rdquo; of the invocation. If, at runtime, the implementation of an algorithm attempts to use an internal method of an object that the object does not support, a *TypeError* exception is thrown.</p>
         <p>Internal slots correspond to internal state that is associated with objects and used by various ECMAScript specification algorithms. Internal slots are not object properties and they are not inherited. Depending upon the specific internal slot specification, such state may consist of values of any ECMAScript language type or of specific ECMAScript specification type values. Unless explicitly specified otherwise, internal slots are allocated as part of the process of creating an object and may not be dynamically added to an object. Unless specified otherwise, the initial value of an internal slot is the value *undefined*. Various algorithms within this specification create objects that have internal slots. However, the ECMAScript language provides no direct way to associate internal slots with an object.</p>
         <p>Internal methods and internal slots are identified within this specification using names enclosed in double square brackets [[ ]].</p>
@@ -1362,14 +1362,14 @@
             </tbody>
           </table>
         </emu-table>
-        <p>The semantics of the essential internal methods for ordinary objects and standard exotic objects are specified in clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>. If any specified use of an internal method of an exotic object is not supported by an implementation, that usage must throw a *TypeError* exception when attempted.</p>
+        <p>The semantics of the essential internal methods for ordinary objects and standard exotic objects are specified in clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviors"></emu-xref>. If any specified use of an internal method of an exotic object is not supported by an implementation, that usage must throw a *TypeError* exception when attempted.</p>
       </emu-clause>
 
       <!-- es6num="6.1.7.3" -->
       <emu-clause id="sec-invariants-of-the-essential-internal-methods">
         <h1>Invariants of the Essential Internal Methods</h1>
         <p>The Internal Methods of Objects of an ECMAScript engine must conform to the list of invariants specified below. Ordinary ECMAScript Objects as well as all standard exotic objects in this specification maintain these invariants. ECMAScript Proxy objects maintain these invariants by means of runtime checks on the result of traps invoked on the [[ProxyHandler]] object.</p>
-        <p>Any implementation provided exotic objects must also maintain these invariants for those objects. Violation of these invariants may cause ECMAScript code to have unpredictable behaviour and create security issues. However, violation of these invariants must never compromise the memory safety of an implementation.</p>
+        <p>Any implementation provided exotic objects must also maintain these invariants for those objects. Violation of these invariants may cause ECMAScript code to have unpredictable behavior and create security issues. However, violation of these invariants must never compromise the memory safety of an implementation.</p>
         <p>An implementation must not allow these invariants to be circumvented in any manner such as by providing alternative interfaces that implement the functionality of the essential internal methods without enforcing their invariants.</p>
         <h2>Definitions:</h2>
         <ul>
@@ -2566,7 +2566,7 @@
     <!-- es6num="6.2.2" -->
     <emu-clause id="sec-completion-record-specification-type" aoid="Completion">
       <h1>The Completion Record Specification Type</h1>
-      <p>The Completion type is a Record used to explain the runtime propagation of values and control flow such as the behaviour of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
+      <p>The Completion type is a Record used to explain the runtime propagation of values and control flow such as the behavior of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
       <p>Values of the Completion type are Record values whose fields are defined as by <emu-xref href="#table-8"></emu-xref>. Such values are referred to as <dfn>Completion Record</dfn>s.</p>
       <emu-table id="table-8" caption="Completion Record Fields">
         <table>
@@ -2711,7 +2711,7 @@
     <emu-clause id="sec-reference-specification-type">
       <h1>The Reference Specification Type</h1>
       <emu-note>
-        <p>The Reference type is used to explain the behaviour of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a reference.</p>
+        <p>The Reference type is used to explain the behavior of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a reference.</p>
       </emu-note>
       <p>A <dfn>Reference</dfn> is a resolved name or property binding. A Reference consists of three components, the base value component, the referenced name component, and the Boolean-valued strict reference flag. The base value component is either *undefined*, an Object, a Boolean, a String, a Symbol, a Number, or an Environment Record. A base value component of *undefined* indicates that the Reference could not be resolved to a binding. The referenced name component is a String or Symbol value.</p>
       <p>A <dfn id="super-reference">Super Reference</dfn> is a Reference that is used to represents a name binding that was expressed using the super keyword. A Super Reference has an additional thisValue component, and its base value component will never be an Environment Record.</p>
@@ -2943,7 +2943,7 @@
     <!-- es6num="6.2.5" -->
     <emu-clause id="sec-lexical-environment-and-environment-record-specification-types">
       <h1>The Lexical Environment and Environment Record Specification Types</h1>
-      <p>The Lexical Environment and Environment Record types are used to explain the behaviour of name resolution in nested functions and blocks. These types and the operations upon them are defined in <emu-xref href="#sec-lexical-environments"></emu-xref>.</p>
+      <p>The Lexical Environment and Environment Record types are used to explain the behavior of name resolution in nested functions and blocks. These types and the operations upon them are defined in <emu-xref href="#sec-lexical-environments"></emu-xref>.</p>
     </emu-clause>
 
     <!-- es6num="6.2.6" -->
@@ -3085,7 +3085,7 @@
         1. Return ? OrdinaryToPrimitive(_input_, _hint_).
       </emu-alg>
       <emu-note>
-        <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were Number. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Date objects treat no hint as if the hint were String.</p>
+        <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were Number. However, objects may over-ride this behavior by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behavior. Date objects treat no hint as if the hint were String.</p>
       </emu-note>
 
       <emu-clause id="sec-ordinarytoprimitive" aoid="OrdinaryToPrimitive">
@@ -4713,7 +4713,7 @@
       <emu-clause id="sec-declarative-environment-records">
         <h1>Declarative Environment Records</h1>
         <p>Each declarative Environment Record is associated with an ECMAScript program scope containing variable, constant, let, class, module, import, and/or function declarations. A declarative Environment Record binds the set of identifiers defined by the declarations contained within its scope.</p>
-        <p>The behaviour of the concrete specification methods for declarative Environment Records is defined by the following algorithms.</p>
+        <p>The behavior of the concrete specification methods for declarative Environment Records is defined by the following algorithms.</p>
 
         <!-- es6num="8.1.1.1.1" -->
         <emu-clause id="sec-declarative-environment-records-hasbinding-n">
@@ -4846,7 +4846,7 @@
         <h1>Object Environment Records</h1>
         <p>Each object Environment Record is associated with an object called its <em>binding object</em>. An object Environment Record binds the set of string identifier names that directly correspond to the property names of its binding object. Property keys that are not strings in the form of an |IdentifierName| are not included in the set of bound identifiers. Both own and inherited properties are included in the set regardless of the setting of their [[Enumerable]] attribute. Because properties can be dynamically added and deleted from objects, the set of identifiers bound by an object Environment Record may potentially change as a side-effect of any operation that adds or deletes properties. Any bindings that are created as a result of such a side-effect are considered to be a mutable binding even if the Writable attribute of the corresponding property has the value *false*. Immutable bindings do not exist for object Environment Records.</p>
         <p>Object Environment Records created for `with` statements (<emu-xref href="#sec-with-statement"></emu-xref>) can provide their binding object as an implicit *this* value for use in function calls. The capability is controlled by a _withEnvironment_ Boolean value that is associated with each object Environment Record. By default, the value of _withEnvironment_ is *false* for any object Environment Record.</p>
-        <p>The behaviour of the concrete specification methods for object Environment Records is defined by the following algorithms.</p>
+        <p>The behavior of the concrete specification methods for object Environment Records is defined by the following algorithms.</p>
 
         <!-- es6num="8.1.1.2.1" -->
         <emu-clause id="sec-object-environment-records-hasbinding-n">
@@ -5084,7 +5084,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p>The behaviour of the additional concrete specification methods for function Environment Records is defined by the following algorithms:</p>
+        <p>The behavior of the additional concrete specification methods for function Environment Records is defined by the following algorithms:</p>
 
         <!-- es6num="8.1.1.3.1" -->
         <emu-clause id="sec-bindthisvalue">
@@ -5288,7 +5288,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p>The behaviour of the concrete specification methods for global Environment Records is defined by the following algorithms.</p>
+        <p>The behavior of the concrete specification methods for global Environment Records is defined by the following algorithms.</p>
 
         <!-- es6num="8.1.1.4.1" -->
         <emu-clause id="sec-global-environment-records-hasbinding-n">
@@ -5579,7 +5579,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p>The behaviour of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
+        <p>The behavior of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
 
         <!-- es6num="8.1.1.5.1" -->
         <emu-clause id="sec-module-environment-records-getbindingvalue-n-s">
@@ -6268,8 +6268,8 @@
 </emu-clause>
 
 <!-- es6num="9" -->
-<emu-clause id="sec-ordinary-and-exotic-objects-behaviours">
-  <h1>Ordinary and Exotic Objects Behaviours</h1>
+<emu-clause id="sec-ordinary-and-exotic-objects-behaviors">
+  <h1>Ordinary and Exotic Objects Behaviors</h1>
 
   <!-- es6num="9.1" -->
   <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots">
@@ -7172,10 +7172,10 @@
   <!-- es6num="9.3" -->
   <emu-clause id="sec-built-in-function-objects">
     <h1>Built-in Function Objects</h1>
-    <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided exotic function objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
-    <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such exotic function objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
+    <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behavior is provided using ECMAScript code or as implementation provided exotic function objects whose behavior is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
+    <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behavior specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such exotic function objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
     <p>Unless otherwise specified every built-in function object has the %FunctionPrototype% object as the initial value of its [[Prototype]] internal slot.</p>
-    <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value `"classConstructor"`.</p>
+    <p>The behavior specified for each built-in function via algorithm steps or other means is the specification of the function body behavior for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behavior must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behavior other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value `"classConstructor"`.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
     <p>Built-in functions that are not constructors do not have a `prototype` property unless otherwise specified in the description of a particular function.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
@@ -7218,7 +7218,7 @@
       <p>The abstract operation CreateBuiltinFunction takes arguments _realm_, _steps_, and _prototype_. The optional argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. CreateBuiltinFunction returns a built-in function object created by the following steps:</p>
       <emu-alg>
         1. Assert: _realm_ is a Realm Record.
-        1. Assert: _steps_ is either a set of algorithm steps or other definition of a function's behaviour provided in this specification.
+        1. Assert: _steps_ is either a set of algorithm steps or other definition of a function's behavior provided in this specification.
         1. Let _func_ be a new built-in function object that when called performs the action described by _steps_. The new function object has internal slots whose names are the elements of _internalSlotsList_. The initial value of each of those internal slots is *undefined*.
         1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[Prototype]] to _prototype_.
@@ -7418,7 +7418,7 @@
           1. Return ? Construct(_C_, &laquo; _length_ &raquo;).
         </emu-alg>
         <emu-note>
-          <p>If _originalArray_ was created using the standard built-in Array constructor for a realm that is not the realm of the running execution context, then a new Array is created using the realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behaviour for the Array.prototype methods that now are defined using ArraySpeciesCreate.</p>
+          <p>If _originalArray_ was created using the standard built-in Array constructor for a realm that is not the realm of the running execution context, then a new Array is created using the realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behavior for the Array.prototype methods that now are defined using ArraySpeciesCreate.</p>
         </emu-note>
       </emu-clause>
 
@@ -7460,7 +7460,7 @@
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>In steps 3 and 4, if _Desc_.[[Value]] is an object then its `valueOf` method is called twice. This is legacy behaviour that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
+          <p>In steps 3 and 4, if _Desc_.[[Value]] is an object then its `valueOf` method is called twice. This is legacy behavior that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -8815,7 +8815,7 @@
     <p>The components of a combining character sequence are treated as individual Unicode code points even though a user might think of the whole sequence as a single character.</p>
     <emu-note>
       <p>In string literals, regular expression literals, template literals and identifiers, any Unicode code point may also be expressed using Unicode escape sequences that explicitly express a code point's numeric value. Within a comment, such an escape sequence is effectively ignored as part of the comment.</p>
-      <p>ECMAScript differs from the Java programming language in the behaviour of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a string literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a string literal&mdash;one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the String value of a string literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a string literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the string literal.</p>
+      <p>ECMAScript differs from the Java programming language in the behavior of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a string literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a string literal&mdash;one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the String value of a string literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a string literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the string literal.</p>
     </emu-note>
 
     <!-- es6num="10.1.1" -->
@@ -8895,7 +8895,7 @@
     <!-- es6num="10.2.2" -->
     <emu-clause id="sec-non-ecmascript-functions">
       <h1>Non-ECMAScript Functions</h1>
-      <p>An ECMAScript implementation may support the evaluation of exotic function objects whose evaluative behaviour is expressed in some implementation defined form of executable code other than via ECMAScript code. Whether a function object is an ECMAScript code function or a non-ECMAScript function is not semantically observable from the perspective of an ECMAScript code function that calls or is called by such a non-ECMAScript function.</p>
+      <p>An ECMAScript implementation may support the evaluation of exotic function objects whose evaluative behavior is expressed in some implementation defined form of executable code other than via ECMAScript code. Whether a function object is an ECMAScript code function or a non-ECMAScript function is not semantically observable from the perspective of an ECMAScript code function that calls or is called by such a non-ECMAScript function.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>
@@ -9142,7 +9142,7 @@
   <!-- es6num="11.3" -->
   <emu-clause id="sec-line-terminators">
     <h1>Line Terminators</h1>
-    <p>Like white space code points, line terminator code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other. However, unlike white space code points, line terminators have some influence over the behaviour of the syntactic grammar. In general, line terminators may occur between any two tokens, but there are a few places where they are forbidden by the syntactic grammar. Line terminators also affect the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A line terminator cannot occur within any token except a |StringLiteral|, |Template|, or |TemplateSubstitutionTail|. Line terminators may only occur within a |StringLiteral| token as part of a |LineContinuation|.</p>
+    <p>Like white space code points, line terminator code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other. However, unlike white space code points, line terminators have some influence over the behavior of the syntactic grammar. In general, line terminators may occur between any two tokens, but there are a few places where they are forbidden by the syntactic grammar. Line terminators also affect the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A line terminator cannot occur within any token except a |StringLiteral|, |Template|, or |TemplateSubstitutionTail|. Line terminators may only occur within a |StringLiteral| token as part of a |LineContinuation|.</p>
     <p>A line terminator can occur within a |MultiLineComment| but cannot occur within a |SingleLineComment|.</p>
     <p>Line terminators are included in the set of white space code points that are matched by the `\\s` class in regular expressions.</p>
     <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-33"></emu-xref>.</p>
@@ -11779,7 +11779,7 @@
         <div class="rhs">
           |MemberExpression| `.` |IdentifierName|
         </div>
-        <p>is identical in its behaviour to</p>
+        <p>is identical in its behavior to</p>
         <div class="rhs">
           |MemberExpression| `[` &lt;<i>identifier-name-string</i>&gt; `]`
         </div>
@@ -11787,7 +11787,7 @@
         <div class="rhs">
           |CallExpression| `.` |IdentifierName|
         </div>
-        <p>is identical in its behaviour to</p>
+        <p>is identical in its behavior to</p>
         <div class="rhs">
           |CallExpression| `[` &lt;<i>identifier-name-string</i>&gt; `]`
         </div>
@@ -12725,7 +12725,7 @@
         <emu-note>
           <p>In C and C++, the remainder operator accepts only integral operands; in ECMAScript, it also accepts floating-point operands.</p>
         </emu-note>
-        <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2008. The IEEE 754-2008 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual integer remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java integer remainder operator; this may be compared with the C library function fmod.</p>
+        <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2008. The IEEE 754-2008 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behavior is not analogous to that of the usual integer remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java integer remainder operator; this may be compared with the C library function fmod.</p>
         <p>The result of an ECMAScript floating-point remainder operation is determined by the rules of IEEE arithmetic:</p>
         <ul>
           <li>
@@ -12779,7 +12779,7 @@
           <li>If _base_ &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integer, the result is *NaN*.</li>
         </ul>
         <emu-note>
-          <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity* differs from IEEE 754-2008. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2008 specified *1*. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
+          <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity* differs from IEEE 754-2008. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2008 specified *1*. The historical ECMAScript behavior is preserved for compatibility reasons.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -19661,7 +19661,7 @@
                 1. If _vnDefinable_ is *false*, throw a *TypeError* exception.
                 1. If _vn_ is not an element of _declaredVarNames_, then
                   1. Append _vn_ to _declaredVarNames_.
-        1. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviours that cause abnormal terminations in some of the following steps.
+        1. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviors that cause abnormal terminations in some of the following steps.
         1. NOTE: Annex <emu-xref href="#sec-web-compat-globaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
         1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _script_.
         1. For each element _d_ in _lexDeclarations_ do
@@ -21576,13 +21576,13 @@
   <p>An implementation shall report all errors as specified, except for the following:</p>
   <ul>
     <li>
-      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may extend |Script| syntax, |Module| syntax, and regular expression pattern or flag syntax. To permit this, all operations (such as calling `eval`, using a regular expression literal, or using the `Function` or `RegExp` constructor) that are allowed to throw *SyntaxError* are permitted to exhibit implementation-defined behaviour instead of throwing *SyntaxError* when they encounter an implementation-defined extension to the script syntax or regular expression pattern or flag syntax.
+      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may extend |Script| syntax, |Module| syntax, and regular expression pattern or flag syntax. To permit this, all operations (such as calling `eval`, using a regular expression literal, or using the `Function` or `RegExp` constructor) that are allowed to throw *SyntaxError* are permitted to exhibit implementation-defined behavior instead of throwing *SyntaxError* when they encounter an implementation-defined extension to the script syntax or regular expression pattern or flag syntax.
     </li>
     <li>
-      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may provide additional types, values, objects, properties, and functions beyond those described in this specification. This may cause constructs (such as looking up a variable in the global scope) to have implementation-defined behaviour instead of throwing an error (such as *ReferenceError*).
+      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may provide additional types, values, objects, properties, and functions beyond those described in this specification. This may cause constructs (such as looking up a variable in the global scope) to have implementation-defined behavior instead of throwing an error (such as *ReferenceError*).
     </li>
   </ul>
-  <p>An implementation may define behaviour other than throwing *RangeError* for `toFixed`, `toExponential`, and `toPrecision` when the _fractionDigits_ or _precision_ argument is outside the specified range.</p>
+  <p>An implementation may define behavior other than throwing *RangeError* for `toFixed`, `toExponential`, and `toPrecision` when the _fractionDigits_ or _precision_ argument is outside the specified range.</p>
 
   <emu-clause id="sec-host-report-errors" aoid="HostReportErrors">
     <h1>HostReportErrors ( _errorList_ )</h1>
@@ -21608,7 +21608,7 @@
         If an implementation extends non-strict or built-in function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
       </li>
       <li>
-        The behaviour of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, `%TypedArray%.prototype.toLocaleString`.
+        The behavior of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, `%TypedArray%.prototype.toLocaleString`.
       </li>
       <li>
         The RegExp pattern grammars in <emu-xref href="#sec-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[+U]| when the U grammar parameter is present.
@@ -21639,7 +21639,7 @@
   <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in Function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in Function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;`this` value&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
-  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>
+  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behavior relating to such arguments as long as the behavior is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>
   <emu-note>
     <p>Implementations that add additional capabilities to the set of built-in functions are encouraged to do so by adding new functions rather than adding new parameters to existing functions.</p>
   </emu-note>
@@ -22880,7 +22880,7 @@
             1. If SameValue(_O_, _V_) is *true*, return *true*.
         </emu-alg>
         <emu-note>
-          <p>The ordering of steps 1 and 2 preserves the behaviour specified by previous editions of this specification for the case where _V_ is not an object and the *this* value is *undefined* or *null*.</p>
+          <p>The ordering of steps 1 and 2 preserves the behavior specified by previous editions of this specification for the case where _V_ is not an object and the *this* value is *undefined* or *null*.</p>
         </emu-note>
       </emu-clause>
 
@@ -22913,7 +22913,7 @@
         </emu-alg>
         <p>The optional parameters to this function are not used but are intended to correspond to the parameter pattern used by ECMA-402 `toLocalString` functions. Implementations that do not include ECMA-402 support must not use those parameter positions for other purposes.</p>
         <emu-note>
-          <p>This function provides a generic `toLocaleString` implementation for objects that have no locale-specific `toString` behaviour. `Array`, `Number`, `Date`, and `Typed Arrays` provide their own locale-sensitive `toLocaleString` methods.</p>
+          <p>This function provides a generic `toLocaleString` implementation for objects that have no locale-specific `toString` behavior. `Array`, `Number`, `Date`, and `Typed Arrays` provide their own locale-sensitive `toLocaleString` methods.</p>
         </emu-note>
         <emu-note>
           <p>ECMA-402 intentionally does not provide an alternative to this default implementation.</p>
@@ -22975,7 +22975,7 @@
     <emu-clause id="sec-function-constructor">
       <h1>The Function Constructor</h1>
       <p>The Function constructor is the <dfn>%Function%</dfn> intrinsic object and the initial value of the `Function` property of the global object. When `Function` is called as a function rather than as a constructor, it creates and initializes a new Function object. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</p>
-      <p>The `Function` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instances with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction` subclass.</p>
+      <p>The `Function` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behavior must include a `super` call to the `Function` constructor to create and initialize a subclass instances with the internal slots necessary for built-in function behavior. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction` subclass.</p>
 
       <!-- es6num="19.2.1.1" -->
       <emu-clause id="sec-function-p1-p2-pn-body">
@@ -23232,7 +23232,7 @@
       <!-- es6num="19.2.4.1" -->
       <emu-clause id="sec-function-instances-length">
         <h1>length</h1>
-        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a function when invoked on a number of arguments other than the number specified by its `length` property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behavior of a function when invoked on a number of arguments other than the number specified by its `length` property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <!-- es6num="19.2.4.2" -->
@@ -23262,7 +23262,7 @@
     <emu-clause id="sec-boolean-constructor">
       <h1>The Boolean Constructor</h1>
       <p>The Boolean constructor is the <dfn>%Boolean%</dfn> intrinsic object and the initial value of the `Boolean` property of the global object. When called as a constructor it creates and initializes a new Boolean object. When `Boolean` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `Boolean` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behaviour must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</p>
+      <p>The `Boolean` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behavior must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</p>
 
       <!-- es6num="19.3.1.1" -->
       <emu-clause id="sec-boolean-constructor-boolean-value">
@@ -23617,7 +23617,7 @@
     <emu-clause id="sec-error-constructor">
       <h1>The Error Constructor</h1>
       <p>The Error constructor is the <dfn>%Error%</dfn> intrinsic object and the initial value of the `Error` property of the global object. When `Error` is called as a function rather than as a constructor, it creates and initializes a new Error object. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</p>
-      <p>The `Error` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
+      <p>The `Error` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behavior must include a `super` call to the `Error` constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
 
       <!-- es6num="19.5.1.1" -->
       <emu-clause id="sec-error-message">
@@ -23749,7 +23749,7 @@
       <emu-clause id="sec-nativeerror-constructors">
         <h1>_NativeError_ Constructors</h1>
         <p>When a _NativeError_ constructor is called as a function rather than as a constructor, it creates and initializes a new _NativeError_ object. A call of the object as a function is equivalent to calling it as a constructor with the same arguments. Thus the function call <code><var>NativeError</var>(&hellip;)</code> is equivalent to the object creation expression <code>new <var>NativeError</var>(&hellip;)</code> with the same arguments.</p>
-        <p>Each _NativeError_ constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
+        <p>Each _NativeError_ constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behavior must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with a [[ErrorData]] internal slot.</p>
 
         <!-- es6num="19.5.6.1.1" -->
         <emu-clause id="sec-nativeerror">
@@ -23829,7 +23829,7 @@
     <emu-clause id="sec-number-constructor">
       <h1>The Number Constructor</h1>
       <p>The Number constructor is the <dfn>%Number%</dfn> intrinsic object and the initial value of the `Number` property of the global object. When called as a constructor, it creates and initializes a new Number object. When `Number` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `Number` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behaviour must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</p>
+      <p>The `Number` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behavior must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</p>
 
       <!-- es6num="20.1.1.1" -->
       <emu-clause id="sec-number-constructor-number-value">
@@ -24024,7 +24024,7 @@
             1. Let _x_ be -_x_.
           1. If _x_ = *+&infin;*, then
             1. Return the concatenation of the Strings _s_ and `"Infinity"`.
-          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toExponential` for values of _f_ less than 0 or greater than 20. In this case `toExponential` would not necessarily throw *RangeError* for such values.
+          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behavior of `toExponential` for values of _f_ less than 0 or greater than 20. In this case `toExponential` would not necessarily throw *RangeError* for such values.
           1. If _x_ = 0, then
             1. Let _m_ be the String consisting of _f_+1 occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.
@@ -24049,7 +24049,7 @@
           1. Let _m_ be the concatenation of the four Strings _m_, `"e"`, _c_, and _d_.
           1. Return the concatenation of the Strings _s_ and _m_.
         </emu-alg>
-        <p>If the `toExponential` method is called with more than one argument, then the behaviour is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
+        <p>If the `toExponential` method is called with more than one argument, then the behavior is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
         <emu-note>
           <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 10.b.i be used as a guideline:</p>
           <emu-alg type="i">
@@ -24068,7 +24068,7 @@
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToInteger(_fractionDigits_). (If _fractionDigits_ is *undefined*, this step produces the value 0.)
-          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toFixed` for values of _f_ less than 0 or greater than 20. In this case `toFixed` would not necessarily throw *RangeError* for such values.
+          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behavior of `toFixed` for values of _f_ less than 0 or greater than 20. In this case `toFixed` would not necessarily throw *RangeError* for such values.
           1. If _x_ is *NaN*, return the String `"NaN"`.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
@@ -24089,7 +24089,7 @@
               1. Let _m_ be the concatenation of the three Strings _a_, `"."`, and _b_.
           1. Return the concatenation of the Strings _s_ and _m_.
         </emu-alg>
-        <p>If the `toFixed` method is called with more than one argument, then the behaviour is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
+        <p>If the `toFixed` method is called with more than one argument, then the behavior is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
         <emu-note>
           <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent number values. For example,</p>
           <p>`(1000000000000000128).toString()` returns `"1000000000000000100"`, while
@@ -24121,7 +24121,7 @@
             1. Let _x_ be -_x_.
           1. If _x_ = *+&infin;*, then
             1. Return the String that is the concatenation of _s_ and `"Infinity"`.
-          1. If _p_ &lt; 1 or _p_ &gt; 21, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toPrecision` for values of _p_ less than 1 or greater than 21. In this case `toPrecision` would not necessarily throw *RangeError* for such values.
+          1. If _p_ &lt; 1 or _p_ &gt; 21, throw a *RangeError* exception. However, an implementation is permitted to extend the behavior of `toPrecision` for values of _p_ less than 1 or greater than 21. In this case `toPrecision` would not necessarily throw *RangeError* for such values.
           1. If _x_ = 0, then
             1. Let _m_ be the String consisting of _p_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.
@@ -24146,7 +24146,7 @@
             1. Let _m_ be the String formed by the concatenation of code unit 0x0030 (DIGIT ZERO), code unit 0x002E (FULL STOP), -(_e_+1) occurrences of code unit 0x0030 (DIGIT ZERO), and the String _m_.
           1. Return the String that is the concatenation of _s_ and _m_.
         </emu-alg>
-        <p>If the `toPrecision` method is called with more than one argument, then the behaviour is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
+        <p>If the `toPrecision` method is called with more than one argument, then the behavior is undefined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
       </emu-clause>
 
       <!-- es6num="20.1.3.6" -->
@@ -24278,7 +24278,7 @@
       <p>Each of the following `Math` object functions applies the ToNumber abstract operation to each of its arguments (in left-to-right order if there is more than one). If ToNumber returns an abrupt completion, that Completion Record is immediately returned. Otherwise, the function performs a computation on the resulting Number value(s). The value returned by each function is a Number.</p>
       <p>In the function descriptions below, the symbols *NaN*, *-0*, *+0*, *-&infin;* and *+&infin;* refer to the Number values described in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>.</p>
       <emu-note>
-        <p>The behaviour of the functions `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `atan2`, `cbrt`, `cos`, `cosh`, `exp`, `expm1`, `hypot`, `log`,`log1p`, `log2`, `log10`, `pow`, `random`, `sin`, `sinh`, `sqrt`, `tan`, and `tanh` is not precisely specified here except to require specific results for certain argument values that represent boundary cases of interest. For other argument values, these functions are intended to compute approximations to the results of familiar mathematical functions, but some latitude is allowed in the choice of approximation algorithms. The general intent is that an implementer should be able to use the same mathematical library for ECMAScript on a given hardware platform that is available to C programmers on that platform.</p>
+        <p>The behavior of the functions `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `atan2`, `cbrt`, `cos`, `cosh`, `exp`, `expm1`, `hypot`, `log`,`log1p`, `log2`, `log10`, `pow`, `random`, `sin`, `sinh`, `sqrt`, `tan`, and `tanh` is not precisely specified here except to require specific results for certain argument values that represent boundary cases of interest. For other argument values, these functions are intended to compute approximations to the results of familiar mathematical functions, but some latitude is allowed in the choice of approximation algorithms. The general intent is that an implementer should be able to use the same mathematical library for ECMAScript on a given hardware platform that is available to C programmers on that platform.</p>
         <p>Although the choice of algorithms is left to the implementation, it is recommended (but not specified by this standard) that implementations use the approximation algorithms for IEEE 754-2008 arithmetic contained in `fdlibm`, the freely distributable mathematical library from Sun Microsystems (<a href="http://www.netlib.org/fdlibm">http://www.netlib.org/fdlibm</a>).</p>
       </emu-note>
 
@@ -25530,8 +25530,8 @@ THH:mm:ss.sss
     <emu-clause id="sec-date-constructor">
       <h1>The Date Constructor</h1>
       <p>The Date constructor is the <dfn>%Date%</dfn> intrinsic object and the initial value of the `Date` property of the global object. When called as a constructor it creates and initializes a new Date object. When `Date` is called as a function rather than as a constructor, it returns a String representing the current time (UTC).</p>
-      <p>The `Date` constructor is a single function whose behaviour is overloaded based upon the number and types of its arguments.</p>
-      <p>The `Date` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behaviour must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</p>
+      <p>The `Date` constructor is a single function whose behavior is overloaded based upon the number and types of its arguments.</p>
+      <p>The `Date` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behavior must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</p>
       <p>The `length` property of the `Date` constructor function is 7.</p>
 
       <!-- es6num="20.3.2.1" -->
@@ -26308,7 +26308,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-string-constructor">
       <h1>The String Constructor</h1>
       <p>The String constructor is the <dfn>%String%</dfn> intrinsic object and the initial value of the `String` property of the global object. When called as a constructor it creates and initializes a new String object. When `String` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `String` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behaviour must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</p>
+      <p>The `String` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behavior must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</p>
 
       <!-- es6num="21.1.1.1" -->
       <emu-clause id="sec-string-constructor-string-value">
@@ -27109,7 +27109,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The result must be derived according to the locale-insensitive case mappings in the Unicode Character Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive mappings in the SpecialCasings.txt file that accompanies it).</p>
         <emu-note>
-          <p>The case mapping of some code points may produce multiple code points. In this case the result String may not be the same length as the source String. Because both `toUpperCase` and `toLowerCase` have context-sensitive behaviour, the functions are not symmetrical. In other words, `s.toUpperCase().toLowerCase()` is not necessarily equal to `s.toLowerCase()`.</p>
+          <p>The case mapping of some code points may produce multiple code points. In this case the result String may not be the same length as the source String. Because both `toUpperCase` and `toLowerCase` have context-sensitive behavior, the functions are not symmetrical. In other words, `s.toUpperCase().toLowerCase()` is not necessarily equal to `s.toLowerCase()`.</p>
         </emu-note>
         <emu-note>
           <p>The `toLowerCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -27448,7 +27448,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-pattern-semantics">
       <h1>Pattern Semantics</h1>
       <p>A regular expression pattern is converted into an internal procedure using the process described below. An implementation is encouraged to use more efficient algorithms than the ones listed below, as long as the results are the same. The internal procedure is used as the value of a RegExp object's [[RegExpMatcher]] internal slot.</p>
-      <p>A |Pattern| is either a BMP pattern or a Unicode pattern depending upon whether or not its associated flags contain a `"u"`. A BMP pattern matches against a String interpreted as consisting of a sequence of 16-bit values that are Unicode code points in the range of the Basic Multilingual Plane. A Unicode pattern matches against a String interpreted as consisting of Unicode code points encoded using UTF-16. In the context of describing the behaviour of a BMP pattern &ldquo;character&rdquo; means a single 16-bit Unicode BMP code point. In the context of describing the behaviour of a Unicode pattern &ldquo;character&rdquo; means a UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). In either context, &ldquo;character value&rdquo; means the numeric value of the corresponding non-encoded code point.</p>
+      <p>A |Pattern| is either a BMP pattern or a Unicode pattern depending upon whether or not its associated flags contain a `"u"`. A BMP pattern matches against a String interpreted as consisting of a sequence of 16-bit values that are Unicode code points in the range of the Basic Multilingual Plane. A Unicode pattern matches against a String interpreted as consisting of Unicode code points encoded using UTF-16. In the context of describing the behavior of a BMP pattern &ldquo;character&rdquo; means a single 16-bit Unicode BMP code point. In the context of describing the behavior of a Unicode pattern &ldquo;character&rdquo; means a UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). In either context, &ldquo;character value&rdquo; means the numeric value of the corresponding non-encoded code point.</p>
       <p>The syntax and semantics of |Pattern| is defined as if the source code for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>
       <emu-note>
         <p>For example, consider a pattern expressed in source text as the single non-BMP character U+1D11E (MUSICAL SYMBOL G CLEF). Interpreted as a Unicode pattern, it would be a single element (character) List consisting of the single code point 0x1D11E. However, interpreted as a BMP pattern, it is first UTF-16 encoded to produce a two element List consisting of the code units 0xD834 and 0xDD1E.</p>
@@ -27639,7 +27639,7 @@ THH:mm:ss.sss
             <p>which returns the gcd in unary notation `"aaaaa"`.</p>
           </emu-note>
           <emu-note>
-            <p>Step 4 of the RepeatMatcher clears |Atom|'s captures each time |Atom| is repeated. We can see its behaviour in the regular expression</p>
+            <p>Step 4 of the RepeatMatcher clears |Atom|'s captures each time |Atom| is repeated. We can see its behavior in the regular expression</p>
             <pre><code class="javascript">/(z)((a+)?(b+)?(c))*/.exec("zaacbbbcac")</code></pre>
             <p>which returns the array</p>
             <pre><code class="javascript">["zaacbbbcac", "z", "ac", "a", undefined, "c"]</code></pre>
@@ -28104,10 +28104,10 @@ THH:mm:ss.sss
               1. Return _cu_.
           </emu-alg>
           <emu-note>
-            <p>Parentheses of the form `(` |Disjunction| `)` serve both to group the components of the |Disjunction| pattern together and to save the result of the match. The result can be used either in a backreference (`\\` followed by a nonzero decimal number), referenced in a replace String, or returned as part of an array from the regular expression matching internal procedure. To inhibit the capturing behaviour of parentheses, use the form `(?:` |Disjunction| `)` instead.</p>
+            <p>Parentheses of the form `(` |Disjunction| `)` serve both to group the components of the |Disjunction| pattern together and to save the result of the match. The result can be used either in a backreference (`\\` followed by a nonzero decimal number), referenced in a replace String, or returned as part of an array from the regular expression matching internal procedure. To inhibit the capturing behavior of parentheses, use the form `(?:` |Disjunction| `)` instead.</p>
           </emu-note>
           <emu-note>
-            <p>The form `(?=` |Disjunction| `)` specifies a zero-width positive lookahead. In order for it to succeed, the pattern inside |Disjunction| must match at the current position, but the current position is not advanced before matching the sequel. If |Disjunction| can match at the current position in several ways, only the first one is tried. Unlike other regular expression operators, there is no backtracking into a `(?=` form (this unusual behaviour is inherited from Perl). This only matters when the |Disjunction| contains capturing parentheses and the sequel of the pattern contains backreferences to those captures.</p>
+            <p>The form `(?=` |Disjunction| `)` specifies a zero-width positive lookahead. In order for it to succeed, the pattern inside |Disjunction| must match at the current position, but the current position is not advanced before matching the sequel. If |Disjunction| can match at the current position in several ways, only the first one is tried. Unlike other regular expression operators, there is no backtracking into a `(?=` form (this unusual behavior is inherited from Perl). This only matters when the |Disjunction| contains capturing parentheses and the sequel of the pattern contains backreferences to those captures.</p>
             <p>For example,</p>
             <pre><code class="javascript">/(?=(a+))/.exec("baaabac")</code></pre>
             <p>matches the empty String immediately after the first `b` and therefore returns the array:</p>
@@ -28507,7 +28507,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-regexp-constructor">
       <h1>The RegExp Constructor</h1>
       <p>The RegExp constructor is the <dfn>%RegExp%</dfn> intrinsic object and the initial value of the `RegExp` property of the global object. When `RegExp` is called as a function rather than as a constructor, it creates and initializes a new RegExp object. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</p>
-      <p>The `RegExp` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behaviour must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</p>
+      <p>The `RegExp` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behavior must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</p>
 
       <!-- es6num="21.2.3.1" -->
       <emu-clause id="sec-regexp-pattern-flags">
@@ -28626,7 +28626,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>RegExp prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>RegExp prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -28675,7 +28675,7 @@ THH:mm:ss.sss
             1. Return ? RegExpBuiltinExec(_R_, _S_).
           </emu-alg>
           <emu-note>
-            <p>If a callable `exec` property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behaviour for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of `exec`.</p>
+            <p>If a callable `exec` property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behavior for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of `exec`.</p>
           </emu-note>
         </emu-clause>
 
@@ -28843,7 +28843,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.match]"`.</p>
         <emu-note>
-          <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behaviour of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
+          <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behavior of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
         </emu-note>
       </emu-clause>
 
@@ -29078,7 +29078,7 @@ THH:mm:ss.sss
           1. Return _result_.
         </emu-alg>
         <emu-note>
-          <p>The returned String has the form of a |RegularExpressionLiteral| that evaluates to another RegExp object with the same behaviour as this object.</p>
+          <p>The returned String has the form of a |RegularExpressionLiteral| that evaluates to another RegExp object with the same behavior as this object.</p>
         </emu-note>
       </emu-clause>
 
@@ -29130,8 +29130,8 @@ THH:mm:ss.sss
     <emu-clause id="sec-array-constructor">
       <h1>The Array Constructor</h1>
       <p>The Array constructor is the <dfn>%Array%</dfn> intrinsic object and the initial value of the `Array` property of the global object. When called as a constructor it creates and initializes a new exotic Array object. When `Array` is called as a function rather than as a constructor, it also creates and initializes a new Array object. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</p>
-      <p>The `Array` constructor is a single function whose behaviour is overloaded based upon the number and types of its arguments.</p>
-      <p>The `Array` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behaviour must include a `super` call to the `Array` constructor to initialize subclass instances that are exotic Array objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their `this` value being an exotic Array object.</p>
+      <p>The `Array` constructor is a single function whose behavior is overloaded based upon the number and types of its arguments.</p>
+      <p>The `Array` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behavior must include a `super` call to the `Array` constructor to initialize subclass instances that are exotic Array objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their `this` value being an exotic Array object.</p>
       <p>The `length` property of the `Array` constructor function is 1.</p>
 
       <!-- es6num="22.1.1.1" -->
@@ -29315,7 +29315,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>Array prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>Array prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -30118,7 +30118,7 @@ THH:mm:ss.sss
         <p>The sort order is also implementation defined if any of the following conditions are true:</p>
         <ul>
           <li>
-            If _obj_ is an exotic object (including Proxy exotic objects) whose behaviour for [[Get]], [[Set]], [[Delete]], and [[GetOwnProperty]] is not the ordinary object implementation of these internal methods.
+            If _obj_ is an exotic object (including Proxy exotic objects) whose behavior for [[Get]], [[Set]], [[Delete]], and [[GetOwnProperty]] is not the ordinary object implementation of these internal methods.
           </li>
           <li>
             If any index property of _obj_ whose name is a nonnegative integer less than _len_ is an accessor property or is a data property whose [[Writable]] attribute is *false*.
@@ -30418,7 +30418,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         <emu-note>
-          <p>The own property names of this object are property names that were not included as standard properties of `Array.prototype` prior to the ECMAScript 2015 specification. These names are ignored for `with` statement binding purposes in order to preserve the behaviour of existing code that might use one of these names as a binding in an outer scope that is shadowed by a `with` statement whose binding object is an Array object.</p>
+          <p>The own property names of this object are property names that were not included as standard properties of `Array.prototype` prior to the ECMAScript 2015 specification. These names are ignored for `with` statement binding purposes in order to preserve the behavior of existing code that might use one of these names as a binding in an outer scope that is shadowed by a `with` statement whose binding object is an Array object.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -30901,7 +30901,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>%TypedArrayPrototype% methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>%TypedArrayPrototype% methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -30967,7 +30967,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.copywithin">
         <h1>%TypedArray%.prototype.copyWithin (_target_, _start_ [ , _end_ ] )</h1>
         <p>%TypedArray%`.prototype.copyWithin` is a distinct function that implements the same algorithm as `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"` and the actual copying of values in step 12 must be performed in a manner that preserves the bit-level encoding of the source data</p>
-        <p>The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
 
         <!-- es6num="22.2.3.5.1" -->
@@ -30999,14 +30999,14 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.7" -->
       <emu-clause id="sec-%typedarray%.prototype.every">
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.8" -->
       <emu-clause id="sec-%typedarray%.prototype.fill">
         <h1>%TypedArray%.prototype.fill (_value_ [ , _start_ [ , _end_ ] ] )</h1>
-        <p>%TypedArray%`.prototype.fill` is a distinct function that implements the same algorithm as `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.fill` is a distinct function that implements the same algorithm as `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -31045,41 +31045,41 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.10" -->
       <emu-clause id="sec-%typedarray%.prototype.find">
         <h1>%TypedArray%.prototype.find (_predicate_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.11" -->
       <emu-clause id="sec-%typedarray%.prototype.findindex">
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.12" -->
       <emu-clause id="sec-%typedarray%.prototype.foreach">
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.includes">
         <h1>%TypedArray%.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>`%TypedArray%.prototype.includes` is a distinct function that implements the same algorithm as `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>`%TypedArray%.prototype.includes` is a distinct function that implements the same algorithm as `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.13" -->
       <emu-clause id="sec-%typedarray%.prototype.indexof">
         <h1>%TypedArray%.prototype.indexOf (_searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.14" -->
       <emu-clause id="sec-%typedarray%.prototype.join">
         <h1>%TypedArray%.prototype.join ( _separator_ )</h1>
-        <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -31097,7 +31097,7 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.16" -->
       <emu-clause id="sec-%typedarray%.prototype.lastindexof">
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -31145,28 +31145,28 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.19" -->
       <emu-clause id="sec-%typedarray%.prototype.reduce">
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.20" -->
       <emu-clause id="sec-%typedarray%.prototype.reduceright">
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.21" -->
       <emu-clause id="sec-%typedarray%.prototype.reverse">
         <h1>%TypedArray%.prototype.reverse ( )</h1>
-        <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <!-- es6num="22.2.3.22" -->
       <emu-clause id="sec-%typedarray%.prototype.set-overloaded-offset">
         <h1>%TypedArray%.prototype.set ( _overloaded_ [ , _offset_ ])</h1>
-        <p>%TypedArray%`.prototype.set` is a single function whose behaviour is overloaded based upon the type of its first argument.</p>
+        <p>%TypedArray%`.prototype.set` is a single function whose behavior is overloaded based upon the type of its first argument.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
 
         <!-- es6num="22.2.3.22.1" -->
@@ -31306,7 +31306,7 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.24" -->
       <emu-clause id="sec-%typedarray%.prototype.some">
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -31374,7 +31374,7 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.27" -->
       <emu-clause id="sec-%typedarray%.prototype.tolocalestring">
         <h1>%TypedArray%.prototype.toLocaleString ([ _reserved1_ [ , _reserved2_ ] ])</h1>
-        <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behavior of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
         <emu-note>
           <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this function is based upon the algorithm for `Array.prototype.toLocaleString` that is in the ECMA-402 specification.</p>
@@ -31425,9 +31425,9 @@ THH:mm:ss.sss
     <emu-clause id="sec-typedarray-constructors">
       <h1>The _TypedArray_ Constructors</h1>
       <p>Each of the _TypedArray_ constructor objects is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-49"></emu-xref>.</p>
-      <p>The _TypedArray_ intrinsic constructor functions are single functions whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</p>
+      <p>The _TypedArray_ intrinsic constructor functions are single functions whose behavior is overloaded based upon the number and types of its arguments. The actual behavior of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</p>
       <p>The _TypedArray_ constructors are not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray`%.prototype` built-in methods.</p>
+      <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behavior must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray`%.prototype` built-in methods.</p>
       <p>The `length` property of the _TypedArray_ constructor function is 3.</p>
 
       <!-- es6num="22.2.4.1" -->
@@ -31695,7 +31695,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-map-constructor">
       <h1>The Map Constructor</h1>
       <p>The Map constructor is the <dfn>%Map%</dfn> intrinsic object and the initial value of the `Map` property of the global object. When called as a constructor it creates and initializes a new Map object. `Map` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Map` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behaviour must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</p>
+      <p>The `Map` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behavior must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</p>
 
       <!-- es6num="23.1.1.1" -->
       <emu-clause id="sec-map-iterable">
@@ -32068,7 +32068,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-set-constructor">
       <h1>The Set Constructor</h1>
       <p>The Set constructor is the <dfn>%Set%</dfn> intrinsic object and the initial value of the `Set` property of the global object. When called as a constructor it creates and initializes a new Set object. `Set` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Set` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behaviour must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</p>
+      <p>The `Set` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behavior must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</p>
 
       <!-- es6num="23.2.1.1" -->
       <emu-clause id="sec-set-iterable">
@@ -32419,7 +32419,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-weakmap-constructor">
       <h1>The WeakMap Constructor</h1>
       <p>The WeakMap constructor is the <dfn>%WeakMap%</dfn> intrinsic object and the initial value of the `WeakMap` property of the global object. When called as a constructor it creates and initializes a new WeakMap object. `WeakMap` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `WeakMap` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behaviour must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</p>
+      <p>The `WeakMap` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behavior must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</p>
 
       <!-- es6num="23.3.1.1" -->
       <emu-clause id="sec-weakmap-iterable">
@@ -32584,7 +32584,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-weakset-constructor">
       <h1>The WeakSet Constructor</h1>
       <p>The WeakSet constructor is the <dfn>%WeakSet%</dfn> intrinsic object and the initial value of the `WeakSet` property of the global object. When called as a constructor it creates and initializes a new WeakSet object. `WeakSet` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `WeakSet` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behaviour must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</p>
+      <p>The `WeakSet` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behavior must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</p>
 
       <!-- es6num="23.4.1.1" -->
       <emu-clause id="sec-weakset-iterable">
@@ -32841,7 +32841,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-arraybuffer-constructor">
       <h1>The ArrayBuffer Constructor</h1>
       <p>The ArrayBuffer constructor is the <dfn>%ArrayBuffer%</dfn> intrinsic object and the initial value of the `ArrayBuffer` property of the global object. When called as a constructor it creates and initializes a new ArrayBuffer object. `ArrayBuffer` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `ArrayBuffer` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behaviour must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</p>
+      <p>The `ArrayBuffer` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behavior must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</p>
 
       <!-- es6num="24.1.2.1" -->
       <emu-clause id="sec-arraybuffer-length">
@@ -32888,7 +32888,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>ArrayBuffer prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>ArrayBuffer prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -33020,7 +33020,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-dataview-constructor">
       <h1>The DataView Constructor</h1>
       <p>The DataView constructor is the <dfn>%DataView%</dfn> intrinsic object and the initial value of the `DataView` property of the global object. When called as a constructor it creates and initializes a new DataView object. `DataView` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `DataView` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behaviour must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</p>
+      <p>The `DataView` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behavior must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</p>
 
       <!-- es6num="24.2.2.1" -->
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
@@ -33874,7 +33874,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-generatorfunction-constructor">
       <h1>The GeneratorFunction Constructor</h1>
       <p>The `GeneratorFunction` constructor is the <dfn>%GeneratorFunction%</dfn> intrinsic. When `GeneratorFunction` is called as a function rather than as a constructor, it creates and initializes a new GeneratorFunction object. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</p>
-      <p>`GeneratorFunction` is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `GeneratorFunction` behaviour must include a `super` call to the `GeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of `GeneratorFunction`. There is no syntactic means to create instances of `GeneratorFunction` subclasses.</p>
+      <p>`GeneratorFunction` is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `GeneratorFunction` behavior must include a `super` call to the `GeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behavior. All ECMAScript syntactic forms for defining generator function objects create direct instances of `GeneratorFunction`. There is no syntactic means to create instances of `GeneratorFunction` subclasses.</p>
 
       <!-- es6num="25.2.1.1" -->
       <emu-clause id="sec-generatorfunction">
@@ -33951,7 +33951,7 @@ THH:mm:ss.sss
       <!-- es6num="25.2.4.1" -->
       <emu-clause id="sec-generatorfunction-instances-length">
         <h1>length</h1>
-        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the GeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a GeneratorFunction when invoked on a number of arguments other than the number specified by its `length` property depends on the function.</p>
+        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the GeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behavior of a GeneratorFunction when invoked on a number of arguments other than the number specified by its `length` property depends on the function.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -34554,7 +34554,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-promise-constructor">
       <h1>The Promise Constructor</h1>
       <p>The Promise constructor is the <dfn>%Promise%</dfn> intrinsic object and the initial value of the `Promise` property of the global object. When called as a constructor it creates and initializes a new Promise object. `Promise` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Promise` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behaviour must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</p>
+      <p>The `Promise` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behavior must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</p>
 
       <!-- es6num="25.4.3.1" -->
       <emu-clause id="sec-promise-executor">
@@ -34578,7 +34578,7 @@ THH:mm:ss.sss
           <p>The _executor_ argument must be a function object. It is called for initiating and reporting completion of the possibly deferred action represented by this Promise object. The executor is called with two arguments: _resolve_ and _reject_. These are functions that may be used by the _executor_ function to report eventual completion or failure of the deferred computation. Returning from the executor function does not mean that the deferred action has been completed but only that the request to eventually perform the deferred action has been accepted.</p>
           <p>The _resolve_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _resolve_ function to indicate that it wishes to resolve the associated Promise object. The argument passed to the _resolve_ function represents the eventual value of the deferred action and can be either the actual fulfillment value or another Promise object which will provide the value if it is fulfilled.</p>
           <p>The _reject_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _reject_ function to indicate that the associated Promise is rejected and will never be fulfilled. The argument passed to the _reject_ function is used as the rejection value of the promise. Typically it will be an `Error` object.</p>
-          <p>The resolve and reject functions passed to an _executor_ function by the Promise constructor have the capability to actually resolve and reject the associated promise. Subclasses may have different constructor behaviour that passes in customized values for resolve and reject.</p>
+          <p>The resolve and reject functions passed to an _executor_ function by the Promise constructor have the capability to actually resolve and reject the associated promise. Subclasses may have different constructor behavior that passes in customized values for resolve and reject.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -34770,7 +34770,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
         <emu-note>
-          <p>Promise prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>Promise prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behavior by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -35512,8 +35512,8 @@ THH:mm:ss.sss
   <h1>Additional ECMAScript Features for Web Browsers</h1>
   <p>The ECMAScript language syntax and semantics defined in this annex are required when the ECMAScript host is a web browser. The content of this annex is normative but optional if the ECMAScript host is not a web browser.</p>
   <emu-note>
-    <p>This annex describes various legacy features and other characteristics of web browser based ECMAScript implementations. All of the language features and behaviours specified in this annex have one or more undesirable characteristics and in the absence of legacy usage would be removed from this specification. However, the usage of these features by large numbers of existing web pages means that web browsers must continue to support them. The specifications in this annex define the requirements for interoperable implementations of these legacy features.</p>
-    <p>These features are not considered part of the core ECMAScript language. Programmers should not use or assume the existence of these features and behaviours when writing new ECMAScript code. ECMAScript implementations are discouraged from implementing these features unless the implementation is part of a web browser or is required to run the same legacy ECMAScript code that web browsers encounter.</p>
+    <p>This annex describes various legacy features and other characteristics of web browser based ECMAScript implementations. All of the language features and behaviors specified in this annex have one or more undesirable characteristics and in the absence of legacy usage would be removed from this specification. However, the usage of these features by large numbers of existing web pages means that web browsers must continue to support them. The specifications in this annex define the requirements for interoperable implementations of these legacy features.</p>
+    <p>These features are not considered part of the core ECMAScript language. Programmers should not use or assume the existence of these features and behaviors when writing new ECMAScript code. ECMAScript implementations are discouraged from implementing these features unless the implementation is part of a web browser or is required to run the same legacy ECMAScript code that web browsers encounter.</p>
   </emu-note>
 
   <!-- es6num="B.1" -->
@@ -36448,7 +36448,7 @@ THH:mm:ss.sss
         </li>
       </ol>
       <p>The first use case is interoperable with the semantics of |Block| level function declarations provided by ECMAScript 2015. Any pre-existing ECMAScript code that employs that use case will operate using the Block level function declarations semantics defined by clauses 9, 13, and 14 of this specification.</p>
-      <p>ECMAScript 2015 interoperability for the second and third use cases requires the following extensions to the clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, clause <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>, clause <emu-xref href="#sec-eval-x"></emu-xref> and clause <emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref> semantics.</p>
+      <p>ECMAScript 2015 interoperability for the second and third use cases requires the following extensions to the clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviors"></emu-xref>, clause <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>, clause <emu-xref href="#sec-eval-x"></emu-xref> and clause <emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref> semantics.</p>
       <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatibility semantics are applied and introduce observable differences from non-compatibility semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
       <emu-annex id="sec-web-compat-functiondeclarationinstantiation">
         <h1>Changes to FunctionDeclarationInstantiation</h1>
@@ -36605,7 +36605,7 @@ THH:mm:ss.sss
       <emu-note>
         <p>The |Block| of a |Catch| clause may contain `var` declarations that bind a name that is also bound by the |CatchParameter|. At runtime, such bindings are instantiated in the VariableDeclarationEnvironment. They do not shadow the same-named bindings introduced by the |CatchParameter| and hence the |Initializer| for such `var` declarations will assign to the corresponding catch parameter rather than the `var` binding. The relaxation of the normal static semantic rule does not apply to names only bound by for-of statements.</p>
       </emu-note>
-      <p>This modified behaviour also applies to `var` and `function` declarations introduced by direct eval calls contained within the |Block| of a |Catch| clause. This change is accomplished by modify the algorithm of <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref> as follows:</p>
+      <p>This modified behavior also applies to `var` and `function` declarations introduced by direct eval calls contained within the |Block| of a |Catch| clause. This change is accomplished by modify the algorithm of <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref> as follows:</p>
       <p>Step 5.d.ii.2.a.i is replaced by:</p>
       <emu-alg type="i">
         1. If _thisEnvRec_ is not the Environment Record for a |Catch| clause, throw a *SyntaxError* exception.
@@ -36685,10 +36685,10 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>: The 5<sup>th</sup> Edition moved the capture of the current array length prior to the integer conversion of the array index or new length value. However, the captured length value could become invalid if the conversion process has the side-effect of changing the array length. ECMAScript 2015 specifies that the current array length must be captured after the possible occurrence of such side-effects.</p>
   <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0* or *-0* as the representation of a 0 time value. ECMAScript 2015 specifies that *+0* always returned. This means that for ECMAScript 2015 the time value of a Date object is never observably *-0* and methods that return time values never return *-0*.</p>
   <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a time zone offset is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as `"z"`.</p>
-  <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
+  <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behavior for that case.</p>
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by Date.prototype.toString when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value is `"Invalid Date"`.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the `source` property of an RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `"/"`.</p>
-  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` is flag set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by one only if the pattern matched the empty string.</p>
+  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` is flag set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behavior is that `lastIndex` should be incremented by one only if the pattern matched the empty string.</p>
   <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>, <emu-xref href="#sec-sortcompare"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0* was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation dependent. In practice, implementations call ToNumber.</p>
 </emu-annex>
 
@@ -36698,7 +36698,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>: In ECMAScript 2015, ToNumber applied to a String value now recognizes and converts |BinaryIntegerLiteral| and |OctalIntegerLiteral| numeric strings. In previous editions such strings were converted to *NaN*.</p>
   <p><emu-xref href="#sec-reference-specification-type"></emu-xref>: In ECMAScript 2015, Function calls are not allowed to return a Reference value.</p>
   <p><emu-xref href="#sec-names-and-keywords"></emu-xref>: In ECMAScript 2015, the valid code points for an |IdentifierName| are specified in terms of the Unicode properties &ldquo;ID_Start&rdquo; and &ldquo;ID_Continue&rdquo;. In previous editions, the valid |IdentifierName| or |Identifier| code points were specified by enumerating various Unicode code point categories.</p>
-  <p><emu-xref href="#sec-rules-of-automatic-semicolon-insertion"></emu-xref>: In ECMAScript 2015, Automatic Semicolon Insertion adds a semicolon at the end of a do-while statement if the semicolon is missing. This change aligns the specification with the actual behaviour of most existing implementations.</p>
+  <p><emu-xref href="#sec-rules-of-automatic-semicolon-insertion"></emu-xref>: In ECMAScript 2015, Automatic Semicolon Insertion adds a semicolon at the end of a do-while statement if the semicolon is missing. This change aligns the specification with the actual behavior of most existing implementations.</p>
   <p><emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>: In ECMAScript 2015, it is no longer an early error to have duplicate property names in Object Initializers.</p>
   <p><emu-xref href="#sec-assignment-operators-static-semantics-early-errors"></emu-xref>: In ECMAScript 2015, strict mode code containing an assignment to an immutable binding such as the function name of a |FunctionExpression| does not produce an early error. Instead it produces a runtime error.</p>
   <p><emu-xref href="#sec-block"></emu-xref>: In ECMAScript 2015, a |StatementList| beginning with the token let followed by the input elements |LineTerminator| then |Identifier| is the start of a |LexicalDeclaration|. In previous editions, automatic semicolon insertion would always insert a semicolon before the |Identifier| input element.</p>


### PR DESCRIPTION
The word optionally might be taken as implementation defined to use
the respective arguments it refers to. Removing it makes it clear
the following steps will be taken when Date.UTC is called with 3 or
more arguments.

cc @jugglinmike 