### PR TITLE
Normative: Remove implementation-defined behavior for Number methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24979,7 +24979,6 @@
           1. Let _m_ be the concatenation of the four Strings _m_, `"e"`, _c_, and _d_.
           1. Return the concatenation of the Strings _s_ and _m_.
         </emu-alg>
-        <p>If the `toExponential` method is called with more than one argument, then the behaviour is implementation-defined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
         <emu-note>
           <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 10.b.i be used as a guideline:</p>
           <emu-alg type="i">
@@ -25019,7 +25018,6 @@
               1. Let _m_ be the concatenation of the three Strings _a_, `"."`, and _b_.
           1. Return the concatenation of the Strings _s_ and _m_.
         </emu-alg>
-        <p>If the `toFixed` method is called with more than one argument, then the behaviour is implementation-defined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
         <emu-note>
           <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent number values. For example,</p>
           <p>`(1000000000000000128).toString()` returns `"1000000000000000100"`, while
@@ -25077,7 +25075,6 @@
             1. Let _m_ be the String formed by the concatenation of code unit 0x0030 (DIGIT ZERO), code unit 0x002E (FULL STOP), -(_e_+1) occurrences of code unit 0x0030 (DIGIT ZERO), and the String _m_.
           1. Return the String that is the concatenation of _s_ and _m_.
         </emu-alg>
-        <p>If the `toPrecision` method is called with more than one argument, then the behaviour is implementation-defined (see clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>).</p>
       </emu-clause>
 
       <!-- es6num="20.1.3.6" -->


### PR DESCRIPTION
Number.prototype.toFixed, toExponential and toPrecision previously
permitted a second argument, with implementation-defined behavior.
This language dates back to the original specification in ES3.
However, in testing with eshost and looking at the sources of V8,
SpiderMonkey, JSC and ChakraCore, I cannot find a usage of this
second argument.

This patch removes the implementation-defined behavior clause to
simplify spec reading and reduce a potential point of variability
and confusion among new implementations.