### PR TITLE
Normative: do not call super constructor when ThisBindingStatus is already initialized

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12078,9 +12078,10 @@
           1. Let _func_ be ? GetSuperConstructor().
           1. Let _argList_ be ArgumentListEvaluation of |Arguments|.
           1. ReturnIfAbrupt(_argList_).
-          1. Let _result_ be ? Construct(_func_, _argList_, _newTarget_).
           1. Let _thisER_ be GetThisEnvironment( ).
-          1. Return ? _thisER_.BindThisValue(_result_).
+          1. If _thisER_.[[ThisBindingStatus]] is "initialized", throw a *ReferenceError*.
+          1. Let _result_ be ? Construct(_func_, _argList_, _newTarget_).
+          1. Return ! _thisER_.BindThisValue(_result_).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -12081,7 +12081,7 @@
           1. Let _thisER_ be GetThisEnvironment( ).
           1. If _thisER_.[[ThisBindingStatus]] is "initialized", throw a *ReferenceError*.
           1. Let _result_ be ? Construct(_func_, _argList_, _newTarget_).
-          1. Return ! _thisER_.BindThisValue(_result_).
+          1. Return ? _thisER_.BindThisValue(_result_).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
Given:

```js
class A { constructor() { print('a') } };
class B extends A {
  constructor() {
    super();
    super();
  }
}
```

The current spec says 'a' is printed twice as the second super will
invoke the super constructor before throwing an error due to `this`
being initialized.

This change throws just before invoking the super constructor if this
has already been initialized. The argument list is evaluated as it
may initialize `this` by invoking super (i.e. `super(super())`).

Current implementations agree on the current spec behavior so it's
questionable whether this change is worth doing. However this came up in
real world code (due to a merge mishap) and caused significant confusion
so if we can get away with changing it I think we should.