### PR TITLE
Normative: Ensure that TypedArray.prototype.fill does one coercion

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31995,8 +31995,27 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.8" -->
       <emu-clause id="sec-%typedarray%.prototype.fill">
         <h1>%TypedArray%.prototype.fill ( _value_ [ , _start_ [ , _end_ ] ] )</h1>
-        <p>%TypedArray%`.prototype.fill` is a distinct function that implements the same algorithm as `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The `fill` method takes up to three arguments _value_, _start_ and _end_.</p>
+        <emu-note>
+          <p>The _start_ and _end_ arguments are optional with default values of 0 and the length of the *this* object. If _start_ is negative, it is treated as <emu-eqn>_length_+_start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_+_end_</emu-eqn>.</p>
+        </emu-note>
+        <p>The following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _value_ be ? ToNumber(_value_).
+          1. Let _len_ be ? _O_.[[ArrayLength]].
+          1. Let _relativeStart_ be ? ToInteger(_start_).
+          1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
+          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
+          1. Repeat, while _k_ &lt; _final_
+            1. Let _Pk_ be ! ToString(_k_).
+            1. Perform ? Set(_O_, _Pk_, _value_, *true*).
+            1. Increase _k_ by 1.
+          1. Return _O_.
+        </emu-alg>
       </emu-clause>
 
       <!-- es6num="22.2.3.9" -->


### PR DESCRIPTION
Previously, TypedArray.prototype.fill failed to coerce its value
argument multiple in the beginning of the definition, instead coercing
it when writing into the TypedArray each time. This patch tweaks
the definition to perform the coercion once.

Fixes #855 