### PR TITLE
Add missing BindingInitialization production

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14985,6 +14985,14 @@
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
+        <emu-grammar>
+          ObjectBindingPattern :
+            `{` BindingPropertyList `}`
+            `{` BindingPropertyList `,` `}`
+        </emu-grammar>
+        <emu-alg>
+          1. Return the result of performing BindingInitialization for |BindingPropertyList| using _value_ and _environment_ as the arguments.
+        </emu-alg>
         <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
           1. Let _status_ be the result of performing BindingInitialization for |BindingPropertyList| using _value_ and _environment_ as arguments.


### PR DESCRIPTION
This only covered the empty pattern case. This is just a pass through to BindingPropertyList but in future proposals this will be an important refactoring point.

For clarity: The equivalent ObjectAssignmentPattern performs `RequireObjectCoercible(value)` but we don't do that here because it is already covered by the `BindingPattern` production.

cc @bterlson 
