### PR TITLE
Editorial: clarify parsing semantics for `await` tokens

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9678,7 +9678,7 @@
             `break` `do` `in` `typeof` `case` `else` `instanceof` `var` `catch` `export` `new` `void` `class` `extends` `return` `while` `const` `finally` `super` `with` `continue` `for` `switch` `yield` `debugger` `function` `this` `default` `if` `throw` `delete` `import` `try` `await`
         </emu-grammar>
         <emu-note>
-          <p>In some contexts `yield` is given the semantics of an |Identifier|. See <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>. In strict mode code, `let` and `static` are treated as reserved words through static semantic restrictions (see <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-let-and-const-declarations-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-early-errors"></emu-xref>, and <emu-xref href="#sec-class-definitions-static-semantics-early-errors"></emu-xref>) rather than the lexical grammar.</p>
+          <p>In some contexts `yield` and `await` are given the semantics of an |Identifier|. See <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>. In strict mode code, `let` and `static` are treated as reserved words through static semantic restrictions (see <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-let-and-const-declarations-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-early-errors"></emu-xref>, and <emu-xref href="#sec-class-definitions-static-semantics-early-errors"></emu-xref>) rather than the lexical grammar.</p>
         </emu-note>
       </emu-clause>
 


### PR DESCRIPTION
This clarifies that `await` can sometimes be given the semantics of an identifier rather than unconditionally being parsed as a keyword.

Edit: I just noticed https://github.com/tc39/ecma262/pull/818, which also addresses this.