### PR TITLE
ES2017 review third round

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5583,7 +5583,7 @@
             1. Return NormalCompletion(~empty~).
           </emu-alg>
           <emu-note>
-            <p>Global function declarations are always represented as own properties of the global object. If possible, an existing own property is reconfigured to have a standard set of attribute values. Steps 10-12 are equivalent to what calling the InitializeBinding concrete method would do and if _globalObject_ is a Proxy will produce the same sequence of Proxy trap calls.</p>
+            <p>Global function declarations are always represented as own properties of the global object. If possible, an existing own property is reconfigured to have a standard set of attribute values. Steps 8-9 are equivalent to what calling the InitializeBinding concrete method would do and if _globalObject_ is a Proxy will produce the same sequence of Proxy trap calls.</p>
           </emu-note>
         </emu-clause>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -4472,12 +4472,12 @@
           1. If Type(_key_) is String, then
             1. Let _desc_ be ? _O_.[[GetOwnProperty]](_key_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
-              1. If _kind_ is *"key"*, append _key_ to _properties_.
+              1. If _kind_ is `"key"`, append _key_ to _properties_.
               1. Else,
                 1. Let _value_ be ? Get(_O_, _key_).
-                1. If _kind_ is *"value"*, append _value_ to _properties_.
+                1. If _kind_ is `"value"`, append _value_ to _properties_.
                 1. Else,
-                  1. Assert: _kind_ is *"key+value"*.
+                  1. Assert: _kind_ is `"key+value"`.
                   1. Let _entry_ be CreateArrayFromList(&laquo; _key_, _value_ &raquo;).
                   1. Append _entry_ to _properties_.
         1. Order the elements of _properties_ so they are in the same relative order as would be produced by the Iterator that would be returned if the EnumerateObjectProperties internal method were invoked with _O_.
@@ -23606,7 +23606,7 @@
         <p>When the `entries` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, *"key+value"*).
+          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, `"key+value"`).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -23738,7 +23738,7 @@
         <p>When the `keys` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, *"key"*).
+          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, `"key"`).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -23793,7 +23793,7 @@
         <p>When the `values` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, *"value"*).
+          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, `"value"`).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -27352,7 +27352,7 @@ THH:mm:ss.sss
     <!-- es6num="21.1.3" -->
     <emu-clause id="sec-properties-of-the-string-prototype-object">
       <h1>Properties of the String Prototype Object</h1>
-      <p>The String prototype object is the intrinsic object <dfn>%StringPrototype%</dfn>. The String prototype object is a String exotic object and has the internal methods specified for such objects. It has a [[StringData]] internal slot with the value *""*. It has a `length` property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      <p>The String prototype object is the intrinsic object <dfn>%StringPrototype%</dfn>. The String prototype object is a String exotic object and has the internal methods specified for such objects. It has a [[StringData]] internal slot with the value `""`. It has a `length` property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       <p>The value of the [[Prototype]] internal slot of the String prototype object is the intrinsic object %ObjectPrototype%.</p>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
       <p>The abstract operation <dfn id="sec-thisstringvalue" aoid="thisStringValue">thisStringValue</dfn>(_value_) performs the following steps:</p>
@@ -27643,7 +27643,7 @@ THH:mm:ss.sss
           <p>The first argument _maxLength_ will be clamped such that it can be no smaller than the length of the *this* value.</p>
         </emu-note>
         <emu-note>
-          <p>The optional second argument _fillString_ defaults to *" "* (a String consisting of 0x0020 SPACE).</p>
+          <p>The optional second argument _fillString_ defaults to `" "` (a String consisting of 0x0020 SPACE).</p>
         </emu-note>
       </emu-clause>
 
@@ -27667,7 +27667,7 @@ THH:mm:ss.sss
           <p>The first argument _maxLength_ will be clamped such that it can be no smaller than the length of the *this* value.</p>
         </emu-note>
         <emu-note>
-          <p>The optional second argument _fillString_ defaults to *" "* (a String consisting of 0x0020 SPACE).</p>
+          <p>The optional second argument _fillString_ defaults to `" "` (a String consisting of 0x0020 SPACE).</p>
         </emu-note>
       </emu-clause>
 
@@ -34988,7 +34988,7 @@ THH:mm:ss.sss
                   1. NOTE: This algorithm intentionally does not throw an exception if CreateDataProperty returns *false*.
                 1. Add 1 to _I_.
             1. Else,
-              1. Let _keys_ be ? EnumerableOwnProperties(_val_, *"key"*).
+              1. Let _keys_ be ? EnumerableOwnProperties(_val_, `"key"`).
               1. For each String _P_ in _keys_, do
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_).
                 1. If _newElement_ is *undefined*, then
@@ -35205,7 +35205,7 @@ THH:mm:ss.sss
           1. If _PropertyList_ is not *undefined*, then
             1. Let _K_ be _PropertyList_.
           1. Else,
-            1. Let _K_ be ? EnumerableOwnProperties(_value_, *"key"*).
+            1. Let _K_ be ? EnumerableOwnProperties(_value_, `"key"`).
           1. Let _partial_ be a new empty List.
           1. For each element _P_ of _K_, do
             1. Let _strP_ be ? SerializeJSONProperty(_P_, _value_).
@@ -36555,7 +36555,7 @@ THH:mm:ss.sss
 
       <p>The value of the [[Extensible]] internal slot of the AsyncFunction constructor is *true*.</p>
 
-      <p>The value of the *name* property of the AsyncFunction is "AsyncFunction".</p>
+      <p>The value of the *name* property of the AsyncFunction is `"AsyncFunction"`.</p>
 
       <p>The AsyncFunction constructor has the following properties:</p>
 

--- a/spec.html
+++ b/spec.html
@@ -17820,7 +17820,7 @@
           If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.
+          If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
         </li>
         <li>
           It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -18780,7 +18780,7 @@
           If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.
+          If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
         </li>
         <li>
           It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -19498,7 +19498,7 @@
         <li>It is a Syntax Error if ContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
         <li>If the source code matching this production is strict code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If the source code matching this production is strict code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.</li>
+        <li>If the source code matching this production is strict code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperProperty| is *true*.</li>
@@ -39163,7 +39163,7 @@ THH:mm:ss.sss
       Assignment to an undeclared identifier or otherwise unresolvable reference does not create a property in the global object. When a simple assignment occurs within strict mode code, its |LeftHandSideExpression| must not evaluate to an unresolvable Reference. If it does a *ReferenceError* exception is thrown (<emu-xref href="#sec-putvalue"></emu-xref>). The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value {[[Writable]]: *false*}, to an accessor property with the attribute value {[[Set]]: *undefined*}, nor to a non-existent property of an object whose [[Extensible]] internal slot has the value *false*. In these cases a `TypeError` exception is thrown (<emu-xref href="#sec-assignment-operators"></emu-xref>).
     </li>
     <li>
-      The identifier `eval` or `arguments` may not appear as the |LeftHandSideExpression| of an Assignment operator (<emu-xref href="#sec-assignment-operators"></emu-xref>) or of a |UpdateExpression| (<emu-xref href="#sec-update-expressions"></emu-xref>) or as the |UnaryExpression| operated upon by a Prefix Increment (<emu-xref href="#sec-prefix-increment-operator"></emu-xref>) or a Prefix Decrement (<emu-xref href="#sec-prefix-decrement-operator"></emu-xref>) operator.
+      An |IdentifierReference| with the StringValue `"eval"` or `"arguments"` may not appear as the |LeftHandSideExpression| of an Assignment operator (<emu-xref href="#sec-assignment-operators"></emu-xref>) or of an |UpdateExpression| (<emu-xref href="#sec-update-expressions"></emu-xref>) or as the |UnaryExpression| operated upon by a Prefix Increment (<emu-xref href="#sec-prefix-increment-operator"></emu-xref>) or a Prefix Decrement (<emu-xref href="#sec-prefix-decrement-operator"></emu-xref>) operator.
     </li>
     <li>
       Arguments objects for strict functions define a non-configurable accessor property `"callee"` which throws a *TypeError* exception on access (<emu-xref href="#sec-createunmappedargumentsobject"></emu-xref>).
@@ -39175,7 +39175,7 @@ THH:mm:ss.sss
       For strict functions, if an arguments object is created the binding of the local identifier `arguments` to the arguments object is immutable and hence may not be the target of an assignment expression. (<emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>).
     </li>
     <li>
-      It is a *SyntaxError* if the |IdentifierName| `eval` or the |IdentifierName| `arguments` occurs as a |BindingIdentifier| within strict mode code (<emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>).
+      It is a *SyntaxError* if the StringValue of a |BindingIdentifier| is `"eval"` or `"arguments"` within strict mode code (<emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
       Strict mode eval code cannot instantiate variables or functions in the variable environment of the caller to eval. Instead, a new variable environment is created and that environment is used for declaration binding instantiation for the eval code (<emu-xref href="#sec-eval-x"></emu-xref>).

--- a/spec.html
+++ b/spec.html
@@ -10819,7 +10819,7 @@
           It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, `"static"`, or `"yield"`.
         </li>
         <li>
-          It is a Syntax Error if StringValue of |IdentifierName| is the same String value as the StringValue of any |ReservedWord| except for `yield`.
+          It is a Syntax Error if StringValue of |IdentifierName| is the same String value as the StringValue of any |ReservedWord| except for `yield` or `await`.
         </li>
       </ul>
       <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -9611,8 +9611,21 @@
         <p>The following tokens are ECMAScript keywords and may not be used as |Identifier|s in ECMAScript programs.</p>
         <h2>Syntax</h2>
         <emu-grammar>
-          Keyword :: one of
-            `break` `do` `in` `typeof` `case` `else` `instanceof` `var` `catch` `export` `new` `void` `class` `extends` `return` `while` `const` `finally` `super` `with` `continue` `for` `switch` `yield` `debugger` `function` `this` `default` `if` `throw` `delete` `import` `try` `await`
+          Keyword ::
+            `await`
+            `break`
+            `case` `catch` `class` `const` `continue`
+            `debugger` `default` `delete` `do`
+            `else` `export` `extends`
+            `finally` `for` `function`
+            `if` `import` `in` `instanceof`
+            `new`
+            `return`
+            `super` `switch`
+            `this` `throw` `try` `typeof`
+            `var` `void`
+            `while` `with`
+            `yield`
         </emu-grammar>
         <emu-note>
           <p>In some contexts `yield` and `await` are given the semantics of an |Identifier|. See <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>. In strict mode code, `let` and `static` are treated as reserved words through static semantic restrictions (see <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-let-and-const-declarations-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-early-errors"></emu-xref>, and <emu-xref href="#sec-class-definitions-static-semantics-early-errors"></emu-xref>) rather than the lexical grammar.</p>
@@ -9672,8 +9685,20 @@
     <h1>Punctuators</h1>
     <h2>Syntax</h2>
     <emu-grammar>
-      Punctuator :: one of
-        `{` `(` `)` `[` `]` `.` `...` `;` `,` `&lt;` `&gt;` `&lt;=` `&gt;=` `==` `!=` `===` `!==` `+` `-` `*` `%` `++` `--` `&lt;&lt;` `&gt;&gt;` `&gt;&gt;&gt;` `&amp;` `|` `^` `!` `~` `&amp;&amp;` `||` `?` `:` `=` `+=` `-=` `*=` `%=` `&lt;&lt;=` `&gt;&gt;=` `&gt;&gt;&gt;=` `&amp;=` `|=` `^=` `=&gt;` `**` `**=`
+      Punctuator ::
+        `{` `(` `)` `[` `]`
+        `.` `...` `;` `,`
+        `&lt;` `&gt;` `&lt;=` `&gt;=`
+        `==` `!=` `===` `!==`
+        `+` `-` `*` `%` `**`
+        `++` `--`
+        `&lt;&lt;` `&gt;&gt;` `&gt;&gt;&gt;`
+        `&amp;` `|` `^`
+        `!` `~`
+        `&amp;&amp;` `||`
+        `?` `:`
+        `=` `+=` `-=` `*=` `%=` `**=` `&lt;&lt;=` `&gt;&gt;=` `&gt;&gt;&gt;=` `&amp;=` `|=` `^=`
+        `=&gt;`
 
       DivPunctuator ::
         `/`

--- a/spec.html
+++ b/spec.html
@@ -32483,7 +32483,7 @@ THH:mm:ss.sss
       <p>Each of the _TypedArray_ constructor objects is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-49"></emu-xref>.</p>
       <p>The _TypedArray_ intrinsic constructor functions are single functions whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</p>
       <p>The _TypedArray_ constructors are not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray`%.prototype` built-in methods.</p>
+      <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the `%TypedArray%.prototype` built-in methods.</p>
       <p>The `length` property of the _TypedArray_ constructor function is 3.</p>
 
       <!-- es6num="22.2.4.1" -->

--- a/spec.html
+++ b/spec.html
@@ -3132,7 +3132,7 @@
             1. Throw a *TypeError* exception.
           1. If _hint_ is `"default"`, set _hint_ to `"number"`.
           1. Return ? OrdinaryToPrimitive(_input_, _hint_).
-        1. Else, return _input_.
+        1. Return _input_.
       </emu-alg>
       <emu-note>
         <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were Number. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Date objects treat no hint as if the hint were String.</p>
@@ -16827,12 +16827,12 @@
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
-        1. Else, return *false*.
+        1. Return *false*.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
-        1. Else, return *false*.
+        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -16868,12 +16868,12 @@
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
-        1. Else, return *false*.
+        1. Return *false*.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
-        1. Else, return *false*.
+        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -16909,12 +16909,12 @@
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. Else, return *false*.
+        1. Return *false*.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. Else, return *false*.
+        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -16932,7 +16932,7 @@
         1. Else, let _names_ be a new empty List.
         1. Append to _names_ the elements of the LexicallyDeclaredNames of the |DefaultClause|.
         1. If the second |CaseClauses| is not present, return _names_.
-        1. Else, return the result of appending to _names_ the elements of the LexicallyDeclaredNames of the second |CaseClauses|.
+        1. Return the result of appending to _names_ the elements of the LexicallyDeclaredNames of the second |CaseClauses|.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
@@ -16943,12 +16943,12 @@
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
-        1. Else, return a new empty List.
+        1. Return a new empty List.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
-        1. Else, return a new empty List.
+        1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -16966,7 +16966,7 @@
         1. Else, let _declarations_ be a new empty List.
         1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of the |DefaultClause|.
         1. If the second |CaseClauses| is not present, return _declarations_.
-        1. Else, return the result of appending to _declarations_ the elements of the LexicallyScopedDeclarations of the second |CaseClauses|.
+        1. Return the result of appending to _declarations_ the elements of the LexicallyScopedDeclarations of the second |CaseClauses|.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
@@ -16977,12 +16977,12 @@
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
-        1. Else, return a new empty List.
+        1. Return a new empty List.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
-        1. Else, return a new empty List.
+        1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -17004,7 +17004,7 @@
         1. Else, let _names_ be a new empty List.
         1. Append to _names_ the elements of the VarDeclaredNames of the |DefaultClause|.
         1. If the second |CaseClauses| is not present, return _names_.
-        1. Else, return the result of appending to _names_ the elements of the VarDeclaredNames of the second |CaseClauses|.
+        1. Return the result of appending to _names_ the elements of the VarDeclaredNames of the second |CaseClauses|.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
@@ -17015,12 +17015,12 @@
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
-        1. Else, return a new empty List.
+        1. Return a new empty List.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
-        1. Else, return a new empty List.
+        1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -17042,7 +17042,7 @@
         1. Else, let _declarations_ be a new empty List.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of the |DefaultClause|.
         1. If the second |CaseClauses| is not present, return _declarations_.
-        1. Else, return the result of appending to _declarations_ the elements of the VarScopedDeclarations of the second |CaseClauses|.
+        1. Return the result of appending to _declarations_ the elements of the VarScopedDeclarations of the second |CaseClauses|.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
@@ -17053,12 +17053,12 @@
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
-        1. Else, return a new empty List.
+        1. Return a new empty List.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
-        1. Else, return a new empty List.
+        1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -29029,7 +29029,7 @@ THH:mm:ss.sss
             1. If _IgnoreCase_ is *false*, return _ch_.
             1. If _Unicode_ is *true*, then
               1. If the file CaseFolding.txt of the Unicode Character Database provides a simple or common case folding mapping for _ch_, return the result of applying that mapping to _ch_.
-              1. Else, return _ch_.
+              1. Return _ch_.
             1. Else,
               1. Assert: _ch_ is a UTF-16 code unit.
               1. Let _s_ be the ECMAScript String value consisting of the single code unit _ch_.
@@ -29811,7 +29811,7 @@ THH:mm:ss.sss
               1. Let _result_ be ? RegExpExec(_rx_, _S_).
               1. If _result_ is *null*, then
                 1. If _n_=0, return *null*.
-                1. Else, return _A_.
+                1. Return _A_.
               1. Else _result_ is not *null*,
                 1. Let _matchStr_ be ? ToString(? Get(_result_, `"0"`)).
                 1. Let _status_ be CreateDataProperty(_A_, ! ToString(_n_), _matchStr_).
@@ -35092,11 +35092,11 @@ THH:mm:ss.sss
           1. If Type(_value_) is String, return QuoteJSONString(_value_).
           1. If Type(_value_) is Number, then
             1. If _value_ is finite, return ! ToString(_value_).
-            1. Else, return `"null"`.
+            1. Return `"null"`.
           1. If Type(_value_) is Object and IsCallable(_value_) is *false*, then
             1. Let _isArray_ be ? IsArray(_value_).
             1. If _isArray_ is *true*, return ? SerializeJSONArray(_value_).
-            1. Else, return ? SerializeJSONObject(_value_).
+            1. Return ? SerializeJSONObject(_value_).
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>
@@ -35678,10 +35678,11 @@ THH:mm:ss.sss
             1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. Set _generator_.[[GeneratorState]] to `"completed"`.
             1. Once a generator enters the `"completed"` state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
-            1. If _result_ is a normal completion, let _resultValue_ be *undefined*.
+            1. If _result_.[[Type]] is ~normal~, let _resultValue_ be *undefined*.
+            1. Else if _result_.[[Type]] is ~return~, let _resultValue_ be _result_.[[Value]].
             1. Else,
-              1. If _result_.[[Type]] is ~return~, let _resultValue_ be _result_.[[Value]].
-              1. Else, return Completion(_result_).
+              1. Assert: _result_.[[Type]] is ~throw~.
+              1. Return Completion(_result_).
             1. Return CreateIterResultObject(_resultValue_, *true*).
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Set _generator_.[[GeneratorState]] to `"suspendedStart"`.

--- a/spec.html
+++ b/spec.html
@@ -24195,7 +24195,7 @@
     <!-- es6num="19.2.4" -->
     <emu-clause id="sec-function-instances">
       <h1>Function Instances</h1>
-      <p>Every Function instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. Function instances created using the `Function.prototype.bind` method (<emu-xref href="#sec-function.prototype.bind"></emu-xref>) have the internal slots listed in <emu-xref href="#table-28"></emu-xref>.</p>
+      <p>Every Function instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. Function objects created using the `Function.prototype.bind` method (<emu-xref href="#sec-function.prototype.bind"></emu-xref>) have the internal slots listed in <emu-xref href="#table-28"></emu-xref>.</p>
       <p>Function instances have the following properties:</p>
 
       <!-- es6num="19.2.4.1" -->

--- a/spec.html
+++ b/spec.html
@@ -19497,8 +19497,8 @@
       <ul>
         <li>It is a Syntax Error if ContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
-        <li>If the source code matching this production is strict code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If the source code matching this production is strict code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
+        <li>If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperProperty| is *true*.</li>

--- a/spec.html
+++ b/spec.html
@@ -17857,7 +17857,7 @@
         </li>
       </ul>
       <emu-note>
-        <p>Multiple occurrences of the same |BindingIdentifier| in a |FormalParameterList| is only allowed for functions and generator functions which have simple parameter lists and which are not defined in strict mode code.</p>
+        <p>Multiple occurrences of the same |BindingIdentifier| in a |FormalParameterList| is only allowed for functions which have simple parameter lists and which are not defined in strict mode code.</p>
       </emu-note>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <ul>

--- a/spec.html
+++ b/spec.html
@@ -23035,9 +23035,7 @@
                     1. Else _C_ is in _reservedSet_,
                       1. Let _S_ be the substring of _string_ from index _start_ to index _k_ inclusive.
                   1. Else _V_ &ge; 0x10000,
-                    1. Let _L_ be (((_V_ - 0x10000) &amp; 0x3FF) + 0xDC00).
-                    1. Let _H_ be ((((_V_ - 0x10000) &gt;&gt; 10) &amp; 0x3FF) + 0xD800).
-                    1. Let _S_ be the String containing the two code units _H_ and _L_.
+                    1. Let _S_ be the String value whose elements are, in order, the elements in UTF16Encoding(_V_).
               1. Set _R_ to a new String value computed by concatenating the previous value of _R_ and _S_.
               1. Increase _k_ by 1.
           </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -18649,8 +18649,12 @@
         1. ReturnIfAbrupt(_propKey_).
         1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. If _functionPrototype_ was passed as a parameter, let _kind_ be ~Normal~; otherwise let _kind_ be ~Method~.
-        1. If _functionPrototype_ was passed as a parameter, let _prototype_ be _functionPrototype_; otherwise let _prototype_ be the intrinsic object %FunctionPrototype%.
+        1. If _functionPrototype_ was passed as a parameter, then
+          1. Let _kind_ be ~Normal~.
+          1. Let _prototype_ be _functionPrototype_.
+        1. Else,
+          1. Let _kind_ be ~Method~.
+          1. Let _prototype_ be the intrinsic object %FunctionPrototype%.
         1. Let _closure_ be FunctionCreate(_kind_, |UniqueFormalParameters|, |FunctionBody|, _scope_, _strict_, _prototype_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Return the Record{[[Key]]: _propKey_, [[Closure]]: _closure_}.

--- a/spec.html
+++ b/spec.html
@@ -34321,7 +34321,6 @@ THH:mm:ss.sss
             1. Let _viewByteLength_ be ? ToIndex(_byteLength_).
             1. If _offset_+_viewByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DataViewPrototype%"`, &laquo; [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] &raquo;).
-          1. Set _O_.[[DataView]] to *true*.
           1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
           1. Set _O_.[[ByteLength]] to _viewByteLength_.
           1. Set _O_.[[ByteOffset]] to _offset_.

--- a/spec.html
+++ b/spec.html
@@ -22501,7 +22501,7 @@
     <p>An implementation must not extend this specification in the following ways:</p>
     <ul>
       <li>
-        Other than as defined in this specification, ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"` other than those that are created by applying the AddRestrictedFunctionProperties abstract operation to the function. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
+        ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"`. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
       </li>
       <li>
         If an implementation extends non-strict or built-in function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
@@ -39192,7 +39192,7 @@ THH:mm:ss.sss
       It is a *SyntaxError* if the same |BindingIdentifier| appears more than once in the |FormalParameters| of a strict function. An attempt to create such a function using a `Function`, `Generator`, or `AsyncFunction` constructor is a *SyntaxError* (<emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-createdynamicfunction"></emu-xref>).
     </li>
     <li>
-      An implementation may not extend, beyond that defined in this specification, the meanings within strict functions of properties named `caller` or `arguments` of function instances. ECMAScript code may not create or modify properties with these names on function objects that correspond to strict functions (<emu-xref href="#sec-forbidden-extensions"></emu-xref>).
+      An implementation may not extend, beyond that defined in this specification, the meanings within strict functions of properties named `caller` or `arguments` of function instances.
     </li>
   </ul>
 </emu-annex>

--- a/spec.html
+++ b/spec.html
@@ -32064,16 +32064,13 @@ THH:mm:ss.sss
       <!-- es6num="22.2.3.8" -->
       <emu-clause id="sec-%typedarray%.prototype.fill">
         <h1>%TypedArray%.prototype.fill ( _value_ [ , _start_ [ , _end_ ] ] )</h1>
-        <p>The `fill` method takes up to three arguments _value_, _start_ and _end_.</p>
-        <emu-note>
-          <p>The _start_ and _end_ arguments are optional with default values of 0 and the length of the *this* object. If _start_ is negative, it is treated as <emu-eqn>_length_+_start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_+_end_</emu-eqn>.</p>
-        </emu-note>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.fill` are the same as for `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref>.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
           1. Let _value_ be ? ToNumber(_value_).
-          1. Let _len_ be ? _O_.[[ArrayLength]].
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
@@ -32081,7 +32078,7 @@ THH:mm:ss.sss
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
           1. Repeat, while _k_ &lt; _final_
             1. Let _Pk_ be ! ToString(_k_).
-            1. Perform ? Set(_O_, _Pk_, _value_, *true*).
+            1. Perform ! Set(_O_, _Pk_, _value_, *true*).
             1. Increase _k_ by 1.
           1. Return _O_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -34108,7 +34108,7 @@ THH:mm:ss.sss
         <p>When the `SharedArrayBuffer` function is called with optional argument _length_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _byteLength_ be ? ToIndex(_numberLength_).
+          1. Let _byteLength_ be ? ToIndex(_length_).
           1. Return ? AllocateSharedArrayBuffer(NewTarget, _byteLength_).
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -11439,7 +11439,8 @@
         </emu-grammar>
         <emu-alg>
           1. Let _obj_ be ObjectCreate(%ObjectPrototype%).
-          1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_ and *true*.
+          1. Let _status_ be the result of performing PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_ and *true*.
+          1. ReturnIfAbrupt(_status_).
           1. Return _obj_.
         </emu-alg>
         <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
@@ -11470,7 +11471,8 @@
         <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
         <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
-          1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _object_ and _enumerable_.
+          1. Let _status_ be the result of performing PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _object_ and _enumerable_.
+          1. ReturnIfAbrupt(_status_).
           1. Return the result of performing PropertyDefinitionEvaluation of |PropertyDefinition| with arguments _object_ and _enumerable_.
         </emu-alg>
         <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
@@ -13866,7 +13868,8 @@
         1. Let _assignmentPattern_ be the parse of the source text corresponding to |LeftHandSideExpression| using |AssignmentPattern| as the goal symbol with its <sub>[Yield]</sub> and <sub>[Await]</sub> parameters set to the values used when parsing |LeftHandSideExpression|.
         1. Let _rref_ be the result of evaluating |AssignmentExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Perform ? DestructuringAssignmentEvaluation of _assignmentPattern_ using _rval_ as the argument.
+        1. Let _status_ be the result of performing DestructuringAssignmentEvaluation of _assignmentPattern_ using _rval_ as the argument.
+        1. ReturnIfAbrupt(_status_).
         1. Return _rval_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
@@ -14020,7 +14023,8 @@
         </emu-alg>
         <emu-grammar>AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
         <emu-alg>
-          1. Perform ? DestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
+          1. Let _status_ be the result of performing DestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
+          1. ReturnIfAbrupt(_status_).
           1. Return the result of performing DestructuringAssignmentEvaluation for |AssignmentProperty| using _value_ as the argument.
         </emu-alg>
         <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
@@ -14054,7 +14058,8 @@
         </emu-alg>
         <emu-grammar>AssignmentElementList : AssignmentElementList `,` AssignmentElisionElement</emu-grammar>
         <emu-alg>
-          1. Perform ? IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| using _iteratorRecord_ as the argument.
+          1. Let _status_ be the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| using _iteratorRecord_ as the argument.
+          1. ReturnIfAbrupt(_status_).
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| using _iteratorRecord_ as the argument.
         </emu-alg>
         <emu-grammar>AssignmentElisionElement : AssignmentElement</emu-grammar>
@@ -14063,7 +14068,8 @@
         </emu-alg>
         <emu-grammar>AssignmentElisionElement : Elision AssignmentElement</emu-grammar>
         <emu-alg>
-          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+          1. Let _status_ be the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+          1. ReturnIfAbrupt(_status_).
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with _iteratorRecord_ as the argument.
         </emu-alg>
         <emu-grammar>Elision : `,`</emu-grammar>
@@ -14077,7 +14083,8 @@
         </emu-alg>
         <emu-grammar>Elision : Elision `,`</emu-grammar>
         <emu-alg>
-          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+          1. Let _status_ be the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+          1. ReturnIfAbrupt(_status_).
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be IteratorStep(_iteratorRecord_.[[Iterator]]).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -15288,7 +15295,8 @@
         </emu-alg>
         <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
-          1. Perform ? BindingInitialization for |BindingPropertyList| using _value_ and _environment_ as arguments.
+          1. Let _status_ be the result of performing BindingInitialization for |BindingPropertyList| using _value_ and _environment_ as arguments.
+          1. ReturnIfAbrupt(_status_).
           1. Return the result of performing BindingInitialization for |BindingProperty| using _value_ and _environment_ as arguments.
         </emu-alg>
         <emu-grammar>BindingProperty : SingleNameBinding</emu-grammar>
@@ -15323,7 +15331,8 @@
         <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. If |Elision| is present, then
-            1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+            1. Let _status_ be the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+            1. ReturnIfAbrupt(_status_).
           1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
         <emu-grammar>ArrayBindingPattern : `[` BindingElementList `]`</emu-grammar>
@@ -15336,14 +15345,17 @@
         </emu-alg>
         <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
         <emu-alg>
-          1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+          1. Let _status_ be the result of performing IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+          1. ReturnIfAbrupt(_status_).
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
         </emu-alg>
         <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
-          1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+          1. Let _status_ be the result of performing IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+          1. ReturnIfAbrupt(_status_).
           1. If |Elision| is present, then
-            1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+            1. Let _status_ be the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+            1. ReturnIfAbrupt(_status_).
           1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
         <emu-grammar>BindingElementList : BindingElisionElement</emu-grammar>
@@ -15352,7 +15364,8 @@
         </emu-alg>
         <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
         <emu-alg>
-          1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+          1. Let _status_ be the result of performing IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+          1. ReturnIfAbrupt(_status_).
           1. Return the result of performing IteratorBindingInitialization for |BindingElisionElement| using _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
         <emu-grammar>BindingElisionElement : BindingElement</emu-grammar>
@@ -15361,7 +15374,8 @@
         </emu-alg>
         <emu-grammar>BindingElisionElement : Elision BindingElement</emu-grammar>
         <emu-alg>
-          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+          1. Let _status_ be the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+          1. ReturnIfAbrupt(_status_).
           1. Return the result of performing IteratorBindingInitialization of |BindingElement| with _iteratorRecord_ and _environment_ as the arguments.
         </emu-alg>
         <emu-grammar>BindingElement : SingleNameBinding</emu-grammar>
@@ -18122,12 +18136,14 @@
       </emu-alg>
       <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Let _restIndex_ be the result of performing IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
+        1. ReturnIfAbrupt(_restIndex_).
         1. Return the result of performing IteratorBindingInitialization for |FunctionRestParameter| using _iteratorRecord_ and _environment_ as the arguments.
       </emu-alg>
       <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Let _status_ be the result of performing IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
+        1. ReturnIfAbrupt(_status_).
         1. Return the result of performing IteratorBindingInitialization for |FormalParameter| using _iteratorRecord_ and _environment_ as the arguments.
       </emu-alg>
       <emu-grammar>FormalParameter : BindingElement</emu-grammar>
@@ -19376,7 +19392,8 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
-        1. Perform ? BindingClassDeclarationEvaluation of this |ClassDeclaration|.
+        1. Let _status_ be the result of BindingClassDeclarationEvaluation of this |ClassDeclaration|.
+        1. ReturnIfAbrupt(_status_).
         1. Return NormalCompletion(~empty~).
       </emu-alg>
       <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -39018,13 +39018,18 @@ THH:mm:ss.sss
       </emu-annex>
       <emu-annex id="sec-web-compat-blockdeclarationinstantiation">
         <h1>Changes to BlockDeclarationInstantiation</h1>
+        <p>During BlockDeclarationInstantiation the following steps are performed in place of step 4.a.ii.1:</p>
+        <emu-alg>
+          1. If _envRec_.HasBinding(_dn_) is *false*, then
+            1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+        </emu-alg>
         <p>During BlockDeclarationInstantiation the following steps are performed in place of step 4.b.iii:</p>
         <emu-alg>
-          1. If _envRec_.HasBinding(_fn_) is *true*, then
+          1. If _envRec_.HasBinding(_fn_) is *false*, then
+            1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
+          1. Else,
             1. Assert: _d_ is a |FunctionDeclaration|.
             1. Perform _envRec_.SetMutableBinding(_fn_, _fo_, *false*).
-          1. Else,
-            1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
         </emu-alg>
       </emu-annex>
     </emu-annex>

--- a/spec.html
+++ b/spec.html
@@ -36523,6 +36523,8 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-async-function-objects">
     <h1>AsyncFunction Objects</h1>
+    <p>AsyncFunction objects are functions that are usually created by evaluating |AsyncFunctionDeclaration|s, |AsyncFunctionExpression|s, |AsyncMethod|s, and |AsyncArrowFunction|s. They may also be created by calling the %AsyncFunction% intrinsic.</p>
+
     <emu-clause id="sec-async-function-constructor">
       <h1>The AsyncFunction Constructor</h1>
 

--- a/spec.html
+++ b/spec.html
@@ -10818,6 +10818,9 @@
           It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, `"static"`, or `"yield"`.
         </li>
         <li>
+          It is a Syntax Error if the goal symbol of the syntactic grammar is |Module| and the StringValue of |IdentifierName| is `"await"`.
+        </li>
+        <li>
           It is a Syntax Error if StringValue of |IdentifierName| is the same String value as the StringValue of any |ReservedWord| except for `yield` or `await`.
         </li>
       </ul>

--- a/spec.html
+++ b/spec.html
@@ -11746,14 +11746,14 @@
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Return the string consisting of the code units of _tail_.
+          1. Return the String consisting of the code units of _tail_.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _head_ be the result of evaluating |TemplateMiddleList|.
           1. ReturnIfAbrupt(_head_).
           1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Return the string whose code units are the elements of _head_ followed by the elements of _tail_.
+          1. Return the String value whose code units are the elements of _head_ followed by the elements of _tail_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
@@ -24771,7 +24771,7 @@
         <!-- es6num="19.5.6.3.3" -->
         <emu-clause id="sec-nativeerror.prototype.name">
           <h1>_NativeError_.prototype.name</h1>
-          <p>The initial value of the `name` property of the prototype for a given _NativeError_ constructor is a string consisting of the name of the constructor (the name used instead of _NativeError_).</p>
+          <p>The initial value of the `name` property of the prototype for a given _NativeError_ constructor is a String consisting of the name of the constructor (the name used instead of _NativeError_).</p>
         </emu-clause>
       </emu-clause>
 
@@ -28168,11 +28168,11 @@ THH:mm:ss.sss
               1. Set _O_.[[IteratedString]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
             1. Let _first_ be the code unit value at index _position_ in _s_.
-            1. If _first_ &lt; 0xD800 or _first_ &gt; 0xDBFF or _position_+1 = _len_, let _resultString_ be the string consisting of the single code unit _first_.
+            1. If _first_ &lt; 0xD800 or _first_ &gt; 0xDBFF or _position_+1 = _len_, let _resultString_ be the String consisting of the single code unit _first_.
             1. Else,
               1. Let _second_ be the code unit value at index _position_+1 in the String _S_.
-              1. If _second_ &lt; 0xDC00 or _second_ &gt; 0xDFFF, let _resultString_ be the string consisting of the single code unit _first_.
-              1. Else, let _resultString_ be the string consisting of the code unit _first_ followed by the code unit _second_.
+              1. If _second_ &lt; 0xDC00 or _second_ &gt; 0xDFFF, let _resultString_ be the String consisting of the single code unit _first_.
+              1. Else, let _resultString_ be the String consisting of the code unit _first_ followed by the code unit _second_.
             1. Let _resultSize_ be the number of code units in _resultString_.
             1. Set _O_.[[StringIteratorNextIndex]] to _position_ + _resultSize_.
             1. Return CreateIterResultObject(_resultString_, *false*).
@@ -29730,10 +29730,10 @@ THH:mm:ss.sss
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
               1. Else if _fullUnicode_ is *true*, then
                 1. Assert: _captureI_ is a List of code points.
-                1. Let _capturedValue_ be a string whose code units are the UTF16Encoding of the code points of _captureI_.
+                1. Let _capturedValue_ be a String value whose code units are the UTF16Encoding of the code points of _captureI_.
               1. Else _fullUnicode_ is *false*,
                 1. Assert: _captureI_ is a List of code units.
-                1. Let _capturedValue_ be a string consisting of the code units of _captureI_.
+                1. Let _capturedValue_ be a String consisting of the code units of _captureI_.
               1. Perform ! CreateDataProperty(_A_, ! ToString(_i_), _capturedValue_).
             1. Return _A_.
           </emu-alg>
@@ -29995,7 +29995,7 @@ THH:mm:ss.sss
           1. If _flags_ contains `"u"`, let _unicodeMatching_ be *true*.
           1. Else, let _unicodeMatching_ be *false*.
           1. If _flags_ contains `"y"`, let _newFlags_ be _flags_.
-          1. Else, let _newFlags_ be the string that is the concatenation of _flags_ and `"y"`.
+          1. Else, let _newFlags_ be the String that is the concatenation of _flags_ and `"y"`.
           1. Let _splitter_ be ? Construct(_C_, &laquo; _rx_, _newFlags_ &raquo;).
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _lengthA_ be 0.
@@ -34868,14 +34868,14 @@ THH:mm:ss.sss
         1. Let _w_ be ! AtomicLoad(_typedArray_, _i_).
         1. If _v_ is not equal to _w_, then
           1. Perform LeaveCriticalSection(_WL_).
-          1. Return the string `"not-equal"`.
+          1. Return the String `"not-equal"`.
         1. Let _W_ be AgentSignifier().
         1. Perform AddWaiter(_WL_, _W_).
         1. Let _awoken_ be Suspend(_WL_, _W_, _t_).
         1. Perform RemoveWaiter(_WL_, _W_).
         1. Perform LeaveCriticalSection(_WL_).
-        1. If _awoken_ is *true*, return the string `"ok"`.
-        1. Return the string `"timed-out"`.
+        1. If _awoken_ is *true*, return the String `"ok"`.
+        1. Return the String `"timed-out"`.
       </emu-alg>
     </emu-clause>
 
@@ -35211,7 +35211,7 @@ THH:mm:ss.sss
             1. Let _strP_ be ? SerializeJSONProperty(_P_, _value_).
             1. If _strP_ is not *undefined*, then
               1. Let _member_ be QuoteJSONString(_P_).
-              1. Set _member_ to the concatenation of _member_ and the string `":"`.
+              1. Set _member_ to the concatenation of _member_ and the String `":"`.
               1. If _gap_ is not the empty String, then
                 1. Set _member_ to the concatenation of _member_ and code unit 0x0020 (SPACE).
               1. Set _member_ to the concatenation of _member_ and _strP_.

--- a/spec.html
+++ b/spec.html
@@ -4918,8 +4918,7 @@
           <emu-alg>
             1. Let _envRec_ be the object Environment Record for which the method was invoked.
             1. Let _bindings_ be the binding object for _envRec_.
-            1. If _D_ is *true*, let _configValue_ be *true*; otherwise let _configValue_ be *false*.
-            1. Return ? DefinePropertyOrThrow(_bindings_, _N_, PropertyDescriptor{[[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: _configValue_}).
+            1. Return ? DefinePropertyOrThrow(_bindings_, _N_, PropertyDescriptor{[[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: _D_}).
           </emu-alg>
           <emu-note>
             <p>Normally _envRec_ will not have a binding for _N_ but if it does, the semantics of DefinePropertyOrThrow may result in an existing binding being replaced or shadowed or cause an abrupt completion to be returned.</p>
@@ -23977,7 +23976,7 @@
             1. Set _bodyText_ to ? ToString(_bodyText_).
             1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
             1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
-            1. If ContainsUseStrict of _body_ is *true*, let _strict_ be *true*, else let _strict_ be *false*.
+            1. Let _strict_ be ContainsUseStrict of _body_.
             1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied. Parsing and early error detection may be interweaved in an implementation-dependent manner.
             1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
             1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.

--- a/spec.html
+++ b/spec.html
@@ -11559,6 +11559,20 @@
           TemplateMiddleList[?Yield, ?Await] TemplateMiddle Expression[+In, ?Yield, ?Await]
       </emu-grammar>
 
+      <emu-clause id="sec-primary-expression-template-literals-static-semantics-early-errors">
+        <h1>Static Semantics: Early Errors</h1>
+        <emu-grammar>
+          TemplateLiteral :
+            NoSubstitutionTemplate
+            TemplateHead Expression TemplateSpans
+        </emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if the number of elements in the result of TemplateStrings of |TemplateLiteral| with argument *false* is greater than 2<sup>32</sup>-1.
+          </li>
+        </ul>
+      </emu-clause>
+
       <!-- es6num="12.2.9.1" -->
       <emu-clause id="sec-static-semantics-templatestrings">
         <h1>Static Semantics: TemplateStrings</h1>
@@ -11653,6 +11667,7 @@
               1. Return _e_.[[Array]].
           1. Let _cookedStrings_ be TemplateStrings of _templateLiteral_ with argument *false*.
           1. Let _count_ be the number of elements in the List _cookedStrings_.
+          1. Assert: _count_ &le; 2<sup>32</sup>-1.
           1. Let _template_ be ! ArrayCreate(_count_).
           1. Let _rawObj_ be ! ArrayCreate(_count_).
           1. Let _index_ be 0.
@@ -28360,6 +28375,12 @@ THH:mm:ss.sss
       <!-- es6num="21.2.1.1" -->
       <emu-clause id="sec-patterns-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
+        <emu-grammar>Pattern :: Disjunction</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if _NcapturingParens_ &ge; 2<sup>32</sup>-1.
+          </li>
+        </ul>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
         <ul>
           <li>
@@ -29696,6 +29717,7 @@ THH:mm:ss.sss
             1. If _global_ is *true* or _sticky_ is *true*, then
               1. Perform ? Set(_R_, `"lastIndex"`, _e_, *true*).
             1. Let _n_ be the length of _r_'s _captures_ List. (This is the same value as <emu-xref href="#sec-notation"></emu-xref>'s _NcapturingParens_.)
+            1. Assert: _n_ &lt; 2<sup>32</sup>-1.
             1. Let _A_ be ! ArrayCreate(_n_ + 1).
             1. Assert: The value of _A_'s `"length"` property is _n_ + 1.
             1. Let _matchIndex_ be _lastIndex_.

--- a/spec.html
+++ b/spec.html
@@ -39193,9 +39193,6 @@ THH:mm:ss.sss
       Strict mode code may not include a |WithStatement|. The occurrence of a |WithStatement| in such a context is a *SyntaxError* (<emu-xref href="#sec-with-statement-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
-      It is a *SyntaxError* if a |TryStatement| with a |Catch| occurs within strict mode code and the |Identifier| of the |Catch| is `eval` or `arguments` (<emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref>).
-    </li>
-    <li>
       It is a *SyntaxError* if the same |BindingIdentifier| appears more than once in the |FormalParameters| of a strict function. An attempt to create such a function using a `Function`, `Generator`, or `AsyncFunction` constructor is a *SyntaxError* (<emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-createdynamicfunction"></emu-xref>).
     </li>
     <li>

--- a/spec.html
+++ b/spec.html
@@ -6658,11 +6658,10 @@
             1. Else,
               1. If _O_ is not *undefined*, convert the property named _P_ of object _O_ from an accessor property to a data property. Preserve the existing values of the converted property's [[Configurable]] and [[Enumerable]] attributes and set the rest of the property's attributes to their default values.
           1. Else if IsDataDescriptor(_current_) and IsDataDescriptor(_Desc_) are both *true*, then
-            1. If _current_.[[Configurable]] is *false*, then
-              1. If _current_.[[Writable]] is *false*, then
-                1. If _Desc_.[[Writable]] is present and _Desc_.[[Writable]] is *true*, return *false*.
-                1. If _Desc_.[[Value]] is present and SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*, return *false*.
-                1. Return *true*.
+            1. If _current_.[[Configurable]] is *false* and _current_.[[Writable]] is *false*, then
+              1. If _Desc_.[[Writable]] is present and _Desc_.[[Writable]] is *true*, return *false*.
+              1. If _Desc_.[[Value]] is present and SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*, return *false*.
+              1. Return *true*.
           1. Else IsAccessorDescriptor(_current_) and IsAccessorDescriptor(_Desc_) are both *true*,
             1. If _current_.[[Configurable]] is *false*, then
               1. If _Desc_.[[Set]] is present and SameValue(_Desc_.[[Set]], _current_.[[Set]]) is *false*, return *false*.

--- a/spec.html
+++ b/spec.html
@@ -35563,8 +35563,7 @@ THH:mm:ss.sss
       <!-- es6num="25.2.4.1" -->
       <emu-clause id="sec-generatorfunction-instances-length">
         <h1>length</h1>
-        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the GeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a GeneratorFunction when invoked on a number of arguments other than the number specified by its `length` property depends on the function.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The specification for the `length` property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to GeneratorFunction instances.</p>
       </emu-clause>
 
       <!-- es6num="25.2.4.2" -->
@@ -36600,14 +36599,11 @@ THH:mm:ss.sss
       <p>Each AsyncFunction instance has the following own properties:</p>
       <emu-clause id="sec-async-function-instances-length">
         <h1>length</h1>
-        <p>The value of the *length* property is an integer that indicates the typical number of arguments expected by the AsyncFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of an AsyncFunction when invoked on a number of arguments other than the number specified by its `length` property depends on the function.</p>
-
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The specification for the `length` property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to AsyncFunction instances.</p>
       </emu-clause>
 
       <emu-clause id="sec-async-function-instances-name">
         <h1>name</h1>
-
         <p>The specification for the `name` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncFunction instances.</p>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -24195,8 +24195,8 @@
     <!-- es6num="19.2.4" -->
     <emu-clause id="sec-function-instances">
       <h1>Function Instances</h1>
-      <p>Every function instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. Function instances created using the `Function.prototype.bind` method (<emu-xref href="#sec-function.prototype.bind"></emu-xref>) have the internal slots listed in <emu-xref href="#table-28"></emu-xref>.</p>
-      <p>The Function instances have the following properties:</p>
+      <p>Every Function instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. Function instances created using the `Function.prototype.bind` method (<emu-xref href="#sec-function.prototype.bind"></emu-xref>) have the internal slots listed in <emu-xref href="#table-28"></emu-xref>.</p>
+      <p>Function instances have the following properties:</p>
 
       <!-- es6num="19.2.4.1" -->
       <emu-clause id="sec-function-instances-length">
@@ -24214,7 +24214,7 @@
       <!-- es6num="19.2.4.3" -->
       <emu-clause id="sec-function-instances-prototype">
         <h1>prototype</h1>
-        <p>Function instances that can be used as a constructor have a `prototype` property. Whenever such a function instance is created another ordinary object is also created and is the initial value of the function's `prototype` property. Unless otherwise specified, the value of the `prototype` property is used to initialize the [[Prototype]] internal slot of the object created when that function is invoked as a constructor.</p>
+        <p>Function instances that can be used as a constructor have a `prototype` property. Whenever such a Function instance is created another ordinary object is also created and is the initial value of the function's `prototype` property. Unless otherwise specified, the value of the `prototype` property is used to initialize the [[Prototype]] internal slot of the object created when that function is invoked as a constructor.</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>Function objects created using `Function.prototype.bind`, or by evaluating a |MethodDefinition| (that is not a |GeneratorMethod|) or an |ArrowFunction| do not have a `prototype` property.</p>
@@ -35578,7 +35578,7 @@ THH:mm:ss.sss
         <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's `prototype` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Unlike function instances, the object that is the value of the a GeneratorFunction's `prototype` property does not have a `constructor` property whose value is the GeneratorFunction instance.</p>
+          <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's `prototype` property does not have a `constructor` property whose value is the GeneratorFunction instance.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
Maybe it's time to update https://tc39.github.io/ecma262/#sec-algorithm-conventions to allow the `?` short-hand when invoking algorithms associated to grammar productions instead of just abstract operations. 