### PR TITLE
Editorial: separate clauses for Reference abstract ops

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2805,31 +2805,63 @@
       </emu-note>
       <p>A <dfn>Reference</dfn> is a resolved name or property binding. A Reference consists of three components, the base value component, the referenced name component, and the Boolean-valued strict reference flag. The base value component is either *undefined*, an Object, a Boolean, a String, a Symbol, a Number, or an Environment Record. A base value component of *undefined* indicates that the Reference could not be resolved to a binding. The referenced name component is a String or Symbol value.</p>
       <p>A <dfn id="super-reference">Super Reference</dfn> is a Reference that is used to represents a name binding that was expressed using the super keyword. A Super Reference has an additional thisValue component, and its base value component will never be an Environment Record.</p>
-      <p>The following abstract operations are used in this specification to access the components of references:</p>
-      <ul>
-        <li>
-          <dfn aoid="GetBase" id="ao-getbase">GetBase</dfn>(_V_). Returns the base value component of the reference _V_.
-        </li>
-        <li>
-          <dfn aoid="GetReferencedName" id="ao-getreferencedname">GetReferencedName</dfn>(_V_). Returns the referenced name component of the reference _V_.
-        </li>
-        <li>
-          <dfn aoid="IsStrictReference" id="ao-isstrictreference">IsStrictReference</dfn>(_V_). Returns the strict reference flag of the reference _V_.
-        </li>
-        <li>
-          <dfn aoid="HasPrimitiveBase" id="ao-hasprimitivebase">HasPrimitiveBase</dfn>(_V_). Returns *true* if Type(_V_'s base value component) is Boolean, String, Symbol, or Number; otherwise returns *false*.
-        </li>
-        <li>
-          <dfn aoid="IsPropertyReference" id="ao-ispropertyreference">IsPropertyReference</dfn>(_V_). Returns *true* if either the base value component of the reference _V_ is an object or HasPrimitiveBase(_V_) is *true*; otherwise returns *false*.
-        </li>
-        <li>
-          <dfn aoid="IsUnresolvableReference" id="ao-isunresolvablereference">IsUnresolvableReference</dfn>(_V_). Returns *true* if the base value component of the reference _V_ is *undefined*; otherwise returns *false*.
-        </li>
-        <li>
-          <dfn aoid="IsSuperReference" id="ao-issuperreference">IsSuperReference</dfn>(_V_). Returns *true* if the reference _V_ has a thisValue component; otherwise returns *false*.
-        </li>
-      </ul>
       <p>The following abstract operations are used in this specification to operate on references:</p>
+
+      <emu-clause id="sec-getbase" aoid="GetBase">
+        <h1 id="ao-getbase">GetBase ( _V_ )</h1>
+        <emu-alg>
+          1. Assert: Type(_V_) is Reference.
+          1. Return the base value component of _V_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-getreferencedname" aoid="GetReferencedName">
+        <h1 id="ao-getreferencedname">GetReferencedName ( _V_ )</h1>
+        <emu-alg>
+          1. Assert: Type(_V_) is Reference.
+          1. Return the referenced name component of _V_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-isstrictreference" aoid="IsStrictReference">
+        <h1 id="ao-isstrictreference">IsStrictReference ( _V_ )</h1>
+        <emu-alg>
+          1. Assert: Type(_V_) is Reference.
+          1. Return the strict reference flag of _V_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-hasprimitivebase" aoid="HasPrimitiveBase">
+        <h1 id="ao-hasprimitivebase">HasPrimitiveBase ( _V_ )</h1>
+        <emu-alg>
+          1. Assert: Type(_V_) is Reference.
+          1. If Type(_V_'s base value component) is Boolean, String, Symbol, or Number, return *true*; otherwise return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-ispropertyreference" aoid="IsPropertyReference">
+        <h1 id="ao-ispropertyreference">IsPropertyReference ( _V_ )</h1>
+        <emu-alg>
+          1. Assert: Type(_V_) is Reference.
+          1. If either the base value component of _V_ is an Object or HasPrimitiveBase(_V_) is *true*, return *true*; otherwise return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-isunresolvablereference" aoid="IsUnresolvableReference">
+        <h1 id="ao-isunresolvablereference">IsUnresolvableReference ( _V_ )</h1>
+        <emu-alg>
+          1. Assert: Type(_V_) is Reference.
+          1. If the base value component of _V_ is *undefined*, return *true*; otherwise return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-issuperreference" aoid="IsSuperReference">
+        <h1 id="ao-issuperreference">IsSuperReference ( _V_ )</h1>
+        <emu-alg>
+          1. Assert: Type(_V_) is Reference.
+          1. If _V_ has a thisValue component, return *true*; otherwise return *false*.
+        </emu-alg>
+      </emu-clause>
 
       <!-- es6num="6.2.3.1" -->
       <emu-clause id="sec-getvalue" aoid="GetValue">


### PR DESCRIPTION
Originally proposed (among many other commits) in #821, but @bterlson [asked](https://github.com/tc39/ecma262/pull/821#discussion_r107040459) for it to come back as a separate PR.

