### PR TITLE
Annex B.3.3 use cases have a universally-shared bullet with imprecise language

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36405,17 +36405,18 @@ THH:mm:ss.sss
     <!-- es6num="B.3.3" -->
     <emu-annex id="sec-block-level-function-declarations-web-legacy-compatibility-semantics">
       <h1>Block-Level Function Declarations Web Legacy Compatibility Semantics</h1>
-      <p>Prior to ECMAScript 2015, the ECMAScript specification did not define the occurrence of a |FunctionDeclaration| as an element of a |Block| statement's |StatementList|. However, support for that form of |FunctionDeclaration| was an allowable extension and most browser-hosted ECMAScript implementations permitted them. Unfortunately, the semantics of such declarations differ among those implementations. Because of these semantic differences, existing web ECMAScript code that uses |Block| level function declarations is only portable among browser implementation if the usage only depends upon the semantic intersection of all of the browser implementations for such declarations. The following are the use cases that fall within that intersection semantics:</p>
+      <p>Prior to ECMAScript 2015, the ECMAScript specification did not define the occurrence of a |FunctionDeclaration| as an element of a |Block| statement's |StatementList|. However, support for that form of |FunctionDeclaration| was an allowable extension and most browser-hosted ECMAScript implementations permitted them. Unfortunately, the semantics of such declarations differ among those implementations. Because of these semantic differences, existing web ECMAScript code that uses |Block| level function declarations is only portable among browser implementation if the usage only depends upon the semantic intersection of all of the browser implementations for such declarations.</p>
+      <p>These are the threshold requirements for the semantic intersection to potentially occur:</p>
+      <ul>
+        <li>One or more |FunctionDeclaration|s whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_.</li>
+        <li>Those |FunctionDeclaration|s are nested within a single |Block|.</li>
+        <li>No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_.</li>
+      </ul>
+      <p>If those requirements are satisfied, the following use cases fall within the semantic intersection among browser implementations:</p>
       <ol>
         <li>
           <p>A function is declared and only referenced within a single block</p>
           <ul>
-            <li>
-              One or more |FunctionDeclaration|s whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
-            </li>
-            <li>
-              No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
-            </li>
             <li>
               All occurrences of _f_ as an |IdentifierReference| are within the |StatementList| of the |Block| containing the declaration of _f_.
             </li>
@@ -36424,12 +36425,6 @@ THH:mm:ss.sss
         <li>
           <p>A function is declared and possibly used within a single |Block| but also referenced by an inner function definition that is not contained within that same |Block|.</p>
           <ul>
-            <li>
-              One or more |FunctionDeclaration|s whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
-            </li>
-            <li>
-              No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
-            </li>
             <li>
               There may be occurrences of _f_ as an |IdentifierReference| within the |StatementList| of the |Block| containing the declaration of _f_.
             </li>
@@ -36444,12 +36439,6 @@ THH:mm:ss.sss
         <li>
           <p>A function is declared and possibly used within a single block but also referenced within subsequent blocks.</p>
           <ul>
-            <li>
-              One or more |FunctionDeclaration| whose |BindingIdentifier| is the name _f_ occur within the function code of an enclosing function _g_ and that declaration is nested within a |Block|.
-            </li>
-            <li>
-              No other declaration of _f_ that is not a `var` declaration occurs within the function code of _g_
-            </li>
             <li>
               There may be occurrences of _f_ as an |IdentifierReference| within the |StatementList| of the |Block| containing the declaration of _f_.
             </li>


### PR DESCRIPTION
All three use cases in Annex B.3.3 have the same first bullet point: "One or more FunctionDeclarations whose BindingIdentifier is the name f occur within the function code of an enclosing function g and that declaration is nested within a Block."

And within that bullet point, "that declaration" is somewhat ambiguous as to whether it refer to function `g` or to those `FunctionDeclaration`s.

Make the spec text apply to all three use cases, and use more-precise language to refer to those `FunctionDeclaration`s as antecedent.
