### PR TITLE
Add definition of unfolding of AbstractOperation(ReturnIfAbrupt(arg))

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2713,6 +2713,16 @@
           1. Else if _hygienicTemp_ is a Completion Record, let _hygienicTemp_ be _hygienicTemp_.[[Value]].
         </emu-alg>
         <p>Where _hygienicTemp_ is ephemeral and visible only in the steps pertaining to ReturnIfAbrupt.</p>
+        <p>Algorithms steps that say or are otherwise equivalent to:</p>
+        <emu-alg>
+          1. Let _result_ be AbstractOperation(ReturnIfAbrupt(_argument_)).
+        </emu-alg>
+        <p>mean the same thing as:</p>
+        <emu-alg>
+          1. If _argument_ is an abrupt completion, return _argument_.
+          1. Else if _argument_ is a Completion Record, let _argument_ be _argument_.[[Value]].
+          1. Let _result_ be AbstractOperation(_argument_).
+        </emu-alg>
       </emu-clause>
 
       <!-- es6num="6.2.2.5" -->

--- a/spec.html
+++ b/spec.html
@@ -2720,7 +2720,7 @@
         <p>mean the same thing as:</p>
         <emu-alg>
           1. If _argument_ is an abrupt completion, return _argument_.
-          1. Else if _argument_ is a Completion Record, let _argument_ be _argument_.[[Value]].
+          1. If _argument_ is a Completion Record, let _argument_ be _argument_.[[Value]].
           1. Let _result_ be AbstractOperation(_argument_).
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
I had trouble understanding the steps required when a ReturnIfAbrupt is nested in a call to another operation such as `ToBoolean(? Call(...))`
I could not find appropriate guidance in the spec about how to apply the "means the same thing as" macro patterns, when the macro is applied mid-line as in this case.

The attached patch gives what I think is the intended meaning (after some initial discussion on IRC).