### PR TITLE
Make [[Delete]] on module namespace return false for @@toStringTag.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8183,6 +8183,8 @@
         <p>When the [[Delete]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
+          1. If Type(_P_) is Symbol, then
+            1. Return ? OrdinaryDelete(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is an element of _exports_, return *false*.
           1. Return *true*.


### PR DESCRIPTION
A module namespace exotic object has an own Symbol.toStringTag property, which
is non-configurable.  This patch changes [[Delete]] to return false rather than
true for this property, thus making its behavior consistent with other own
properties of the object.

See also: #747 