### PR TITLE
Normative: Remove arguments.caller poison pill

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7547,7 +7547,10 @@
         <p>The ParameterMap object and its property values are used as a device for specifying the arguments object correspondence to argument bindings. The ParameterMap object and the objects that are the values of its properties are not directly observable from ECMAScript code. An ECMAScript implementation does not need to actually create or use such objects to implement the specified semantics.</p>
       </emu-note>
       <emu-note>
-        <p>Arguments objects for strict functions define non-configurable accessor properties named `"caller"` and `"callee"` which throw a *TypeError* exception on access. The `"callee"` property has a more specific meaning for non-strict functions and a `"caller"` property has historically been provided as an implementation-defined extension by some ECMAScript implementations. The strict mode definition of these properties exists to ensure that neither of them is defined in any other manner by conforming ECMAScript implementations.</p>
+        <p>Arguments objects for strict functions define a non-configurable accessor property named `"callee"` which throws a *TypeError* exception on access. The `"callee"` property has a more specific meaning for non-strict functions. The strict mode definition of this property exists to ensure that it is not defined in any other manner by conforming ECMAScript implementations.</p>
+      </emu-note>
+      <emu-note>
+        <p>ECMAScript implementations of arguments objects have historically contained an accessor property named ``"caller"`. Prior to ECMAScript 2017, this specification included the definition of a throwing `"caller"` property on arguments objects for strict functions. Since implementations do not contain this extension any longer, ECMAScript 2017 dropped the requirement for a throwing `"caller"` accessor.</p>
       </emu-note>
 
       <!-- es6num="9.4.4.1" -->
@@ -7562,10 +7565,8 @@
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If _isMapped_ is *true*, then
             1. Set _desc_.[[Value]] to Get(_map_, _P_).
-          1. If IsDataDescriptor(_desc_) is *true* and _P_ is `"caller"` and _desc_.[[Value]] is a strict mode Function object, throw a *TypeError* exception.
           1. Return _desc_.
         </emu-alg>
-        <p>If an implementation does not provide a built-in `caller` property for argument exotic objects then step 7 of this algorithm must be skipped.</p>
       </emu-clause>
 
       <!-- es6num="9.4.4.2" -->
@@ -7629,19 +7630,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-arguments-exotic-objects-hasproperty">
-        <h1>[[HasProperty]] ( _P_ )</h1>
-        <p>The [[HasProperty]] internal method of an arguments exotic object when called with property key _P_, performs the following steps:</p>
-        <emu-alg>
-          1. Let _args_ be the arguments object.
-          1. If _P_ is `"caller"`, then
-            1. Let _desc_ be ! OrdinaryGetOwnProperty(_args_, _P_).
-            1. If IsDataDescriptor(_desc_) is *true*, return *true*.
-          1. Return ? OrdinaryHasProperty(_args_, _P_).
-        </emu-alg>
-        <p>If an implementation does not provide a built-in caller property for argument exotic objects then step 2 of this algorithm must be skipped.</p>
-      </emu-clause>
-
       <!-- es6num="9.4.4.5" -->
       <emu-clause id="sec-arguments-exotic-objects-delete-p">
         <h1>[[Delete]] (_P_)</h1>
@@ -7673,7 +7661,6 @@
             1. Let _index_ be _index_ + 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor {[[Value]]: %ArrayProto_values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
           1. Perform ! DefinePropertyOrThrow(_obj_, `"callee"`, PropertyDescriptor {[[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
-          1. Perform ! DefinePropertyOrThrow(_obj_, `"caller"`, PropertyDescriptor {[[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -21641,6 +21628,9 @@
       </li>
       <li>
         If an implementation extends non-strict or built-in function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
+      </li>
+      <li>
+        Neither mapped nor unmapped arguments objects may be created with an own property named `"caller"`. 
       </li>
       <li>
         The behaviour of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, `%TypedArray%.prototype.toLocaleString`.
@@ -36737,7 +36727,7 @@ THH:mm:ss.sss
       The identifier `eval` or `arguments` may not appear as the |LeftHandSideExpression| of an Assignment operator (<emu-xref href="#sec-assignment-operators"></emu-xref>) or of a |UpdateExpression| (<emu-xref href="#sec-update-expressions"></emu-xref>) or as the |UnaryExpression| operated upon by a Prefix Increment (<emu-xref href="#sec-prefix-increment-operator"></emu-xref>) or a Prefix Decrement (<emu-xref href="#sec-prefix-decrement-operator"></emu-xref>) operator.
     </li>
     <li>
-      Arguments objects for strict functions define non-configurable accessor properties named `"caller"` and `"callee"` which throw a *TypeError* exception on access (<emu-xref href="#sec-createunmappedargumentsobject"></emu-xref>).
+      Arguments objects for strict functions defines a non-configurable accessor property `"callee"` which throw a *TypeError* exception on access (<emu-xref href="#sec-createunmappedargumentsobject"></emu-xref>).
     </li>
     <li>
       Arguments objects for strict functions do not dynamically share their array indexed property values with the corresponding formal parameter bindings of their functions. (<emu-xref href="#sec-arguments-exotic-objects"></emu-xref>).


### PR DESCRIPTION
Implementations have not had this extension for many years so continuing
to poison pill it is needless. This removes all mention of arguments
object's "caller" property with the exception of a note that gives a bit
of history (mostly so people can still ctrl+f "caller").

Closes #670.