### PR TITLE
Fix typology in the spec at async expressions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19423,7 +19423,7 @@
     </emu-grammar>
 
     <emu-note>
-      <p>`await` is parsed as an |AwaitExpression| when the <sub>[Await]</sub> parameter in present. The <sub>[Await]</sub> parameter is present in the following contexts:</p>
+      <p>`await` is parsed as an |AwaitExpression| when the <sub>[Await]</sub> parameter is present. The <sub>[Await]</sub> parameter is present in the following contexts:</p>
       <ul>
         <li>In an |AsyncFunctionBody|.</li>
         <li>In the |FormalParameters| of an |AsyncFunctionDeclaration| and |AsyncFunctionExpression|. |AwaitExpression| in this position is a Syntax error via static semantics.</li>


### PR DESCRIPTION
Changed the typology of the note about Async Expression (" [...] when the Await parameter in present. " to " [...] when the Await parameter is present. ")