### PR TITLE
Normative: Specify accuracy of numeric functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12926,6 +12926,7 @@
         <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is an odd integer, the result is *-&infin;*.</li>
         <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is not an odd integer, the result is *+&infin;*.</li>
         <li>If _base_ &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integer, the result is *NaN*.</li>
+        <li> In the remaining cases, the result is an approximation of raising _base_ to the power _exponent_, where the difference between the result and the mathematical value is less than 1 ulp.</li>
       </ul>
       <emu-note>
         <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity* differs from IEEE 754-2008. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2008 specified *1*. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
@@ -25665,6 +25666,9 @@
           <li>
             If all arguments are either *+0* or *-0*, the result is *+0*.
           </li>
+          <li>
+            In the remaining cases, the result is an approximation the square root of the sum of squares of the arguments, where the difference between the result and the mathematical value is less than 1 ulp.
+          </li>
         </ul>
         <emu-note>
           <p>Implementations should take care to avoid the loss of precision from overflows and underflows that are prone to occur in naive implementations when this function is called with two or more arguments.</p>
@@ -25703,6 +25707,9 @@
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
           </li>
+          <li>
+            In the remaining cases, the result is an approximation of the natural logarithm of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
+          </li>
         </ul>
       </emu-clause>
 
@@ -25728,6 +25735,9 @@
           </li>
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the natural logarithm of 1 + _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
       </emu-clause>
@@ -25755,6 +25765,9 @@
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
           </li>
+          <li>
+            In the remaining cases, the result is an approximation of the base 10 logarithm of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
+          </li>
         </ul>
       </emu-clause>
 
@@ -25780,6 +25793,9 @@
           </li>
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the base 2 logarithm of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
       </emu-clause>
@@ -25910,6 +25926,9 @@
           <li>
             If _x_ is *+&infin;* or *-&infin;*, the result is *NaN*.
           </li>
+          <li>
+            In the remaining cases, the result is an approximation of the sine of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
+          </li>
         </ul>
       </emu-clause>
 
@@ -25932,6 +25951,9 @@
           </li>
           <li>
             If _x_ is *-&infin;*, the result is *-&infin;*.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the hyperbolic sine of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
         <emu-note>
@@ -25959,6 +25981,9 @@
           <li>
             If _x_ is *+&infin;*, the result is *+&infin;*.
           </li>
+          <li>
+            In the remaining cases, the square root is computed and rounded to the nearest representable value using IEEE 754-2008 round to nearest, ties to even mode.
+          </li>
         </ul>
       </emu-clause>
 
@@ -25978,6 +26003,9 @@
           </li>
           <li>
             If _x_ is *+&infin;* or *-&infin;*, the result is *NaN*.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the tangent of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
       </emu-clause>
@@ -26001,6 +26029,9 @@
           </li>
           <li>
             If _x_ is *-&infin;*, the result is -1.
+          </li>
+          <li>
+            In the remaining cases, the result is an approximation of the hyperbolic tangent of _x_, where the difference between the result and the mathematical value is less than 1 ulp.
           </li>
         </ul>
         <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -964,7 +964,7 @@
       <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>52</sup>, and _e_ is -1074.</p>
       <p>Note that all the positive and negative integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the integer 0 has two representations, *+0* and *-0*).</p>
       <p>A finite number has an <em>odd significand</em> if it is nonzero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
-      <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact nonzero real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 &ldquo;round to nearest, ties to even&rdquo; mode.)</p>
+      <p>In this specification, the phrase &ldquo;<dfn>the Number value</dfn> for _x_&rdquo; where _x_ represents an exact nonzero real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 &ldquo;round to nearest, ties to even&rdquo; mode.)</p>
       <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup>-1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup>-1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
     </emu-clause>
 
@@ -25133,30 +25133,34 @@
       <!-- es6num="20.2.1.1" -->
       <emu-clause id="sec-math.e">
         <h1>Math.E</h1>
-        <p>The Number value for _e_, the base of the natural logarithms, which is approximately 2.7182818284590452354.</p>
+        <p>The Number value for _e_, the base of the natural logarithms.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <emu-note>`Math.E` can be accurately reprented by the ECMAScript Number literal `2.7182818284590452354`.</emu-note>
       </emu-clause>
 
       <!-- es6num="20.2.1.2" -->
       <emu-clause id="sec-math.ln10">
         <h1>Math.LN10</h1>
-        <p>The Number value for the natural logarithm of 10, which is approximately 2.302585092994046.</p>
+        <p>The Number value for the natural logarithm of 10.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <emu-note>`Math.LN10` can be accurately reprented by the ECMAScript Number literal `2.302585092994046`.</emu-note>
       </emu-clause>
 
       <!-- es6num="20.2.1.3" -->
       <emu-clause id="sec-math.ln2">
         <h1>Math.LN2</h1>
-        <p>The Number value for the natural logarithm of 2, which is approximately 0.6931471805599453.</p>
+        <p>The Number value for the natural logarithm of 2.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <emu-note>`Math.LN2` can be accurately reprented by the ECMAScript Number literal `0.6931471805599453`.</emu-note>
       </emu-clause>
 
       <!-- es6num="20.2.1.4" -->
       <emu-clause id="sec-math.log10e">
         <h1>Math.LOG10E</h1>
-        <p>The Number value for the base-10 logarithm of _e_, the base of the natural logarithms; this value is approximately 0.4342944819032518.</p>
+        <p>The Number value for the base-10 logarithm of _e_, the base of the natural logarithms.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
+          <p>`Math.LOG10E` can be accurately reprented by the ECMAScript Number literal `0.4342944819032518`.</emu-note>
           <p>The value of `Math.LOG10E` is approximately the reciprocal of the value of `Math.LN10`.</p>
         </emu-note>
       </emu-clause>
@@ -25164,9 +25168,10 @@
       <!-- es6num="20.2.1.5" -->
       <emu-clause id="sec-math.log2e">
         <h1>Math.LOG2E</h1>
-        <p>The Number value for the base-2 logarithm of _e_, the base of the natural logarithms; this value is approximately 1.4426950408889634.</p>
+        <p>The Number value for the base-2 logarithm of _e_, the base of the natural logarithms.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
+          <p>`Math.LOG2E` can be accurately reprented by the ECMAScript Number literal `1.4426950408889634`.</emu-note>
           <p>The value of `Math.LOG2E` is approximately the reciprocal of the value of `Math.LN2`.</p>
         </emu-note>
       </emu-clause>
@@ -25174,16 +25179,18 @@
       <!-- es6num="20.2.1.6" -->
       <emu-clause id="sec-math.pi">
         <h1>Math.PI</h1>
-        <p>The Number value for &pi;, the ratio of the circumference of a circle to its diameter, which is approximately 3.1415926535897932.</p>
+        <p>The Number value for &pi;, the ratio of the circumference of a circle to its diameter.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <emu-note>`Math.PI` can be accurately reprented by the ECMAScript Number literal `3.141592653589793`.</emu-note>
       </emu-clause>
 
       <!-- es6num="20.2.1.7" -->
       <emu-clause id="sec-math.sqrt1_2">
         <h1>Math.SQRT1_2</h1>
-        <p>The Number value for the square root of &frac12;, which is approximately 0.7071067811865476.</p>
+        <p>The Number value for the square root of &frac12;.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
+          <p>`Math.SQRT1_2` can be accurately reprented by the ECMAScript Number literal `0.7071067811865476`.</emu-note>
           <p>The value of `Math.SQRT1_2` is approximately the reciprocal of the value of `Math.SQRT2`.</p>
         </emu-note>
       </emu-clause>
@@ -25191,8 +25198,9 @@
       <!-- es6num="20.2.1.8" -->
       <emu-clause id="sec-math.sqrt2">
         <h1>Math.SQRT2</h1>
-        <p>The Number value for the square root of 2, which is approximately 1.4142135623730951.</p>
+        <p>The Number value for the square root of 2.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <emu-note>`Math.SQRT2` can be accurately reprented by the ECMAScript Number literal `1.4142135623730951`.</emu-note>
       </emu-clause>
 
       <!-- es6num="20.2.1.9" -->


### PR DESCRIPTION
This patch further specifies Math library functions which are defined
as implementation-defined approximations. The functions are given
restricted ranges of accuracy:
- Trigonometric functions, logarithms, Math.pow and Math.hypot are specified
  accurate within one ulp
- Math.sqrt is defined to have correct rounding

Based on revised test262 tests, JSC, ChakraCore, SpiderMonkey and V8
all seem to implement these semantics already.

Specifying Math functions was discussed at the July 2014 and May 2015
TC39 meetings; this patch attempts to capture the conclusion of that
discussion.