### PR TITLE
Use the default sort function when calling Array.prototype.sort to sort the exported names of a module

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8274,7 +8274,7 @@
               List of String
             </td>
             <td>
-              A List containing the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using `Array.prototype.sort` using SortCompare as _comparefn_.
+              A List containing the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
             </td>
           </tr>
           <tr>
@@ -8423,7 +8423,7 @@
           1. Let _M_ be a newly created object.
           1. Set _M_'s essential internal methods to the definitions specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref>.
           1. Set _M_.[[Module]] to _module_.
-          1. Let _sortedExports_ be a new List containing the same values as the list _exports_ where the values are ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using SortCompare as _comparefn_.
+          1. Let _sortedExports_ be a new List containing the same values as the list _exports_ where the values are ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
           1. Set _M_.[[Exports]] to _sortedExports_.
           1. Create own properties of _M_ corresponding to the definitions in <emu-xref href="#sec-module-namespace-objects"></emu-xref>.
           1. Set _module_.[[Namespace]] to _M_.


### PR DESCRIPTION
SortCompare is an internal abstract operation, so it cannot be used as the comparator function argument for `Array.prototype.sort`. 