### PR TITLE
Only allow standalone reserve solidus in Annex B regular expression when immediately followed by `c`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -647,6 +647,7 @@
           DecimalDigit [lookahead &lt;! DecimalDigit]
       </emu-grammar>
       <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
+      <p>Similarly, if the phrase &ldquo;[lookahead &isin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the immediately following input token sequence is a member of the given _set_. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead = _terminal_]&rdquo; may be used.</p>
       <p>If the phrase &ldquo;[no |LineTerminator| here]&rdquo; appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a |LineTerminator| occurs in the input stream at the indicated position. For example, the production:</p>
       <emu-grammar>
         ThrowStatement :
@@ -29444,7 +29445,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The production <emu-grammar>ClassEscape :: `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the CharSet containing the single character - U+002D (HYPHEN-MINUS).
+          1. Return the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
         </emu-alg>
         <p>The production <emu-grammar>ClassEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
@@ -38148,6 +38149,7 @@ THH:mm:ss.sss
         ExtendedAtom ::
           `.`
           `\` AtomEscape[~U]
+          `\` [lookahead == `c`]
           CharacterClass[~U]
           `(` Disjunction[~U] `)`
           `(` `?` `:` Disjunction[~U] `)`
@@ -38160,7 +38162,7 @@ THH:mm:ss.sss
           `{` DecimalDigits `,` DecimalDigits `}`
 
         ExtendedPatternCharacter ::
-          SourceCharacter but not one of `^` `$` `.` `*` `+` `?` `(` `)` `[` `|`
+          SourceCharacter but not one of `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `|`
 
         AtomEscape[U] ::
           [+U] DecimalEscape
@@ -38218,6 +38220,11 @@ THH:mm:ss.sss
         <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) evaluation rules for the <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
 
         <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules are also added:</p>
+        <p>The production <emu-grammar>ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
+          1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
+        </emu-alg>
         <p>The production <emu-grammar>ExtendedAtom :: InvalidBracedQuantifier</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Throw a *SyntaxError* exception.
@@ -38272,7 +38279,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. If _Unicode_ is *false*, then
               1. If _A_ does not contain exactly one character or _B_ does not contain exactly one character, then
-                1. Let _C_ be the CharSet containing the single character - U+002D (HYPHEN-MINUS).
+                1. Let _C_ be the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
                 1. Return the union of CharSets _A_, _B_ and _C_.
             1. Return CharacterRange(_A_, _B_).
           </emu-alg>


### PR DESCRIPTION
This makes it easier to disallow invalid `\k` escapes for https://tc39.github.io/proposal-regexp-named-groups/#annex-b-grammar and also disallows `/\/` 😰 .


cc @littledan 