### PR TITLE
Add TZOffset{UTC,Local} in place of LocalTZA/DSTA

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25946,8 +25946,8 @@
       <!-- es6num="20.3.1.8" -->
       <emu-clause id="sec-time-zone-offset-from-localtime">
         <h1>Time Zone Offset from LocalTime</h1>
-        <p>An implementation of ECMAScript is expected to determine the local time zone offset from local time TZOffsetLocal(<emu-eqn>_t_<sub>local</sub></emu-eqn>) using the best available information on time zones. The time zone offset from local time  <emu-eqn>_t_<sub>local</sub></emu-eqn> is a value <dfn>TZOffsetLocal(<emu-eqn>_t_<sub>local</sub></emu-eqn>)</dfn> measured in milliseconds which when added to the local time represents UTC.</p>
-        <p>When <emu-eqn>_t_<sub>local</sub></emu-eqn> represents wall time repeating multiple times at a negative time zone offset transition (e.g. when the daylight savings time ends or the time zone offset is decreased) or skipped wall time at a positive time zone offset transitions (e.g. when the daylight savings time starts or the time zone offset is increased), <emu-eqn>_t_<sub>local</sub></emu-eqn> should be interpreted with the time zone offset after the transition.</p>
+        <p>An implementation of ECMAScript is expected to determine the local time zone offset from local time TZOffsetLocal(<emu-eqn>_t_<sub>local</sub></emu-eqn>) using the best available information on time zones. The time zone offset at the local time <emu-eqn>_t_<sub>local</sub></emu-eqn> is a value <dfn>TZOffsetLocal(<emu-eqn>_t_<sub>local</sub></emu-eqn>)</dfn> measured in milliseconds which when added to the local time represents UTC.</p>
+        <p>When <emu-eqn>_t_<sub>local</sub></emu-eqn> represents wall time repeating multiple times at a positive time zone offset transition (e.g. when the daylight savings time ends or the time zone offset is increased) or skipped wall time at a negative time zone offset transitions (e.g. when the daylight savings time starts or the time zone offset is decreased), <emu-eqn>_t_<sub>local</sub></emu-eqn> should be interpreted with the time zone offset after the transition.</p>
         <emu-note>
           <p>It is recommended that implementations use the time zone information of the IANA Time Zone Database <a href="http://www.iana.org/time-zones/">http://www.iana.org/time-zones/</a>.</p>
           <p>1:30 AM on November 5, 2017 in America/New_York is repeated twice (fall backward), but it should be interpreted as 1:30 AM UTC-05 instead of 1:30 AM UTC-04. TZOffsetLocal should be <emu-eqn>+5 &times; msPerHour</emu-eqn>.</p>
@@ -25963,7 +25963,7 @@
           1. Return _t_ - TZOffsetUTC(_t_).
         </emu-alg>
         <emu-note>
-          <p>Two different time values (_t_ (UTC)) are converted to the same local time <emu-eqn>t<sub>local</sub></emu-eqn> at a negative time zone transition when there are repeated times (e.g. the daylight savings time ends or the time zone offset is decreased.).</p>
+          <p>Two different time values (_t_ (UTC)) are converted to the same local time <emu-eqn>t<sub>local</sub></emu-eqn> at a positive time zone offset transition when there are repeated times (e.g. the daylight savings time ends or the time zone offset is increased.).</p>
         </emu-note>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -25935,20 +25935,23 @@
       </emu-clause>
 
       <!-- es6num="20.3.1.7" -->
-      <emu-clause id="sec-local-time-zone-adjustment">
-        <h1>Local Time Zone Adjustment</h1>
-        <p>An implementation of ECMAScript is expected to determine the local time zone adjustment. The local time zone adjustment is a value <dfn>LocalTZA</dfn> measured in milliseconds which when added to UTC represents the local <em>standard</em> time. Daylight saving time is <em>not</em> reflected by LocalTZA.</p>
+      <emu-clause id="sec-time-zone-offset-from-utc">
+        <h1>Time Zone Offset from UTC</h1>
+        <p>An implementation of ECMAScript is expected to determine the local time zone offset from UTC TZOffsetUTC(_t_) using the best available information on time zones. The time zone offset from UTC at time represented by time value _t_ (UTC) is a value <dfn>TZOffsetUTC(_t_)</dfn> measured in milliseconds which when subtracted from UTC represents the local time.</p>
         <emu-note>
           <p>It is recommended that implementations use the time zone information of the IANA Time Zone Database <a href="http://www.iana.org/time-zones/">http://www.iana.org/time-zones/</a>.</p>
         </emu-note>
       </emu-clause>
 
       <!-- es6num="20.3.1.8" -->
-      <emu-clause id="sec-daylight-saving-time-adjustment">
-        <h1>Daylight Saving Time Adjustment</h1>
-        <p>An implementation dependent algorithm using best available information on time zones to determine the local daylight saving time adjustment DaylightSavingTA(_t_), measured in milliseconds. An implementation of ECMAScript is expected to make its best effort to determine the local daylight saving time adjustment.</p>
+      <emu-clause id="sec-time-zone-offset-from-localtime">
+        <h1>Time Zone Offset from LocalTime</h1>
+        <p>An implementation of ECMAScript is expected to determine the local time zone offset from local time TZOffsetLocal(<emu-eqn>_t_<sub>local</sub></emu-eqn>) using the best available information on time zones. The time zone offset from local time  <emu-eqn>_t_<sub>local</sub></emu-eqn> is a value <dfn>TZOffsetLocal(<emu-eqn>_t_<sub>local</sub></emu-eqn>)</dfn> measured in milliseconds which when added to the local time represents UTC.</p>
+        <p>When <emu-eqn>_t_<sub>local</sub></emu-eqn> represents wall time repeating multiple times at a negative time zone offset transition (e.g. when the daylight savings time ends or the time zone offset is decreased) or skipped wall time at a positive time zone offset transitions (e.g. when the daylight savings time starts or the time zone offset is increased), <emu-eqn>_t_<sub>local</sub></emu-eqn> should be interpreted with the time zone offset after the transition.</p>
         <emu-note>
           <p>It is recommended that implementations use the time zone information of the IANA Time Zone Database <a href="http://www.iana.org/time-zones/">http://www.iana.org/time-zones/</a>.</p>
+          <p>1:30 AM on November 5, 2017 in America/New_York is repeated twice (fall backward), but it should be interpreted as 1:30 AM UTC-05 instead of 1:30 AM UTC-04. TZOffsetLocal should be <emu-eqn>+5 &times; msPerHour</emu-eqn>.</p>
+          <p>2:30 AM on March 12, 2017 in America/New_York does not exist, but it should be interpreted as 2:30 AM UTC-04. TZOffsetLocal should be <emu-eqn>+4 &times; msPerHour</emu-eqn>.</p>.
         </emu-note>
       </emu-clause>
 
@@ -25957,19 +25960,22 @@
         <h1>LocalTime ( _t_ )</h1>
         <p>The abstract operation LocalTime with argument _t_ converts _t_ from UTC to local time by performing the following steps:</p>
         <emu-alg>
-          1. Return _t_ + LocalTZA + DaylightSavingTA(_t_).
+          1. Return _t_ - TZOffsetUTC(_t_).
         </emu-alg>
+        <emu-note>
+          <p>Two different time values (_t_ (UTC)) are converted to the same local time <emu-eqn>t<sub>local</sub></emu-eqn> at a negative time zone transition when there are repeated times (e.g. the daylight savings time ends or the time zone offset is decreased.).</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="20.3.1.10" -->
       <emu-clause id="sec-utc-t" aoid="UTC">
-        <h1>UTC ( _t_ )</h1>
-        <p>The abstract operation UTC with argument _t_ converts _t_ from local time to UTC. It performs the following steps:</p>
+        <h1>UTC ( <emu-eqn>_t_<sub>local</sub></emu-eqn> )</h1>
+        <p>The abstract operation UTC with argument <emu-eqn>_t_<sub>local</sub></emu-eqn> converts <emu-eqn>_t_<sub>local</sub></emu-eqn> from local time to UTC. It performs the following steps:</p>
         <emu-alg>
-          1. Return _t_ - LocalTZA - DaylightSavingTA(_t_ - LocalTZA).
+          1. Return _t_ + TZOffsetLocal(<emu-eqn>_t_<sub>local</sub></emu-eqn>)
         </emu-alg>
         <emu-note>
-          <p><emu-eqn>UTC(LocalTime(_t_))</emu-eqn> is not necessarily always equal to _t_.</p>
+          <p><emu-eqn>UTC(LocalTime(_t_))</emu-eqn> is not necessarily always equal to _t_. <emu-eqn>LocalTime(UTC(_t_<sub>local</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>local</sub></emu-eqn>, either.</p>
         </emu-note>
       </emu-clause>
 


### PR DESCRIPTION
Currently, LocalTimezoneAdjustment is assumed to be constant across time
zone rule changes and does not take any argument. Daylight Savings Time
Adjustment does take an argument t.

DSTA(t) can 'absorb' the standard time zone offset changes (e.g. Europe/Moscow
changed the standard time zone offset multiple times in the last decade.). However,
the spec stipulates that it should only reprsent an additional
adjustment necessary when DST is in effect.

In practice, at least two implementations (Spidermonkey/Firefox and
JSC/Safari) do not follow the spec to the letter to produce results
expected by users across time zone rule changes.

This PR drops LocalTZA and DaylightSavingsTimeAdjustment(t) and
introduce TZOffsetUTC(t) and TZOffsetLocal(t_local). The former takes
't' (UTC) and gives a time zone offset in effect at t for the local
time zone (for US ET, it'd be ```4*msPerHour``` in summer and ```5*msPerHour``` in
winter). The latter takes 't_local' (local time value) and gives a time
zone offset in effect at t_local.

It's also specified that TZOffsetLocal(t_local) will return the offset
*after* the transition when t_local is wall time repeating multiple
times at a negative transition (e.g. fall backward) or skipped wall time
at a positive time zone transition (e.g. spring forward). This is in
line with the aforementioned two implementations. In the future, it
may as well be considered to introduce options to control this behavior.
[1] [2]

UTC(t_local) and Localtime(t) are reformulated with
TZOffsetLocal(t_local) and TZOffsetUTC(t).

Will fix #725 modulo an option to specify the behavior to handle
skipped or repeated wall time.

[1] ICU Calendar API has skipped wall time option (https://goo.gl/h0bP26) and
repeated wall time option (https://goo.gl/Q1VX3j).

[2] Python proposal to handle skipped/repeated time:
    https://www.python.org/dev/peps/pep-0495/