### PR TITLE
Layering: change SetImmutablePrototype to use [[GetPrototypeOf]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8451,7 +8451,7 @@
         <p>When the SetImmutablePrototype abstract operation is called with arguments _O_ and _V_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
-          1. Let _current_ be _O_.[[Prototype]].
+          1. Let _current_ be ? _O_.[[GetPrototypeOf]]().
           1. If SameValue(_V_, _current_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>


### PR DESCRIPTION
SetImmutablePrototype is meant for use by a variety of objects beyond the ECMA-262 spec. Some of those objects do not have a [[Prototype]], or have a [[Prototype]] but use custom [[GetPrototypeOf]] logic to act is they don't sometimes. (Respectively: HTML's WindowProxy and Location objects.) As such, SetImmutablePrototype should look up the prototype using [[GetPrototypeOf]] instead of trying to look at the possibly-nonexistant [[Prototype]] slot directly.

Some background:

* https://github.com/w3c/web-platform-tests/pull/5015#issuecomment-284802893
* https://github.com/whatwg/html/pull/2400

/cc @annevk @littledan.

This should have no normative impact on ECMA262 since Object's [[GetPrototypeOf]\]() just returns [[Prototype]]. It makes https://github.com/whatwg/html/pull/2400 work correctly though. There are tests for the web platform parts of this in https://github.com/w3c/web-platform-tests/pull/5015.