### PR TITLE
Normative: `Array.prototype.sort`: comparefn must be fn or undefined

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32671,6 +32671,7 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
         <p>Upon entry, the following steps are performed to initialize evaluation of the `sort` function. These steps are used instead of the entry steps in <emu-xref href="#sec-array.prototype.sort"></emu-xref>:</p>
         <emu-alg>
+          1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Let _buffer_ be ? ValidateTypedArray(_obj_).
           1. Let _len_ be _obj_.[[ArrayLength]].

--- a/spec.html
+++ b/spec.html
@@ -31386,6 +31386,7 @@ THH:mm:ss.sss
         <p>The elements of this array are sorted. The sort is not necessarily stable (that is, elements that compare equal do not necessarily remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative value if _x_ &lt; _y_, zero if _x_ = _y_, or a positive value if _x_ &gt; _y_.</p>
         <p>Upon entry, the following steps are performed to initialize evaluation of the `sort` function:</p>
         <emu-alg>
+          1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_obj_, `"length"`)).
         </emu-alg>


### PR DESCRIPTION
This requires implementations throw a `TypeError` when the compare function is neither undefined nor a function, which is currently vaguely implied but not explicitly required.

This reflects web reality in that every engine except v8 already throws in this case. (Safari does not, but Safari TP and webkit latest do)

eshost output of `[1, 2].sort(true)`:
```
┌─────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────┐
│ chakra              │                                                                                             │
│ chakra-es6          │ TypeError: Array.prototype.sort: argument is not a JavaScript object                        │
│ chakra-experimental │                                                                                             │
├─────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│ d8                  │ 1,2                                                                                         │
│ d8 harmony          │                                                                                             │
├─────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│ sm                  │                                                                                             │
│                     │ TypeError: invalid Array.prototype.sort argument                                            │
├─────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│ jsc                 │                                                                                             │
│                     │ TypeError: Array.prototype.sort requires the comparsion function be a function or undefined │
└─────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘
```

This will likely need "web reality" and "needs consensus" labels.