### PR TITLE
Clean up definition of Immutable Prototype Exotic Objects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8156,11 +8156,21 @@
 
     <emu-clause id="sec-immutable-prototype-exotic-objects">
       <h1>Immutable Prototype Exotic Objects</h1>
-      <p>An <dfn>immutable prototype exotic object</dfn> is an exotic object that has an immutable [[Prototype]] internal slot.</p>
+      <p>An <dfn>immutable prototype exotic object</dfn> is an exotic object that has an [[Prototype]] internal slot that will not change once it is initialized.</p>
+
+      <p>Immutable prototype exotic objects have the same internal slots as ordinary objects. They are exotic only in the following internal methods. All other internal methods of immutable prototype exotic objects that are not explicitly defined below are instead defined as in <a href="#sec-ordinary-object-internal-methods-and-internal-slots">ordinary objects.</a></p>
 
       <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v">
         <h1>[[SetPrototypeOf]] (_V_)</h1>
         <p>When the [[SetPrototypeOf]] internal method of an immutable prototype exotic object _O_ is called with argument _V_, the following steps are taken:</p>
+        <emu-alg>
+          1. Return ? SetImmutablePrototype(O, V).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-set-immutable-prototype">
+        <h1>SetImmutablePrototype ( _O_, _V_ )</h1>
+        <p>When the SetImmutablePrototype abstract operation is called with arguments _O_ and _V_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
           1. Let _current_ be _O_.[[Prototype]].

--- a/spec.html
+++ b/spec.html
@@ -8170,6 +8170,7 @@
 
       <emu-clause id="sec-set-immutable-prototype">
         <h1>SetImmutablePrototype ( _O_, _V_ )</h1>
+        <!-- This is used by host environment specs, even though it only has one consumer in this spec; don't inline it -->
         <p>When the SetImmutablePrototype abstract operation is called with arguments _O_ and _V_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.


### PR DESCRIPTION
- Explicitly state that they are just like ordinary objects, and have
  the same internal slots, except for one weird trick. (closes #705)
- Factor out the body of the [[SetPrototypeOf]] method of immutable
  prototype exotic objects into an abstract operation to make it
  easier to do integration with embedders.
  (see https://github.com/whatwg/html/issues/2035)