### PR TITLE
Editorial: %s/StrictFormalParameters/UniqueFormalParameters/g

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17430,7 +17430,7 @@
       FunctionExpression :
         `function` BindingIdentifier[~Yield]? `(` FormalParameters[~Yield] `)` `{` FunctionBody[~Yield] `}`
 
-      StrictFormalParameters[Yield] :
+      UniqueFormalParameters[Yield] :
         FormalParameters[?Yield]
 
       FormalParameters[Yield] :
@@ -17482,7 +17482,7 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>StrictFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
           If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.
@@ -17509,7 +17509,7 @@
       <emu-note>
         <p>The LexicallyDeclaredNames of a |FunctionBody| does not include identifiers bound using var or function declarations.</p>
       </emu-note>
-      <emu-grammar>StrictFormalParameters : FormalParameters</emu-grammar>
+      <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |FormalParameters| contains any duplicate elements.
@@ -17978,7 +17978,7 @@
       is recognized the following grammar is used to refine the interpretation of |CoverParenthesizedExpressionAndArrowParameterList|:</p>
     <emu-grammar>
       ArrowFormalParameters[Yield] :
-        `(` StrictFormalParameters[?Yield] `)`
+        `(` UniqueFormalParameters[?Yield] `)`
     </emu-grammar>
 
     <!-- es6num="14.2.1" -->
@@ -18218,7 +18218,7 @@
     <h2>Syntax</h2>
     <emu-grammar>
       MethodDefinition[Yield] :
-        PropertyName[?Yield] `(` StrictFormalParameters[~Yield] `)` `{` FunctionBody[~Yield] `}`
+        PropertyName[?Yield] `(` UniqueFormalParameters[~Yield] `)` `{` FunctionBody[~Yield] `}`
         GeneratorMethod[?Yield]
         `get` PropertyName[?Yield] `(` `)` `{` FunctionBody[~Yield] `}`
         `set` PropertyName[?Yield] `(` PropertySetParameterList `)` `{` FunctionBody[~Yield] `}`
@@ -18230,13 +18230,13 @@
     <!-- es6num="14.3.1" -->
     <emu-clause id="sec-method-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>MethodDefinition : PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |StrictFormalParameters| is *false*.
+          It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.
         </li>
         <li>
-          It is a Syntax Error if any element of the BoundNames of |StrictFormalParameters| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
+          It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
         </li>
       </ul>
       <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
@@ -18260,7 +18260,7 @@
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
       <emu-grammar>
         MethodDefinition :
-          PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`
+          PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
           `get` PropertyName `(` `)` `{` FunctionBody `}`
           `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
       </emu-grammar>
@@ -18284,9 +18284,9 @@
     <emu-clause id="sec-method-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar>MethodDefinition : PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. If |StrictFormalParameters| Contains |SuperCall| is *true*, return *true*.
+        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |FunctionBody| Contains |SuperCall|.
       </emu-alg>
       <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
@@ -18306,7 +18306,7 @@
       <emu-see-also-para op="PropName"></emu-see-also-para>
       <emu-grammar>
         MethodDefinition :
-          PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`
+          PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
           `get` PropertyName `(` `)` `{` FunctionBody `}`
           `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
       </emu-grammar>
@@ -18318,7 +18318,7 @@
     <!-- es6num="14.3.7" -->
     <emu-clause id="sec-static-semantics-specialmethod">
       <h1>Static Semantics: SpecialMethod</h1>
-      <emu-grammar>MethodDefinition : PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -18337,14 +18337,14 @@
     <emu-clause id="sec-runtime-semantics-definemethod">
       <h1>Runtime Semantics: DefineMethod</h1>
       <p>With parameters _object_ and optional parameter _functionPrototype_.</p>
-      <emu-grammar>MethodDefinition : PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
         1. If _functionPrototype_ was passed as a parameter, let _kind_ be ~Normal~; otherwise let _kind_ be ~Method~.
-        1. Let _closure_ be FunctionCreate(_kind_, |StrictFormalParameters|, |FunctionBody|, _scope_, _strict_). If _functionPrototype_ was passed as a parameter, then pass its value as the _prototype_ optional argument of FunctionCreate.
+        1. Let _closure_ be FunctionCreate(_kind_, |UniqueFormalParameters|, |FunctionBody|, _scope_, _strict_). If _functionPrototype_ was passed as a parameter, then pass its value as the _prototype_ optional argument of FunctionCreate.
         1. Perform MakeMethod(_closure_, _object_).
         1. Return the Record{[[Key]]: _propKey_, [[Closure]]: _closure_}.
       </emu-alg>
@@ -18355,7 +18355,7 @@
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
       <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-      <emu-grammar>MethodDefinition : PropertyName `(` StrictFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _methodDef_ be DefineMethod of |MethodDefinition| with argument _object_.
         1. ReturnIfAbrupt(_methodDef_).
@@ -18399,7 +18399,7 @@
     <h2>Syntax</h2>
     <emu-grammar>
       GeneratorMethod[Yield] :
-        `*` PropertyName[?Yield] `(` StrictFormalParameters[+Yield] `)` `{` GeneratorBody `}`
+        `*` PropertyName[?Yield] `(` UniqueFormalParameters[+Yield] `)` `{` GeneratorBody `}`
 
       GeneratorDeclaration[Yield, Default] :
         `function` `*` BindingIdentifier[?Yield] `(` FormalParameters[+Yield] `)` `{` GeneratorBody `}`
@@ -18429,19 +18429,19 @@
     <!-- es6num="14.4.1" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` StrictFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if HasDirectSuper of |GeneratorMethod| is *true*.
         </li>
         <li>
-          It is a Syntax Error if |StrictFormalParameters| Contains |YieldExpression| is *true*.
+          It is a Syntax Error if |UniqueFormalParameters| Contains |YieldExpression| is *true*.
         </li>
         <li>
-          It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |StrictFormalParameters| is *false*.
+          It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.
         </li>
         <li>
-          It is a Syntax Error if any element of the BoundNames of |StrictFormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
+          It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
         </li>
       </ul>
       <emu-grammar>
@@ -18453,7 +18453,7 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>StrictFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
           If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.
@@ -18504,7 +18504,7 @@
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` StrictFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
       </emu-alg>
@@ -18534,9 +18534,9 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` StrictFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. If |StrictFormalParameters| Contains |SuperCall| is *true*, return *true*.
+        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |GeneratorBody| Contains |SuperCall|.
       </emu-alg>
     </emu-clause>
@@ -18583,7 +18583,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` StrictFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return PropName of |PropertyName|.
       </emu-alg>
@@ -18635,13 +18635,13 @@
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameter _object_ and _enumerable_.</p>
       <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` StrictFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. If the function code for this |GeneratorMethod| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _closure_ be GeneratorFunctionCreate(~Method~, |StrictFormalParameters|, |GeneratorBody|, _scope_, _strict_).
+        1. Let _closure_ be GeneratorFunctionCreate(~Method~, |UniqueFormalParameters|, |GeneratorBody|, _scope_, _strict_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
         1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
@@ -23071,7 +23071,7 @@
             1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
             1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
             1. If _bodyText_ is strict mode code, then let _strict_ be *true*, else let _strict_ be *false*.
-            1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar>StrictFormalParameters : FormalParameters</emu-grammar> are applied. Parsing and early error detection may be interweaved in an implementation dependent manner.
+            1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied. Parsing and early error detection may be interweaved in an implementation dependent manner.
             1. If ContainsUseStrict of _body_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
             1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.
             1. If _body_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
@@ -35418,7 +35418,7 @@ THH:mm:ss.sss
     <h1>Functions and Classes</h1>
     <emu-prodref name=FunctionDeclaration></emu-prodref>
     <emu-prodref name=FunctionExpression></emu-prodref>
-    <emu-prodref name=StrictFormalParameters></emu-prodref>
+    <emu-prodref name=UniqueFormalParameters></emu-prodref>
     <emu-prodref name=FormalParameters></emu-prodref>
     <emu-prodref name=FormalParameterList></emu-prodref>
     <emu-prodref name=FormalsList></emu-prodref>


### PR DESCRIPTION
Closes #618.

Other options discussed at various points include "DistinctFormalParameters", "RestrictedFormalParameters" and "ModernFormalParameters" but this suggestion from @allenwb seems best. I'll leave this open for a bit in case there is some disagreement about this renaming.