### PR TITLE
Editorial: Consistent `undefined or null` order

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2751,7 +2751,7 @@
           1. If IsUnresolvableReference(_V_) is *true*, throw a *ReferenceError* exception.
           1. If IsPropertyReference(_V_) is *true*, then
             1. If HasPrimitiveBase(_V_) is *true*, then
-              1. Assert: In this case, _base_ will never be *null* or *undefined*.
+              1. Assert: In this case, _base_ will never be *undefined* or *null*.
               1. Let _base_ be ! ToObject(_base_).
             1. Return ? _base_.[[Get]](GetReferencedName(_V_), GetThisValue(_V_)).
           1. Else _base_ must be an Environment Record,
@@ -2777,7 +2777,7 @@
             1. Return ? Set(_globalObj_, GetReferencedName(_V_), _W_, *false*).
           1. Else if IsPropertyReference(_V_) is *true*, then
             1. If HasPrimitiveBase(_V_) is *true*, then
-              1. Assert: In this case, _base_ will never be *null* or *undefined*.
+              1. Assert: In this case, _base_ will never be *undefined* or *null*.
               1. Set _base_ to ! ToObject(_base_).
             1. Let _succeeded_ be ? _base_.[[Set]](GetReferencedName(_V_), _W_, GetThisValue(_V_)).
             1. If _succeeded_ is *false* and IsStrictReference(_V_) is *true*, throw a *TypeError* exception.
@@ -6843,7 +6843,7 @@
           1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
           1. If _thisMode_ is ~strict~, let _thisValue_ be _thisArgument_.
           1. Else,
-            1. If _thisArgument_ is *null* or *undefined*, then
+            1. If _thisArgument_ is *undefined* or *null*, then
               1. Let _globalEnv_ be _calleeRealm_.[[GlobalEnv]].
               1. Let _globalEnvRec_ be _globalEnv_'s EnvironmentRecord.
               1. Let _thisValue_ be _globalEnvRec_.[[GlobalThisValue]].
@@ -16082,7 +16082,7 @@
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Let _exprValue_ be ? GetValue(_exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
-            1. If _exprValue_.[[Value]] is *null* or *undefined*, then
+            1. If _exprValue_.[[Value]] is *undefined* or *null*, then
               1. Return Completion{[[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~}.
             1. Let _obj_ be ToObject(_exprValue_).
             1. Return ? EnumerateObjectProperties(_obj_).
@@ -23119,7 +23119,7 @@
         <p>When the `apply` method is called on an object _func_ with arguments _thisArg_ and _argArray_, the following steps are taken:</p>
         <emu-alg>
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
-          1. If _argArray_ is *null* or *undefined*, then
+          1. If _argArray_ is *undefined* or *null*, then
             1. Perform PrepareForTailCall().
             1. Return ? Call(_func_, _thisArg_).
           1. Let _argList_ be ? CreateListFromArrayLike(_argArray_).
@@ -36736,7 +36736,7 @@ THH:mm:ss.sss
       Strict mode eval code cannot instantiate variables or functions in the variable environment of the caller to eval. Instead, a new variable environment is created and that environment is used for declaration binding instantiation for the eval code (<emu-xref href="#sec-eval-x"></emu-xref>).
     </li>
     <li>
-      If *this* is evaluated within strict mode code, then the *this* value is not coerced to an object. A *this* value of *null* or *undefined* is not converted to the global object and primitive values are not converted to wrapper objects. The *this* value passed via a function call (including calls made using `Function.prototype.apply` and `Function.prototype.call`) do not coerce the passed this value to an object (<emu-xref href="#sec-ordinarycallbindthis"></emu-xref>, <emu-xref href="#sec-function.prototype.apply"></emu-xref>, <emu-xref href="#sec-function.prototype.call"></emu-xref>).
+      If *this* is evaluated within strict mode code, then the *this* value is not coerced to an object. A *this* value of *undefined* or *null* is not converted to the global object and primitive values are not converted to wrapper objects. The *this* value passed via a function call (including calls made using `Function.prototype.apply` and `Function.prototype.call`) do not coerce the passed this value to an object (<emu-xref href="#sec-ordinarycallbindthis"></emu-xref>, <emu-xref href="#sec-function.prototype.apply"></emu-xref>, <emu-xref href="#sec-function.prototype.call"></emu-xref>).
     </li>
     <li>
       When a `delete` operator occurs within strict mode code, a *SyntaxError* is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name (<emu-xref href="#sec-delete-operator-static-semantics-early-errors"></emu-xref>).


### PR DESCRIPTION
When comparing to `null/undefined`, ensure that `undefined` goes before
`null` in all cases.

This improves consistency and search experience.