### PR TITLE
Add link to "Finished" proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ ECMAScript
 
 Proposals follow [the TC39 process](https://tc39.github.io/process-document/) and are tracked in the [proposals repository](https://github.com/tc39/proposals).
 
+* [Finished Proposals](https://github.com/tc39/proposals/blob/master/finished-proposals.md)
 * [Stage 1 and Above Proposals](https://github.com/tc39/proposals)
 * [Stage 0 Proposals](https://github.com/tc39/proposals/blob/master/stage-0-proposals.md)
 * [Inactive Proposals](https://github.com/tc39/proposals/blob/master/inactive-proposals.md)


### PR DESCRIPTION
I tend to find myself hitting this readme first when looking for proposal status updates, I think it's because "ecma262" is a clean, specific filter term vs "proposals".

It's currently a minor nuisance to have to click through to the "active proposals" page first, then scroll to the bottom and click "Finished Proposals" in order to navigate to the stage 4 proposals.