### PR TITLE
Unify String and Array maximum lengths

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -767,7 +767,7 @@
     <!-- es6num="6.1.4" -->
     <emu-clause id="sec-ecmascript-language-types-string-type">
       <h1>The String Type</h1>
-      <p>The String type is the set of all ordered sequences of zero or more 16-bit unsigned integer values (&ldquo;elements&rdquo;) up to a maximum length of 2<sup>53</sup>-1 elements. The String type is generally used to represent textual data in a running ECMAScript program, in which case each element in the String is treated as a UTF-16 code unit value. Each element is regarded as occupying a position within the sequence. These positions are indexed with nonnegative integers. The first element (if any) is at index 0, the next element (if any) at index 1, and so on. The length of a String is the number of elements (i.e., 16-bit values) within it. The empty String has length zero and therefore contains no elements.</p>
+      <p>The String type is the set of all ordered sequences of zero or more 16-bit unsigned integer values (&ldquo;elements&rdquo;) up to a maximum length of 2<sup>32</sup>-1 elements. The String type is generally used to represent textual data in a running ECMAScript program, in which case each element in the String is treated as a UTF-16 code unit value. Each element is regarded as occupying a position within the sequence. These positions are indexed with nonnegative integers. The first element (if any) is at index 0, the next element (if any) at index 1, and so on. The length of a String is the number of elements (i.e., 16-bit values) within it. The empty String has length zero and therefore contains no elements.</p>
       <p>Where ECMAScript operations interpret String values, each element is interpreted as a single UTF-16 code unit. However, ECMAScript does not place any restrictions or requirements on the sequence of code units in a String value, so they may be ill-formed when interpreted as UTF-16 code unit sequences. Operations that do not interpret String contents treat them as sequences of undifferentiated 16-bit unsigned integers. The function `String.prototype.normalize` (see <emu-xref href="#sec-string.prototype.normalize"></emu-xref>) can be used to explicitly normalize a String value. `String.prototype.localeCompare` (see <emu-xref href="#sec-string.prototype.localecompare"></emu-xref>) internally normalizes String values, but no other operations implicitly normalize the strings upon which they operate. Only operations that are explicitly specified to be language or locale sensitive produce language-sensitive results.</p>
       <emu-note>
         <p>The rationale behind this design was to keep the implementation of Strings as simple and high-performing as possible. If ECMAScript source text is in Normalized Form C, string literals are guaranteed to also be normalized, as long as they do not contain any Unicode escape sequences.</p>
@@ -28738,7 +28738,7 @@ THH:mm:ss.sss
           <p>The abstract operation AdvanceStringIndex with arguments _S_, _index_, and _unicode_ performs the following steps:</p>
           <emu-alg>
             1. Assert: Type(_S_) is String.
-            1. Assert: _index_ is an integer such that 0&le;_index_&le;2<sup>53</sup>-1.
+            1. Assert: _index_ is an integer such that 0&le;_index_&le;2<sup>32</sup>-1.
             1. Assert: Type(_unicode_) is Boolean.
             1. If _unicode_ is *false*, return _index_+1.
             1. Let _length_ be the number of code units in _S_.


### PR DESCRIPTION
Currently Strings are defined to consist of up to 2<sup>53</sup> - 1 elements (See [6.1.4 The String Type](https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type)).  Arrays on the other hand can have up to 2<sup>32</sup> - 1 indexed elements (See [6.1.7 The Object Type](https://tc39.github.io/ecma262/#sec-object-type) and the definition of _array index_).  Given that there are functions that convert readily between Arrays and Strings, it makes sense that their limits be the same.  Another way of looking at this is that a String is an array of elements.
