### PR TITLE
Normative: Define particular precision for toFixed and friends

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24999,7 +24999,7 @@
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToInteger(_fractionDigits_). (If _fractionDigits_ is *undefined*, this step produces the value 0.)
-          1. If _f_ &lt; -20 or _f_ &gt; 100, throw a *RangeError* exception.
+          1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ is *NaN*, return the String `"NaN"`.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then

--- a/spec.html
+++ b/spec.html
@@ -22446,7 +22446,6 @@
       Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may provide additional types, values, objects, properties, and functions beyond those described in this specification. This may cause constructs (such as looking up a variable in the global scope) to have implementation-defined behaviour instead of throwing an error (such as *ReferenceError*).
     </li>
   </ul>
-  <p>An implementation may define behaviour other than throwing *RangeError* for `toFixed`, `toExponential`, and `toPrecision` when the _fractionDigits_ or _precision_ argument is outside the specified range.</p>
 
   <emu-clause id="sec-host-report-errors" aoid="HostReportErrors">
     <h1>HostReportErrors ( _errorList_ )</h1>
@@ -24956,7 +24955,7 @@
             1. Let _x_ be -_x_.
           1. If _x_ = *+&infin;*, then
             1. Return the concatenation of the Strings _s_ and `"Infinity"`.
-          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toExponential` for values of _f_ less than 0 or greater than 20. In this case `toExponential` would not necessarily throw *RangeError* for such values.
+          1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ = 0, then
             1. Let _m_ be the String consisting of _f_+1 occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.
@@ -25000,7 +24999,7 @@
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToInteger(_fractionDigits_). (If _fractionDigits_ is *undefined*, this step produces the value 0.)
-          1. If _f_ &lt; 0 or _f_ &gt; 20, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toFixed` for values of _f_ less than 0 or greater than 20. In this case `toFixed` would not necessarily throw *RangeError* for such values.
+          1. If _f_ &lt; -20 or _f_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ is *NaN*, return the String `"NaN"`.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
@@ -25053,7 +25052,7 @@
             1. Let _x_ be -_x_.
           1. If _x_ = *+&infin;*, then
             1. Return the String that is the concatenation of _s_ and `"Infinity"`.
-          1. If _p_ &lt; 1 or _p_ &gt; 21, throw a *RangeError* exception. However, an implementation is permitted to extend the behaviour of `toPrecision` for values of _p_ less than 1 or greater than 21. In this case `toPrecision` would not necessarily throw *RangeError* for such values.
+          1. If _p_ &lt; 1 or _p_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ = 0, then
             1. Let _m_ be the String consisting of _p_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.


### PR DESCRIPTION
Previously, the specification for Number.prototype.toFixed, Number
gave a fixed range for the fractionDigits parameter, but allowed
implementations to permit a larger range. Historically, only
SpiderMonkey accepted a larger range, and other implementations
threw a RangeError outside the range.

This patch specifies the SpiderMonkey behavior. The range checks
always permitted more decimal digits to be printed than what is
provided by the accuracy, so the limits are arbitrary. Waldemar
Horwat has mentioned that SpiderMonkey's higher limits have
been useful for him in explaining floating point numbers to
others.

An alternative would be to retain the previous limits and remove
the implementation-dependent aspects. Either way, locking down
this detail should help developers get consistent behavior
between implementations.