### PR TITLE
Normative: Specify RegExp malformed character class behavior

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38581,7 +38581,6 @@ THH:mm:ss.sss
           [~U] `c` ClassControlLetter
           CharacterClassEscape
           CharacterEscape[?U]
-          [~U] `c`
 
         ClassControlLetter ::
           DecimalDigit
@@ -38663,12 +38662,6 @@ THH:mm:ss.sss
           1. Let _j_ be the remainder of dividing _i_ by 32.
           1. Let _d_ be the character whose character value is _j_.
           1. Return the CharSet containing the single character _d_.
-        </emu-alg>
-
-        <p>ClassEscape (<emu-xref href="#sec-classescape"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>ClassEscape :: `c`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the CharSet containing the characters `\` and `c`.
         </emu-alg>
 
         <emu-annex id="sec-runtime-semantics-characterrangeorunion-abstract-operation" aoid="CharacterRangeOrUnion">

--- a/spec.html
+++ b/spec.html
@@ -38585,6 +38585,11 @@ THH:mm:ss.sss
         ClassControlLetter ::
           DecimalDigit
           `_`
+
+        ClassAtomNoDash[U] ::
+          SourceCharacter but not one of `\` or `]` or `-`
+          `\` ClassEscape[?U]
+          `\`
       </emu-grammar>
       <emu-note>
         <p>When the same left hand sides occurs with both [+U] and [\~U] guards it is to control the disambiguation priority.</p>
@@ -38663,6 +38668,14 @@ THH:mm:ss.sss
           1. Let _d_ be the character whose character value is _j_.
           1. Return the CharSet containing the single character _d_.
         </emu-alg>
+
+        <p>ClassAtomNoDash (<emu-xref href="#sec-classatomnodash"></emu-xref>) includes the following additional evaluation rule:</p>
+        <p>The production <emu-grammar>ClassAtomNoDash :: `\`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing the single character `\`.
+        </emu-alg>
+
+        <emu-note>This production can only be reached from the sequence `\c` within a character class where it is not followed by an acceptable control character.</emu-note>
 
         <emu-annex id="sec-runtime-semantics-characterrangeorunion-abstract-operation" aoid="CharacterRangeOrUnion">
           <h1>Runtime Semantics: CharacterRangeOrUnion ( _A_, _B_ )</h1>

--- a/spec.html
+++ b/spec.html
@@ -38581,6 +38581,7 @@ THH:mm:ss.sss
           [~U] `c` ClassControlLetter
           CharacterClassEscape
           CharacterEscape[?U]
+          [~U] `c`
 
         ClassControlLetter ::
           DecimalDigit
@@ -38662,6 +38663,12 @@ THH:mm:ss.sss
           1. Let _j_ be the remainder of dividing _i_ by 32.
           1. Let _d_ be the character whose character value is _j_.
           1. Return the CharSet containing the single character _d_.
+        </emu-alg>
+
+        <p>ClassEscape (<emu-xref href="#sec-classescape"></emu-xref>) includes the following additional evaluation rule:</p>
+        <p>The production <emu-grammar>ClassEscape :: `c`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing the characters `\` and `c`.
         </emu-alg>
 
         <emu-annex id="sec-runtime-semantics-characterrangeorunion-abstract-operation" aoid="CharacterRangeOrUnion">

--- a/spec.html
+++ b/spec.html
@@ -38589,7 +38589,7 @@ THH:mm:ss.sss
         ClassAtomNoDash[U] ::
           SourceCharacter but not one of `\` or `]` or `-`
           `\` ClassEscape[?U]
-          `\`
+          `\` [lookahead == `c`]
       </emu-grammar>
       <emu-note>
         <p>When the same left hand sides occurs with both [+U] and [\~U] guards it is to control the disambiguation priority.</p>
@@ -38670,7 +38670,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>ClassAtomNoDash (<emu-xref href="#sec-classatomnodash"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>ClassAtomNoDash :: `\`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassAtomNoDash :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character `\`.
         </emu-alg>


### PR DESCRIPTION
This patch specifies a previously unspecified piece of RegExp
syntax and semantics: If a character class has a control escape
(\c) which is not followed by an extended control character
[a-ZA-Z0-9_], then four engines will accept it as syntactically
valid. V8, JSC and SpiderMonkey will treat it as the character
class [\\c]; ChakraCore's behavior differs and depends on what
follows.

This patch codifies the majority behavior within the Annex B
RegExp extensions. This change is consistent with malformed \c
behavior when it takes place outside of a character class: It
behaves like \\c, rather than an identity escape.

Closes #863

Thanks @schuay for raising this issue and @anba for already specifying all the other surrounding cases I came across.