### PR TITLE
Apply chain rule to IsFunctionDefinition UnaryExpression: UpdateExpression

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12253,7 +12253,6 @@
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
       <emu-grammar>
         UnaryExpression :
-          UpdateExpression
           `delete` UnaryExpression
           `void` UnaryExpression
           `typeof` UnaryExpression


### PR DESCRIPTION
Since a _FunctionExpression_ is a _PrimaryExpression_, I believe returning `false` in `IsFunctionDefinition` for every production of _UnaryExpression_ is incorrect. It's also not consistent with the rules for every other expression.

Otherwise I think `IsFunctionDefinition` would return `false` when evaluating initializers (e.g. `function foo(bar=function(){}) {}`), after "unrolling" all production rules.

Or am I misinterpreting the rules?
