### PR TITLE
Editorial: Clarify how Boolean objects are coerced to Boolean values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -245,7 +245,7 @@
       <h1>Boolean object</h1>
       <p>member of the Object type that is an instance of the standard built-in `Boolean` constructor</p>
       <emu-note>
-        <p>A Boolean object is created by using the `Boolean` constructor in a `new` expression, supplying a Boolean value as an argument. The resulting object has an internal slot whose value is the Boolean value. A Boolean object can be coerced to a Boolean value.</p>
+        <p>A Boolean object is created by using the `Boolean` constructor in a `new` expression, supplying a Boolean value as an argument. The resulting object has an internal slot whose value is the Boolean value. A Boolean object can be coerced to a Boolean value by calling the `Boolean` constructor as a function (<emu-xref href="#sec-boolean-constructor-boolean-value"></emu-xref>).</p>
       </emu-note>
     </emu-clause>
 


### PR DESCRIPTION
This addition is consistent with #sec-string-object (4.3.19) and #sec-number-object (4.3.22) where the spec contains references to how the respective coercions are carried out.