### PR TITLE
Editorial: Rearrange tables to be consistent with section ordering

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1255,6 +1255,17 @@
             </tr>
             <tr>
               <td>
+                [[DefineOwnProperty]]
+              </td>
+              <td>
+                (_propertyKey_, _PropertyDescriptor_) <b>&rarr;</b> Boolean
+              </td>
+              <td>
+                Create or alter the own property, whose key is _propertyKey_, to have the state described by _PropertyDescriptor_. Return *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
+              </td>
+            </tr>
+            <tr>
+              <td>
                 [[HasProperty]]
               </td>
               <td>
@@ -1295,17 +1306,6 @@
               </td>
               <td>
                 Remove the own property whose key is _propertyKey_ from this object. Return *false* if the property was not deleted and is still present. Return *true* if the property was deleted or is not present.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[DefineOwnProperty]]
-              </td>
-              <td>
-                (_propertyKey_, _PropertyDescriptor_) <b>&rarr;</b> Boolean
-              </td>
-              <td>
-                Create or alter the own property, whose key is _propertyKey_, to have the state described by _PropertyDescriptor_. Return *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
               </td>
             </tr>
             <tr>

--- a/spec.html
+++ b/spec.html
@@ -8228,6 +8228,14 @@
         </tr>
         <tr>
           <td>
+            [[DefineOwnProperty]]
+          </td>
+          <td>
+            `defineProperty`
+          </td>
+        </tr>
+        <tr>
+          <td>
             [[HasProperty]]
           </td>
           <td>
@@ -8256,14 +8264,6 @@
           </td>
           <td>
             `deleteProperty`
-          </td>
-        </tr>
-        <tr>
-          <td>
-            [[DefineOwnProperty]]
-          </td>
-          <td>
-            `defineProperty`
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Table 5 and Table 30's row orderings are inconsistent with the subsection ordering of sections 9.1 and 9.5 respectively.
Precisely, `[[DefineOwnProperty]]` is lower in the table than in the section ordering.

This inconsistency bugged me a bit. :)