### PR TITLE
Restrict super() in eval-scripts when in constructor methods of derived classes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22633,12 +22633,12 @@
             1. Let _F_ be _thisEnvRec_.[[FunctionObject]].
             1. Let _inFunction_ be *true*.
             1. Let _inMethod_ be _thisEnvRec_.HasSuperBinding().
-            1. If _F_.[[FunctionKind]] is `"classConstructor"`, let _inConstructor_ be *true*; otherwise, let _inConstructor_ be *false*.
+            1. If _F_.[[ConstructorKind]] is `"derived"`, let _inDerivedConstructor_ be *true*; otherwise, let _inDerivedConstructor_ be *false*.
           1. Else,
             1. Let _inFunction_ be *false*.
             1. Let _inMethod_ be *false*.
-            1. Let _inConstructor_ be *false*.
-          1. Let _script_ be the ECMAScript code that is the result of parsing _x_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If _inFunction_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-functions"></emu-xref> are applied. If _inMethod_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-methods"></emu-xref> are applied. If _inConstructor_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-constructors"></emu-xref> are applied. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>). Parsing and early error detection may be interweaved in an implementation dependent manner.
+            1. Let _inDerivedConstructor_ be *false*.
+          1. Let _script_ be the ECMAScript code that is the result of parsing _x_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If _inFunction_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-functions"></emu-xref> are applied. If _inMethod_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-methods"></emu-xref> are applied. If _inDerivedConstructor_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-constructors"></emu-xref> are applied. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>). Parsing and early error detection may be interweaved in an implementation dependent manner.
           1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
           1. Let _body_ be the |ScriptBody| of _script_.
           1. If _strictCaller_ is *true*, let _strictEval_ be *true*.


### PR DESCRIPTION
Restricts `eval("super()")` to be only valid when a plain `super()` is valid. 