### PR TITLE
Normative: Prohibit ASI between 'let' and 'yield'/'await'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10724,18 +10724,18 @@
     <emu-grammar>
       IdentifierReference[Yield, Await] :
         Identifier
-        [~Yield] `yield`
-        [~Await] `await`
+        `yield`
+        `await`
 
       BindingIdentifier[Yield, Await] :
         Identifier
-        [~Yield] `yield`
-        [~Await] `await`
+        `yield`
+        `await`
 
       LabelIdentifier[Yield, Await] :
         Identifier
-        [~Yield] `yield`
-        [~Await] `await`
+        `yield`
+        `await`
 
       Identifier :
         IdentifierName but not ReservedWord
@@ -10751,27 +10751,33 @@
         </li>
       </ul>
       <emu-grammar>
-        IdentifierReference : `yield`
+        IdentifierReference[Yield, Await] : `yield`
 
-        BindingIdentifier : `yield`
+        BindingIdentifier[Yield, Await] : `yield`
 
-        LabelIdentifier : `yield`
+        LabelIdentifier[Yield, Await] : `yield`
       </emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the code matched by this production is contained in strict mode code.
         </li>
+        <li>
+          It is a Syntax Error if this production is matched with the Yield grammar parameter set.
+        </li>
       </ul>
       <emu-grammar>
-        IdentifierReference : `await`
+        IdentifierReference[Yield, Await] : `await`
 
-        BindingIdentifier : `await`
+        BindingIdentifier[Yield, Await] : `await`
 
-        LabelIdentifier : `await`
+        LabelIdentifier[Yield, Await] : `await`
       </emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the goal symbol of the syntactic grammar is |Module|.
+        </li>
+        <li>
+          It is a Syntax Error if this production is matched with the Await grammar parameter set.
         </li>
       </ul>
       <emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -10724,8 +10724,8 @@
     <emu-grammar>
       IdentifierReference[Yield, Await] :
         Identifier
-        `yield`
-        `await`
+        [~Yield] `yield`
+        [~Await] `await`
 
       BindingIdentifier[Yield, Await] :
         Identifier
@@ -10734,12 +10734,14 @@
 
       LabelIdentifier[Yield, Await] :
         Identifier
-        `yield`
-        `await`
+        [~Yield] `yield`
+        [~Await] `await`
 
       Identifier :
         IdentifierName but not ReservedWord
     </emu-grammar>
+
+    <emu-note>`yield` and `await` are permitted as |BindingIdentifier| in the grammar, and prohibited with static semantics below, to prohibit ASI in cases such as `let\nawait`.</emu-note>
 
     <!-- es6num="12.1.1" -->
     <emu-clause id="sec-identifiers-static-semantics-early-errors">

--- a/spec.html
+++ b/spec.html
@@ -10741,7 +10741,8 @@
         IdentifierName but not ReservedWord
     </emu-grammar>
 
-    <emu-note>`yield` and `await` are permitted as |BindingIdentifier| in the grammar, and prohibited with static semantics below, to prohibit ASI in cases such as `let\nawait`.</emu-note>
+    <emu-note>`yield` and `await` are permitted as |BindingIdentifier| in the grammar, and prohibited with static semantics below, to prohibit ASI in cases such as <pre><code class="javascript">let
+await 0;</code></pre></emu-note>
 
     <!-- es6num="12.1.1" -->
     <emu-clause id="sec-identifiers-static-semantics-early-errors">
@@ -10753,33 +10754,43 @@
         </li>
       </ul>
       <emu-grammar>
-        IdentifierReference[Yield, Await] : `yield`
+        IdentifierReference : `yield`
 
-        BindingIdentifier[Yield, Await] : `yield`
+        BindingIdentifier : `yield`
 
-        LabelIdentifier[Yield, Await] : `yield`
+        LabelIdentifier : `yield`
       </emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the code matched by this production is contained in strict mode code.
         </li>
-        <li>
-          It is a Syntax Error if this production is matched with the Yield grammar parameter set.
-        </li>
       </ul>
       <emu-grammar>
-        IdentifierReference[Yield, Await] : `await`
+        IdentifierReference : `await`
 
-        BindingIdentifier[Yield, Await] : `await`
+        BindingIdentifier : `await`
 
-        LabelIdentifier[Yield, Await] : `await`
+        LabelIdentifier : `await`
       </emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the goal symbol of the syntactic grammar is |Module|.
         </li>
+      </ul>
+      <emu-grammar>
+        BindingIdentifier : `yield`
+      </emu-grammar>
+      <ul>
         <li>
-          It is a Syntax Error if this production is matched with the Await grammar parameter set.
+          It is a Syntax Error if this production has a <sub>[Yield]</sub> parameter.
+        </li>
+      </ul>
+      <emu-grammar>
+        BindingIdentifier : `await`
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if this production has an <sub>[Await]</sub> parameter.
         </li>
       </ul>
       <emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -10741,7 +10741,7 @@
         IdentifierName but not ReservedWord
     </emu-grammar>
 
-    <emu-note>`yield` and `await` are permitted as |BindingIdentifier| in the grammar, and prohibited with static semantics below, to prohibit ASI in cases such as <pre><code class="javascript">let
+    <emu-note>`yield` and `await` are permitted as |BindingIdentifier| in the grammar, and prohibited with static semantics below, to prohibit automatic semicolon insertion in cases such as <pre><code class="javascript">let
 await 0;</code></pre></emu-note>
 
     <!-- es6num="12.1.1" -->


### PR DESCRIPTION
Previously, @jswalden found that ASI would depend on whether the
[Yield] and [Await] flags were set. This minor change prohibits
yield and await as BindingIdentifiers based on static semantics
rules, rather than grammar parameters, in order to make ASI
invariant between the two flags.

Inspired by https://github.com/tc39/test262/pull/956