### PR TITLE
Fix EnumerateObjectProperties definition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16176,8 +16176,10 @@
                 if (typeof key === "symbol") continue;
                 const desc = Reflect.getOwnPropertyDescriptor(obj, key);
                 if (desc && !visited.has(key)) {
-                  visited.add(key);
-                  if (desc.enumerable) yield key;
+                  if (desc.enumerable) {
+                    visited.add(key);
+                    yield key;
+                  }
                 }
               }
               const proto = Reflect.getPrototypeOf(obj);


### PR DESCRIPTION
It seems like `Reflect.enumerate` should enumerate keys that are enumerable in the prototype but not the object itself. (As `for ... in` does.) Or maybe I am misunderstanding something?

+credit: @bengl