### PR TITLE
Editorial: Hyphenate “left-capturing”

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19278,7 +19278,7 @@
 
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
-        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}` 
+        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
@@ -19331,7 +19331,7 @@
 
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
-        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}` 
+        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
@@ -19354,7 +19354,7 @@
     <emu-clause id="sec-async-function-definitions-static-semantics-HasName">
       <h1>Static Semantics: HasName</h1>
       <emu-grammar>
-        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}` 
+        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -19382,7 +19382,7 @@
     <emu-clause id="sec-async-function-definitions-static-semantics-IsFunctionDefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-grammar>
-        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}` 
+        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
@@ -19480,7 +19480,7 @@
       </emu-alg>
 
       <emu-grammar>
-        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}` 
+        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. If the function code for |AsyncFunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
@@ -28162,7 +28162,7 @@ THH:mm:ss.sss
             _InputLength_ is the number of characters in _Input_.
           </li>
           <li>
-            _NcapturingParens_ is the total number of left capturing parentheses (i.e. the total number of times the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production is expanded) in the pattern. A left capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production.
+            _NcapturingParens_ is the total number of left-capturing parentheses (i.e. the total number of times the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production is expanded) in the pattern. A left-capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production.
           </li>
           <li>
             _IgnoreCase_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains `"i"` and otherwise is *false*.
@@ -28279,8 +28279,8 @@ THH:mm:ss.sss
           1. Evaluate |Atom| to obtain a Matcher _m_.
           1. Evaluate |Quantifier| to obtain the three results: an integer _min_, an integer (or &infin;) _max_, and Boolean _greedy_.
           1. If _max_ is finite and less than _min_, throw a *SyntaxError* exception.
-          1. Let _parenIndex_ be the number of left capturing parentheses in the entire regular expression that occur to the left of this production expansion's |Term|. This is the total number of times the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production is expanded prior to this production's |Term| plus the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> productions enclosing this |Term|.
-          1. Let _parenCount_ be the number of left capturing parentheses in the expansion of this production's |Atom|. This is the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> productions enclosed by this production's |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this production expansion's |Term|. This is the total number of times the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production is expanded prior to this production's |Term| plus the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> productions enclosing this |Term|.
+          1. Let _parenCount_ be the number of left-capturing parentheses in the expansion of this production's |Atom|. This is the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> productions enclosed by this production's |Atom|.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps when evaluated:
             1. Call RepeatMatcher(_m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_) and return its result.
         </emu-alg>
@@ -28741,7 +28741,7 @@ THH:mm:ss.sss
         <p>The production <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
-          1. Let _parenIndex_ be the number of left capturing parentheses in the entire regular expression that occur to the left of this production expansion's initial left parenthesis. This is the total number of times the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production is expanded prior to this production's |Atom| plus the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> productions enclosing this |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this production expansion's initial left parenthesis. This is the total number of times the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production is expanded prior to this production's |Atom| plus the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> productions enclosing this |Atom|.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps:
             1. Let _d_ be an internal Continuation closure that takes one State argument _y_ and performs the following steps:
               1. Let _cap_ be a fresh copy of _y_'s _captures_ List.
@@ -29053,7 +29053,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The definitions of &ldquo;the MV of |NonZeroDigit|&rdquo; and &ldquo;the MV of |DecimalDigits|&rdquo; are in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
         <emu-note>
-          <p>If `\\` is followed by a decimal number _n_ whose first digit is not `0`, then the escape sequence is considered to be a backreference. It is an error if _n_ is greater than the total number of left capturing parentheses in the entire regular expression.</p>
+          <p>If `\\` is followed by a decimal number _n_ whose first digit is not `0`, then the escape sequence is considered to be a backreference. It is an error if _n_ is greater than the total number of left-capturing parentheses in the entire regular expression.</p>
         </emu-note>
       </emu-clause>
 
@@ -36157,7 +36157,7 @@ THH:mm:ss.sss
     <p>When processing the production <emu-prodref name=CallExpression a=callcover></emu-prodref> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
     <emu-prodref name=CallMemberExpression></emu-prodref>
     <p>&nbsp;</p>
-  
+
     <emu-prodref name=SuperCall></emu-prodref>
     <emu-prodref name=Arguments></emu-prodref>
     <emu-prodref name=ArgumentList></emu-prodref>


### PR DESCRIPTION
This is a very minor nitpick that came up recently: https://github.com/tc39/proposal-regexp-named-groups/commit/55b638988573b0e08e99e84a18d7799f06cfd7db#commitcomment-20385510

Note that my editor removed some trailing whitespace on unrelated lines as per the configuration in `.editorconfig`.