### PR TITLE
remove mentions of unused [[SourceText]] internal slot; renumber lists

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19409,21 +19409,19 @@
       </emu-grammar>
       <emu-alg>
         1. If the function code for |AsyncFunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
-        2. Let _name_ be StringValue of |BindingIdentifier|.
-        3. Let _F_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
-        4. Perform ! SetFunctionName(_F_, _name_).
-        1. Set _F_.[[SourceText]] to the source text matched by |AsyncFunctionDeclaration|.
-        5. Return _F_.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _F_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
+        1. Perform ! SetFunctionName(_F_, _name_).
+        1. Return _F_.
       </emu-alg>
       <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. If the function code for |AsyncFunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
-        2. Let _F_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
-        3. Perform ! SetFunctionName(_F_, `"default"`).
-        1. Set _F_.[[SourceText]] to the source text matched by |AsyncFunctionDeclaration|.
-        4. Return _F_.
+        1. Let _F_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
+        1. Perform ! SetFunctionName(_F_, `"default"`).
+        1. Return _F_.
       </emu-alg>
     </emu-clause>
 
@@ -19458,7 +19456,6 @@
         1. Let _closure_ be ! AsyncFunctionCreate(~Method~, |UniqueFormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
         1. Perform ! MakeMethod(_closure_, _object_).
         1. Perform ! SetFunctionName(_closure_, _propKey_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncMethod|.
         1. Let _desc_ be the PropertyDescriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
@@ -19486,7 +19483,6 @@
         1. If the function code for |AsyncFunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _closure_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncFunctionExpression|.
         1. Return _closure_.
       </emu-alg>
 
@@ -19501,7 +19497,6 @@
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform ! _envRec_.CreateImmutableBinding(_name_).
         1. Let _closure_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _funcEnv_, _strict_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncFunctionExpression|.
         1. Perform ! SetFunctionName(_closure_, _name_).
         1. Perform ! _envRec_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
@@ -19742,23 +19737,21 @@
       </emu-grammar>
       <emu-alg>
         1. If the function code for this |AsyncArrowFunction| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
-        2. Let _scope_ be the LexicalEnvironment of the running execution context.
-        3. Let _parameters_ be |AsyncArrowBindingIdentifier|.
-        4. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncArrowFunction|.
-        5. Return _closure_.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _parameters_ be |AsyncArrowBindingIdentifier|.
+        1. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
+        1. Return _closure_.
       </emu-alg>
       <emu-grammar>
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
         1. If the function code for this |AsyncArrowFunction| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
-        2. Let _scope_ be the LexicalEnvironment of the running execution context.
-        3. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
-        4. Let _parameters_ be the |ArrowFormalParameters| of _head_.
-        5. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncArrowFunction|.
-        6. Return _closure_.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. Let _parameters_ be the |ArrowFormalParameters| of _head_.
+        1. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
+        1. Return _closure_.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This slot was added by me to the async function proposal, assuming the Function.prototype.toString rewrite would land first. I'm removing these unused internal slot assignments from the main spec text and will be adding them back in #697 once this is merged. In the process, I've renumbered the lists for easier diffing since they were misnumbered to begin with.