### PR TITLE
Correct all references to "well known" Symbols

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24150,21 +24150,21 @@
       <!-- es6num="19.4.2.2" -->
       <emu-clause id="sec-symbol.hasinstance">
         <h1>Symbol.hasInstance</h1>
-        <p>The initial value of `Symbol.hasInstance` is the well known symbol @@hasInstance (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.hasInstance` is the well-known symbol @@hasInstance (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <!-- es6num="19.4.2.3" -->
       <emu-clause id="sec-symbol.isconcatspreadable">
         <h1>Symbol.isConcatSpreadable</h1>
-        <p>The initial value of `Symbol.isConcatSpreadable` is the well known symbol @@isConcatSpreadable (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.isConcatSpreadable` is the well-known symbol @@isConcatSpreadable (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <!-- es6num="19.4.2.4" -->
       <emu-clause id="sec-symbol.iterator">
         <h1>Symbol.iterator</h1>
-        <p>The initial value of `Symbol.iterator` is the well known symbol @@iterator (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.iterator` is the well-known symbol @@iterator (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -24184,7 +24184,7 @@
       <!-- es6num="19.4.2.6" -->
       <emu-clause id="sec-symbol.match">
         <h1>Symbol.match</h1>
-        <p>The initial value of `Symbol.match` is the well known symbol @@match (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.match` is the well-known symbol @@match (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -24198,49 +24198,49 @@
       <!-- es6num="19.4.2.8" -->
       <emu-clause id="sec-symbol.replace">
         <h1>Symbol.replace</h1>
-        <p>The initial value of `Symbol.replace` is the well known symbol @@replace (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.replace` is the well-known symbol @@replace (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <!-- es6num="19.4.2.9" -->
       <emu-clause id="sec-symbol.search">
         <h1>Symbol.search</h1>
-        <p>The initial value of `Symbol.search` is the well known symbol @@search (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.search` is the well-known symbol @@search (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <!-- es6num="19.4.2.10" -->
       <emu-clause id="sec-symbol.species">
         <h1>Symbol.species</h1>
-        <p>The initial value of `Symbol.species` is the well known symbol @@species (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.species` is the well-known symbol @@species (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <!-- es6num="19.4.2.11" -->
       <emu-clause id="sec-symbol.split">
         <h1>Symbol.split</h1>
-        <p>The initial value of `Symbol.split` is the well known symbol @@split (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.split` is the well-known symbol @@split (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <!-- es6num="19.4.2.12" -->
       <emu-clause id="sec-symbol.toprimitive">
         <h1>Symbol.toPrimitive</h1>
-        <p>The initial value of `Symbol.toPrimitive` is the well known symbol @@toPrimitive (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.toPrimitive` is the well-known symbol @@toPrimitive (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <!-- es6num="19.4.2.13" -->
       <emu-clause id="sec-symbol.tostringtag">
         <h1>Symbol.toStringTag</h1>
-        <p>The initial value of `Symbol.toStringTag` is the well known symbol @@toStringTag (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.toStringTag` is the well-known symbol @@toStringTag (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <!-- es6num="19.4.2.14" -->
       <emu-clause id="sec-symbol.unscopables">
         <h1>Symbol.unscopables</h1>
-        <p>The initial value of `Symbol.unscopables` is the well known symbol @@unscopables (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.unscopables` is the well-known symbol @@unscopables (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
The spec first defines them as "well-known" so this just corrects a few places where they were referred to as "well known", which could cause some problems for anyone trying to search the spec for all references to well-known symbols.