### PR TITLE
Normative: Perform legacy hoisting for `function arguments() {}`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7317,7 +7317,9 @@
           1. Else,
             1. Perform ! _envRec_.CreateMutableBinding(`"arguments"`, *false*).
           1. Call _envRec_.InitializeBinding(`"arguments"`, _ao_).
-          1. Append `"arguments"` to _parameterNames_.
+          1. Let _parameterBindings_ be a new List of _parameterNames_ with `"arguments"` appended.
+        1. Else,
+          1. Let _parameterBindings_ be _parameterNames_.
         1. Let _iteratorRecord_ be Record {[[Iterator]]: CreateListIterator(_argumentsList_), [[Done]]: *false*}.
         1. If _hasDuplicates_ is *true*, then
           1. Perform ? IteratorBindingInitialization for _formals_ with _iteratorRecord_ and *undefined* as arguments.
@@ -7325,7 +7327,7 @@
           1. Perform ? IteratorBindingInitialization for _formals_ with _iteratorRecord_ and _env_ as arguments.
         1. If _hasParameterExpressions_ is *false*, then
           1. NOTE: Only a single lexical environment is needed for the parameters and top-level vars.
-          1. Let _instantiatedVarNames_ be a copy of the List _parameterNames_.
+          1. Let _instantiatedVarNames_ be a copy of the List _parameterBindings_.
           1. For each _n_ in _varNames_, do
             1. If _n_ is not an element of _instantiatedVarNames_, then
               1. Append _n_ to _instantiatedVarNames_.
@@ -7343,7 +7345,7 @@
             1. If _n_ is not an element of _instantiatedVarNames_, then
               1. Append _n_ to _instantiatedVarNames_.
               1. Perform ! _varEnvRec_.CreateMutableBinding(_n_, *false*).
-              1. If _n_ is not an element of _parameterNames_ or if _n_ is an element of _functionNames_, let _initialValue_ be *undefined*.
+              1. If _n_ is not an element of _parameterBindings_ or if _n_ is an element of _functionNames_, let _initialValue_ be *undefined*.
               1. Else,
                 1. Let _initialValue_ be ! _envRec_.GetBindingValue(_n_, *false*).
               1. Call _varEnvRec_.InitializeBinding(_n_, _initialValue_).


### PR DESCRIPTION
An editorial change accidentally blocked this hoisting; this patch
restores it. Corresponding tests already pass on JSC and ChakraCore.

Closes #815