### PR TITLE
Use already computed byteLength instead of getting [[ByteLength]] slot

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32527,11 +32527,10 @@ THH:mm:ss.sss
           1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
           1. If SameValue(_elementType_, _srcType_) is *true*, then
-            1. Let _srcByteLength_ be _srcArray_.[[ByteLength]].
             1. If IsSharedArrayBuffer(_srcData_) is *false*, then
-              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _srcByteLength_).
+              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_).
             1. Else,
-              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _srcByteLength_, %ArrayBuffer%).
+              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, %ArrayBuffer%).
           1. Else,
             1. If IsSharedArrayBuffer(_srcData_) is *false*, then
               1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).


### PR DESCRIPTION
_srcByteLength_ is the same value as _byteLength_, so we can use the latter instead of getting [[ByteLength]] from the input typed array.