### PR TITLE
Editorial: Tweak Array.prototype.join

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29726,8 +29726,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
-          1. If _separator_ is *undefined*, let _separator_ be a single-element String `","`.
-          1. Let _sep_ be ? ToString(_separator_).
+          1. If _separator_ is *undefined*, let _sep_ be a single-element String `","`.
+          1. Else, let _sep_ be ? ToString(_separator_).
           1. Let _R_ be an empty String.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_


### PR DESCRIPTION
Follow-up to #638.

Drop `separator` parameter reassignment and extra `ToString` call for default `separator` value.