### PR TITLE
Remove odd language for IsLockFree

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6437,7 +6437,7 @@
 
       <p>There is no [[IsLockFree4]] property: 4-byte atomic operations are always lock-free.</p>
 
-      <p>Formally, atomic operations are lock-free if, infinitely often, some atomic operation finishes in a finite number of program steps.  In practice, if an atomic operation is implemented with any type of lock the operation is not lock-free.  Lock-free does not imply wait-free: there is no upper bound on how many machine steps may be required to complete a lock-free atomic operation.</p>
+      <p>In practice, if an atomic operation is implemented with any type of lock the operation is not lock-free.  Lock-free does not imply wait-free: there is no upper bound on how many machine steps may be required to complete a lock-free atomic operation.</p>
 
       <p>That an atomic access of size <em>n</em> is lock-free does not imply anything about the (perceived) atomicity of non-atomic accesses of size <em>n</em>, specifically, non-atomic accesses may still be performed as a sequence of several separate memory accesses.  See ReadSharedMemory and WriteSharedMemory for details.</p>
     </emu-note>


### PR DESCRIPTION
See discussion in https://github.com/tc39/ecmascript_sharedmem/issues/131.

The formalish language in the informative note for the IsLockFree fields of the Agent Record comes from a concurrency textbook.  It seems the sentence adds heat but no light, so let's remove it, leaving just the informal (but intuitive) language in place.
