### PR TITLE
Editorial: Tweak EnumerateObjectProperties informative definition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16181,7 +16181,7 @@
                   }
                 }
               }
-              let proto = Reflect.getPrototypeOf(obj)
+              let proto = Reflect.getPrototypeOf(obj);
               if (proto === null) return;
               for (let protoName of EnumerateObjectProperties(proto)) {
                 if (!visited.has(protoName)) yield protoName;

--- a/spec.html
+++ b/spec.html
@@ -16173,12 +16173,11 @@
             function* EnumerateObjectProperties(obj) {
               let visited = new Set;
               for (let key of Reflect.ownKeys(obj)) {
-                if (typeof key === "string") {
-                  let desc = Reflect.getOwnPropertyDescriptor(obj, key);
-                  if (desc && !visited.has(key)) {
-                    visited.add(key);
-                    if (desc.enumerable) yield key;
-                  }
+                if (typeof key === "symbol") continue;
+                let desc = Reflect.getOwnPropertyDescriptor(obj, key);
+                if (desc && !visited.has(key)) {
+                  visited.add(key);
+                  if (desc.enumerable) yield key;
                 }
               }
               let proto = Reflect.getPrototypeOf(obj);

--- a/spec.html
+++ b/spec.html
@@ -16171,18 +16171,18 @@
           <p>The following is an informative definition of an ECMAScript generator function that conforms to these rules:</p>
           <pre><code class="javascript">
             function* EnumerateObjectProperties(obj) {
-              let visited = new Set;
-              for (let key of Reflect.ownKeys(obj)) {
+              const visited = new Set;
+              for (const key of Reflect.ownKeys(obj)) {
                 if (typeof key === "symbol") continue;
-                let desc = Reflect.getOwnPropertyDescriptor(obj, key);
+                const desc = Reflect.getOwnPropertyDescriptor(obj, key);
                 if (desc && !visited.has(key)) {
                   visited.add(key);
                   if (desc.enumerable) yield key;
                 }
               }
-              let proto = Reflect.getPrototypeOf(obj);
+              const proto = Reflect.getPrototypeOf(obj);
               if (proto === null) return;
-              for (let protoKey of EnumerateObjectProperties(proto)) {
+              for (const protoKey of EnumerateObjectProperties(proto)) {
                 if (!visited.has(protoKey)) yield protoKey;
               }
             }

--- a/spec.html
+++ b/spec.html
@@ -16183,8 +16183,8 @@
               }
               let proto = Reflect.getPrototypeOf(obj);
               if (proto === null) return;
-              for (let protoName of EnumerateObjectProperties(proto)) {
-                if (!visited.has(protoName)) yield protoName;
+              for (let protoKey of EnumerateObjectProperties(proto)) {
+                if (!visited.has(protoKey)) yield protoKey;
               }
             }
           </code></pre>

--- a/spec.html
+++ b/spec.html
@@ -16171,7 +16171,7 @@
           <p>The following is an informative definition of an ECMAScript generator function that conforms to these rules:</p>
           <pre><code class="javascript">
             function* EnumerateObjectProperties(obj) {
-              const visited = new Set;
+              const visited = new Set();
               for (const key of Reflect.ownKeys(obj)) {
                 if (typeof key === "symbol") continue;
                 const desc = Reflect.getOwnPropertyDescriptor(obj, key);


### PR DESCRIPTION
1. Add missing semicolon.
1. Improve variable naming consistency (`protoName` --> `protoKey`, because `key`).
1. Early `continue` for `symbol`s (less indentation, more obvious what keys are skipped).
1. Use `const` instead of `let`.