### PR TITLE
Normative: Invoke superclass constructor even if its .prototype is null

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19070,7 +19070,7 @@
         1. If |ClassBody_opt| is not present, let _constructor_ be ~empty~.
         1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
         1. If _constructor_ is ~empty~, then
-          1. If |ClassHeritage_opt| is present and _protoParent_ is not *null*, then
+          1. If |ClassHeritage_opt| is present and _superclass_ is not *null*, then
             1. Let _constructor_ be the result of parsing the source text
               <pre><code class="javascript">constructor(... args){ super (...args);}</code></pre>
               using the syntactic grammar with the goal symbol |MethodDefinition[~Yield, ~Await]|.
@@ -19082,7 +19082,7 @@
         1. Let _constructorInfo_ be the result of performing DefineMethod for _constructor_ with arguments _proto_ and _constructorParent_ as the optional _functionPrototype_ argument.
         1. Assert: _constructorInfo_ is not an abrupt completion.
         1. Let _F_ be _constructorInfo_.[[Closure]].
-        1. If |ClassHeritage_opt| is present and _protoParent_ is not *null*, then set _F_.[[ConstructorKind]] to `"derived"`.
+        1. If |ClassHeritage_opt| is present and _superclass_ is not *null*, then set _F_.[[ConstructorKind]] to `"derived"`.
         1. Perform MakeConstructor(_F_, *false*, _proto_).
         1. Perform MakeClassConstructor(_F_).
         1. Perform CreateMethodProperty(_proto_, `"constructor"`, _F_).


### PR DESCRIPTION
Fixes #699: currently the below `new` does not invoke `A`; with this change it does.

```js
function A() { this.x = 1; }
A.prototype = null;

new class extends A {}
```

As mentioned there, this is a normative change, but it causes the spec to match current behavior on (at least) Chrome and Firefox and so probably isn't breaking.

At the moment it does nothing to resolve the scoping issue mentioned [here](https://github.com/tc39/ecma262/issues/699#issuecomment-254676629).