### PR TITLE
(10).toPrecision(1) to give "1e+1", not "1.e+1"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24171,8 +24171,9 @@
             1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _e_ &lt; -6 or _e_ &ge; _p_, then
               1. Assert: _e_ &ne; 0.
-              1. Let _a_ be the first element of _m_, and let _b_ be the remaining _p_-1 elements of _m_.
-              1. Let _m_ be the concatenation of _a_, `"."`, and _b_.
+              1. If _p_ &ne; 1, then
+                1. Let _a_ be the first element of _m_, and let _b_ be the remaining _p_-1 elements of _m_.
+                1. Let _m_ be the concatenation of _a_, `"."`, and _b_.
               1. If _e_ &gt; 0, then
                 1. Let _c_ be code unit 0x002B (PLUS SIGN).
               1. Else _e_ &lt; 0,


### PR DESCRIPTION
It is strange, but web browsers do this correctly, so may be I am misinterpreting the spec text.