### PR TITLE
Allow resetting a Module Namespace object's prototype to null

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8007,7 +8007,7 @@
               Null
             </td>
             <td>
-              This slot is initialized to *null* at creation time and never changes (see <emu-xref href="#sec-module-namespace-exotic-objects-setprototypeof-v"></emu-xref>).
+              This slot is always *null* (see <emu-xref href="#sec-module-namespace-exotic-objects-setprototypeof-v"></emu-xref>).
             </td>
           </tr>
           </tbody>

--- a/spec.html
+++ b/spec.html
@@ -8019,6 +8019,7 @@
         <p>When the [[SetPrototypeOf]] internal method of a module namespace exotic object _O_ is called with argument _V_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
+          1. If SameValue(_V_, *null*) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -7999,28 +7999,28 @@
               A List containing the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using `Array.prototype.sort` using SortCompare as _comparefn_.
             </td>
           </tr>
+          <tr>
+            <td>
+              [[Prototype]]
+            </td>
+            <td>
+              Null
+            </td>
+            <td>
+              This slot is initialized to *null* at creation time.
+            </td>
+          </tr>
           </tbody>
         </table>
       </emu-table>
-      <p>Module namespace exotic objects provide alternative definitions for all of the internal methods.</p>
-
-      <!-- es6num="9.4.6.1" -->
-      <emu-clause id="sec-module-namespace-exotic-objects-getprototypeof">
-        <h1>[[GetPrototypeOf]] ( )</h1>
-        <p>When the [[GetPrototypeOf]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
-        <emu-alg>
-          1. Return *null*.
-        </emu-alg>
-      </emu-clause>
+      <p>Module namespace exotic objects provide alternative definitions for all of the internal methods except [[GetPrototypeOf]], which behaves as defined in <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-clause>.</p>
 
       <!-- es6num="9.4.6.2" -->
       <emu-clause id="sec-module-namespace-exotic-objects-setprototypeof-v">
         <h1>[[SetPrototypeOf]] ( _V_ )</h1>
         <p>When the [[SetPrototypeOf]] internal method of a module namespace exotic object _O_ is called with argument _V_, the following steps are taken:</p>
         <emu-alg>
-          1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
-          1. If SameValue(_V_, *null*) is *true*, return *true*.
-          1. Return *false*.
+          1. Return ? SetImmutablePrototype(_O_, _V_).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -8013,7 +8013,7 @@
           </tbody>
         </table>
       </emu-table>
-      <p>Module namespace exotic objects provide alternative definitions for all of the internal methods except [[GetPrototypeOf]], which behaves as defined in <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-clause>.</p>
+      <p>Module namespace exotic objects provide alternative definitions for all of the internal methods except [[GetPrototypeOf]], which behaves as defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>.</p>
 
       <!-- es6num="9.4.6.2" -->
       <emu-clause id="sec-module-namespace-exotic-objects-setprototypeof-v">

--- a/spec.html
+++ b/spec.html
@@ -8007,7 +8007,7 @@
               Null
             </td>
             <td>
-              This slot is always *null* (see <emu-xref href="#sec-module-namespace-exotic-objects-setprototypeof-v"></emu-xref>).
+              This slot always contains the value *null* (see <emu-xref href="#sec-module-namespace-exotic-objects-setprototypeof-v"></emu-xref>).
             </td>
           </tr>
           </tbody>

--- a/spec.html
+++ b/spec.html
@@ -8007,7 +8007,7 @@
               Null
             </td>
             <td>
-              This slot is initialized to *null* at creation time.
+              This slot is initialized to *null* at creation time and never changes (see <emu-xref href="#sec-module-namespace-exotic-objects-setprototypeof-v"></emu-xref>).
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
This makes its [[SetPrototypeOf]] method consistent with
other objects whose prototypes are immutable.

TC39 came to consensus on this change at the November 2016 meeting.