### PR TITLE
Normative: use ToIndex instead of ToInteger in ValidateAtomicAccess

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34518,9 +34518,7 @@ THH:mm:ss.sss
         <p>The abstract operation ValidateAtomicAccess takes two arguments, _typedArray_ and _requestIndex_. It performs the following steps:</p>
         <emu-alg>
           1. Assert: _typedArray_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
-          1. Let _numberIndex_ be ? ToNumber(_requestIndex_).
-          1. Let _accessIndex_ be ToInteger(_numberIndex_).
-          1. If _numberIndex_ &ne; _accessIndex_, throw a *RangeError* exception.
+          1. Let _accessIndex_ be ? ToIndex(_requestIndex_).
           1. Let _length_ be _typedArray_.[[ArrayLength]].
           1. If _accessIndex_ &lt; 0 or _accessIndex_ &ge; _length_, throw a *RangeError* exception.
           1. Return _accessIndex_.


### PR DESCRIPTION
Addresses #807 