### PR TITLE
Proposal: Nested import declarations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6065,6 +6065,37 @@
         1. Return _currentRealm_.[[GlobalObject]].
       </emu-alg>
     </emu-clause>
+
+    <!-- es6num="8.3.6" -->
+    <emu-clause id="sec-createlexicalbindings" aoid="CreateLexicalBindings">
+      <h1>CreateLexicalBindings ( _declarations_ , _env_ , _scriptOrModule_ )</h1>
+      <p>The abstract operation CreateLexicalBindings creates bindings on the EnvironmentRecord of the Lexical Environment _env_ based on a List of lexically scoped _declarations_. The _scriptOrModule_ parameter identifies the Module Record or Script Record from which the associated code originates, or *null* if there is no originating script or module.</p>
+      <emu-alg>
+        1. Let _envRec_ be _env_'s EnvironmentRecord.
+        1. Assert: _envRec_ is a declarative Environment Record.
+        1. For each element _d_ in _declarations_, do
+          1. If _d_ is an |ImportDeclaration|, then
+            1. Assert: _scriptOrModule_ is an instance of a concrete subclass of Module Record.
+            1. Let _module_ be _scriptOrModule_.
+            1. For each ImportEntry Record _entry_ in the ImportEntries of _d_, do
+              1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _entry_.[[ModuleRequest]]).
+              1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], which were previously resolved in ParseModule.
+              1. If _entry_.[[ImportName]] is `"*"`, then
+                1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
+                1. Perform ! _envRec_.CreateImmutableBinding(_entry_.[[LocalName]], *true*).
+                1. Call _envRec_.InitializeBinding(_entry_.[[LocalName]], _namespace_).
+              1. Else,
+                1. Let _resolution_ be ? _importedModule_.ResolveExport(_entry_.[[ImportName]], &laquo; &raquo;, &laquo; &raquo;).
+                1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
+                1. Call _envRec_.CreateImportBinding(_entry_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
+          1. Else, for each element _dn_ of the BoundNames of _d_ do
+            1. If IsConstantDeclaration of _d_ is *true*, then
+              1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
+            1. Else,
+              1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+        1. Return NormalCompletion(~empty~).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <!-- es6num="8.4" -->

--- a/spec.html
+++ b/spec.html
@@ -4791,13 +4791,23 @@
         <!-- es6num="8.1.1.1.6" -->
         <emu-clause id="sec-declarative-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue (_N_, _S_)</h1>
-          <p>The concrete Environment Record method GetBindingValue for declarative Environment Records simply returns the value of its bound identifier whose name is the value of the argument _N_. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.</p>
+          <p>The concrete Environment Record method GetBindingValue for declarative Environment Records returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.</p>
           <emu-alg>
             1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. Assert: _envRec_ has a binding for _N_.
+            1. If the binding for _N_ is an indirect binding, then
+              1. Assert: _S_ is *true*.
+              1. Let _M_ and _N2_ be the indirection values provided when this binding for _N_ was created.
+              1. Let _targetEnv_ be _M_.[[Environment]].
+              1. If _targetEnv_ is *undefined*, throw a *ReferenceError* exception.
+              1. Let _targetER_ be _targetEnv_'s EnvironmentRecord.
+              1. Return ? _targetER_.GetBindingValue(_N2_, *true*).
             1. If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.
             1. Return the value currently bound to _N_ in _envRec_.
           </emu-alg>
+          <emu-note>
+            <p>Since indirect bindings can be created only in a |Module|, _S_ must be *true* if _N_ is an indirect binding, because a |Module| is always strict mode code.</p>
+          </emu-note>
         </emu-clause>
 
         <!-- es6num="8.1.1.1.7" -->
@@ -4837,6 +4847,20 @@
           <p>Declarative Environment Records always return *undefined* as their WithBaseObject.</p>
           <emu-alg>
             1. Return *undefined*.
+          </emu-alg>
+        </emu-clause>
+
+        <!-- es6num="8.1.1.1.11" -->
+        <emu-clause id="sec-declarative-environment-records-createimportbinding-n-m-n2">
+          <h1>CreateImportBinding (_N_, _M_, _N2_)</h1>
+          <p>The concrete Environment Record method CreateImportBinding for declarative Environment Records creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _M_ is a Module Record, and _N2_ is the name of a binding that exists in M's module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding.</p>
+          <emu-alg>
+            1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
+            1. Assert: _envRec_ does not already have a binding for _N_.
+            1. Assert: _M_ is a Module Record.
+            1. Assert: When _M_.[[Environment]] is instantiated it will have a direct binding for _N2_.
+            1. Create an immutable indirect binding in _envRec_ for _N_ that references _M_ and _N2_ as its target binding and record that the binding is initialized.
+            1. Return NormalCompletion(~empty~).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -5562,14 +5586,6 @@
             </tr>
             <tr>
               <td>
-                CreateImportBinding(N, M, N2)
-              </td>
-              <td>
-                Create an immutable indirect binding in a module Environment Record. The String value _N_ is the text of the bound name. _M_ is a Module Record, and _N2_ is a binding that exists in M's module Environment Record.
-              </td>
-            </tr>
-            <tr>
-              <td>
                 GetThisBinding()
               </td>
               <td>
@@ -5580,28 +5596,6 @@
           </table>
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
-
-        <!-- es6num="8.1.1.5.1" -->
-        <emu-clause id="sec-module-environment-records-getbindingvalue-n-s">
-          <h1>GetBindingValue (_N_, _S_)</h1>
-          <p>The concrete Environment Record method GetBindingValue for module Environment Records returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown.</p>
-          <emu-alg>
-            1. Assert: _S_ is *true*.
-            1. Let _envRec_ be the module Environment Record for which the method was invoked.
-            1. Assert: _envRec_ has a binding for _N_.
-            1. If the binding for _N_ is an indirect binding, then
-              1. Let _M_ and _N2_ be the indirection values provided when this binding for _N_ was created.
-              1. Let _targetEnv_ be _M_.[[Environment]].
-              1. If _targetEnv_ is *undefined*, throw a *ReferenceError* exception.
-              1. Let _targetER_ be _targetEnv_'s EnvironmentRecord.
-              1. Return ? _targetER_.GetBindingValue(_N2_, *true*).
-            1. If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.
-            1. Return the value currently bound to _N_ in _envRec_.
-          </emu-alg>
-          <emu-note>
-            <p>_S_ will always be *true* because a |Module| is always strict mode code.</p>
-          </emu-note>
-        </emu-clause>
 
         <!-- es6num="8.1.1.5.2" -->
         <emu-clause id="sec-module-environment-records-deletebinding-n">
@@ -5629,20 +5623,6 @@
           <h1>GetThisBinding ()</h1>
           <emu-alg>
             1. Return *undefined*.
-          </emu-alg>
-        </emu-clause>
-
-        <!-- es6num="8.1.1.5.5" -->
-        <emu-clause id="sec-createimportbinding">
-          <h1>CreateImportBinding (_N_, _M_, _N2_)</h1>
-          <p>The concrete Environment Record method CreateImportBinding for module Environment Records creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _M_ is a Module Record, and _N2_ is the name of a binding that exists in M's module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding.</p>
-          <emu-alg>
-            1. Let _envRec_ be the module Environment Record for which the method was invoked.
-            1. Assert: _envRec_ does not already have a binding for _N_.
-            1. Assert: _M_ is a Module Record.
-            1. Assert: When _M_.[[Environment]] is instantiated it will have a direct binding for _N2_.
-            1. Create an immutable indirect binding in _envRec_ for _N_ that references _M_ and _N2_ as its target binding and record that the binding is initialized.
-            1. Return NormalCompletion(~empty~).
           </emu-alg>
         </emu-clause>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -14136,7 +14136,11 @@
       StatementListItem[Yield, Return] :
         Statement[?Yield, ?Return]
         Declaration[?Yield]
+        ImportDeclaration
     </emu-grammar>
+    <emu-note>
+      Although an |ImportDeclaration| sounds like it should be a |Declaration|, it is important for the grammar that an |ImportDeclaration| not be allowed to appear anywhere a |Declaration| can appear, as that would allow |ExportDeclaration|s to export |ImportDeclaration|s, for example.
+    </emu-note>
 
     <!-- es6num="13.2.1" -->
     <emu-clause id="sec-block-static-semantics-early-errors">
@@ -14167,7 +14171,11 @@
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |StatementListItem| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>
+        StatementListItem :
+          Declaration
+          ImportDeclaration
+      </emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14188,7 +14196,11 @@
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |StatementListItem| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>
+        StatementListItem :
+          Declaration
+          ImportDeclaration
+      </emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14209,7 +14221,11 @@
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |StatementListItem| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>
+        StatementListItem :
+          Declaration
+          ImportDeclaration
+      </emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14234,6 +14250,11 @@
         1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyDeclaredNames of |LabelledStatement|.
         1. Return a new empty List.
       </emu-alg>
+      <emu-grammar>StatementListItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Let _importEntries_ be the ImportEntries of |ImportDeclaration|.
+        1. Return ImportedLocalNames(_importEntries_).
+      </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |Declaration|.
@@ -14255,6 +14276,12 @@
         1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyScopedDeclarations of |LabelledStatement|.
         1. Return a new empty List.
       </emu-alg>
+      <emu-grammar>
+        StatementListItem : ImportDeclaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new List containing the |ImportDeclaration|.
+      </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return a new List containing DeclarationPart of |Declaration|.
@@ -14274,6 +14301,10 @@
       <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementListItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return the LexicallyDeclaredNames of |ImportDeclaration|.
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
@@ -14304,6 +14335,12 @@
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
+      <emu-grammar>
+        StatementListItem : ImportDeclaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new List containing the |ImportDeclaration|.
+      </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
@@ -14326,6 +14363,13 @@
         1. Append to _names_ the elements of the TopLevelVarDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
+      <emu-grammar>StatementListItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-note>
+        Local names declared by an |ImportDeclaration| are always treated like lexical declarations, and never like `var` declarations.
+      </emu-note>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
@@ -14361,6 +14405,10 @@
         1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
         1. Return VarScopedDeclarations of |Statement|.
       </emu-alg>
+      <emu-grammar>StatementListItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
@@ -14384,7 +14432,11 @@
         1. Append to _names_ the elements of the VarDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>
+        StatementListItem :
+          Declaration
+          ImportDeclaration
+      </emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -14404,13 +14456,60 @@
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>
+        StatementListItem :
+          Declaration
+          ImportDeclaration
+      </emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
     <!-- es6num="13.2.13" -->
+    <emu-clause id="sec-block-static-semantics-importentries">
+      <h1>Static Semantics: ImportEntries</h1>
+      <emu-see-also-para op="ImportEntries"></emu-see-also-para>
+      <emu-grammar>
+        StatementList : StatementList StatementListItem
+      </emu-grammar>
+      <emu-alg>
+        1. Let _importEntries_ be the ImportEntries of |StatementList|.
+        1. Append to _importEntries_ the elements of the ImportEntries of |StatementListItem|.
+        1. Return _importEntries_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return the ImportEntries of |ImportDeclaration|.
+      </emu-alg>
+      <emu-grammar>
+        StatementListItem :
+          Statement
+          Declaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+    </emu-clause>
+
+    <!-- es6num="13.2.14" -->
+    <emu-clause id="sec-block-static-semantics-modulerequests">
+      <h1>Static Semantics: ModuleRequests</h1>
+      <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
+      <emu-grammar>StatementListItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return ModuleRequests of |ImportDeclaration|.
+      </emu-alg>
+      <emu-grammar>
+        StatementListItem :
+          Statement
+          Declaration
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+    </emu-clause>
+
+    <!-- es6num="13.2.15" -->
     <emu-clause id="sec-block-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Block : `{` `}`</emu-grammar>
@@ -14447,7 +14546,7 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.2.14" -->
+    <!-- es6num="13.2.16" -->
     <emu-clause id="sec-blockdeclarationinstantiation" aoid="BlockDeclarationInstantiation">
       <h1>Runtime Semantics: BlockDeclarationInstantiation( _code_, _env_ )</h1>
       <emu-note>
@@ -19102,7 +19201,9 @@
         <emu-grammar>
           FunctionStatementList : [empty]
 
-          StatementListItem : Declaration
+          StatementListItem :
+            Declaration
+            ImportDeclaration
 
           Statement :
             VariableStatement
@@ -19694,7 +19795,6 @@
         ModuleItemList ModuleItem
 
       ModuleItem :
-        ImportDeclaration
         ExportDeclaration
         StatementListItem[~Yield, ~Return]
     </emu-grammar>
@@ -19752,11 +19852,7 @@
           1. If _hasDuplicates_ is *true*, return *true*.
           1. Return ContainsDuplicateLabels of |ModuleItem| with argument _labelSet_.
         </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            ExportDeclaration
-        </emu-grammar>
+        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
@@ -19773,11 +19869,7 @@
           1. If _hasUndefinedLabels_ is *true*, return *true*.
           1. Return ContainsUndefinedBreakTarget of |ModuleItem| with argument _labelSet_.
         </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            ExportDeclaration
-        </emu-grammar>
+        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
@@ -19794,11 +19886,7 @@
           1. If _hasUndefinedLabels_ is *true*, return *true*.
           1. Return ContainsUndefinedContinueTarget of |ModuleItem| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            ExportDeclaration
-        </emu-grammar>
+        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
@@ -19817,11 +19905,7 @@
           1. Append to _names_ the elements of the ExportedBindings of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            StatementListItem
-        </emu-grammar>
+        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -19844,11 +19928,7 @@
         <emu-alg>
           1. Return the ExportedNames of |ExportDeclaration|.
         </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            StatementListItem
-        </emu-grammar>
+        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -19868,11 +19948,7 @@
           1. Append to _entries_ the elements of the ExportEntries of |ModuleItem|.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            StatementListItem
-        </emu-grammar>
+        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -19892,11 +19968,7 @@
           1. Append to _entries_ the elements of the ImportEntries of |ModuleItem|.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ExportDeclaration
-            StatementListItem
-        </emu-grammar>
+        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -19952,10 +20024,6 @@
           1. Append to _names_ the elements of the LexicallyDeclaredNames of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |ImportDeclaration|.
-        </emu-alg>
         <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. If |ExportDeclaration| is `export` |VariableStatement|, return a new empty List.
@@ -19984,10 +20052,6 @@
           1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |ModuleItem|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
       </emu-clause>
 
       <!-- es6num="15.2.1.13" -->
@@ -20003,10 +20067,6 @@
           1. Let _names_ be VarDeclaredNames of |ModuleItemList|.
           1. Append to _names_ the elements of the VarDeclaredNames of |ModuleItem|.
           1. Return _names_.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
         </emu-alg>
         <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
@@ -20028,10 +20088,6 @@
           1. Let _declarations_ be VarScopedDeclarations of |ModuleItemList|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |ModuleItem|.
           1. Return _declarations_.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
         </emu-alg>
         <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
@@ -20919,10 +20975,6 @@
         <emu-note>
           <p>The value of a |ModuleItemList| is the value of the last value producing item in the |ModuleItemList|.</p>
         </emu-note>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return NormalCompletion(~empty~).
-        </emu-alg>
       </emu-clause>
     </emu-clause>
 
@@ -20974,10 +21026,12 @@
       <!-- es6num="15.2.2.1" -->
       <emu-clause id="sec-imports-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar>
+          ImportDeclaration : `import` ImportClause FromClause `;`
+        </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the BoundNames of |ImportDeclaration| contains any duplicate entries.
+            It is a Syntax Error if the BoundNames of |ImportClause| contain any duplicate entries.
           </li>
         </ul>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -7154,13 +7154,8 @@
         1. Let _lexEnvRec_ be _lexEnv_'s EnvironmentRecord.
         1. Set the LexicalEnvironment of _calleeContext_ to _lexEnv_.
         1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
-        1. For each element _d_ in _lexDeclarations_ do
-          1. NOTE A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated here but not initialized.
-          1. For each element _dn_ of the BoundNames of _d_ do
-            1. If IsConstantDeclaration of _d_ is *true*, then
-              1. Perform ! _lexEnvRec_.CreateImmutableBinding(_dn_, *true*).
-            1. Else,
-              1. Perform ! _lexEnvRec_.CreateMutableBinding(_dn_, *false*).
+        1. Call CreateLexicalBindings(_lexDeclarations_, _lexEnv_, _func_.[[ScriptOrModule]]).
+        1. NOTE A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated by CreateLexicalBindings but not initialized.
         1. For each parsed grammar phrase _f_ in _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
           1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
@@ -14586,14 +14581,10 @@
       <p>BlockDeclarationInstantiation is performed as follows using arguments _code_ and _env_. _code_ is the grammar production corresponding to the body of the block. _env_ is the Lexical Environment in which bindings are to be created.</p>
       <emu-alg>
         1. Let _envRec_ be _env_'s EnvironmentRecord.
-        1. Assert: _envRec_ is a declarative Environment Record.
         1. Let _declarations_ be the LexicallyScopedDeclarations of _code_.
-        1. For each element _d_ in _declarations_ do
-          1. For each element _dn_ of the BoundNames of _d_ do
-            1. If IsConstantDeclaration of _d_ is *true*, then
-              1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
-            1. Else,
-              1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+        1. Let _scriptOrModule_ be GetActiveScriptOrModule().
+        1. Call CreateLexicalBindings(_declarations_, _env_, _scriptOrModule_).
+        1. For each element _d_ in _declarations_, do
           1. If _d_ is a |GeneratorDeclaration| production or a |FunctionDeclaration| production, then
             1. Let _fn_ be the sole element of the BoundNames of _d_.
             1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
@@ -20858,17 +20849,6 @@
               1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
             1. Assert: All named exports from _module_ are resolvable.
             1. Let _envRec_ be _env_'s EnvironmentRecord.
-            1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
-              1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
-              1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
-              1. If _in_.[[ImportName]] is `"*"`, then
-                1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
-                1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
-                1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
-              1. Else,
-                1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;, &laquo; &raquo;).
-                1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
-                1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
             1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
             1. Let _declaredVarNames_ be a new empty List.
             1. For each element _d_ in _varDeclarations_ do
@@ -20878,12 +20858,9 @@
                   1. Call _envRec_.InitializeBinding(_dn_, *undefined*).
                   1. Append _dn_ to _declaredVarNames_.
             1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
+            1. Call CreateLexicalBindings(_lexDeclarations_, _env_, _module_).
             1. For each element _d_ in _lexDeclarations_ do
               1. For each element _dn_ of the BoundNames of _d_ do
-                1. If IsConstantDeclaration of _d_ is *true*, then
-                  1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
-                1. Else,
-                  1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
                 1. If _d_ is a |GeneratorDeclaration| production or a |FunctionDeclaration| production, then
                   1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
                   1. Call _envRec_.InitializeBinding(_dn_, _fo_).

--- a/spec.html
+++ b/spec.html
@@ -6079,7 +6079,6 @@
             1. Let _module_ be _scriptOrModule_.
             1. For each ImportEntry Record _entry_ in the ImportEntries of _d_, do
               1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _entry_.[[ModuleRequest]]).
-              1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], which were previously resolved in ParseModule.
               1. If _entry_.[[ImportName]] is `"*"`, then
                 1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
                 1. Perform ! _envRec_.CreateImmutableBinding(_entry_.[[LocalName]], *true*).
@@ -20308,17 +20307,6 @@
             </tr>
             <tr>
               <td>
-                [[RequestedModules]]
-              </td>
-              <td>
-                List of String
-              </td>
-              <td>
-                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
-              </td>
-            </tr>
-            <tr>
-              <td>
                 [[LocalExportEntries]]
               </td>
               <td>
@@ -20742,7 +20730,6 @@
             1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
             1. Parse _sourceText_ using |Module| as the goal symbol and analyze the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* or *ReferenceError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation dependent, but at least one must be present.
             1. If _body_ is a List of errors, then return _body_.
-            1. Let _requestedModules_ be the ModuleRequests of _body_.
             1. Let _importEntries_ be ImportEntries of _body_.
             1. Let _importedBoundNames_ be ImportedLocalNames(_importEntries_).
             1. Let _indirectExportEntries_ be a new empty List.
@@ -20764,7 +20751,7 @@
                 1. Append _ee_ to _starExportEntries_.
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
-            1. Return Source Text Module Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[HostDefined]]: _hostDefined_, [[Namespace]]: *undefined*, [[Evaluated]]: *false*, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[LocalExportEntries]]: _localExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_}.
+            1. Return Source Text Module Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[HostDefined]]: _hostDefined_, [[Namespace]]: *undefined*, [[Evaluated]]: *false*, [[ECMAScriptCode]]: _body_, [[LocalExportEntries]]: _localExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_}.
           </emu-alg>
           <emu-note>
             <p>An implementation may parse module source text and analyze it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -20858,7 +20845,7 @@
             1. If _module_.[[Environment]] is not *undefined*, return NormalCompletion(~empty~).
             1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
             1. Set _module_.[[Environment]] to _env_.
-            1. For each String _required_ that is an element of _module_.[[RequestedModules]] do,
+            1. For each String _required_ of the ModuleRequests of _code_, do
               1. NOTE: Before instantiating a module, all of the modules it requested must be available. An implementation may perform this test at any time prior to this point.
               1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
               1. Perform ? _requiredModule_.ModuleDeclarationInstantiation().

--- a/spec.html
+++ b/spec.html
@@ -6096,6 +6096,31 @@
         1. Return NormalCompletion(~empty~).
       </emu-alg>
     </emu-clause>
+
+    <!-- es6num="8.3.7" -->
+    <emu-clause id="sec-evaluaterequestedmodules" aoid="EvaluateRequestedModules">
+      <h1>EvaluateRequestedModules ( _body_ , _scriptOrModule_ )</h1>
+      <p>The abstract operation EvaluateRequestedModules gathers the ModuleRequests of _body_, resolves those requests using HostResolveImportedModule, and ensures that each requested module has been instantiated and evaluated.</p>
+      <p>The _scriptOrModule_ parameter identifies the Module Record or Script Record from which the _body_ originates, or *null* if there is no originating script or module. The _scriptOrModule_ parameter must be an instance of a concrete subclass of Module Record if there are any modules to evaluate.</p>
+      <emu-alg>
+        1. Let _modules_ be a new empty List.
+        1. For each String _request_ of the ModuleRequests of _body_, do
+          1. Assert: _scriptOrModule_ is an instance of a concrete subclass of Module Record.
+          1. Let _m_ be ! HostResolveImportedModule(_scriptOrModule_, _request_).
+          1. If _m_ is not an element of _modules_, append _m_ to _modules_.
+        1. If _modules_ is empty, return NormalCompletion(*false*).
+        1. For each element _m_ of _modules_, do
+          1. Perform ? _m_.ModuleDeclarationInstantiation().
+          1. NOTE _m_.ModuleDeclarationInstantiation() may have been performed already, but it is idempotent, and a prerequisite for calling _m_.ModuleEvaluation().
+        1. For each element _m_ of _modules_, do
+          1. Perform ? _m_.ModuleEvaluation().
+          1. NOTE This is a separate loop so that any errors from ModuleDeclarationInstantiation occur before any ModuleEvaluation calls.
+        1. Return NormalCompletion(*true*).
+      </emu-alg>
+      <emu-note>
+        The ModuleRequests of _body_ contain only those |ModuleSpecifier| strings from |ImportDeclaration|s and |ExportDeclaration|s contained directly within _body_, and not any strings nested within blocks contained by _body_.
+      </emu-note>
+    </emu-clause>
   </emu-clause>
 
   <!-- es6num="8.4" -->
@@ -14548,6 +14573,7 @@
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|StatementList|, _blockEnv_).
         1. Set the running execution context's LexicalEnvironment to _blockEnv_.
+        1. Perform ? EvaluateRequestedModules(|StatementList|, GetActiveScriptOrModule()).
         1. Let _blockValue_ be the result of evaluating |StatementList|.
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return _blockValue_.
@@ -16913,6 +16939,7 @@
       </emu-alg>
       <emu-grammar>CaseClause : `case` Expression `:` StatementList</emu-grammar>
       <emu-alg>
+        1. Perform ? EvaluateRequestedModules(|StatementList|, GetActiveScriptOrModule()).
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:`</emu-grammar>
@@ -16921,6 +16948,7 @@
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList</emu-grammar>
       <emu-alg>
+        1. Perform ? EvaluateRequestedModules(|StatementList|, GetActiveScriptOrModule()).
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
     </emu-clause>
@@ -17881,6 +17909,7 @@
       <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
+        1. Perform ? EvaluateRequestedModules(|FunctionStatementList|, _functionObject_.[[ScriptOrModule]]).
         1. Return the result of evaluating |FunctionStatementList|.
       </emu-alg>
     </emu-clause>
@@ -20867,10 +20896,8 @@
             1. Assert: _module_.[[Realm]] is not *undefined*.
             1. If _module_.[[Evaluated]] is *true*, return *undefined*.
             1. Set _module_.[[Evaluated]] to *true*.
-            1. For each String _required_ that is an element of _module_.[[RequestedModules]] do,
-              1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-              1. NOTE: ModuleDeclarationInstantiation must be completed prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-              1. Perform ? _requiredModule_.ModuleEvaluation().
+            1. Let _code_ be _module_.[[ECMAScriptCode]].
+            1. Perform ? EvaluateRequestedModules(_code_, _module_).
             1. Let _moduleCxt_ be a new ECMAScript code execution context.
             1. Set the Function of _moduleCxt_ to *null*.
             1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
@@ -20880,7 +20907,7 @@
             1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
             1. Suspend the currently running execution context.
             1. Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.
-            1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
+            1. Let _result_ be the result of evaluating _code_.
             1. Suspend _moduleCxt_ and remove it from the execution context stack.
             1. Resume the context that is now on the top of the execution context stack as the running execution context.
             1. Return Completion(_result_).

--- a/spec.html
+++ b/spec.html
@@ -20290,17 +20290,6 @@
             </tr>
             <tr>
               <td>
-                [[ImportEntries]]
-              </td>
-              <td>
-                List of ImportEntry Records
-              </td>
-              <td>
-                A List of ImportEntry records derived from the code of this module.
-              </td>
-            </tr>
-            <tr>
-              <td>
                 [[LocalExportEntries]]
               </td>
               <td>
@@ -20746,7 +20735,7 @@
                 1. Append _ee_ to _starExportEntries_.
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
-            1. Return Source Text Module Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[HostDefined]]: _hostDefined_, [[Namespace]]: *undefined*, [[Evaluated]]: *false*, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_}.
+            1. Return Source Text Module Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[HostDefined]]: _hostDefined_, [[Namespace]]: *undefined*, [[Evaluated]]: *false*, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[LocalExportEntries]]: _localExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_}.
           </emu-alg>
           <emu-note>
             <p>An implementation may parse module source text and analyze it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -21834,6 +21834,7 @@
                     1. Append _vn_ to _declaredVarNames_.
           1. NOTE: No abnormal terminations occur after this algorithm step unless _varEnvRec_ is a global Environment Record and the global object is a Proxy exotic object.
           1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _body_.
+          1. NOTE Because the PerformEval operation parses its string argument with goal symbol |Script|, it is not possible for _lexDeclarations_ to contain any |ImportDeclaration|s, so there is no need to call CreateLexicalBindings here.
           1. For each element _d_ in _lexDeclarations_ do
             1. NOTE Lexically declared names are only instantiated here but not initialized.
             1. For each element _dn_ of the BoundNames of _d_ do


### PR DESCRIPTION
**Stage:** 0

**Champion:** Ben Newman (Meteor Development Group)

**Specification:** Work in progress; see attached [commits](https://github.com/tc39/ecma262/pull/646/commits).


## Summary

This proposal argues for relaxing the current restriction that `import` declarations may appear only at the top level of a module.

Specifically, this proposal would allow `import` declarations that are

1. **nestable** within functions and blocks, enabling multiple new and worthwhile `import` idioms;
1. **hoisted** to the beginning of the enclosing scope; that is, _declarative_ rather than _imperative_;
1. **lexically scoped** to the enclosing block;
1. **synchronously evaluated**, with clear and manageable consequences for runtime module fetching; and
1. **backwards compatible** with the semantics of existing top-level `import` declarations.

At this time, no changes are proposed regarding the placement or semantics of `export`
declarations. In the opinion of the author, keeping all `export` declarations at the top
level remains important for many of the static properties of the ECMAScript module system.

**Read the full proposal [here](https://github.com/benjamn/reify/blob/master/PROPOSAL.md).**