### PR TITLE
Normative: Add three missing checks in proxy internal methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10013,6 +10013,8 @@
         1. If _resultDesc_.[[Configurable]] is *false*, then
           1. If _targetDesc_ is *undefined* or _targetDesc_.[[Configurable]] is *true*, then
             1. Throw a *TypeError* exception.
+          1. If _resultDesc_ has a [[Writable]] field and _resultDesc_.[[Writable]] is *false*, then
+            1. If _targetDesc_.[[Writable]] is *true*, throw a *TypeError* exception.
         1. Return _resultDesc_.
       </emu-alg>
       <emu-note>
@@ -10025,13 +10027,16 @@
             A property cannot be reported as non-existent, if it exists as a non-configurable own property of the target object.
           </li>
           <li>
-            A property cannot be reported as non-existent, if it exists as an own property of the target object and the target object is not extensible.
+            A property cannot be reported as non-existent, if the target object is not extensible, unless it does not exist as an own property of the target object.
           </li>
           <li>
-            A property cannot be reported as existent, if it does not exist as an own property of the target object and the target object is not extensible.
+            A property cannot be reported as existent, if the target object is not extensible, unless it exists as an own property of the target object.
           </li>
           <li>
-            A property cannot be reported as non-configurable, if it does not exist as an own property of the target object or if it exists as a configurable own property of the target object.
+            A property cannot be reported as non-configurable, unless it exists as a non-configurable own property of the target object.
+          </li>
+          <li>
+            A property cannot be reported as both non-configurable and non-writable, unless it exists as a non-configurable, non-writable own property of the target object.
           </li>
         </ul>
       </emu-note>
@@ -10063,6 +10068,8 @@
         1. Else,
           1. If IsCompatiblePropertyDescriptor(_extensibleTarget_, _Desc_, _targetDesc_) is *false*, throw a *TypeError* exception.
           1. If _settingConfigFalse_ is *true* and _targetDesc_.[[Configurable]] is *true*, throw a *TypeError* exception.
+          1. If IsDataDescriptor(_targetDesc_) is *true*, _targetDesc_.[[Configurable]] is *false*, and _targetDesc_.[[Writable]] is *true*, then
+            1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *false*, throw a *TypeError* exception.
         1. Return *true*.
       </emu-alg>
       <emu-note>
@@ -10076,6 +10083,9 @@
           </li>
           <li>
             A property cannot be non-configurable, unless there exists a corresponding non-configurable own property of the target object.
+          </li>
+          <li>
+            A non-configurable property cannot be non-writable, unless there exists a corresponding non-configurable, non-writable own property of the target object.
           </li>
           <li>
             If a property has a corresponding target object property then applying the Property Descriptor of the property to the target object using [[DefineOwnProperty]] will not throw an exception.
@@ -10210,6 +10220,8 @@
         1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
         1. If _targetDesc_ is *undefined*, return *true*.
         1. If _targetDesc_.[[Configurable]] is *false*, throw a *TypeError* exception.
+        1. Let _extensibleTarget_ be ? IsExtensible(_target_).
+        1. If _extensibleTarget_ is *false*, throw a *TypeError* exception.
         1. Return *true*.
       </emu-alg>
       <emu-note>
@@ -10220,6 +10232,9 @@
           </li>
           <li>
             A property cannot be reported as deleted, if it exists as a non-configurable own property of the target object.
+          </li>
+          <li>
+            A property cannot be reported as deleted, if it exists as an own property of the target object and the target object is non-extensible.
           </li>
         </ul>
       </emu-note>


### PR DESCRIPTION
Those checks are needed in order to maintain the [Invariants of the essential internal methods](https://tc39.github.io/ecma262/#sec-invariants-of-the-essential-internal-methods). Their omission is a bug in the spec. This is a minimal patch for resolving them.

It remains glitches in some weird edge cases (commented below), but they need a little more refactoring.

/cc @erights, @tvcutsem

Fixes #652
