### PR TITLE
tolength: remove superfluous +Infinity check

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3791,7 +3791,6 @@
       <emu-alg>
         1. Let _len_ be ? ToInteger(_argument_).
         1. If _len_ &le; *+0*, return *+0*.
-        1. If _len_ is *+&infin;*, return 2<sup>53</sup>-1.
         1. Return min(_len_, 2<sup>53</sup>-1).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
The `+Infinity` check is superfluous as the `min` function takes care
of that as well.