### PR TITLE
Normative: spell out initialization of agent clusters' candidate execution

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3032,7 +3032,7 @@
       <p>For notational convenience within this specification, an array-like syntax can be used to access the individual bytes of a Data Block value. This notation presents a Data Block value as a 0-origined integer indexed sequence of bytes. For example, if _db_ is a 5 byte Data Block value then _db_[2] can be used to access its 3<sup>rd</sup> byte.</p>
       <p>A data block that resides in memory that can be referenced from multiple agents concurrently is designated a <dfn>Shared Data Block</dfn>. A Shared Data Block has an identity (for the purposes of equality testing Shared Data Block values) that is <em>address-free</em>: it is tied not to the virtual addresses the block is mapped to in any process, but to the set of locations in memory that the block represents. Shared Data Blocks can also be distinguished from Data Blocks.</p>
       <p>The semantics of Shared Data Blocks is defined using Shared Data Block events by the memory model. Abstract operations below introduce Shared Data Block events and act as the interface between evaluation semantics and the event semantics of the memory model. The events form a candidate execution, on which the memory model acts as a filter. Please consult the memory model for full semantics.</p>
-      <p>Shared Data Block events are modeled by Records, defined in the memory model. All agents in an agent cluster share the same candidate execution record in its Agent Record's [[CandidateExecution] field, which is initialized to an empty candidate execution Record.</p>
+      <p>Shared Data Block events are modeled by Records, defined in the memory model.</p>
       <p>The following abstract operations are used in this specification to operate upon Data Block values:</p>
 
       <!-- es6num="6.2.6.1" -->
@@ -6500,6 +6500,12 @@
 
     <emu-note>
       <p>Examples of that type of termination are: operating systems or users terminating agents that are running in separate processes; the embedding itself terminating an agent that is running in-process with the other agents when per-agent resource accounting indicates that the agent is runaway.</p>
+    </emu-note>
+
+    <p>Prior to any evaluation of any ECMAScript code by any agent in a cluster, the [[CandidateExecution]] field of the Agent Record for all agents in the cluster is set to the initial candidate execution. The initial candidate execution is an empty candidate execution whose [[EventLists]] field is a List containing, for each agent, an Agent Events Record whose [[AgentSignifier]] field is that agent's signifier and whose [[EventList]] field is an empty List.</p>
+
+    <emu-note>
+      <p>All agents in an agent cluster share the same candidate execution in its Agent Record's [[CandidateExecution]] field. The candidate execution is a specification mechanism used by the memory model.</p>
     </emu-note>
 
     <emu-note>


### PR DESCRIPTION
Per previous discussion, use prose instead of an algorithm since the initialization is of a spec mechanism and has no meaningful, observable ordering.