### PR TITLE
Normative: Specify String.prototype.replace edge case

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27849,7 +27849,7 @@ THH:mm:ss.sss
                   `n` is one of `1 2 3 4 5 6 7 8 9` and `$n` is not followed by a decimal digit
                 </td>
                 <td>
-                  The _n_<sup>th</sup> element of _captures_, where _n_ is a single digit in the range 1 to 9. If _n_&le;_m_ and the _n_<sup>th</sup> element of _captures_ is *undefined*, or if _n_&gt;_m_, use the empty String instead. If _n_&gt;_m_, no replacement is done.
+                  The _n_<sup>th</sup> element of _captures_, where _n_ is a single digit in the range 1 to 9. If _n_&le;_m_ and the _n_<sup>th</sup> element of _captures_ is *undefined*, use the empty String instead. If _n_&gt;_m_, no replacement is done.
                 </td>
               </tr>
               <tr>

--- a/spec.html
+++ b/spec.html
@@ -27849,7 +27849,7 @@ THH:mm:ss.sss
                   `n` is one of `1 2 3 4 5 6 7 8 9` and `$n` is not followed by a decimal digit
                 </td>
                 <td>
-                  The _n_<sup>th</sup> element of _captures_, where _n_ is a single digit in the range 1 to 9. If _n_&le;_m_ and the _n_<sup>th</sup> element of _captures_ is *undefined*, use the empty String instead. If _n_&gt;_m_, the result is implementation-defined.
+                  The _n_<sup>th</sup> element of _captures_, where _n_ is a single digit in the range 1 to 9. If _n_&le;_m_ and the _n_<sup>th</sup> element of _captures_ is *undefined*, or if _n_&gt;_m_, use the empty String instead. If _n_&gt;_m_, no replacement is done.
                 </td>
               </tr>
               <tr>
@@ -27866,7 +27866,7 @@ THH:mm:ss.sss
                   `n` is one of `0 1 2 3 4 5 6 7 8 9`
                 </td>
                 <td>
-                  The _nn_<sup>th</sup> element of _captures_, where _nn_ is a two-digit decimal number in the range 01 to 99. If _nn_&le;_m_ and the _nn_<sup>th</sup> element of _captures_ is *undefined*, use the empty String instead. If _nn_ is 00 or _nn_&gt;_m_, the result is implementation-defined.
+                  The _nn_<sup>th</sup> element of _captures_, where _nn_ is a two-digit decimal number in the range 01 to 99. If _nn_&le;_m_ and the _nn_<sup>th</sup> element of _captures_ is *undefined*, use the empty String instead. If _nn_ is 00 or _nn_&gt;_m_, no replacement is done.
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
In RegExp.prototype[Symbol.replace] as applied to RegExps, if a
substitution string is used with a numerical group reference which
is out of bounds, the behavior was previously implementation-defined.
This patch changes the behavior to not do a replacement.
Testing with eshost showed that V8, SpiderMonkey, JSC and ChakraCore
all agree on these semantics.