### PR TITLE
Annex B.3.3.1's monkeypatching of FunctionDeclarationInstantiation is out of date

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7053,6 +7053,11 @@
         <p>When an execution context is established for evaluating an ECMAScript function a new function Environment Record is created and bindings for each formal parameter are instantiated in that Environment Record. Each declaration in the function body is also instantiated. If the function's formal parameters do not include any default value initializers then the body declarations are instantiated in the same Environment Record as the parameters. If default value parameter initializers exist, a second Environment Record is created for the body declarations. Formal parameters and functions are initialized as part of FunctionDeclarationInstantiation. All other bindings are initialized during evaluation of the function body.</p>
       </emu-note>
       <p>FunctionDeclarationInstantiation is performed as follows using arguments _func_ and _argumentsList_. _func_ is the function object for which the execution context is being established.</p>
+      <!--
+        WARNING: If you add, remove, rename, or repurpose any variable names
+                 within this algorithm, you may need to update
+                 #sec-web-compat-functiondeclarationinstantiation accordingly.
+      -->
       <emu-alg>
         1. Let _calleeContext_ be the running execution context.
         1. Let _env_ be the LexicalEnvironment of _calleeContext_.
@@ -14474,6 +14479,11 @@
         <p>When a |Block| or |CaseBlock| production is evaluated a new declarative Environment Record is created and bindings for each block scoped variable, constant, function, generator function, or class declared in the block are instantiated in the Environment Record.</p>
       </emu-note>
       <p>BlockDeclarationInstantiation is performed as follows using arguments _code_ and _env_. _code_ is the grammar production corresponding to the body of the block. _env_ is the Lexical Environment in which bindings are to be created.</p>
+      <!--
+        WARNING: If you add, remove, rename, or repurpose any variable names
+                 within this algorithm, you may need to update
+                 #sec-web-compat-blockdeclarationinstantiation accordingly.
+      -->
       <emu-alg>
         1. Let _envRec_ be _env_'s EnvironmentRecord.
         1. Assert: _envRec_ is a declarative Environment Record.
@@ -19647,6 +19657,11 @@
         <p>When an execution context is established for evaluating scripts, declarations are instantiated in the current global environment. Each global binding declared in the code is instantiated.</p>
       </emu-note>
       <p>GlobalDeclarationInstantiation is performed as follows using arguments _script_ and _env_. _script_ is the |ScriptBody| for which the execution context is being established. _env_ is the global lexical environment in which bindings are to be created.</p>
+      <!--
+        WARNING: If you add, remove, rename, or repurpose any variable names
+                 within this algorithm, you may need to update
+                 #sec-web-compat-globaldeclarationinstantiation accordingly.
+      -->
       <emu-alg>
         1. Let _envRec_ be _env_'s EnvironmentRecord.
         1. Assert: _envRec_ is a global Environment Record.
@@ -21779,6 +21794,12 @@
       <emu-clause id="sec-evaldeclarationinstantiation" aoid="EvalDeclarationInstantiation">
         <h1>Runtime Semantics: EvalDeclarationInstantiation( _body_, _varEnv_, _lexEnv_, _strict_)</h1>
         <p>When the abstract operation EvalDeclarationInstantiation is called with arguments _body_, _varEnv_, _lexEnv_, and _strict_, the following steps are taken:</p>
+        <!--
+          WARNING: If you add, remove, rename, or repurpose any variable names
+                   within this algorithm, you may need to update
+                   #sec-web-compat-evaldeclarationinstantiation and
+                   #sec-variablestatements-in-catch-blocks accordingly.
+        -->
         <emu-alg>
           1. Let _varNames_ be the VarDeclaredNames of _body_.
           1. Let _varDeclarations_ be the VarScopedDeclarations of _body_.
@@ -36469,7 +36490,7 @@ THH:mm:ss.sss
           1. If _strict_ is *false*, then
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|,
               1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
-              1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of BoundNames of _argumentsList_, then
+              1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of _parameterNames_, then
                 1. NOTE A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
                 1. If _instantiatedVarNames_ does not contain _F_, then
                   1. Perform ! _varEnvRec_.CreateMutableBinding(_F_, *false*).
@@ -36617,7 +36638,7 @@ THH:mm:ss.sss
       <emu-note>
         <p>The |Block| of a |Catch| clause may contain `var` declarations that bind a name that is also bound by the |CatchParameter|. At runtime, such bindings are instantiated in the VariableDeclarationEnvironment. They do not shadow the same-named bindings introduced by the |CatchParameter| and hence the |Initializer| for such `var` declarations will assign to the corresponding catch parameter rather than the `var` binding. The relaxation of the normal static semantic rule does not apply to names only bound by for-of statements.</p>
       </emu-note>
-      <p>This modified behaviour also applies to `var` and `function` declarations introduced by direct eval calls contained within the |Block| of a |Catch| clause. This change is accomplished by modify the algorithm of <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref> as follows:</p>
+      <p>This modified behaviour also applies to `var` and `function` declarations introduced by direct eval calls contained within the |Block| of a |Catch| clause. This change is accomplished by modifying the algorithm of <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref> as follows:</p>
       <p>Step 5.d.ii.2.a.i is replaced by:</p>
       <emu-alg type="i">
         1. If _thisEnvRec_ is not the Environment Record for a |Catch| clause, throw a *SyntaxError* exception.


### PR DESCRIPTION
It refers to "BoundNames of `argumentsList`", but `argumentsList` is now an actual value, not a grammar production.  I suspect the name used to be correct, then someone renamed `argumentsList` to `formals`, and things got skew.  Now `parameterNames` exists as the "BoundNames of `formals`", so it's the best thing to use.

I also went and added big WARNING comments next to all the monkey-patched spec algorithms, so maybe renames of stuff will remember to update Annex B as well.  There were already NOTE: steps that theoretically should have been enough reminder to the spec-modifier, but I guess they weren't.  It seems to me like a comment at the start of the algorithms is most likely to be read by someone skimming the algorithms to see where to do variable renames, so it's worth adding even atop the NOTEs.