### PR TITLE
Normative: Relax restrictions on `with` statement

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16660,9 +16660,6 @@
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the code that matches this production is contained in strict mode code.
-        </li>
-        <li>
           It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
         </li>
       </ul>
@@ -39140,9 +39137,6 @@ THH:mm:ss.sss
     </li>
     <li>
       When a `delete` operator occurs within strict mode code, a *TypeError* is thrown if the property to be deleted has the attribute { [[Configurable]]: *false* } (<emu-xref href="#sec-delete-operator-runtime-semantics-evaluation"></emu-xref>).
-    </li>
-    <li>
-      Strict mode code may not include a |WithStatement|. The occurrence of a |WithStatement| in such a context is a *SyntaxError* (<emu-xref href="#sec-with-statement-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
       It is a *SyntaxError* if a |TryStatement| with a |Catch| occurs within strict mode code and the |Identifier| of the |Catch| is `eval` or `arguments` (<emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref>).


### PR DESCRIPTION
@bterlson This is normative, but I don't think it's significant enough to warrant the "needs consensus" label. Probably you can just merge it immediately.

See also the requisite update for Test262: https://github.com/tc39/test262/pull/943

Commit message:

> Recent industry trends have shown an increased interest in the use of
> the `with` statement as a means for more concise code. Because class
> bodies and module code are always strict mode code, this restriction
> severely limits usage of this statement.
>
> Remove the strict mode restriction so that the `with` statement may be
> leveraged in more contexts.