### PR TITLE
Normative: Swap side effect and check in TypedArray constructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32606,6 +32606,8 @@ THH:mm:ss.sss
           1. Let _elementSize_ be the Number value of the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
+          1. If _length_ is present and _length_ is not *undefined*, then
+            1. Let _newLength_ be ? ToIndex(_length_).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
           1. If _length_ is either not present or *undefined*, then
@@ -32613,7 +32615,6 @@ THH:mm:ss.sss
             1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
             1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
           1. Else,
-            1. Let _newLength_ be ? ToIndex(_length_).
             1. Let _newByteLength_ be _newLength_ &times; _elementSize_.
             1. If _offset_+_newByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
           1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.


### PR DESCRIPTION
Previously, in one of the TypedArray constructor paths, an ArrayBuffer
was checked for being detached, and then a ToIndex calculation is done.
Because ToIndex may detach the ArrayBuffer itself, this patch moves
the detached check to afterwards, so that it can include that possible
time when the ArrayBuffer may be detached.

Closes #842