### PR TITLE
SAB integration editorial and normative fixes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34729,6 +34729,12 @@ THH:mm:ss.sss
         1. Return AtomicReadModifyWrite(_typedArray_, _index_, _value_, `xor`).
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-atomics-@@tostringtag">
+      <h1>Atomics [ @@toStringTag ]</h1>
+      <p>The initial value of the @@toStringTag property is the String value `"Atomics"`.</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+    </emu-clause>
   </emu-clause>
 
   <!-- es6num="24.3" -->

--- a/spec.html
+++ b/spec.html
@@ -34721,7 +34721,7 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="Atomics.xor">
+    <emu-clause id="sec-atomics.xor">
       <h1>Atomics.xor( _typedArray_, _index_, _value_ )</h1>
       <p>Let `xor` denote a semantic function of two List of byte values arguments that applies the bitwise-xor operation element-wise to the two arguments and returns a List of byte values corresponding to the result of that operation.</p>
       <p>The following steps are taken:</p>


### PR DESCRIPTION
Fixes a clause id and add Atomics[@@toStringTag], which was missing.