### PR TITLE
Layering: add HostObjectDefinePropertyReturnFalse

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22679,9 +22679,20 @@
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. Let _key_ be ? ToPropertyKey(_P_).
           1. Let _desc_ be ? ToPropertyDescriptor(_Attributes_).
+          1. If ! HostObjectDefinePropertyReturnFalse(_O_, _key_, _desc_) is *true*, return *false*.
           1. Perform ? DefinePropertyOrThrow(_O_, _key_, _desc_).
           1. Return _O_.
         </emu-alg>
+
+        <emu-clause id="sec-hostobjectdefinepropertyreturnfalse" aoid="HostObjectDefinePropertyReturnFalse">
+          <h1>HostObjectDefinePropertyReturnFalse( _O_, _key_, _desc_ )</h1>
+
+          <p>HostObjectDefinePropertyReturnFalse is an implementation-defined abstract operation that allows host environments to override the usual failure behavior of `Object.defineProperty` under certain circumstances necessary for legacy code.</p>
+
+          <p>An implementation of HostObjectDefinePropertyReturnFalse must complete normally, with a completion value of either *true* or *false*. An implementation of HostObjectDefinePropertyReturnFalse must only return *true* for implementation-provided exotic objects, and only when the normal behavior of using DefinePropertyOrThrow(_O_, _key_, _desc_) would cause legacy code to fail.</p>
+
+          <p>The default implementation of HostObjectDefinePropertyReturnFalse is to unconditionally return *false*.</p>
+        </emu-clause>
       </emu-clause>
 
       <!-- es6num="19.1.2.5" -->


### PR DESCRIPTION
This allows host environments which need to override the Object.defineProperty behavior, for legacy compatibility, to preserve invariants while avoiding breaking web applications that depend on not-throwing when defining non-configurable, non-writable properties on WindowProxy. This does not alter the behavior of Reflect.defineProperty or [[DefineOwnProperty]].

Closes #672 (from the ES spec side). See also https://bugzilla.mozilla.org/show_bug.cgi?id=1197958.
