### PR TITLE
Editorial: Refactor Array.prototype.toLocaleString

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30320,21 +30320,15 @@ THH:mm:ss.sss
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_array_, `"length"`)).
           1. Let _separator_ be the String value for the list-separator String appropriate for the host environment's current locale (this is derived in an implementation-defined way).
-          1. If _len_ is zero, return the empty String.
-          1. Let _firstElement_ be ? Get(_array_, `"0"`).
-          1. If _firstElement_ is *undefined* or *null*, then
-            1. Let _R_ be the empty String.
-          1. Else,
-            1. Let _R_ be ? ToString(? Invoke(_firstElement_, `"toLocaleString"`)).
-          1. Let _k_ be 1.
+          1. Let _R_ be an empty String.
+          1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
-            1. Let _S_ be a String value produced by concatenating _R_ and _separator_.
+            1. If _k_ &gt; 0, then
+              1. Let _R_ be a String value produced by concatenating _R_ and _separator_.
             1. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
-            1. If _nextElement_ is *undefined* or *null*, then
-              1. Let _R_ be the empty String.
-            1. Else,
-              1. Let _R_ be ? ToString(? Invoke(_nextElement_, `"toLocaleString"`)).
-            1. Let _R_ be a String value produced by concatenating _S_ and _R_.
+            1. If _nextElement_ is not *undefined* or *null*, then
+              1. Let _S_ be ? ToString(? Invoke(_nextElement_, `"toLocaleString"`)).
+              1. Let _R_ be a String value produced by concatenating _R_ and _S_.
             1. Increase _k_ by 1.
           1. Return _R_.
         </emu-alg>


### PR DESCRIPTION
Follow-up to #638.

Move special handling of first index into the loop body, removing some
duplication. Drop extra reassignments of `R` and concatenations with empty strings.