### PR TITLE
Editiorial: Small corrections following #689

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7550,7 +7550,7 @@
         <p>Arguments objects for strict functions define a non-configurable accessor property named `"callee"` which throws a *TypeError* exception on access. The `"callee"` property has a more specific meaning for non-strict functions. The strict mode definition of this property exists to ensure that it is not defined in any other manner by conforming ECMAScript implementations.</p>
       </emu-note>
       <emu-note>
-        <p>ECMAScript implementations of arguments objects have historically contained an accessor property named ``"caller"`. Prior to ECMAScript 2017, this specification included the definition of a throwing `"caller"` property on arguments objects for strict functions. Since implementations do not contain this extension any longer, ECMAScript 2017 dropped the requirement for a throwing `"caller"` accessor.</p>
+        <p>ECMAScript implementations of arguments objects have historically contained an accessor property named `"caller"`. Prior to ECMAScript 2017, this specification included the definition of a throwing `"caller"` property on arguments objects for strict functions. Since implementations do not contain this extension any longer, ECMAScript 2017 dropped the requirement for a throwing `"caller"` accessor.</p>
       </emu-note>
 
       <!-- es6num="9.4.4.1" -->
@@ -7677,7 +7677,6 @@
           1. Set the [[DefineOwnProperty]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set the [[Get]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-get-p-receiver"></emu-xref>.
           1. Set the [[Set]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-set-p-v-receiver"></emu-xref>.
-          1. Set the [[HasProperty]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-hasproperty"></emu-xref>.
           1. Set the [[Delete]] internal method of _obj_ as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
           1. Set the remainder of _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _obj_.[[Prototype]] to %ObjectPrototype%.
@@ -21630,7 +21629,7 @@
         If an implementation extends non-strict or built-in function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
       </li>
       <li>
-        Neither mapped nor unmapped arguments objects may be created with an own property named `"caller"`. 
+        Neither mapped nor unmapped arguments objects may be created with an own property named `"caller"`.
       </li>
       <li>
         The behaviour of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, `%TypedArray%.prototype.toLocaleString`.


### PR DESCRIPTION
- typo: ``"caller"` → `"caller"`
- bug: remove a leftover reference to a special [[HasProperty]]
  implementation that is gone with #689
