### PR TITLE
Editorial: Rename variable (indx --> index)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29832,9 +29832,9 @@ THH:mm:ss.sss
             1. Return *undefined*.
           1. Else _len_ &gt; 0,
             1. Let _newLen_ be _len_-1.
-            1. Let _indx_ be ! ToString(_newLen_).
-            1. Let _element_ be ? Get(_O_, _indx_).
-            1. Perform ? DeletePropertyOrThrow(_O_, _indx_).
+            1. Let _index_ be ! ToString(_newLen_).
+            1. Let _element_ be ? Get(_O_, _index_).
+            1. Perform ? DeletePropertyOrThrow(_O_, _index_).
             1. Perform ? Set(_O_, `"length"`, _newLen_, *true*).
             1. Return _element_.
         </emu-alg>


### PR DESCRIPTION
Rename variable in `Array.prototype.pop` to be consistent with naming in other algorithms.