### PR TITLE
Editorial: Simplify description of CreateImmutableBinding

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4646,7 +4646,7 @@
               CreateImmutableBinding(N, S)
             </td>
             <td>
-              Create a new but uninitialized immutable binding in an Environment Record. The String value _N_ is the text of the bound name. If _S_ is *true* then attempts to access the value of the binding before it is initialized or set it after it has been initialized will always throw an exception, regardless of the strict mode setting of operations that reference that binding.
+              Create a new but uninitialized immutable binding in an Environment Record. The String value _N_ is the text of the bound name. If _S_ is *true* then attempts to set it after it has been initialized will always throw an exception, regardless of the strict mode setting of operations that reference that binding.
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
The `S` argument is only used to make decisions about sets occuring
after initialization, so the mention of "before initialization"
here was spurious.