### PR TITLE
Editorial: remove `await` from FutureReservedWords.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9677,6 +9677,7 @@
           Keyword :: one of
             `break` `do` `in` `typeof` `case` `else` `instanceof` `var` `catch` `export` `new` `void` `class` `extends` `return` `while` `const` `finally` `super` `with` `continue` `for` `switch` `yield` `debugger` `function` `this` `default` `if` `throw` `delete` `import` `try` `await`
         </emu-grammar>
+        <p>`await` is only treated as a |Keyword| when |Module| is the goal symbol of the syntactic grammar.</p>
         <emu-note>
           <p>In some contexts `yield` is given the semantics of an |Identifier|. See <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>. In strict mode code, `let` and `static` are treated as reserved words through static semantic restrictions (see <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-let-and-const-declarations-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-early-errors"></emu-xref>, and <emu-xref href="#sec-class-definitions-static-semantics-early-errors"></emu-xref>) rather than the lexical grammar.</p>
         </emu-note>
@@ -9690,9 +9691,7 @@
         <emu-grammar>
           FutureReservedWord ::
             `enum`
-            `await`
         </emu-grammar>
-        <p>`await` is only treated as a |FutureReservedWord| when |Module| is the goal symbol of the syntactic grammar.</p>
         <emu-note>
           <p>Use of the following tokens within strict mode code is also reserved. That usage is restricted using static semantic restrictions (see <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>) rather than the lexical grammar:</p>
           <figure>


### PR DESCRIPTION
`await` was added as Keyword in https://github.com/tc39/ecma262/commit/869f1c60b17d32069d201849d5dd65d6157dd8d4#diff-3540caefa502006d8a33cb1385720803R9390 but wasn't removed from FutureReservedWords