### PR TITLE
Editorial: Remove stray ! from async function spec

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19610,7 +19610,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-        1. Let _declResult_ be ! FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
+        1. Let _declResult_ be FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. If _declResult_ is not an abrupt completion, then
           1. Perform ! AsyncFunctionStart(_promiseCapability_, |FunctionBody|).
         1. Else _declResult_ is an abrupt completion,
@@ -19898,7 +19898,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-        1. Let _declResult_ be ! FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
+        1. Let _declResult_ be FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. If _declResult_ is not an abrupt completion, then
           1. Perform ! AsyncFunctionStart(_promiseCapability_, |AssignmentExpression|).
         1. Else _declResult_ is an abrupt completion,


### PR DESCRIPTION
FunctionDeclarationInstantion may return an abrupt completion, and the
following lines handle that abrupt competion, so there should be no !.