### PR TITLE
Call SpeciesConstructor in TypedArray constructor to reduce indirections

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33303,16 +33303,14 @@ THH:mm:ss.sss
           1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
           1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
-          1. If SameValue(_elementType_, _srcType_) is *true*, then
-            1. If IsSharedArrayBuffer(_srcData_) is *false*, then
-              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_).
-            1. Else,
-              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, %ArrayBuffer%).
+          1. If IsSharedArrayBuffer(_srcData_) is *false*, then
+            1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
           1. Else,
-            1. If IsSharedArrayBuffer(_srcData_) is *false*, then
-              1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
-            1. Else,
-              1. Let _bufferConstructor_ be %ArrayBuffer%.
+            1. Let _bufferConstructor_ be %ArrayBuffer%.
+          1. If SameValue(_elementType_, _srcType_) is *true*, then
+            1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
+            1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).
+          1. Else,
             1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
             1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
             1. Let _srcByteIndex_ be _srcByteOffset_.
@@ -34559,17 +34557,14 @@ THH:mm:ss.sss
 
       <!-- es6num="24.1.1.4" -->
       <emu-clause id="sec-clonearraybuffer" aoid="CloneArrayBuffer">
-        <h1>CloneArrayBuffer ( _srcBuffer_, _srcByteOffset_, _srcLength_ [ , _cloneConstructor_ ] )</h1>
-        <p>The abstract operation CloneArrayBuffer takes four parameters, an ArrayBuffer _srcBuffer_, an integer offset _srcByteOffset_, an integer length _srcLength_, and optionally a constructor function _cloneConstructor_. It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. This operation performs the following steps:</p>
+        <h1>CloneArrayBuffer ( _srcBuffer_, _srcByteOffset_, _srcLength_, _cloneConstructor_ )</h1>
+        <p>The abstract operation CloneArrayBuffer takes four parameters, an ArrayBuffer _srcBuffer_, an integer offset _srcByteOffset_, an integer length _srcLength_, and a constructor function _cloneConstructor_. It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. This operation performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_srcBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
-          1. If _cloneConstructor_ is not present, then
-            1. Set _cloneConstructor_ to ? SpeciesConstructor(_srcBuffer_, %ArrayBuffer%).
-            1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-          1. Else, Assert: IsConstructor(_cloneConstructor_) is *true*.
-          1. Let _srcBlock_ be _srcBuffer_.[[ArrayBufferData]].
+          1. Assert: IsConstructor(_cloneConstructor_) is *true*.
           1. Let _targetBuffer_ be ? AllocateArrayBuffer(_cloneConstructor_, _srcLength_).
           1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
+          1. Let _srcBlock_ be _srcBuffer_.[[ArrayBufferData]].
           1. Let _targetBlock_ be _targetBuffer_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _srcLength_).
           1. Return _targetBuffer_.


### PR DESCRIPTION
This allows us to remove the code path in CloneArrayBuffer when the _cloneConstructor_ argument is absent and simplifies the TypedArray constructor algorithm a bit. 
I didn't remove the extra `IsDetachedBuffer(_srcData_)` step for the same element case to avoid introducing a semantic change, but I think we should either remove this extra check or apply it for both cases. 