### PR TITLE
Normative: Clarify rules around NewTarget in eval

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4971,7 +4971,7 @@
       <!-- es6num="8.1.1.3" -->
       <emu-clause id="sec-function-environment-records">
         <h1>Function Environment Records</h1>
-        <p>A function Environment Record is a declarative Environment Record that is used to represent the top-level scope of a function and, if the function is not an |ArrowFunction|, provides a `this` binding. If a function is not an |ArrowFunction| function and references `super`, its function Environment Record also contains the state that is used to perform `super` method invocations from within the function.</p>
+        <p>A <dfn>function Environment Record</dfn> is a declarative Environment Record that is used to represent the top-level scope of a function and, if the function is not an |ArrowFunction|, provides a `this` binding. If a function is not an |ArrowFunction| function and references `super`, its function Environment Record also contains the state that is used to perform `super` method invocations from within the function.</p>
         <p>Function Environment Records have the additional state fields listed in <emu-xref href="#table-16"></emu-xref>.</p>
         <emu-table id="table-16" caption="Additional Fields of Function Environment Records">
           <table>
@@ -19431,7 +19431,7 @@
           It is a Syntax Error if |StatementList| Contains `super` unless the source code containing `super` is eval code that is being processed by a direct eval. Additional early error rules for `super` within direct eval are defined in <emu-xref href="#sec-performeval"></emu-xref>.
         </li>
         <li>
-          It is a Syntax Error if |StatementList| Contains |NewTarget| unless the source code containing |NewTarget| is eval code that is being processed by a direct eval that is contained in function code that is not the function code of an |ArrowFunction|.
+          It is a Syntax Error if |StatementList| Contains |NewTarget| unless the source code containing |NewTarget| is eval code that is being processed by a direct eval. Additional early error rules for |NewTarget| in direct eval are defined in <emu-xref href="#sec-performeval"></emu-xref>
         </li>
         <li>
           It is a Syntax Error if ContainsDuplicateLabels of |StatementList| with argument &laquo; &raquo; is *true*.
@@ -21719,12 +21719,13 @@
           1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
           1. If Type(_x_) is not String, return _x_.
           1. Let _thisEnvRec_ be ! GetThisEnvironment().
+          1. If _thisEnvRec_ is a function Environment Record, let _inFunction_ be true; otherwise, let _inFunction_ be false.
           1. Let _inMethod_ be *false*.
           1. Let _inConstructor_ be *false*.
           1. If _thisEnvRec_ has a [[HomeObject]] field, then
             1. Let _inMethod_ be *true*.
             1. If _thisEnvRec_.[[FunctionObject]] has a [[Construct]] field, let _inConstructor_ be *true*.
-          1. Let _script_ be the ECMAScript code that is the result of parsing _x_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If _inMethod_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-methods"></emu-xref> are applied. If _inConstructor_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-constructors"></emu-xref> are applied. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>). Parsing and early error detection may be interweaved in an implementation dependent manner.
+          1. Let _script_ be the ECMAScript code that is the result of parsing _x_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If _inFunction_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-functions"></emu-xref> are applied. If _inMethod_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-methods"></emu-xref> are applied. If _inConstructor_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-constructors"></emu-xref> are applied. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>). Parsing and early error detection may be interweaved in an implementation dependent manner.
           1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
           1. Let _body_ be the |ScriptBody| of _script_.
           1. If _strictCaller_ is *true*, let _strictEval_ be *true*.
@@ -21745,7 +21746,7 @@
           1. Set the _evalCxt_'s VariableEnvironment to _varEnv_.
           1. Set the _evalCxt_'s LexicalEnvironment to _lexEnv_.
           1. Push _evalCxt_ on to the execution context stack; _evalCxt_ is now the running execution context.
-          1. Let _result_ be EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _strictEval_).
+          1. Let _result_ be EvalDeclarationInstantiatioOun(_body_, _varEnv_, _lexEnv_, _strictEval_).
           1. If _result_.[[Type]] is ~normal~, then
             1. Let _result_ be the result of evaluating _body_.
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
@@ -21758,8 +21759,18 @@
           <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if the calling context is evaluating formal parameter initializers or if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new VariableEnvironment that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new LexicalEnvironment.</p>
         </emu-note>
 
+        <emu-clause id="sec-performeval-rules-outside-functions">
+          <h1>Additional Early Error Rules for Eval Outside Functions</h1>
+          <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of any function.</p>
+          <emu-grammar>ScriptBody : StatementList</emu-grammar>
+          <ul>
+            <li>It is a Syntax Error if |StatementList| contains |NewTarget|.</li>
+          </ul>
+        </emu-clause>
+
         <emu-clause id="sec-performeval-rules-outside-methods">
           <h1>Additional Early Error Rules for Eval Outside Methods</h1>
+          <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of a method.</p>
           <emu-grammar>ScriptBody : StatementList</emu-grammar>
           <ul>
             <li>It is a Syntax Error if |StatementList| contains `super`.</li>
@@ -21768,6 +21779,7 @@
 
         <emu-clause id="sec-performeval-rules-outside-constructors">
           <h1>Additional Early Error Rules for Eval Outside Constructors</h1>
+          <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of a constructor.</p>
           <emu-grammar>ScriptBody : StatementList</emu-grammar>
           <ul>
             <li>It is a Syntax Error if |StatementList| contains |SuperCall|.</li>


### PR DESCRIPTION
Previously, NewTarget was disallowed in nested eval contexts and in eval inside arrow functions. This change allows NewTarget inside eval anywhere it would be allowed outside of eval.

This PR is on top of #685 as it uses a similar pattern. 
