### PR TITLE
Normative: Specify Date string conversion functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27149,7 +27149,10 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
-            1. Return String value formed by concatenating ToString(HourFromTime(_tv_)), `":"`, ToString(MinFromTime(_tv_)), `":"`, ToString(SecFromTime(_tv_)) and `" GMT"`
+            1. Let _hour_ be be the String representation of HourFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. Let _minute_ be be the String representation of MinFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. Let _second_ be be the String representation of SecFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. Return String value formed by concatenating _hour_, `":"`, _minute_, `":"`, _second_, and `" GMT"`
           </emu-alg>
         </emu-clause>
 
@@ -27162,7 +27165,9 @@ THH:mm:ss.sss
             1. If _weekdaySeparator_ is not provided, let _weekdaySeparator_ be `" "`.
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
-            1. Let _result_ be the String value formed by concatenating _weekday_, _weekdaySeparator_, _month_, `" "`, ToString(DateFromTime(_tv_)), `" "`, and ToString(YearFromTime(_tv_)).
+            1. Let _day_ be be the String representation of DateFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. Let _year_ be be the String representation of YearFromTime(_tv_), formatted as a number of at least four digits, padded to the left with zeroes if necessary.
+            1. Let _result_ be the String value formed by concatenating _weekday_, _weekdaySeparator_, _month_, `" "`, _day_, `" "`, and _year_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
             <table>
@@ -27354,7 +27359,7 @@ THH:mm:ss.sss
             1. Assert: _tv_ is not *NaN*.
             1. Let _offset_ be LocalTZA + DaylightSavingTA(_tv_)
             1. If _offset_ &ge; 0, let _offsetSign_ be `"+"`; otherwise, let _offsetSign_ be `"-"`.
-            1. Let _offsetMin_  be the String representation of MinFromTime(abs(_offset_)), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. Let _offsetMin_ be the String representation of MinFromTime(abs(_offset_)), formatted as a two-digit number, padded to the left with a zero if necessary.
             1. Let _offsetHour_ be the String representation of HourFromTime(abs(_offset_)), formatted as a two-digit number, padded to the left with a zero if necessary.
             1. If _offset_ &ge; 0, let _offsetSign_ be `"+"`; otherwise, let _offsetSign_ be `"-"`.
             1. Let _tzName_ be an implementation-defined string, either `""` or a string of the form `" ("` _name_ `")"` where _name_ is an implementation-defined timezone name.

--- a/spec.html
+++ b/spec.html
@@ -27157,17 +27157,16 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-datestring" aoid="DateString">
-          <h1>Runtime Semantics: DateString( _tv_, _weekdaySeparator_ )</h1>
+          <h1>Runtime Semantics: DateString( _tv_ )</h1>
           <p>The following steps are performed:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
-            1. If _weekdaySeparator_ is not provided, let _weekdaySeparator_ be `" "`.
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
             1. Let _day_ be be the String representation of DateFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
             1. Let _year_ be be the String representation of YearFromTime(_tv_), formatted as a number of at least four digits, padded to the left with zeroes if necessary.
-            1. Let _result_ be the String value formed by concatenating _weekday_, _weekdaySeparator_, _month_, `" "`, _day_, `" "`, and _year_.
+            1. Return the String value formed by concatenating _weekday_, `" "`, _month_, `" "`, _day_, `" "`, and _year_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
             <table>
@@ -27399,7 +27398,11 @@ THH:mm:ss.sss
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
           1. If _tv_ is *NaN*, return `"Invalid Date"`.
-          1. Return the String value formed by concatenating DateString(_tv_, `", "`), `" "`, and TimeString(_tv_).
+          1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
+          1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
+          1. Let _day_ be be the String representation of DateFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
+          1. Let _year_ be be the String representation of YearFromTime(_tv_), formatted as a number of at least four digits, padded to the left with zeroes if necessary.
+          1. Return the String value formed by concatenating _weekday_, `", "`, _month_, `" "`, _day_, `" "`, _year_, `" "`, and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -27154,14 +27154,15 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-datestring" aoid="DateString">
-          <h1>Runtime Semantics: DateString( _tv_, _zone_, _components_ )</h1>
+          <h1>Runtime Semantics: DateString( _tv_, _weekdaySeparator_ )</h1>
           <p>The following steps are performed:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
-            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_t_).
-            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_t_).
-            1. Let _result_ be the String value formed by concatenating _weekday_, `" "`, _month_, `" "`, ToString(DateFromTime(_t_)), `" "`, and ToString(YearFromTime(_t_)).
+            1. If _weekdaySeparator_ is not provided, let _weekdaySeparator_ be `" "`.
+            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
+            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
+            1. Let _result_ be the String value formed by concatenating _weekday_, _weekdaySeparator_, _month_, `" "`, ToString(DateFromTime(_tv_)), `" "`, and ToString(YearFromTime(_tv_)).
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
             <table>
@@ -27393,7 +27394,7 @@ THH:mm:ss.sss
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
           1. If _tv_ is *NaN*, return `"Invalid Date"`.
-          1. Return the String value formed by concatenating DateString(_tv_), `" "`, and TimeString(_tv_).
+          1. Return the String value formed by concatenating DateString(_tv_, `", "`), `" "`, and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -27149,7 +27149,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
-            1. Return String value formed by concatenating _result_, ToString(HourFromTime(_tv_)), `":"`, ToString(MinFromTime(_tv_)), `":"`, ToString(SecFromTime(_tv_)) and `" GMT"`
+            1. Return String value formed by concatenating ToString(HourFromTime(_tv_)), `":"`, ToString(MinFromTime(_tv_)), `":"`, ToString(SecFromTime(_tv_)) and `" GMT"`
           </emu-alg>
         </emu-clause>
 
@@ -27356,7 +27356,7 @@ THH:mm:ss.sss
             1. If _offset_ &ge; 0, let _offsetSign_ be `"+"`; otherwise, let _offsetSign_ be `"-"`.
             1. Let _offsetString_ be abs(_offset_) formatted as a four-digit number, padded to the left with zeros if necessary.
             1. Let _tzName_ be an implementation-defined string, either `""` or a string of the form `" ("` _name_ `")"` where _name_ is an implementation-defined timezone name.
-            1. Return the String value formed by concatenating _result_, _offsetSign_, _offsetString_, and _tzName_.
+            1. Return the String value formed by concatenating _offsetSign_, _offsetString_, and _tzName_.
           </emu-alg>
         </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -27351,12 +27351,13 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
-            1. Let _offset_ be (LocalTZA + DaylightSavingTA(_tv_)) / msPerSecond.
-            1. Assert: _offset_ is an integer, and -100000 &lt; _offset_ &lt; 100000.
+            1. Let _offset_ be LocalTZA + DaylightSavingTA(_tv_)
             1. If _offset_ &ge; 0, let _offsetSign_ be `"+"`; otherwise, let _offsetSign_ be `"-"`.
-            1. Let _offsetString_ be abs(_offset_) formatted as a four-digit number, padded to the left with zeros if necessary.
+            1. Let _offsetMin_  be the String representation of MinFromTime(abs(_offset_)), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. Let _offsetHour_ be the String representation of HourFromTime(abs(_offset_)), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. If _offset_ &ge; 0, let _offsetSign_ be `"+"`; otherwise, let _offsetSign_ be `"-"`.
             1. Let _tzName_ be an implementation-defined string, either `""` or a string of the form `" ("` _name_ `")"` where _name_ is an implementation-defined timezone name.
-            1. Return the String value formed by concatenating _offsetSign_, _offsetString_, and _tzName_.
+            1. Return the concatenation of _offsetSign_,  _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>
         </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -27368,7 +27368,7 @@ THH:mm:ss.sss
             1. Assert: Type(_tv_) is Number.
             1. If _tv_ is *NaN*, return `"Invalid Date"`.
             1. Let _t_ be LocalTime(_tv_).
-            1. Return the String value formed by concatenating DateString(_t_), `" "`, and TimeString(_t_), TimeZoneString(_tv_).
+            1. Return the String value formed by concatenating DateString(_t_), `" "`, TimeString(_t_), and TimeZoneString(_tv_).
           </emu-alg>
         </emu-clause>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -27066,7 +27066,13 @@ THH:mm:ss.sss
       <!-- es6num="20.3.4.35" -->
       <emu-clause id="sec-date.prototype.todatestring">
         <h1>Date.prototype.toDateString ( )</h1>
-        <p>This function returns a String value. The contents of the String are implementation-dependent, but are intended to represent the &ldquo;date&rdquo; portion of the Date in the current time zone in a convenient, human-readable form.</p>
+        <emu-alg>
+          1. Let _O_ be this Date object.
+          1. Let _tv_ be ? thisTimeValue(_O_).
+          1. If _tv_ is *NaN*, return `"Invalid Date"`.
+          1. Let _t_ be LocalTime(_tv_).
+          1. Return DateString(_t_).
+        </emu-alg>
       </emu-clause>
 
       <!-- es6num="20.3.4.36" -->
@@ -27137,6 +27143,223 @@ THH:mm:ss.sss
           <p>The `toString` function is intentionally generic; it does not require that its *this* value be a Date object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
+        <emu-clause id="sec-timestring" aoid="TimeString">
+          <h1>Runtime Semantics: TimeString( _tv_ )</h1>
+          <p>The following steps are performed:</p>
+          <emu-alg>
+            1. Assert: Type(_tv_) is Number.
+            1. Assert: _tv_ is not *NaN*.
+            1. Return String value formed by concatenating _result_, ToString(HourFromTime(_tv_)), `":"`, ToString(MinFromTime(_tv_)), `":"`, ToString(SecFromTime(_tv_)) and `" GMT"`
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-datestring" aoid="DateString">
+          <h1>Runtime Semantics: DateString( _tv_, _zone_, _components_ )</h1>
+          <p>The following steps are performed:</p>
+          <emu-alg>
+            1. Assert: Type(_tv_) is Number.
+            1. Assert: _tv_ is not *NaN*.
+            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_t_).
+            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_t_).
+            1. Let _result_ be the String value formed by concatenating _weekday_, `" "`, _month_, `" "`, ToString(DateFromTime(_t_)), `" "`, and ToString(YearFromTime(_t_)).
+          </emu-alg>
+          <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
+            <table>
+              <tbody>
+              <tr>
+                <th>
+                  Number
+                </th>
+                <th>
+                  Name
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  0
+                </td>
+                <td>
+                  `"Sun"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  1
+                </td>
+                <td>
+                  `"Mon"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  2
+                </td>
+                <td>
+                  `"Tue"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  3
+                </td>
+                <td>
+                  `"Wed"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  4
+                </td>
+                <td>
+                  `"Thu"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  5
+                </td>
+                <td>
+                  `"Fri"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  6
+                </td>
+                <td>
+                  `"Sat"`
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </emu-table>
+          <emu-table id="sec-todatestring-month-names" caption="Names of months of the year">
+            <table>
+              <tbody>
+              <tr>
+                <th>
+                  Number
+                </th>
+                <th>
+                  Name
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  0
+                </td>
+                <td>
+                  `"Jan"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  1
+                </td>
+                <td>
+                  `"Feb"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  2
+                </td>
+                <td>
+                  `"Mar"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  3
+                </td>
+                <td>
+                  `"Apr"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  4
+                </td>
+                <td>
+                  `"May"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  5
+                </td>
+                <td>
+                  `"Jun"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  6
+                </td>
+                <td>
+                  `"Jul"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  7
+                </td>
+                <td>
+                  `"Aug"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  8
+                </td>
+                <td>
+                  `"Sep"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  9
+                </td>
+                <td>
+                  `"Oct"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  10
+                </td>
+                <td>
+                  `"Nov"`
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  11
+                </td>
+                <td>
+                  `"Dec"`
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </emu-table>
+        </emu-clause>
+
+        <emu-clause id="sec-timezoneestring" aoid="TimeZoneString">
+          <h1>Runtime Semantics: TimeZoneString( _tv_, )</h1>
+          <p>The following steps are performed:</p>
+          <emu-alg>
+            1. Assert: Type(_tv_) is Number.
+            1. Assert: _tv_ is not *NaN*.
+            1. Let _offset_ be (LocalTZA + DaylightSavingTA(_tv_)) / msPerSecond.
+            1. Assert: _offset_ is an integer, and -100000 &lt; _offset_ &lt; 100000.
+            1. If _offset_ &ge; 0, let _offsetSign_ be `"+"`; otherwise, let _offsetSign_ be `"-"`.
+            1. Let _offsetString_ be abs(_offset_) formatted as a four-digit number, padded to the left with zeros if necessary.
+            1. Let _tzName_ be an implementation-defined string, either `""` or a string of the form `" ("` _name_ `")"` where _name_ is an implementation-defined timezone name.
+            1. Return the String value formed by concatenating _result_, _offsetSign_, _offsetString_, and _tzName_.
+          </emu-alg>
+        </emu-clause>
+
         <!-- es6num="20.3.4.41.1" -->
         <emu-clause id="sec-todatestring" aoid="ToDateString">
           <h1>Runtime Semantics: ToDateString( _tv_ )</h1>
@@ -27144,7 +27367,8 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. If _tv_ is *NaN*, return `"Invalid Date"`.
-            1. Return an implementation-dependent String value that represents _tv_ as a date and time in the current time zone using a convenient, human-readable form.
+            1. Let _t_ be LocalTime(_tv_).
+            1. Return the String value formed by concatenating DateString(_t_), `" "`, and TimeString(_t_), TimeZoneString(_tv_).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -27152,16 +27376,24 @@ THH:mm:ss.sss
       <!-- es6num="20.3.4.42" -->
       <emu-clause id="sec-date.prototype.totimestring">
         <h1>Date.prototype.toTimeString ( )</h1>
-        <p>This function returns a String value. The contents of the String are implementation-dependent, but are intended to represent the &ldquo;time&rdquo; portion of the Date in the current time zone in a convenient, human-readable form.</p>
+        <emu-alg>
+          1. Let _O_ be this Date object.
+          1. Let _tv_ be ? thisTimeValue(_O_).
+          1. If _tv_ is *NaN*, return `"Invalid Date"`.
+          1. Let _t_ be LocalTime(_tv_).
+          1. Return the String value formed by concatenating TimeString(_t_) and TimeZoneString(_tv_).
+        </emu-alg>
       </emu-clause>
 
       <!-- es6num="20.3.4.43" -->
       <emu-clause id="sec-date.prototype.toutcstring">
         <h1>Date.prototype.toUTCString ( )</h1>
-        <p>This function returns a String value. The contents of the String are implementation-dependent, but are intended to represent this time value in a convenient, human-readable form in UTC.</p>
-        <emu-note>
-          <p>The intent is to produce a String representation of a date that is more readable than the format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref>. It is not essential that the chosen format be unambiguous or easily machine parsable. If an implementation does not have a preferred human-readable format it is recommended to use the format defined in <emu-xref href="#sec-date-time-string-format"></emu-xref> but with a space rather than a `"T"` used to separate the date and time elements.</p>
-        </emu-note>
+        <emu-alg>
+          1. Let _O_ be this Date object.
+          1. Let _tv_ be ? thisTimeValue(_O_).
+          1. If _tv_ is *NaN*, return `"Invalid Date"`.
+          1. Return the String value formed by concatenating DateString(_tv_), `" "`, and TimeString(_tv_).
+        </emu-alg>
       </emu-clause>
 
       <!-- es6num="20.3.4.44" -->


### PR DESCRIPTION
Implementations seem to agree on semantics here for the most
part, modulo timezone strings, which are left implementation-defined.

Addresses part of #845