### PR TITLE
Fix CopyDataBlockBytes when copying bytes from shared data block to non-shared data block

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3092,9 +3092,14 @@
               1. NOTE: In implementations, _bytes_ is the result of a non-atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
               1. Let _readEvent_ be ReadSharedMemory{ [[Order]]: `"Unordered"`, [[NoTear]]: *true*, [[Block]]: _fromBlock_, [[ByteIndex]]: _fromIndex_, [[ElementSize]]: 1 }.
               1. Append _readEvent_ to _eventList_.
-              1. Append WriteSharedMemory{ [[Order]]: `"Unordered"`, [[NoTear]]: *true*, [[Block]]: _toBlock_, [[ByteIndex]]: _toIndex_, [[ElementSize]]: 1, [[Payload]]: _bytes_ } to _eventList_.
               1. Append Record { [[Event]]: _readEvent_, [[ChosenValue]]: _bytes_ } to _execution_.[[ChosenValues]].
-            1. Otherwise, set _toBlock_[_toIndex_] to _fromBlock_[_fromIndex_].
+              1. If _toBlock_ is a Shared Data Block, then
+                1. Append WriteSharedMemory{ [[Order]]: `"Unordered"`, [[NoTear]]: *true*, [[Block]]: _toBlock_, [[ByteIndex]]: _toIndex_, [[ElementSize]]: 1, [[Payload]]: _bytes_ } to _eventList_.
+              1. Else,
+                1. Set _toBlock_[_toIndex_] to _bytes_[0].
+            1. Else,
+              1. Assert: _toBlock_ is not a Shared Data Block.
+              1. Set _toBlock_[_toIndex_] to _fromBlock_[_fromIndex_].
             1. Increment _toIndex_ and _fromIndex_ each by 1.
             1. Decrement _count_ by 1.
           1. Return NormalCompletion(~empty~).


### PR DESCRIPTION
This case is possible when CopyDataBlockBytes is called from CloneArrayBuffer as part of cloning the array buffer in 22.2.4.3, step 16.c.i.