### PR TITLE
Editorial: Remove range check for unreachable case

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34564,7 +34564,8 @@ THH:mm:ss.sss
           1. Assert: _typedArray_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
           1. Let _accessIndex_ be ? ToIndex(_requestIndex_).
           1. Let _length_ be _typedArray_.[[ArrayLength]].
-          1. If _accessIndex_ &lt; 0 or _accessIndex_ &ge; _length_, throw a *RangeError* exception.
+          1. Assert: _accessIndex_ &ge; 0.
+          1. If _accessIndex_ &ge; _length_, throw a *RangeError* exception.
           1. Return _accessIndex_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
ToIndex always returns a Number >= 0, so remove the check in
ValidateAtomicAccess for the > 0 case.