### PR TITLE
Editorial: Fix reference in ScriptEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19628,9 +19628,10 @@
         1. Set the LexicalEnvironment of _scriptCxt_ to _globalEnv_.
         1. Suspend the currently running execution context.
         1. Push _scriptCxt_ on to the execution context stack; _scriptCxt_ is now the running execution context.
-        1. Let _result_ be GlobalDeclarationInstantiation(|ScriptBody|, _globalEnv_).
+        1. Let _scriptBody_ be _scriptRecord_.[[ECMAScriptCode]].
+        1. Let _result_ be GlobalDeclarationInstantiation(_scriptBody_, _globalEnv_).
         1. If _result_.[[Type]] is ~normal~, then
-          1. Let _result_ be the result of evaluating |ScriptBody|.
+          1. Let _result_ be the result of evaluating _scriptBody_.
         1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
           1. Let _result_ be NormalCompletion(*undefined*).
         1. Suspend _scriptCxt_ and remove it from the execution context stack.


### PR DESCRIPTION
Fixes dangling reference to `ScriptBody`. Resolves #587.