### PR TITLE
Editorial: collapse `OrdinaryPreventExtensions`/`OrdinaryIsExtensible` to their sole callsite

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6335,16 +6335,8 @@
       <h1>[[IsExtensible]] ( )</h1>
       <p>When the [[IsExtensible]] internal method of _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Return ! OrdinaryIsExtensible(_O_).
+        1. Return _O_.[[Extensible]].
       </emu-alg>
-
-      <emu-clause id="sec-ordinaryisextensible" aoid="OrdinaryIsExtensible">
-        <h1>OrdinaryIsExtensible (_O_)</h1>
-        <p>When the abstract operation OrdinaryIsExtensible is called with Object _O_, the following steps are taken:</p>
-        <emu-alg>
-          1. Return _O_.[[Extensible]].
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <!-- es6num="9.1.4" -->
@@ -6352,17 +6344,9 @@
       <h1>[[PreventExtensions]] ( )</h1>
       <p>When the [[PreventExtensions]] internal method of _O_ is called, the following steps are taken:</p>
       <emu-alg>
-        1. Return ! OrdinaryPreventExtensions(_O_).
+        1. Set _O_.[[Extensible]] to *false*.
+        1. Return *true*.
       </emu-alg>
-
-      <emu-clause id="sec-ordinarypreventextensions" aoid="OrdinaryPreventExtensions">
-        <h1>OrdinaryPreventExtensions (_O_)</h1>
-        <p>When the abstract operation OrdinaryPreventExtensions is called with Object _O_, the following steps are taken:</p>
-        <emu-alg>
-          1. Set _O_.[[Extensible]] to *false*.
-          1. Return *true*.
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <!-- es6num="9.1.5" -->


### PR DESCRIPTION
It seems silly to me to have `OrdinaryPreventExtensions` and `OrdinaryIsExtensible` when they're only used once. Thoughts on removing them?