### PR TITLE
Read `lastIndex` property before processing flags in RegExpBuiltinExec

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29638,11 +29638,11 @@ THH:mm:ss.sss
             1. Assert: _R_ is an initialized RegExp instance.
             1. Assert: Type(_S_) is String.
             1. Let _length_ be the number of code units in _S_.
+            1. Let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
             1. Let _flags_ be _R_.[[OriginalFlags]].
             1. If _flags_ contains `"g"`, let _global_ be *true*, else let _global_ be *false*.
             1. If _flags_ contains `"y"`, let _sticky_ be *true*, else let _sticky_ be *false*.
             1. If _global_ is *false* and _sticky_ is *false*, let _lastIndex_ be 0.
-            1. Else, let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
             1. Let _matcher_ be _R_.[[RegExpMatcher]].
             1. If _flags_ contains `"u"`, let _fullUnicode_ be *true*, else let _fullUnicode_ be *false*.
             1. Let _matchSucceeded_ be *false*.


### PR DESCRIPTION
Fixes #777