### PR TITLE
Editorial: isRegExp => matcher

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4011,8 +4011,8 @@
       <p>The abstract operation IsRegExp with argument _argument_ performs the following steps:</p>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
-        1. Let _isRegExp_ be ? Get(_argument_, @@match).
-        1. If _isRegExp_ is not *undefined*, return ToBoolean(_isRegExp_).
+        1. Let _matcher_ be ? Get(_argument_, @@match).
+        1. If _matcher_ is not *undefined*, return ToBoolean(_matcher_).
         1. If _argument_ has a [[RegExpMatcher]] internal slot, return *true*.
         1. Return *false*.
       </emu-alg>


### PR DESCRIPTION
Renames variable to drop "is" prefix, because its value is not of boolean type. New name is taken from step *2a* of [`String.prototype.match`](https://tc39.github.io/ecma262/#sec-string.prototype.match).

EDIT: also, new name improves search results for `isregexp`.