### PR TITLE
Normative: Throw TypeError if proxy [[OwnPropertyKeys]] returns duplicate entries

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1516,6 +1516,9 @@
             The return value must be a List.
           </li>
           <li>
+            The returned list must not contain any duplicate entries.
+          </li>
+          <li>
             The Type of each element of the returned List is either String or Symbol.
           </li>
           <li>
@@ -8976,9 +8979,11 @@
           1. Return ? _target_.[[OwnPropertyKeys]]().
         1. Let _trapResultArray_ be ? Call(_trap_, _handler_, &laquo; _target_ &raquo;).
         1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, &laquo; String, Symbol &raquo;).
+        1. If _trapResult_ contains any duplicate entries, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. Let _targetKeys_ be ? _target_.[[OwnPropertyKeys]]().
         1. Assert: _targetKeys_ is a List containing only String and Symbol values.
+        1. Assert: _targetKeys_ contains no duplicate entries.
         1. Let _targetConfigurableKeys_ be a new empty List.
         1. Let _targetNonconfigurableKeys_ be a new empty List.
         1. Repeat, for each element _key_ of _targetKeys_,
@@ -8992,11 +8997,11 @@
         1. Let _uncheckedResultKeys_ be a new List which is a copy of _trapResult_.
         1. Repeat, for each _key_ that is an element of _targetNonconfigurableKeys_,
           1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
-          1. Remove all occurrences of _key_ from _uncheckedResultKeys_.
+          1. Remove _key_ from _uncheckedResultKeys_.
         1. If _extensibleTarget_ is *true*, return _trapResult_.
         1. Repeat, for each _key_ that is an element of _targetConfigurableKeys_,
           1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
-          1. Remove all occurrences of _key_ from _uncheckedResultKeys_.
+          1. Remove _key_ from _uncheckedResultKeys_.
         1. If _uncheckedResultKeys_ is not empty, throw a *TypeError* exception.
         1. Return _trapResult_.
       </emu-alg>
@@ -9005,6 +9010,9 @@
         <ul>
           <li>
             The result of [[OwnPropertyKeys]] is a List.
+          </li>
+          <li>
+            The returned List contains no duplicate entries.
           </li>
           <li>
             The Type of each result List element is either String or Symbol.
@@ -16564,7 +16572,7 @@
               for (const key of Reflect.ownKeys(obj)) {
                 if (typeof key === "symbol") continue;
                 const desc = Reflect.getOwnPropertyDescriptor(obj, key);
-                if (desc && !visited.has(key)) {
+                if (desc) {
                   visited.add(key);
                   if (desc.enumerable) yield key;
                 }


### PR DESCRIPTION
Proxy [[OwnPropertyKeys]] now throws if the trap returns an array with duplicate entries and reverts a few of the changes made to handle duplicate property keys in a few places. See also discussion in #461. I believe this is needs-consensus, though I haven't heard arguments against this.

/cc @anba
