### PR TITLE
Normative: Point to the latest version of UTR15

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26716,7 +26716,7 @@ THH:mm:ss.sss
           1. If _form_ is not provided or _form_ is *undefined*, let _form_ be `"NFC"`.
           1. Let _f_ be ? ToString(_form_).
           1. If _f_ is not one of `"NFC"`, `"NFD"`, `"NFKC"`, or `"NFKD"`, throw a *RangeError* exception.
-          1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="http://www.unicode.org/reports/tr15/tr15-29.html">http://www.unicode.org/reports/tr15/tr15-29.html</a>.
+          1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="http://www.unicode.org/reports/tr15/">http://www.unicode.org/reports/tr15/</a>.
           1. Return _ns_.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
Instead of referring to a version snapshot, link to the latest version of UTR15.

Ref. #620.