### PR TITLE
Normative: Date.prototype.toString throws on non-Date receiver

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27195,11 +27195,7 @@ THH:mm:ss.sss
         <h1>Date.prototype.toString ( )</h1>
         <p>The following steps are performed:</p>
         <emu-alg>
-          1. Let _O_ be this Date object.
-          1. If _O_ does not have a [[DateValue]] internal slot, then
-            1. Let _tv_ be *NaN*.
-          1. Else,
-            1. Let _tv_ be thisTimeValue(_O_).
+          1. Let _tv_ be ? thisTimeValue(*this* value).
           1. Return ToDateString(_tv_).
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
JSC and V8 have been shipping the version of the specification
included in this patch, so it is likely to be web-compatible.
Throwing on receivers which are not Date instances is simpler
and more consistent with other methods in ECMAScript.

Closes #849