### PR TITLE
Small Atomics changes to reduce duplications

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34681,21 +34681,6 @@ THH:mm:ss.sss
           1. Return GetModifySetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, _op_).
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-atomicload" aoid="AtomicLoad">
-        <h1>AtomicLoad( _typedArray_, _index_ )</h1>
-        <p>The abstract operation AtomicLoad takes two arguments, _typedArray_, _index_. The operation atomically loads a value and returns the loaded value. It performs the following steps:</p>
-        <emu-alg>
-          1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
-          1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-          1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-          1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-          1. Let _offset_ be _typedArray_.[[ByteOffset]].
-          1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
-          1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, `"SeqCst"`).
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-atomics.add">
@@ -34765,7 +34750,14 @@ THH:mm:ss.sss
       <h1>Atomics.load( _typedArray_, _index_ )</h1>
       <p>The following steps are taken:</p>
       <emu-alg>
-        1. Return ? AtomicLoad(_typedArray_, _index_).
+        1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
+        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
+        1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+        1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+        1. Let _offset_ be _typedArray_.[[ByteOffset]].
+        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
+        1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, `"SeqCst"`).
       </emu-alg>
     </emu-clause>
 
@@ -34820,7 +34812,7 @@ THH:mm:ss.sss
         1. Let _indexedPosition_ be (_i_ &times; 4) + _offset_.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Perform EnterCriticalSection(_WL_).
-        1. Let _w_ be ! AtomicLoad(_typedArray_, _i_).
+        1. Let _w_ be GetValueFromBuffer(_buffer_, _indexedPosition_, `"Int32"`, *true*, `"SeqCst"`).
         1. If _v_ is not equal to _w_, then
           1. Perform LeaveCriticalSection(_WL_).
           1. Return the string `"not-equal"`.

--- a/spec.html
+++ b/spec.html
@@ -34540,17 +34540,15 @@ THH:mm:ss.sss
       <h1>Abstract Operations for Atomics</h1>
 
       <emu-clause id="sec-validatesharedintegertypedarray" aoid="ValidateSharedIntegerTypedArray">
-        <h1>ValidateSharedIntegerTypedArray(_typedArray_ [ , _onlyInt32_ ] )</h1>
-        <p>The abstract operation ValidateSharedIntegerTypedArray takes one argument _typedArray_ and an optional Boolean _onlyInt32_. It performs the following steps:</p>
+        <h1>ValidateSharedIntegerTypedArray(_typedArray_ [ , _allowedTypes_ ] )</h1>
+        <p>The abstract operation ValidateSharedIntegerTypedArray takes one argument _typedArray_ and an optional List _allowedTypes_. It performs the following steps:</p>
         <emu-alg>
-          1. If the _onlyInt32_ argument was not provided, let _onlyInt32_ be *false*.
+          1. If the _allowedTypes_ argument was not provided, then
+            1. Let _allowedTypes_ be &laquo; `"Int8Array"`, `"Uint8Array"`, `"Int16Array"`, `"Uint16Array"`, `"Int32Array"`, `"Uint32Array"` &raquo;.
           1. If Type(_typedArray_) is not Object, throw a *TypeError* exception.
           1. If _typedArray_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Let _typeName_ be _typedArray_.[[TypedArrayName]].
-          1. If _onlyInt32_ is *true*, then
-            1. If _typeName_ is not `"Int32Array"`, throw a *TypeError* exception.
-          1. Else,
-            1. If _typeName_ is not `"Int8Array"`, `"Uint8Array"`, `"Int16Array"`, `"Uint16Array"`, `"Int32Array"`, or `"Uint32Array"`, throw a *TypeError* exception.
+          1. If _typeName_ is not an element of _allowedTypes_, throw a *TypeError* exception.
           1. Assert: _typedArray_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
           1. If IsSharedArrayBuffer(_buffer_) is *false*, throw a *TypeError* exception.
@@ -34800,7 +34798,7 @@ THH:mm:ss.sss
       <h1>Atomics.wait( _typedArray_, _index_, _value_, _timeout_ )</h1>
       <p>`Atomics.wait` puts the calling agent in a wait queue and puts it to sleep until it is awoken or the sleep times out. The following steps are taken:</p>
       <emu-alg>
-        1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_, *true*).
+        1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_, &laquo; `"Int32Array"` &raquo;).
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _v_ be ? ToInt32(_value_).
         1. Let _q_ be ? ToNumber(_timeout_).
@@ -34830,7 +34828,7 @@ THH:mm:ss.sss
       <h1>Atomics.wake( _typedArray_, _index_, _count_ )</h1>
       <p>`Atomics.wake` wakes up some agents that are sleeping in the wait queue.  The following steps are taken:</p>
       <emu-alg>
-        1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_, *true*).
+        1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_, &laquo; `"Int32Array"` &raquo;).
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. If _count_ is *undefined*, let _c_ be *+&infin;*.
         1. Else,

--- a/spec.html
+++ b/spec.html
@@ -34815,6 +34815,7 @@ THH:mm:ss.sss
         1. If _q_ is *NaN*, let _t_ be *+&infin;*, else let _t_ be max(_q_, 0).
         1. Let _B_ be AgentCanSuspend().
         1. If _B_ is *false*, throw a *TypeError* exception.
+        1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _offset_ be _typedArray_.[[ByteOffset]].
         1. Let _indexedPosition_ be (_i_ &times; 4) + _offset_.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
@@ -34843,6 +34844,7 @@ THH:mm:ss.sss
         1. Else,
           1. Let _intCount_ be ? ToInteger(_count_).
           1. Let _c_ be max(_intCount_, 0).
+        1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _offset_ be _typedArray_.[[ByteOffset]].
         1. Let _indexedPosition_ be (_i_ &times; 4) + _offset_.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).

--- a/spec.html
+++ b/spec.html
@@ -34563,8 +34563,12 @@ THH:mm:ss.sss
           1. Assert: _typedArray_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
           1. Let _accessIndex_ be ? ToIndex(_requestIndex_).
           1. Let _length_ be _typedArray_.[[ArrayLength]].
-          1. If _accessIndex_ &lt; 0 or _accessIndex_ &ge; _length_, throw a *RangeError* exception.
-          1. Return _accessIndex_.
+          1. Assert: _accessIndex_ &ge; 0.
+          1. If _accessIndex_ &ge; _length_, throw a *RangeError* exception.
+          1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
+          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Let _offset_ be _typedArray_.[[ByteOffset]].
+          1. Return (_accessIndex_ &times; _elementSize_) + _offset_.
         </emu-alg>
       </emu-clause>
 
@@ -34669,13 +34673,10 @@ THH:mm:ss.sss
         <p>The abstract operation AtomicReadModifyWrite takes four arguments, _typedArray_, _index_, _value_, and a pure combining operation _op_. The pure combining operation _op_ takes two List of byte values arguments and returns a List of byte values. The operation atomically loads a value, combines it with another value, and stores the result of the combination. It returns the loaded value. It performs the following steps:</p>
         <emu-alg>
           1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
-          1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+          1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
           1. Let _v_ be ? ToInteger(_value_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-          1. Let _offset_ be _typedArray_.[[ByteOffset]].
-          1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
           1. Return GetModifySetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, _op_).
         </emu-alg>
       </emu-clause>
@@ -34704,16 +34705,13 @@ THH:mm:ss.sss
       <p>The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _expected_ be ? ToInteger(_expectedValue_).
         1. Let _replacement_ be ? ToInteger(_replacementValue_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
         1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _expectedBytes_ be NumberToRawBytes(_elementType_, _expected_, _isLittleEndian_).
-        1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Let `compareExchange` denote a semantic function of two List of byte values arguments that returns the second argument if the first argument is element-wise equal to _expectedBytes_.
         1. Return GetModifySetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _replacement_, `compareExchange`).
       </emu-alg>
@@ -34749,12 +34747,9 @@ THH:mm:ss.sss
       <p>The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, `"SeqCst"`).
       </emu-alg>
     </emu-clause>
@@ -34773,13 +34768,10 @@ THH:mm:ss.sss
       <p>The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _v_ be ? ToInteger(_value_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, *true*, `"SeqCst"`).
         1. Return _v_.
       </emu-alg>
@@ -34799,15 +34791,13 @@ THH:mm:ss.sss
       <p>`Atomics.wait` puts the calling agent in a wait queue and puts it to sleep until it is awoken or the sleep times out. The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_, &laquo; `"Int32Array"` &raquo;).
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _v_ be ? ToInt32(_value_).
         1. Let _q_ be ? ToNumber(_timeout_).
         1. If _q_ is *NaN*, let _t_ be *+&infin;*, else let _t_ be max(_q_, 0).
         1. Let _B_ be AgentCanSuspend().
         1. If _B_ is *false*, throw a *TypeError* exception.
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; 4) + _offset_.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Perform EnterCriticalSection(_WL_).
         1. Let _w_ be GetValueFromBuffer(_buffer_, _indexedPosition_, `"Int32"`, *true*, `"SeqCst"`).
@@ -34829,14 +34819,12 @@ THH:mm:ss.sss
       <p>`Atomics.wake` wakes up some agents that are sleeping in the wait queue.  The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_, &laquo; `"Int32Array"` &raquo;).
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. If _count_ is *undefined*, let _c_ be *+&infin;*.
         1. Else,
           1. Let _intCount_ be ? ToInteger(_count_).
           1. Let _c_ be max(_intCount_, 0).
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; 4) + _offset_.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Let _n_ be 0.
         1. Perform EnterCriticalSection(_WL_).


### PR DESCRIPTION
Here are possible changes to avoid some duplications in the Atomics section. 

Changes:
- Partially reverts f1239ca, because Atomics.wait actually only needs the GetValueFromBuffer bits from Atomics.load.
- I've replaced the boolean parameter in ValidateSharedIntegerTypedArray with a List, because some prefer to avoid boolean parameters, and because the List approach allows to write a more concise algorithm.
- The buffer address computation was duplicate in multiple operations, we can avoid this by moving it into the ValidateAtomicAccess operation.

Applies on top of #834, but I wanted to keep possible refactorings separate from bug fixes. And I've directly included the changes from #820 in 62ac9b4e1d7aabb01e933fd4ac00a04a860bcf70.