### PR TITLE
Editorial: Re-factor ExportSpecifier

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21759,41 +21759,29 @@
       <emu-grammar>
         ExportDeclaration :
           `export` `*` FromClause `;`
-          `export` ExportClause FromClause `;`
-          `export` ExportClause `;`
+          `export` ExportClause[~Local] FromClause `;`
+          `export` ExportClause[+Local] `;`
           `export` VariableStatement[~Yield, ~Await]
           `export` Declaration[~Yield, ~Await]
           `export` `default` HoistableDeclaration[~Yield, ~Await, +Default]
           `export` `default` ClassDeclaration[~Yield, ~Await, +Default]
           `export` `default` [lookahead &lt;! {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, ~Await] `;`
 
-        ExportClause :
+        ExportClause[Local] :
           `{` `}`
-          `{` ExportsList `}`
-          `{` ExportsList `,` `}`
+          `{` ExportsList[?Local] `}`
+          `{` ExportsList[?Local] `,` `}`
 
-        ExportsList :
-          ExportSpecifier
-          ExportsList `,` ExportSpecifier
+        ExportsList[Local] :
+          ExportSpecifier[?Local]
+          ExportsList[?Local] `,` ExportSpecifier[?Local]
 
-        ExportSpecifier :
-          IdentifierName
-          IdentifierName `as` IdentifierName
+        ExportSpecifier[Local] :
+          [+Local] IdentifierReference
+          [+Local] IdentifierReference `as` IdentifierName
+          [~Local] IdentifierName
+          [~Local] IdentifierName `as` IdentifierName
       </emu-grammar>
-
-      <!-- es6num="15.2.3.1" -->
-      <emu-clause id="sec-exports-static-semantics-early-errors">
-        <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
-        <ul>
-          <li>
-            For each |IdentifierName| _n_ in ReferencedBindings of |ExportClause|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or if the StringValue of _n_ is one of: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, or `"static"`.
-          </li>
-        </ul>
-        <emu-note>
-          <p>The above rule means that each ReferencedBindings of |ExportClause| is treated as an |IdentifierReference|.</p>
-        </emu-note>
-      </emu-clause>
 
       <!-- es6num="15.2.3.2" -->
       <emu-clause id="sec-exports-static-semantics-boundnames">
@@ -21878,6 +21866,13 @@
           1. Append to _names_ the elements of the ExportedBindings of |ExportSpecifier|.
           1. Return _names_.
         </emu-alg>
+        <emu-grammar>
+          ExportSpecifier : IdentifierReference
+
+          ExportSpecifier : IdentifierReference `as` IdentifierName
+        <emu-alg>
+          1. Return a List containing the StringValue of |IdentifierReference|.
+        </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |IdentifierName|.
@@ -21932,7 +21927,15 @@
           1. Append to _names_ the elements of the ExportedNames of |ExportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierReference</emu-grammar>
+        <emu-alg>
+          1. Return a List containing the StringValue of |IdentifierReference|.
+        </emu-alg>
+        <emu-grammar>
+          ExportSpecifier : IdentifierReference `as` IdentifierName
+
+          ExportSpecifier : IdentifierName
+        </emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |IdentifierName|.
         </emu-alg>
@@ -22013,28 +22016,27 @@
           1. Append to _specs_ the elements of the ExportEntriesForModule of |ExportSpecifier| with argument _module_.
           1. Return _specs_.
         </emu-alg>
+        <emu-grammar>ExportSpecifier : IdentifierReference</emu-grammar>
+        <emu-alg>
+          1. Let _sourceName_ be the StringValue of |IdentifierReference|.
+          1. Return a new List containing the Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _sourceName_, [[ExportName]]: _sourceName_ }.
+        </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _sourceName_ be the StringValue of |IdentifierName|.
-          1. If _module_ is *null*, then
-            1. Let _localName_ be _sourceName_.
-            1. Let _importName_ be *null*.
-          1. Else,
-            1. Let _localName_ be *null*.
-            1. Let _importName_ be _sourceName_.
-          1. Return a new List containing the Record {[[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _sourceName_ }.
+          1. Return a new List containing the Record {[[ModuleRequest]]: _module_, [[ImportName]]: _sourceName_, [[LocalName]]: *null*, [[ExportName]]: _sourceName_ }.
+        </emu-alg>
+        <emu-grammar>ExportSpecifier : IdentifierReference `as` IdentifierName</emu-grammar>
+        <emu-alg>
+          1. Let _localName_ be the StringValue of |IdentifierReference|.
+          1. Let _exportName_ be the StringValue of |IdentifierName|.
+          1. Return a new List containing the Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
         </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Let _sourceName_ be the StringValue of the first |IdentifierName|.
+          1. Let _importName_ be the StringValue of the first |IdentifierName|.
           1. Let _exportName_ be the StringValue of the second |IdentifierName|.
-          1. If _module_ is *null*, then
-            1. Let _localName_ be _sourceName_.
-            1. Let _importName_ be *null*.
-          1. Else,
-            1. Let _localName_ be *null*.
-            1. Let _importName_ be _sourceName_.
-          1. Return a new List containing the Record {[[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
+          1. Return a new List containing the Record {[[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: *null*, [[ExportName]]: _exportName_ }.
         </emu-alg>
       </emu-clause>
 
@@ -22112,29 +22114,6 @@
         </emu-grammar>
         <emu-alg>
           1. Return a new empty List.
-        </emu-alg>
-      </emu-clause>
-
-      <!-- es6num="15.2.3.10" -->
-      <emu-clause id="sec-static-semantics-referencedbindings">
-        <h1>Static Semantics: ReferencedBindings</h1>
-        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be the ReferencedBindings of |ExportsList|.
-          1. Append to _names_ the elements of the ReferencedBindings of |ExportSpecifier|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
-        <emu-alg>
-          1. Return a List containing the |IdentifierName|.
-        </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
-        <emu-alg>
-          1. Return a List containing the first |IdentifierName|.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
In prior editions, the ExportSpecifier production was defined using only
IdentifierName. However, when the ExportSpecifier is part of an "local"
ExportDeclaration, the IdentifierName was interpreted as an
IdentifierReference through an Early Error rule. The rule was
undesirable for a number of reasons:
- it duplicated the definition of IdentifierReference
- it relied on an abstract operation, ReferencedBindings, which was
  otherwise unused
- it was not technically necessary (a separate Early Error rule for
  ModuleBody requires that all ExportedBindings are declared within the
  module itself, and it is not possible to create a such a binding)

These details made interpreting ExportSpecifier difficult and tended to
obscure the motivation for the use of IdentifierName.

Re-factor ExportSpecifier with a production parameter describing whether
it belongs to a "local" or "indirect" ExportDeclaration. This allows for
the definition of dedicated grammar productions, obviating the need for
an explicit early error, and removing branching logic from the static
semantics rule ExportEntriesForModule. It also more clearly communicates
the intent behind related definitions of the production.

---

Note that while this patch improves a few aspects of the grammar, there is one
somewhat counterintuitive aspect that it does not address. Both ES2016 and this
modified version contain a use of "ExportEntriesForModule" where the "module"
value is "null". We could move the definitions for the "local" production into
"ExportEntries", but that would require additional considerations for
ExportsList. Maybe there's a better name for ExportEntriesForModule?
