### PR TITLE
Editorial: annotate ToObject calls with `!`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16222,7 +16222,7 @@
           1. If _iterationKind_ is ~enumerate~, then
             1. If _exprValue_.[[Value]] is *undefined* or *null*, then
               1. Return Completion{[[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~}.
-            1. Let _obj_ be ToObject(_exprValue_).
+            1. Let _obj_ be ! ToObject(_exprValue_).
             1. Return ? EnumerateObjectProperties(_obj_).
           1. Else,
             1. Assert: _iterationKind_ is ~iterate~.
@@ -23262,7 +23262,7 @@
           1. If NewTarget is neither *undefined* nor the active function, then
             1. Return ? OrdinaryCreateFromConstructor(NewTarget, `"%ObjectPrototype%"`).
           1. If _value_ is *null*, *undefined* or not supplied, return ObjectCreate(%ObjectPrototype%).
-          1. Return ToObject(_value_).
+          1. Return ! ToObject(_value_).
         </emu-alg>
         <p>The `length` property of the `Object` constructor function is 1.</p>
       </emu-clause>
@@ -23285,7 +23285,7 @@
           1. For each element _nextSource_ of _sources_, in ascending index order,
             1. If _nextSource_ is *undefined* or *null*, let _keys_ be a new empty List.
             1. Else,
-              1. Let _from_ be ToObject(_nextSource_).
+              1. Let _from_ be ! ToObject(_nextSource_).
               1. Let _keys_ be ? _from_.[[OwnPropertyKeys]]().
             1. Repeat for each element _nextKey_ of _keys_ in List order,
               1. Let _desc_ be ? _from_.[[GetOwnProperty]](_nextKey_).
@@ -23639,7 +23639,7 @@
         <emu-alg>
           1. If the *this* value is *undefined*, return `"[object Undefined]"`.
           1. If the *this* value is *null*, return `"[object Null]"`.
-          1. Let _O_ be ToObject(*this* value).
+          1. Let _O_ be ! ToObject(*this* value).
           1. Let _isArray_ be ? IsArray(_O_).
           1. If _isArray_ is *true*, let _builtinTag_ be `"Array"`.
           1. Else if _O_ is an exotic String object, let _builtinTag_ be `"String"`.


### PR DESCRIPTION
These calls are preceded by checks for `null` and `undefined`,
so they're guaranteed to succeed. But not all such calls were
annotated with `!`.