### PR TITLE
Revert to ES2015 semantics for `class extends null`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19137,7 +19137,7 @@
         1. If |ClassBody_opt| is not present, let _constructor_ be ~empty~.
         1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
         1. If _constructor_ is ~empty~, then
-          1. If |ClassHeritage_opt| is present and _superclass_ is not *null*, then
+          1. If |ClassHeritage_opt| is present, then
             1. Let _constructor_ be the result of parsing the source text
               <pre><code class="javascript">constructor(... args){ super (...args);}</code></pre>
               using the syntactic grammar with the goal symbol |MethodDefinition[~Yield, ~Await]|.
@@ -19149,7 +19149,7 @@
         1. Let _constructorInfo_ be the result of performing DefineMethod for _constructor_ with arguments _proto_ and _constructorParent_ as the optional _functionPrototype_ argument.
         1. Assert: _constructorInfo_ is not an abrupt completion.
         1. Let _F_ be _constructorInfo_.[[Closure]].
-        1. If |ClassHeritage_opt| is present and _superclass_ is not *null*, then set _F_.[[ConstructorKind]] to `"derived"`.
+        1. If |ClassHeritage_opt| is present, then set _F_.[[ConstructorKind]] to `"derived"`.
         1. Perform MakeConstructor(_F_, *false*, _proto_).
         1. Perform MakeClassConstructor(_F_).
         1. Perform CreateMethodProperty(_proto_, `"constructor"`, _F_).


### PR DESCRIPTION
This was the consensus reached at the January TC39 meeting.

Future work will be done to re-enable the use of a null
extends clause, but the changes this PR reverts have some
undesirable side-effects.

Manual revert of the following commits, which stemmed from #543:
  98c67f2c2696652005ab7fb7284fe8b4661a5dbf
  a35f0f3b8ac53bbfa019bd35989c4027ce4976e4
  f3881fe4b2363707cc68ba9972b041e1c7233922