### PR TITLE
Editorial: Minor grammar correction regarding arguments.callee

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36749,7 +36749,7 @@ THH:mm:ss.sss
       The identifier `eval` or `arguments` may not appear as the |LeftHandSideExpression| of an Assignment operator (<emu-xref href="#sec-assignment-operators"></emu-xref>) or of a |UpdateExpression| (<emu-xref href="#sec-update-expressions"></emu-xref>) or as the |UnaryExpression| operated upon by a Prefix Increment (<emu-xref href="#sec-prefix-increment-operator"></emu-xref>) or a Prefix Decrement (<emu-xref href="#sec-prefix-decrement-operator"></emu-xref>) operator.
     </li>
     <li>
-      Arguments objects for strict functions defines a non-configurable accessor property `"callee"` which throw a *TypeError* exception on access (<emu-xref href="#sec-createunmappedargumentsobject"></emu-xref>).
+      Arguments objects for strict functions define a non-configurable accessor property `"callee"` which throws a *TypeError* exception on access (<emu-xref href="#sec-createunmappedargumentsobject"></emu-xref>).
     </li>
     <li>
       Arguments objects for strict functions do not dynamically share their array indexed property values with the corresponding formal parameter bindings of their functions. (<emu-xref href="#sec-arguments-exotic-objects"></emu-xref>).


### PR DESCRIPTION
This fixes two pluralization agreement issues introduced by #689.
