### PR TITLE
Normative: fix `Promise#then` so `PerformPromiseThen` returns a promise

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34851,6 +34851,7 @@ THH:mm:ss.sss
           1. If IsPromise(_promise_) is *false*, throw a *TypeError* exception.
           1. Let _C_ be ? SpeciesConstructor(_promise_, %Promise%).
           1. Let _resultCapability_ be ? NewPromiseCapability(_C_).
+          1. Set _resultCapability_.[[Promise]] to _promise_.
           1. Return PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_, _resultCapability_).
         </emu-alg>
 


### PR DESCRIPTION
I noticed while working on the `Promise.prototype.finally` tests that `PerformPromiseThen` returns `resultCapability.[[Promise]]`, but that `Promise.prototype.then` never actually sets that slot.

I labeled this "normative" but if implementors weren't doing this already, `Promise#then` would be returning `undefined`.