### PR TITLE
Meta: Update ecmarkup version dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ env:
 language: node_js
 
 node_js:
-  - "5"
+  - "6"
 
 sudo: false

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "SEE LICENSE IN https://tc39.github.io/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.github.io/ecma262/",
   "dependencies": {
-    "ecmarkup": "^3.3.2"
+    "ecmarkup": "^3.4.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.0.0"


### PR DESCRIPTION
Note that the Travis configuration has been updated accordingly.

Ref. https://github.com/bterlson/ecmarkup/pull/101.