### PR TITLE
Editorial: Clarify `instanceof` runtime semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13443,15 +13443,15 @@
 
     <!-- es6num="12.9.4" -->
     <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
-      <h1>Runtime Semantics: InstanceofOperator ( _O_, _C_ )</h1>
+      <h1>Runtime Semantics: InstanceofOperator ( _V_, _O_ )</h1>
       <p>The abstract operation InstanceofOperator(_O_, _C_) implements the generic algorithm for determining if an object _O_ inherits from the inheritance path defined by constructor _C_. This abstract operation performs the following steps:</p>
       <emu-alg>
-        1. If Type(_C_) is not Object, throw a *TypeError* exception.
-        1. Let _instOfHandler_ be ? GetMethod(_C_, @@hasInstance).
+        1. If Type(_O_) is not Object, throw a *TypeError* exception.
+        1. Let _instOfHandler_ be ? GetMethod(_O_, @@hasInstance).
         1. If _instOfHandler_ is not *undefined*, then
-          1. Return ToBoolean(? Call(_instOfHandler_, _C_, &laquo; _O_ &raquo;)).
-        1. If IsCallable(_C_) is *false*, throw a *TypeError* exception.
-        1. Return ? OrdinaryHasInstance(_C_, _O_).
+          1. Return ToBoolean(? Call(_instOfHandler_, _O_, &laquo; _V_ &raquo;)).
+        1. If IsCallable(_O_) is *false*, throw a *TypeError* exception.
+        1. Return ? OrdinaryHasInstance(_O_, _V_).
       </emu-alg>
       <emu-note>
         <p>Steps 4 and 5 provide compatibility with previous editions of ECMAScript that did not use a @@hasInstance method to define the `instanceof` operator semantics. If a function object does not define or inherit @@hasInstance it uses the default `instanceof` semantics.</p>

--- a/spec.html
+++ b/spec.html
@@ -13444,7 +13444,7 @@
     <!-- es6num="12.9.4" -->
     <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
       <h1>Runtime Semantics: InstanceofOperator ( _V_, _O_ )</h1>
-      <p>The abstract operation InstanceofOperator(_O_, _C_) implements the generic algorithm for determining if an object _O_ inherits from the inheritance path defined by constructor _C_. This abstract operation performs the following steps:</p>
+      <p>The abstract operation InstanceofOperator(_V_, _O_) implements the generic algorithm for determining if ECMAScript value _V_ inherits from the inheritance path defined by object _O_. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. If Type(_O_) is not Object, throw a *TypeError* exception.
         1. Let _instOfHandler_ be ? GetMethod(_O_, @@hasInstance).
@@ -13454,7 +13454,7 @@
         1. Return ? OrdinaryHasInstance(_O_, _V_).
       </emu-alg>
       <emu-note>
-        <p>Steps 4 and 5 provide compatibility with previous editions of ECMAScript that did not use a @@hasInstance method to define the `instanceof` operator semantics. If a function object does not define or inherit @@hasInstance it uses the default `instanceof` semantics.</p>
+        <p>Steps 4 and 5 provide compatibility with previous editions of ECMAScript that did not use a @@hasInstance method to define the `instanceof` operator semantics. If an object does not define or inherit @@hasInstance it uses the default `instanceof` semantics.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
The current text implies (notes and parameter names) that:
* `lhs` is *always* an object
* `rhs` is *always* a constructor function

Both are not always true with custom `@@hasInstance`.