### PR TITLE
Remove @@iterator from Module Namespace objects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35965,26 +35965,13 @@ THH:mm:ss.sss
   <emu-clause id="sec-module-namespace-objects">
     <h1>Module Namespace Objects</h1>
     <p>A Module Namespace Object is a module namespace exotic object that provides runtime property-based access to a module's exported bindings. There is no constructor function for Module Namespace Objects. Instead, such an object is created for each module that is imported by an |ImportDeclaration| that includes a |NameSpaceImport|.</p>
-    <p>In addition to the properties specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref> each Module Namespace Object has the following own properties:</p>
+    <p>In addition to the properties specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref> each Module Namespace Object has the following own property:</p>
 
     <!-- es6num="26.3.1" -->
     <emu-clause id="sec-@@tostringtag">
       <h1>@@toStringTag</h1>
       <p>The initial value of the @@toStringTag property is the String value `"Module"`.</p>
-      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-    </emu-clause>
-
-    <!-- es6num="26.3.2" -->
-    <emu-clause id="sec-@@iterator">
-      <h1>[ @@iterator ] ( )</h1>
-      <p>When the @@iterator method is called with no arguments, the following steps are taken:</p>
-      <emu-alg>
-        1. Let _N_ be the *this* value.
-        1. If _N_ is not a module namespace exotic object, throw a *TypeError* exception.
-        1. Let _exports_ be _N_.[[Exports]].
-        1. Return ! CreateListIterator(_exports_).
-      </emu-alg>
-      <p>The value of the `name` property of this function is `"[Symbol.iterator]"`.</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
Per consensus at the November 2016 meeting, Module Namespace exotic
objects no longer have an @@iterator method.

Also changes the [[Configurable]] property of the @@toStringTag
property to false, as per consensus in the same meeting (and
because it's impossible to reconfigure due to the exotic
methods of such objects).

This closes #693 and #710.