### PR TITLE
SAB: spell out candidate execution initialization for an agent cluster

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6412,12 +6412,12 @@
           <tr>
             <td>[[IsLockFree2]]</td>
             <td>Boolean</td>
-            <td>*true* if atomic operations on two-byte values are lock-free, *false* otherwise.<</td>
+            <td>*true* if atomic operations on two-byte values are lock-free, *false* otherwise.</td>
           </tr>
           <tr>
             <td>[[CandidateExecution]]</td>
             <td>A candidate execution Record</td>
-            <td>See the Atomics memory model. <!-- TODO: Need xref here --></td>
+            <td>See the memory model.</td>
           </tr>
         </tbody>
       </table>
@@ -6510,7 +6510,7 @@
   <emu-clause id="sec-forward-progress">
     <h1>Forward Progress</h1>
     <p>For an agent to <em>make forward progress</em> is for it to perform an evaluation step according to this specification.</p>
-    <p>An agent becomes <em>blocked</em> when its running execution context waits synchronously and indefinitely for an external event.  Only agents whose Agent Record's [[CanBlock]] property is *true* can become blocked in this sense.  An <em>unblocked</em> agent is one that is not blocked. </p>
+    <p>An agent becomes <em>blocked</em> when its running execution context waits synchronously and indefinitely for an external event. Only agents whose Agent Record's [[CanBlock]] property is *true* can become blocked in this sense.  An <em>unblocked</em> agent is one that is not blocked.</p>
 
     <p>Implementations must ensure that:</p>
     <ul>

--- a/spec.html
+++ b/spec.html
@@ -3032,7 +3032,7 @@
       <p>For notational convenience within this specification, an array-like syntax can be used to access the individual bytes of a Data Block value. This notation presents a Data Block value as a 0-origined integer indexed sequence of bytes. For example, if _db_ is a 5 byte Data Block value then _db_[2] can be used to access its 3<sup>rd</sup> byte.</p>
       <p>A data block that resides in memory that can be referenced from multiple agents concurrently is designated a <dfn>Shared Data Block</dfn>. A Shared Data Block has an identity (for the purposes of equality testing Shared Data Block values) that is <em>address-free</em>: it is tied not to the virtual addresses the block is mapped to in any process, but to the set of locations in memory that the block represents. Shared Data Blocks can also be distinguished from Data Blocks.</p>
       <p>The semantics of Shared Data Blocks is defined using Shared Data Block events by the memory model. Abstract operations below introduce Shared Data Block events and act as the interface between evaluation semantics and the event semantics of the memory model. The events form a candidate execution, on which the memory model acts as a filter. Please consult the memory model for full semantics.</p>
-      <p>Shared Data Block events are modeled by Records, defined in the memory model. All agents in an agent cluster share the same candidate execution record in its Agent Record's [[CandidateExecution] field, which is initialized to an empty candidate execution Record.</p>
+      <p>Shared Data Block events are modeled by Records, defined in the memory model.</p>
       <p>The following abstract operations are used in this specification to operate upon Data Block values:</p>
 
       <!-- es6num="6.2.6.1" -->
@@ -6500,6 +6500,20 @@
 
     <emu-note>
       <p>Examples of that type of termination are: operating systems or users terminating agents that are running in separate processes; the embedding itself terminating an agent that is running in-process with the other agents when per-agent resource accounting indicates that the agent is runaway.</p>
+    </emu-note>
+
+    <p>Prior to any evaluation of any ECMAScript code by any agent in a cluster, the candidate execution is initialized for all agents in the cluster. The following steps are performed:</p>
+    <emu-alg>
+      1. Let _execution_ be an empty candidate execution.
+      1. For each agent _agent_ in the agent cluster
+        1. Let _AR_ be _agent_'s Agent Record.
+        1. Let _emptyEventList_ be an Agent Events Record whose [[AgentSignifier]] field is _AR_.[[Signifier]] and whose [[EventList]] field is an empty List.
+        1. Append _emptyEventList_ to _execution_.[[EventLists]].
+        1. Set _AR_.[[CandidateExecution]] to _execution_.
+    </emu-alg>
+
+    <emu-note>
+      <p>All agents in an agent cluster share the same candidate execution in its Agent Record's [[CandidateExecution]] field. The candidate execution is a specification mechanism used by the memory model.</p>
     </emu-note>
 
     <emu-note>


### PR DESCRIPTION
This is a normative change that spells algorithmically an initialization step for agent clusters that's been stated informally. I'd consider this a very involved bug fix.