### PR TITLE
Editorial: Hoist thisBooleanValue declaration

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23317,17 +23317,14 @@
       <h1>Properties of the Boolean Prototype Object</h1>
       <p>The Boolean prototype object is the intrinsic object <dfn>%BooleanPrototype%</dfn>. The Boolean prototype object is an ordinary object. The Boolean prototype is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</p>
       <p>The value of the [[Prototype]] internal slot of the Boolean prototype object is the intrinsic object %ObjectPrototype%.</p>
-      <emu-clause id="sec-thisbooleanvalue" aoid="thisBooleanValue">
-        <h1>thisBooleanValue ( _value_ )</h1>
-        <p>The abstract operation thisBooleanValue(_value_) performs the following steps:</p>
-        <emu-alg>
-          1. If Type(_value_) is Boolean, return _value_.
-          1. If Type(_value_) is Object and _value_ has a [[BooleanData]] internal slot, then
-            1. Assert: _value_.[[BooleanData]] is a Boolean value.
-            1. Return _value_.[[BooleanData]].
-          1. Throw a *TypeError* exception.
-        </emu-alg>
-      </emu-clause>
+      <p>The abstract operation thisBooleanValue(_value_) performs the following steps:</p>
+      <emu-alg>
+        1. If Type(_value_) is Boolean, return _value_.
+        1. If Type(_value_) is Object and _value_ has a [[BooleanData]] internal slot, then
+          1. Assert: _value_.[[BooleanData]] is a Boolean value.
+          1. Return _value_.[[BooleanData]].
+        1. Throw a *TypeError* exception.
+      </emu-alg>
 
       <!-- es6num="19.3.3.1" -->
       <emu-clause id="sec-boolean.prototype.constructor">


### PR DESCRIPTION
Move declaration to parent clause for consistency with other primitives' prototypes.

Additionally, section numbers of subsequent clauses now match with HTML `<!-- es6num=...` comments.