### PR TITLE
fixes #708: removing ResolveExport's exportStarSet in favor of allowing circular valid dependencies

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8154,7 +8154,7 @@
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _m_ be _O_.[[Module]].
-          1. Let _binding_ be ! _m_.ResolveExport(_P_, &laquo; &raquo;, &laquo; &raquo;).
+          1. Let _binding_ be ! _m_.ResolveExport(_P_, &laquo; &raquo;).
           1. Assert: _binding_ is neither *null* nor `"ambiguous"`.
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.
@@ -21479,7 +21479,7 @@
               1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
               1. Perform ? _requiredModule_.ModuleDeclarationInstantiation().
             1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
-              1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;, &laquo; &raquo;).
+              1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
               1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
             1. Assert: All named exports from _module_ are resolvable.
             1. Let _envRec_ be _env_'s EnvironmentRecord.
@@ -21491,7 +21491,7 @@
                 1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                 1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
               1. Else,
-                1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;, &laquo; &raquo;).
+                1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
                 1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
                 1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
             1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
@@ -21577,7 +21577,7 @@
             1. Let _exportedNames_ be ? _module_.GetExportedNames(&laquo; &raquo;).
             1. Let _unambiguousNames_ be a new empty List.
             1. For each _name_ that is an element of _exportedNames_,
-              1. Let _resolution_ be ? _module_.ResolveExport(_name_, &laquo; &raquo;, &laquo; &raquo;).
+              1. Let _resolution_ be ? _module_.ResolveExport(_name_, &laquo; &raquo;).
               1. If _resolution_ is *null*, throw a *SyntaxError* exception.
               1. If _resolution_ is not `"ambiguous"`, append _name_ to _unambiguousNames_.
             1. Let _namespace_ be ModuleNamespaceCreate(_module_, _unambiguousNames_).

--- a/spec.html
+++ b/spec.html
@@ -20855,7 +20855,7 @@
             </tr>
             <tr>
               <td>
-                ResolveExport(exportName, resolveSet, exportStarSet)
+                ResolveExport(exportName, resolveSet)
               </td>
               <td>
                 Return the binding of a name exported by this module. Bindings are represented by a Record of the form {[[Module]]: Module Record, [[BindingName]]: String}
@@ -21422,8 +21422,8 @@
 
         <!-- es6num="15.2.1.16.3" -->
         <emu-clause id="sec-resolveexport">
-          <h1>ResolveExport( _exportName_, _resolveSet_, _exportStarSet_ ) Concrete Method</h1>
-          <p>The ResolveExport concrete method of a Source Text Module Record with arguments _exportName_, _resolveSet_, and _exportStarSet_ performs the following steps:</p>
+          <h1>ResolveExport( _exportName_, _resolveSet_ ) Concrete Method</h1>
+          <p>The ResolveExport concrete method of a Source Text Module Record with arguments _exportName_, and _resolveSet_ performs the following steps:</p>
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. For each Record {[[Module]], [[ExportName]]} _r_ in _resolveSet_, do:
@@ -21439,17 +21439,15 @@
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Assert: _module_ imports a specific binding for this export.
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-                1. Return ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_, _exportStarSet_).
+                1. Return ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
               1. Return *null*.
               1. NOTE A `default` export cannot be provided by an `export *`.
-            1. If _exportStarSet_ contains _module_, return *null*.
-            1. Append _module_ to _exportStarSet_.
             1. Let _starResolution_ be *null*.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_, _exportStarSet_).
+              1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
               1. If _resolution_ is `"ambiguous"`, return `"ambiguous"`.
               1. If _resolution_ is not *null*, then
                 1. If _starResolution_ is *null*, let _starResolution_ be _resolution_.


### PR DESCRIPTION
## Intuitions

The meaning of `export * from <module-specifier>` is to signal that additionally to the local exports, any additional export present in that `<module-specifier>` should also be exported. Which means that the following graph should be valid:

```js
// main.js: entry point
export * from "A";

// A.js
export * from "B";

// B.js
export * from "A";
```

Developers can start with some boilerplates, and then fill the blanks on each module in that graph, and this progression is sounded. E.g.: Add `export const a = 1;` to `B.js`, and the graph should remain valid, but now with one exported name for Main, A, and B.

## Spec

In the spec, there are two mechanisms to deal with circularity:

* `ResolveExport( exportName, resolveSet, exportStarSet )`
* `GetExportedNames( exportStarSet )`

`GetExportedNames` works fine with the scenario above when attempting to resolve the names used to create the namespace object (for the example above it will return an empty List of names). 

`ResolveExport` is responsible to resolved a specific export, including the possibility of an ambiguity, but should not care about the scenario above.

## Proposal

Remove `exportStarSet` from the `ResolveExport()` is sufficient to allow the scenario. 