### PR TITLE
Normative: Perform legacy hoisting for `function arguments() {}` 

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7317,7 +7317,9 @@
           1. Else,
             1. Perform ! _envRec_.CreateMutableBinding(`"arguments"`, *false*).
           1. Call _envRec_.InitializeBinding(`"arguments"`, _ao_).
-          1. Append `"arguments"` to _parameterNames_.
+          1. Let _parameterBindings_ be a new List of _parameterNames_ with `"arguments"` appended.
+        1. Else,
+          1. Let _parameterBindings_ be _parameterNames_.
         1. Let _iteratorRecord_ be Record {[[Iterator]]: CreateListIterator(_argumentsList_), [[Done]]: *false*}.
         1. If _hasDuplicates_ is *true*, then
           1. Perform ? IteratorBindingInitialization for _formals_ with _iteratorRecord_ and *undefined* as arguments.
@@ -7325,7 +7327,7 @@
           1. Perform ? IteratorBindingInitialization for _formals_ with _iteratorRecord_ and _env_ as arguments.
         1. If _hasParameterExpressions_ is *false*, then
           1. NOTE: Only a single lexical environment is needed for the parameters and top-level vars.
-          1. Let _instantiatedVarNames_ be a copy of the List _parameterNames_.
+          1. Let _instantiatedVarNames_ be a copy of the List _parameterBindings_.
           1. For each _n_ in _varNames_, do
             1. If _n_ is not an element of _instantiatedVarNames_, then
               1. Append _n_ to _instantiatedVarNames_.
@@ -7343,7 +7345,7 @@
             1. If _n_ is not an element of _instantiatedVarNames_, then
               1. Append _n_ to _instantiatedVarNames_.
               1. Perform ! _varEnvRec_.CreateMutableBinding(_n_, *false*).
-              1. If _n_ is not an element of _parameterNames_ or if _n_ is an element of _functionNames_, let _initialValue_ be *undefined*.
+              1. If _n_ is not an element of _parameterBindings_ or if _n_ is an element of _functionNames_, let _initialValue_ be *undefined*.
               1. Else,
                 1. Let _initialValue_ be ! _envRec_.GetBindingValue(_n_, *false*).
               1. Call _varEnvRec_.InitializeBinding(_n_, _initialValue_).

--- a/spec.html
+++ b/spec.html
@@ -12928,6 +12928,7 @@
         <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is an odd integer, the result is *-&infin;*.</li>
         <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is not an odd integer, the result is *+&infin;*.</li>
         <li>If _base_ &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integer, the result is *NaN*.</li>
+        <li> In the remaining cases, the result is an approximation of raising _base_ to the power _exponent_, where the difference between the result and the mathematical value is less than 1 ulp.</li>
       </ul>
       <emu-note>
         <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity* differs from IEEE 754-2008. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2008 specified *1*. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
@@ -25667,6 +25668,9 @@
           <li>
             If all arguments are either *+0* or *-0*, the result is *+0*.
           </li>
+          <li>
+            In the remaining cases, the result is an approximation the square root of the sum of squares of the arguments, where the difference between the result and the mathematical value is less than 1 ulp.
+          </li>
         </ul>
         <emu-note>
           <p>Implementations should take care to avoid the loss of precision from overflows and underflows that are prone to occur in naive implementations when this function is called with two or more arguments.</p>
@@ -25705,6 +25709,9 @@
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
           </li>
+          <li>
+            In the remaining cases, the result is an approximation of the natural logarithm of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
+          </li>
         </ul>
       </emu-clause>
 
@@ -25730,6 +25737,9 @@
           </li>
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the natural logarithm of 1 + _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
       </emu-clause>
@@ -25757,6 +25767,9 @@
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
           </li>
+          <li>
+            In the remaining cases, the result is an approximation of the base 10 logarithm of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
+          </li>
         </ul>
       </emu-clause>
 
@@ -25782,6 +25795,9 @@
           </li>
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the base 2 logarithm of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
       </emu-clause>
@@ -25912,6 +25928,9 @@
           <li>
             If _x_ is *+&infin;* or *-&infin;*, the result is *NaN*.
           </li>
+          <li>
+            In the remaining cases, the result is an approximation of the sine of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
+          </li>
         </ul>
       </emu-clause>
 
@@ -25934,6 +25953,9 @@
           </li>
           <li>
             If _x_ is *-&infin;*, the result is *-&infin;*.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the hyperbolic sine of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
         <emu-note>
@@ -25961,6 +25983,9 @@
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
           </li>
+          <li>
+            In the remaining cases, the square root is computed and rounded to the nearest representable value using IEEE 754-2008 round to nearest, ties to even mode.
+          </li>
         </ul>
       </emu-clause>
 
@@ -25980,6 +26005,9 @@
           </li>
           <li>
             If _x_ is *+&infin;* or *-&infin;*, the result is *NaN*.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the tangent of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
       </emu-clause>
@@ -26003,6 +26031,9 @@
           </li>
           <li>
             If _x_ is *-&infin;*, the result is -1.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the hyperbolic tangent of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
         <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -38865,7 +38865,7 @@ THH:mm:ss.sss
               1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of _parameterNames_, then
                 1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
-                1. If _instantiatedVarNames_ does not contain _F_, then
+                1. If _initializedBindings_ does not contain _F_ and _F_ is not `"arguments"`, then
                   1. Perform ! _varEnvRec_.CreateMutableBinding(_F_, *false*).
                   1. Perform _varEnvRec_.InitializeBinding(_F_, *undefined*).
                   1. Append _F_ to _instantiatedVarNames_.


### PR DESCRIPTION
An editorial change accidentally blocked this hoisting; this patch
restores it. Corresponding tests already pass on JSC and ChakraCore.

Closes #815