### PR TITLE
Store and rethrow module instantiation/evaluation errors

### DIFF
--- a/img/module-graph-cycle.svg
+++ b/img/module-graph-cycle.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 181 121">
+<style>
+  rect {
+    fill: white;
+    stroke: black;
+    rx: 10;
+    ry: 10;
+  }
+
+  text {
+    dominant-baseline: central;
+    text-anchor: middle;
+    font-family: sans-serif;
+  }
+
+  line, path {
+    stroke: black;
+    marker-end: url(#arrowhead);
+  }
+
+  svg &gt; path {
+    fill: transparent;
+  }
+</style>
+
+<defs>
+  <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto">
+  <path d="M0,0 L0,6 L9,3 z"></path>
+  </marker>
+</defs>
+
+<rect x="60.5" y="0.5" width="60" height="30"/>
+<text x="90.5" y="15.5">A</text>
+
+<rect x="0.5" y="90.5" width="60" height="30"/>
+<text x="30.5" y="105.5">B</text>
+
+<rect x="120.5" y="90.5" width="60" height="30"/>
+<text x="150.5" y="105.5">C</text>
+
+<!-- <line x1="90.5" y1="30.5" x2="30.5" y2="90.5"/> -->
+<path d="M90.5 30.5 Q 70.5 70.5 30.5 90.5"/>
+<line x1="90.5" y1="30.5" x2="150.5" y2="90.5"/>
+<!-- <line x1="30.5" y1="90.5" x2="90.5" y2="30.5"/> -->
+<path d="M30.5 90.5 Q 50.5 50.5 90.5 30.5"/>
+
+<!--
+Nodes:
+
+ A
+B C
+
+Edges:
+
+A -> B
+A -> C
+B -> A
+
+https://jsbin.com/qopeye
+
+Tweaked to be curvier
+-->
+</svg>

--- a/img/module-graph-missing.svg
+++ b/img/module-graph-missing.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 121 121">
+<style>
+  rect {
+    fill: white;
+    stroke: black;
+    rx: 10;
+    ry: 10;
+  }
+
+  text {
+    dominant-baseline: central;
+    text-anchor: middle;
+    font-family: sans-serif;
+  }
+
+  line {
+    stroke: black;
+    marker-end: url(#arrowhead);
+  }
+</style>
+
+<defs>
+  <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto">
+  <path d="M0,0 L0,6 L9,3 z"></path>
+  </marker>
+</defs>
+
+<rect x="60.5" y="0.5" width="60" height="30"/>
+<text x="90.5" y="15.5">A</text>
+
+<rect x="60.5" y="90.5" width="60" height="30"/>
+<text x="90.5" y="105.5">???</text>
+
+<line x1="90.5" y1="30.5" x2="90.5" y2="90.5"/>
+
+<!--
+Nodes:
+
+ A
+ ???
+
+Edges:
+
+A -> ???
+
+https://jsbin.com/qopeye
+-->
+</svg>

--- a/img/module-graph-simple.svg
+++ b/img/module-graph-simple.svg
@@ -26,13 +26,13 @@
 </defs>
 
 <rect x="60.5" y="0.5" width="60" height="30"/>
-<text x="90.5" y="15.5">a.js</text>
+<text x="90.5" y="15.5">A</text>
 
 <rect x="60.5" y="90.5" width="60" height="30"/>
-<text x="90.5" y="105.5">b.js</text>
+<text x="90.5" y="105.5">B</text>
 
 <rect x="60.5" y="180.5" width="60" height="30"/>
-<text x="90.5" y="195.5">c.js</text>
+<text x="90.5" y="195.5">C</text>
 
 <line x1="90.5" y1="30.5" x2="90.5" y2="90.5"/>
 <line x1="90.5" y1="120.5" x2="90.5" y2="180.5"/>
@@ -40,16 +40,16 @@
 <!--
 Nodes:
 
- a
- b
- c
-  
+ A
+ B
+ C
+
 
 Edges:
 
-a -> b
-b -> c
-    
+A -> B
+B -> C
+
 
 https://jsbin.com/qopeye
 -->

--- a/img/module-graph-simple.svg
+++ b/img/module-graph-simple.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 121 121">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 121 211">
 <style>
   rect {
     fill: white;
@@ -26,23 +26,30 @@
 </defs>
 
 <rect x="60.5" y="0.5" width="60" height="30"/>
-<text x="90.5" y="15.5">A</text>
+<text x="90.5" y="15.5">a.js</text>
 
 <rect x="60.5" y="90.5" width="60" height="30"/>
-<text x="90.5" y="105.5">B</text>
+<text x="90.5" y="105.5">b.js</text>
+
+<rect x="60.5" y="180.5" width="60" height="30"/>
+<text x="90.5" y="195.5">c.js</text>
 
 <line x1="90.5" y1="30.5" x2="90.5" y2="90.5"/>
+<line x1="90.5" y1="120.5" x2="90.5" y2="180.5"/>
 
 <!--
 Nodes:
 
- A
- B
+ a
+ b
+ c
+  
 
 Edges:
 
-A -> B
-
+a -> b
+b -> c
+    
 
 https://jsbin.com/qopeye
 -->

--- a/img/module-graph-simple.svg
+++ b/img/module-graph-simple.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 121 121">
+<style>
+  rect {
+    fill: white;
+    stroke: black;
+    rx: 10;
+    ry: 10;
+  }
+
+  text {
+    dominant-baseline: central;
+    text-anchor: middle;
+    font-family: sans-serif;
+  }
+
+  line {
+    stroke: black;
+    marker-end: url(#arrowhead);
+  }
+</style>
+
+<defs>
+  <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto">
+  <path d="M0,0 L0,6 L9,3 z"></path>
+  </marker>
+</defs>
+
+<rect x="60.5" y="0.5" width="60" height="30"/>
+<text x="90.5" y="15.5">A</text>
+
+<rect x="60.5" y="90.5" width="60" height="30"/>
+<text x="90.5" y="105.5">B</text>
+
+<line x1="90.5" y1="30.5" x2="90.5" y2="90.5"/>
+
+<!--
+Nodes:
+
+ A
+ B
+
+Edges:
+
+A -> B
+
+
+https://jsbin.com/qopeye
+-->
+</svg>

--- a/spec.html
+++ b/spec.html
@@ -20989,13 +20989,24 @@
             </tr>
             <tr>
               <td>
-                [[Evaluated]]
+                [[Status]]
               </td>
               <td>
-                Boolean
+                String
               </td>
               <td>
-                Initially *false*, *true* if evaluation of this module has started. Remains *true* when evaluation completes, even if it is an abrupt completion.
+                Initially `"uninstantiated"`. Can become `"instantiated"`, `"instantiating"`, `"evaluated"`, or `"errored"` as the module progresses throughout its lifecycle.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[ErrorCompletion]]
+              </td>
+              <td>
+                An abrupt completion
+              </td>
+              <td>
+                A completion record representing exception that occurred during instantiation or evaluation; meaningful only if [[Status]] is `"errored"`.
               </td>
             </tr>
             <tr>
@@ -21044,7 +21055,7 @@
                 ModuleDeclarationInstantiation()
               </td>
               <td>
-                Transitively resolve all module dependencies and create a module Environment Record for the module.
+                Transitively resolve all module dependencies and create a module Environment Record for the module. Will transition this module's [[Status]] from `"uninstantiated"` to either `"instantiated"` or `"errored"`. While this is executing, this module's [[Status]] will be `"instantiating"`; this is observable through reentrant invocations via circular dependencies.
               </td>
             </tr>
             <tr>
@@ -21052,8 +21063,8 @@
                 ModuleEvaluation()
               </td>
               <td>
-                <p>Do nothing if this module has already been evaluated. Otherwise, transitively evaluate all module dependences of this module and then evaluate this module.</p>
-                <p>ModuleDeclarationInstantiation must be completed prior to invoking this method.</p>
+                <p>Transitively evaluate all module dependences of this module and then evaluate this module.</p>
+                <p>Will transition this module's [[Status]] from `"instantiated"` to either `"evaluated"` or `"errored"`; if the status is already in one of those states, do nothing or return [[ErrorCompletion]] as appropriate. This method will never be invoked when the module's status is `"uninstantiated"`.</p>
               </td>
             </tr>
             </tbody>
@@ -21646,52 +21657,73 @@
           <p>The ModuleDeclarationInstantiation concrete method of a Source Text Module Record performs the following steps:</p>
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
-            1. Let _realm_ be _module_.[[Realm]].
-            1. Assert: _realm_ is not *undefined*.
-            1. Let _code_ be _module_.[[ECMAScriptCode]].
-            1. If _module_.[[Environment]] is not *undefined*, return NormalCompletion(~empty~).
-            1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
-            1. Set _module_.[[Environment]] to _env_.
-            1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
-              1. NOTE: Before instantiating a module, all of the modules it requested must be available. An implementation may perform this test at any time prior to this point.
-              1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
-              1. Perform ? _requiredModule_.ModuleDeclarationInstantiation().
-            1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
-              1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
-              1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
-            1. Assert: All named exports from _module_ are resolvable.
-            1. Let _envRec_ be _env_'s EnvironmentRecord.
-            1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
-              1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
-              1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
-              1. If _in_.[[ImportName]] is `"*"`, then
-                1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
-                1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
-                1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
-              1. Else,
-                1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
-                1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
-                1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
-            1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
-            1. Let _declaredVarNames_ be a new empty List.
-            1. For each element _d_ in _varDeclarations_, do
-              1. For each element _dn_ of the BoundNames of _d_, do
-                1. If _dn_ is not an element of _declaredVarNames_, then
-                  1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
-                  1. Call _envRec_.InitializeBinding(_dn_, *undefined*).
-                  1. Append _dn_ to _declaredVarNames_.
-            1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
-            1. For each element _d_ in _lexDeclarations_, do
-              1. For each element _dn_ of the BoundNames of _d_, do
-                1. If IsConstantDeclaration of _d_ is *true*, then
-                  1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
-                1. Else,
-                  1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
-                1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|, then
-                  1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
-                  1. Call _envRec_.InitializeBinding(_dn_, _fo_).
-            1. Return NormalCompletion(~empty~).
+            1. Let _result_ be InnerModuleDeclarationInstantiation(_module_).
+            1. If _result_ is an abrupt completion,
+              1. Set _module_.[[Status]] to `"errored"`.
+              1. Set _module_.[[ErrorCompletion]] to _result_.
+            1. Otherwise, set _module_.[[Status]] to `"instantiated"`.
+            1. Return _result_.
           </emu-alg>
+
+          <emu-clause id="sec-innermoduledeclarationinstantiation" aoid="InnerModuleDeclarationInstantiation">
+            <h1>Runtime Semantics: InnerModuleDeclarationInstantiation( _module_ )</h1>
+            <p>The InnerModuleDeclarationInstantiation abstract operation performs the following steps:</p>
+            <emu-alg>
+              1. Let _realm_ be _module_.[[Realm]].
+              1. Assert: _realm_ is not *undefined*.
+              1. Let _code_ be _module_.[[ECMAScriptCode]].
+              1. If _module_.[[Status]] is `"errored"`, return _module_.[[ErrorCompletion]].
+              1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"` or `"evaluated"`,
+                1. Assert: _module_.[[Environment]] is not *undefined*.
+                1. Return NormalCompletion(~empty~).
+              1. Assert: _module_.[[Status]] is `"uninstantiated"`.
+              1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
+              1. Set _module_.[[Environment]] to _env_.
+              1. Set _module_.[[Status]] to `"instantiating"`.
+              1. For each String _required_ that is an element of _module_.[[RequestedModules]],
+                1. NOTE: Before instantiating a module, all of the modules it requested must be available. An implementation may perform this test at any time prior to this point.
+                1. Perform ? HostResolveImportedModule(_module_, _required_).
+              1. For each String _required_ that is an element of _module_.[[RequestedModules]],
+                1. NOTE: this loop is separate from the previous one to ensure that exceptions due to unresolvable modules are thrown before attempting to instantiate any modules.
+                1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
+                1. Perform ? _requiredModule_.ModuleDeclarationInstantiation().
+              1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
+                1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
+                1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
+              1. Assert: All named exports from _module_ are resolvable.
+              1. Let _envRec_ be _env_'s EnvironmentRecord.
+              1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
+                1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
+                1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
+                1. If _in_.[[ImportName]] is `"*"`, then
+                  1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
+                  1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
+                  1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
+                1. Else,
+                  1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
+                  1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
+                  1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
+              1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
+              1. Let _declaredVarNames_ be a new empty List.
+              1. For each element _d_ in _varDeclarations_, do
+                1. For each element _dn_ of the BoundNames of _d_, do
+                  1. If _dn_ is not an element of _declaredVarNames_, then
+                    1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+                    1. Call _envRec_.InitializeBinding(_dn_, *undefined*).
+                    1. Append _dn_ to _declaredVarNames_.
+              1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
+              1. For each element _d_ in _lexDeclarations_, do
+                1. For each element _dn_ of the BoundNames of _d_, do
+                  1. If IsConstantDeclaration of _d_ is *true*, then
+                    1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
+                  1. Else,
+                    1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+                  1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|, then
+                    1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
+                    1. Call _envRec_.InitializeBinding(_dn_, _fo_).
+              1. Return NormalCompletion(~empty~).
+            </emu-alg>
+          </emu-clause>
         </emu-clause>
 
         <!-- es6num="15.2.1.16.5" -->
@@ -21700,14 +21732,18 @@
           <p>The ModuleEvaluation concrete method of a Source Text Module Record performs the following steps:</p>
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
-            1. Assert: ModuleDeclarationInstantiation has already been invoked on _module_ and successfully completed.
             1. Assert: _module_.[[Realm]] is not *undefined*.
-            1. If _module_.[[Evaluated]] is *true*, return *undefined*.
-            1. Set _module_.[[Evaluated]] to *true*.
+            1. Assert: _module_.[[Status]] is not `"uninstantiated"` or `"instantiating"`.
+            1. If _module_.[[Status]] is `"evaluated"`, return *undefined*.
+            1. If _module_.[[Status]] is `"errored"`, return _module_.[[ErrorCompletion]].
             1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
               1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-              1. NOTE: ModuleDeclarationInstantiation must be completed prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-              1. Perform ? _requiredModule_.ModuleEvaluation().
+              1. NOTE: ModuleDeclarationInstantiation must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+              1. Let _requiredModuleStatus_ be _requiredModule_.ModuleEvaluation().
+              1. If _requiredModuleStatus_ is an abrupt completion,
+                1. Set _module_.[[Status]] to `"errored"`.
+                1. Set _module_.[[ErrorCompletion]] to _requiredModuleStatus_.
+                1. Return _requiredModuleStatus_.
             1. Let _moduleCxt_ be a new ECMAScript code execution context.
             1. Set the Function of _moduleCxt_ to *null*.
             1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
@@ -21720,6 +21756,10 @@
             1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
             1. Suspend _moduleCxt_ and remove it from the execution context stack.
             1. Resume the context that is now on the top of the execution context stack as the running execution context.
+            1. If _result_ is an abrupt completion,
+              1. Set _module_.[[Status]] to `"errored"`.
+              1. Set _module_.[[ErrorCompletion]] to _result_.
+            1. Otherwise, set _module_.[[Status]] to `"evaluated"`.
             1. Return Completion(_result_).
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -21652,9 +21652,12 @@
           <p>The PropagateResolution abstract operation performs the following steps:</p>
           <emu-alg>
             1. If _resolution_ is an abrupt completion, then
-              1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
-              1. Set _module_.[[Status]] to `"errored"`.
-              1. Set _module_.[[ErrorCompletion]] to _resolution_.
+              1. If _module_.[[Status]] is `"errored"`, then
+                1. Assert: _module_.[[ErrorCompletion]] is _resolution_.
+              1. Otherwise,
+                1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
+                1. Set _module_.[[Status]] to `"errored"`.
+                1. Set _module_.[[ErrorCompletion]] to _resolution_.
             1. Return _resolution_.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -21625,8 +21625,8 @@
               1. Assert: _module_ imports a specific binding for this export.
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
-              1. Let _requestedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _starNames_ be ? _requestedModule_.GetExportedNames(_exportStarSet_).
+              1. Let _requestedModule_ be ! HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
+              1. Let _starNames_ be ! _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
                 1. If SameValue(_n_, `"default"`) is *false*, then
                   1. If _n_ is not an element of _exportedNames_, then
@@ -21656,7 +21656,7 @@
             1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Assert: _module_ imports a specific binding for this export.
-                1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
+                1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. Return ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
@@ -21664,7 +21664,7 @@
               1. NOTE: A `default` export cannot be provided by an `export *`.
             1. Let _starResolution_ be *null*.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
-              1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
+              1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
               1. If _resolution_ is `"ambiguous"`, return `"ambiguous"`.
               1. If _resolution_ is not *null*, then
@@ -21718,7 +21718,7 @@
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Append _module_ to _stack_.
               1. For each String _required_ that is an element of _module_.[[RequestedModules]],
-                1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
+                1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
                 1. Perform ? InnerModuleDeclarationInstantiation(_requiredModule_, _stack_, _index_+1).
                 1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is "`instantiating`" if and only if _requiredModule_ is in _stack_.
@@ -21750,7 +21750,9 @@
               1. Let _envRec_ be _env_'s EnvironmentRecord.
               1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
                 1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
-                1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
+                <!-- 1. NOTE: The above call cannot fail because imported module
+                     requests are a subset of _module_.[[RequestedModules]], and
+                     these have been resolved earlier in this algorithm. -->
                 1. If _in_.[[ImportName]] is `"*"`, then
                   1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
                   1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
@@ -21888,7 +21890,7 @@
           1. Assert: _module_.[[Status]] is neither `"uninstantiated"` nor `"errored"`.
           1. Let _namespace_ be _module_.[[Namespace]].
           1. If _namespace_ is *undefined*, then
-            1. Let _exportedNames_ be ? _module_.GetExportedNames(&laquo; &raquo;).
+            1. Let _exportedNames_ be ! _module_.GetExportedNames(&laquo; &raquo;).
             1. Let _unambiguousNames_ be a new empty List.
             1. For each _name_ that is an element of _exportedNames_, do
               1. Let _resolution_ be ? _module_.ResolveExport(_name_, &laquo; &raquo;).

--- a/spec.html
+++ b/spec.html
@@ -21055,7 +21055,7 @@
                 Instantiate()
               </td>
               <td>
-                <p>Transitively resolve all module dependencies and create a module Environment Record for the module.</p>
+                <p>Prepare the module for evaluation by transitively resolving all module dependencies and creating a module Environment Record.</p>
                 <p>Will transition this module's [[Status]] from `"uninstantiated"` to either `"instantiated"` or `"errored"`. While this is executing, this module's [[Status]] will be `"instantiating"`; this is observable through reentrant invocations via circular dependencies.</p>
               </td>
             </tr>
@@ -21696,7 +21696,7 @@
 
           <p>The Instantiate concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
-          <p>Instantiate ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller. In particular, this will cause such failures to propagate to any parent modules in the graph, and thus to their strongly connected components.</p>
+          <p>Instantiate ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in this module's [[Status]] and [[ErrorCompletion]] fields. If the error is blamed on a dependent module, it is additionally recorded there in the same way.</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -21720,7 +21720,7 @@
           <emu-clause id="sec-innermoduledeclarationinstantiation" aoid="InnerModuleDeclarationInstantiation">
             <h1>InnerModuleDeclarationInstantiation( _module_, _stack_, _index_ )</h1>
 
-            <p>The InnerModuleDeclarationInstantiation abstract operation is used by Instantiate to perform the actual instantiation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
+            <p>The InnerModuleDeclarationInstantiation abstract operation is used by Instantiate to perform the actual instantiation process for the Source Text Module Record _module_, as well as recursively on all other Source Text Module Records in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to `"instantiated"` together.</p>
 
             <p>This abstract operation performs the following steps:</p>
 
@@ -21920,21 +21920,19 @@
         <emu-clause id="sec-example-source-text-module-record-graphs">
           <h1>Example Source Text Module Record Graphs</h1>
 
-          <p>This section gives a series of non-normative examples of the instantiation and evaluation of various module graphs, with a specific focus on how errors can occur.</p>
+          <p>This non-normative section gives a series of examples of the instantiation and evaluation of a few common module graphs, with a specific focus on how errors can occur.</p>
 
           <p>First consider the following simple module graph:</p>
 
           <emu-figure id="figure-module-graph-simple" caption="A simple module graph">
-            <img alt="A module graph in which module A depends on module B" width="121" height="121" src="img/module-graph-simple.svg">
+            <img alt="A module graph in which module A depends on module B" width="121" height="211" src="img/module-graph-simple.svg">
           </emu-figure>
 
-          <p>Let's first assume that there are no error conditions. Then, a host will call _A_.Instantiate(), which will complete successfully by assumption, and recursively instantiate module _B_ as well. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the module, it can call _A_.Evaluate(), which will complete successfully (again by assumption).</p>
+          <p>Let's first assume that there are no error conditions. When a host first calls _A_.Instantiate(), this will complete successfully by assumption, and recursively instantiate modules _B_ and _C_ as well, such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = `"instantiated"`. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be `"evaluated`".</p>
 
-          <p>Consider then cases involving instantiation errors. If _B_ cannot be instantiated, for example because it imports itself, then _A_.Instantiate() will fail, and the resulting exception will be recorded in both _A_ and _B_'s [[Status]] and [[ErrorCompletion]] fields. If the host then proceeds to call to _A_.Evaluate(), the exception will be re-thrown. Storing the exception also ensures that any time a host tries to reuse _A_ or _B_, it will encounter the same exception. (Hosts are not required to reuse Source Text Module Records; similarly, hosts are not required to expose the exception objects thrown by these methods. However, the specification enables such uses.)</p>
+          <p>Consider then cases involving instantiation errors. If InnerModuleDeclarationInstantiation of _C_ succeeds but, thereafter, fails for _B_, for example because it imports something that _C_ does not provide, then the original _A_.Instantiate() will fail, and the resulting exception will be recorded in both _A_ and _B_'s [[Status]] and [[ErrorCompletion]] fields (_C_ will remain `"instantiated"`). If the host then proceeds to call to _A_.Evaluate(), the exception will be re-thrown. Storing the exception also ensures that any time a host tries to reuse _A_ or _B_, it will encounter the same exception. (Hosts are not required to reuse Source Text Module Records; similarly, hosts are not required to expose the exception objects thrown by these methods. However, the specification enables such uses.)</p>
 
           <p>Evaluation errors, such as throwing an exception at top-level, act much the same way as instantiation errors. Like instantiation errors, they are recorded in the [[Status]] and [[ErrorCompletion]] fields, thus preventing future instantiation or evaluation. They differ only in that detection will be delayed until _A_.Evaluate() is called.</p>
-
-          <p>Note that if the instantiation or evaluation error occurs in _A_, _B_'s [[Status]] and [[ErrorCompletion]] remain unaffected. In other words, there is no propagation of errors to dependencies, only to dependents. (Unless the dependencies are in the same strongly connected component, i.e. are part of a cycle—see below for that case.)</p>
 
           <p>Now consider a different type of error condition:</p>
 
@@ -21942,7 +21940,7 @@
             <img alt="A module graph in which module A depends on a missing (unresolvable) module, represented by ???" width="121" height="121" src="img/module-graph-missing.svg">
           </emu-figure>
 
-          <p>In this scenario, module _A_ declares a dependency (via an `import` statement) on some other module, but no Module Record exists for that module, i.e. HostResolveImportedModule throws an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule throwing an exception when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the exception they throw from HostResolveImportedModule. In any case, this exception causes an instantiation failure, which as before is recorded in _A_.</p>
+          <p>In this scenario, module _A_ declares a dependency on some other module, but no Module Record exists for that module, i.e. HostResolveImportedModule throws an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule throwing an exception when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the exception they throw from HostResolveImportedModule. In any case, this exception causes an instantiation failure, which as before is recorded in _A_.</p>
 
           <p>Finally consider a module graph with a cycle:</p>
 
@@ -21950,9 +21948,9 @@
             <img alt="A module graph in which module A depends on module B and C, but module B also depends on module A" width="181" height="121" src="img/module-graph-cycle.svg">
           </emu-figure>
 
-          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Instantiate(). This in turn calls _B_.Instantiate(). Because of the cycle, _B_.Instantiate() calls _A_.Instantiate(). In this case, _A_.[[Status]] is `"instantiating"`, so it returns the partially-instantiated _A_. This leaves _B_ as `"instantiating"` as well, i.e. the last steps of InnerModuleDeclarationInstantiation are not performed on _B_. But eventually, when we unwind back up and _C_ has become `"instantiated"`, both _A_ and _B_ then transition from `"instantiating"` to `"instantiated"` together; this is by design, since they are part of the same strongly connected component.</p>
+          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Instantiate(), which performs InnerModuleDeclarationInstantiation on _A_. This in turn calls InnerModuleDeclarationInstantiation on _B_. Because of the cycle, this again triggers InnerModuleDeclarationInstantiation on _A_, but at this point it is a no-op since _A_.[[Status]] is already `"instantiating"`. _B_.[[Status]] itself remains `"instantiating"` when control gets back to _A_ and InnerModuleDeclarationInstantiation is triggered on _C_. After this returns with _C_.[[Status]] being `"instantiated"` , both _A_ and _B_ transition from `"instantiating"` to `"instantiated"` together; this is by design, since they form a strongly connected component.</p>
 
-          <p>Now consider a case where _A_ has an instantiation error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to _A_.Instantiate(). However, once we unwind back to the original call to _A_.Instantiate(), it fails during ModuleDeclarationEnvironmentSetup, and in particular during a call to _C_.ResolveExport(). This exception propagates up to Instantiate, which goes through everything in the depth-first search stack and propagates the exception to them. Since the stack at this point consists of both _A_ and _B_, this atomically transitions _A_ and _B_ to the `"errored"` status, as desired. Note that _C_ is left as `"uninstantiated"`.</p>
+          <p>Now consider a case where _A_ has an instantiation error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleDeclarationInstantiation on _A_. However, once we unwind back to the original InnerModuleDeclarationInstantiation on _A_, it fails during ModuleDeclarationEnvironmentSetup, namely in _C_.ResolveExport(). The exception thrown by ResolutionError propagates up to _A_.Instantiate, which records the error in all modules that are currently on its _stack_ (these are always exactly the modules that are still `"instantiating"`). Hence both _A_ and _B_ become `"errored"`. Note that _C_ is left as `"instantiated"`.</p>
 
           <p>Analogous stories occur for evaluation of the cyclic module graph, both in the success and error cases.</p>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -21077,7 +21077,7 @@
       <emu-clause id="sec-source-text-module-records">
         <h1>Source Text Module Records</h1>
 
-        <p>A <dfn>Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (10) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module.</p>
+        <p>A <dfn>Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (<emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module.</p>
 
         <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type. However, non-source text Module Records must not participate in dependency cycles with Source Text Module Records. Concretely, this is enforced below by assertions that non-source text Module Record dependencies do not have a [[Status]] of `"instantiating"` or `"evaluating"` during a call to ModuleDeclarationInstantiation or ModuleEvaluation on a Source Text Module Record.</p>
 

--- a/spec.html
+++ b/spec.html
@@ -21742,7 +21742,7 @@
 
           <p>The ModuleDeclarationInstantiation concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
-          <p>ModuleDeclarationInstantiation ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller.</p>
+          <p>ModuleDeclarationInstantiation ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller. In particular, this will cause such failures to propagate to any parent modules in the graph, and thus to their strongly connected components.</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -21859,7 +21859,7 @@
 
           <p>The ModuleEvaluation concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
-          <p>ModuleEvaluation ensures that if evaluation (the actual work for which is performed by InnerModuleEvaluation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller.</p>
+          <p>ModuleEvaluation ensures that if evaluation (the actual work for which is performed by InnerModuleEvaluation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller. In particular, this will cause such failures to propagate to any parent modules in the graph, and thus to their strongly connected components.</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -21944,6 +21944,46 @@
               1. Resume the context that is now on the top of the execution context stack as the running execution context.
             </emu-alg>
           </emu-clause>
+        </emu-clause>
+
+        <emu-clause id="sec-example-source-text-module-record-graphs">
+          <h1>Example Source Text Module Record Graphs</h1>
+
+          <p>This section gives a series of non-normative examples of the instantiation and evaluation of various module graphs, with a specific focus on how errors can occur.</p>
+
+          <p>First consider the following simple module graph:</p>
+
+          <emu-figure id="figure-module-graph-simple" caption="A simple module graph">
+            <img alt="A module graph in which module A depends on module B" width="121" height="121" src="img/module-graph-simple.svg">
+          </emu-figure>
+
+          <p>Let's first assume that there are no error conditions. Then, a host will call _A_.ModuleDeclarationInstantiation(), which will complete successfully by assumption, and recursively instantiate module _B_ as well. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the module, it can call _A_.ModuleEvaluation(), which will complete successfully (again by assumption).</p>
+
+          <p>Consider then cases involving instantiation errors. If _B_ cannot be instantiated, for example because it imports itself, then _A_.ModuleDeclarationInstantiation() will fail, and the resulting exception will be recorded in both _A_ and _B_'s [[Status]] and [[ErrorCompletion]] fields. If the host then proceeds to call to _A_.ModuleEvaluation(), the exception will be re-thrown. Storing the exception also ensures that any time a host tries to reuse _A_ or _B_, it will encounter the same exception. (Hosts are not required to reuse Source Text Module Records; similarly, hosts are not required to expose the exception objects thrown by these methods. However, the specification enables such uses.)</p>
+
+          <p>Evaluation errors, such as throwing an exception at top-level, act much the same way as instantiation errors. Like instantiation errors, they are recorded in the [[Status]] and [[ErrorCompletion]] fields, thus preventing future instantiation or evaluation. They differ only in that detection will be delayed until _A_.ModuleEvaluation() is called.</p>
+
+          <p>Note that if the instantiation or evaluation error occurs in _A_, _B_'s [[Status]] and [[ErrorCompletion]] remain unaffected. In other words, there is no propagation of errors to dependencies, only to dependents. (Unless the dependencies are in the same strongly connected component, i.e. are part of a cycle—see below for that case.)</p>
+
+          <p>Now consider a different type of error condition:</p>
+
+          <emu-figure id="figure-module-graph-missing" caption="A module graph with an unresolvable module">
+            <img alt="A module graph in which module A depends on a missing (unresolvable) module, represented by ???" width="121" height="121" src="img/module-graph-missing.svg">
+          </emu-figure>
+
+          <p>In this scenario, module _A_ declares a dependency (via an `import` statement) on some other module, but no Module Record exists for that module, i.e. HostResolveImportedModule throws an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule throwing an exception when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the exception they throw from HostResolveImportedModule. In any case, this exception causes an instantiation failure, which as before is recorded in _A_.</p>
+
+          <p>Finally consider a module graph with a cycle:</p>
+
+          <emu-figure id="figure-module-graph-cycle" caption="A cyclic module graph">
+            <img alt="A module graph in which module A depends on module B and C, but module B also depends on module A" width="181" height="121" src="img/module-graph-cycle.svg">
+          </emu-figure>
+
+          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.ModuleDeclarationInstantiation(). This in turn calls _B_.ModuleDeclarationInstantiation(). Because of the cycle, _B_.ModuleDeclarationInstantiation() calls _A_.ModuleDeclarationInstantiation(). In this case, _A_.[[Status]] is `"instantiating"`, so it returns the partially-instantiated _A_. This leaves _B_ as `"instantiating"` as well, i.e. the last steps of InnerModuleDeclarationInstantiation are not performed on _B_. But eventually, when we unwind back up and _C_ has become `"instantiated"`, both _A_ and _B_ then transition from `"instantiating"` to `"instantiated"` together; this is by design, since they are part of the same strongly connected component.</p>
+
+          <p>Now consider a case where _A_ has an instantiation error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to _A_.ModuleDeclarationInstantiation(). However, once we unwind back to the original call to _A_.ModuleDeclarationInstantiation(), it fails during ModuleDeclarationEnvironmentSetup, and in particular during a call to _C_.ResolveExport(). This exception propagates up to ModuleDeclarationInstantiation, which goes through everything in the depth-first search stack and propagates the exception to them. Since the stack at this point consists of both _A_ and _B_, this atomically transitions _A_ and _B_ to the `"errored"` status, as desired. Note that _C_ is left as `"uninstantiated"`.</p>
+
+          <p>Analogous stories occur for evaluation of the cyclic module graph, both in the success and error cases.</p>
         </emu-clause>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -21726,7 +21726,7 @@
               1. Return _result_.
             1. Assert: _module_.[[Status]] is `"instantiated"` or `"evaluated"`.
             1. Assert: _stack_ is empty.
-            1. Return _result_.
+            1. Return *undefined*.
           </emu-alg>
 
           <emu-clause id="sec-innermoduledeclarationinstantiation" aoid="InnerModuleDeclarationInstantiation">
@@ -21735,19 +21735,21 @@
             <emu-alg>
               1. If _module_ is not a Source Text Module Record,
                 1. Assert: _module_.[[Status]] is not `"instantiating"`.
-                1. Return _module_.ModuleDeclarationInstantiation().
+                1. Perform ? _module_.ModuleDeclarationInstantiation().
+                1. Return _index_.
               1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"`, or `"evaluated"`,
-                1. Return *undefined*.
+                1. Return _index_.
               1. If _module_.[[Status]] is `"errored"`,
                 1. Return _module_.[[ErrorCompletion]].
               1. Assert: _module_.[[Status]] is `"uninstantiated"`.
               1. Set _module_.[[Status]] to `"instantiating"`.
               1. Set _module_.[[DFSIndex]] to _index_.
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
+              1. Set _index_ to _index_ + 1.
               1. Append _module_ to _stack_.
               1. For each String _required_ that is an element of _module_.[[RequestedModules]],
                 1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
-                1. Perform ? InnerModuleDeclarationInstantiation(_requiredModule_, _stack_, _index_+1).
+                1. Set _index_ to ? InnerModuleDeclarationInstantiation(_requiredModule_, _stack_, _index_).
                 1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is "`instantiating`" if and only if _requiredModule_ is in _stack_.
                 1. If _requiredModule_.[[Status]] is "`instantiating`", set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
@@ -21759,7 +21761,7 @@
                 1. Remove this element from _stack_.
                 1. Set _requiredModule_.[[Status]] to "`instantiated`".
                 1. If _requiredModule_ is _module_, end the repetition.
-              1. Return *undefined*.
+              1. Return _index_.
             </emu-alg>
           </emu-clause>
 
@@ -21827,7 +21829,7 @@
               1. Return _result_.
             1. Assert: _module_.[[Status]] is `"evaluated"`.
             1. Assert: _stack_ is empty.
-            1. Return _result_.
+            1. Return *undefined*.
           </emu-alg>
 
           <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
@@ -21836,20 +21838,22 @@
             <emu-alg>
               1. If _module_ is not a Source Text Module Record,
                 1. Assert: _module_.[[Status]] is not `"evaluating"`.
-                1. Return _module_.ModuleEvaluation().
+                1. Perform ? _module_.ModuleEvaluation().
+                1. Return _index_.
               1. If _module_.[[Status]] is `"evaluating"` or `"evaluated"`,
-                1. Return *undefined*.
+                1. Return _index_.
               1. If _module_.[[Status]] is `"errored"`,
                 1. Return _module_.[[ErrorCompletion]].
               1. Assert: _module_.[[Status]] is `"instantiated"`.
               1. Set _module_.[[Status]] to `"evaluating"`.
               1. Set _module_.[[DFSIndex]] to _index_.
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
+              1. Set _index_ to _index_ + 1.
               1. Append _module_ to _stack_.
               1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
                 1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
                 1. NOTE: ModuleDeclarationInstantiation must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-                1. Perform ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_ + 1).
+                1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
                 1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is "`evaluating`" if and only if _requiredModule_ is in _stack_.
                 1. If _requiredModule_.[[Status]] is "`evaluating`", set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
@@ -21861,7 +21865,7 @@
                 1. Remove this element from _stack_.
                 1. Set _requiredModule_.[[Status]] to "`evaluated`".
                 1. If _requiredModule_ is _module_, end the repetition.
-              1. Return *undefined*.
+              1. Return _index_.
             </emu-alg>
           </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -21047,7 +21047,7 @@
                 ResolveExport(_exportName_, _resolveSet_)
               </td>
               <td>
-                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form {[[Module]]: Module Record, [[BindingName]]: String}. If the name cannot be resolved, return either the module record that is to blame for the resolution failure or *null* in case there isn't any.</p>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form {[[Module]]: Module Record, [[BindingName]]: String}. If the name cannot be resolved, return either the module record that is to blame for the resolution failure or, in case there isn't any, return *null* or `"ambiguous`" depending on the nature of the failure.</p>
               </td>
             </tr>
             <tr>
@@ -21646,9 +21646,15 @@
 
           <p>If a defining module is found, a ResolvedBinding Record {[[Module]], [[BindingName]]} is returned. This record identifies the resolved binding of the originally requested export.</p>
           
-          <p>If no definition is found or the request is detected to be circular or ambiguous and the resolution attempt yielded a culprit module record, then this module record is returned. If no culprit was found, *null* is returned instead. TODO: give examples.</p>
+          <p>If a defining module cannot be found (i.e. resolution fails), there are three cases.
+          <ul>
+            <li>The resolution failure can be blamed on a particular module. Then this culprit module record is returned.</li>
+            <li>No culprit can be determined and the resolution failure was due to star export ambiguity. Then `"ambiguous"` is returned.</li>
+            <li>No culprit can be determined and the resolution failure was not due to star export ambiguity. Then *null* is returned.</li>
+          </ul>
+          </p>
 
-          <p>(Note that if HostResolveImportedModule throws, the above analysis does not apply; such errors will be rethrown before any mode-specific logic is involved.)</p>
+          <p>(Note that if HostResolveImportedModule throws, the above analysis does not apply; such errors will be propagated immediately.)</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -21669,7 +21675,7 @@
                 1. Assert: _module_ imports a specific binding for this export.
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. Let _resolution_ be ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
-                1. If _resolution_ is *null*, let _resolution_ be _module_.
+                1. If _resolution_ is *null* or `"ambiguous"`, let _resolution_ be _module_.
                 1. Return _resolution_.
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
@@ -21679,13 +21685,13 @@
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
-              1. If _resolution_ is a Module Record, return _resolution_.
+              1. If _resolution_ is `"ambiguous"` or a Module Record, return _resolution_.
               1. If _resolution_ is not *null*, then
                 1. Assert: _resolution_ is a ResolvedBinding Record.
                 1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
-                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return _module_.
+                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return `"ambiguous"`.
             1. Return _starResolution_.
           </emu-alg>
         </emu-clause>
@@ -21767,8 +21773,9 @@
             <emu-alg>
               1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
                 1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
-                1. Assert: _resolution_ is not *null*.
-                1. If _resolution_ is a Module Record (i.e., not a ResolvedBinding Record), return ResolutionError(_resolution_).
+                1. Assert: _resolution_ is neither *null* nor `"ambiguous"`.
+                1. If _resolution_ is a Module Record, return ResolutionError(_resolution_).
+                1. Assert: _resolution_ is a ResolvedBinding Record.
               1. Assert: All named exports from _module_ are resolvable.
               1. Let _realm_ be _module_.[[Realm]].
               1. Assert: _realm_ is not *undefined*.
@@ -21784,7 +21791,7 @@
                   1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
                   1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
-                  1. If _resolution_ is *null*, let _resolution_ be _module_.
+                  1. If _resolution_ is *null* or `"ambiguous"`, let _resolution_ be _module_.
                   1. If _resolution_ is a Module Record, return ResolutionError(_resolution_).
                   1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
               1. Let _code_ be _module_.[[ECMAScriptCode]].

--- a/spec.html
+++ b/spec.html
@@ -21700,7 +21700,7 @@
                   1. Assert: There is more than one `*` import that includes the requested name.
                   1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"normal"`.
                   1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return ResolutionFailure(_resolveMode_).
-            1. If _starResolution_ is *undefined*, return ResolutionFailure(_resolveMode_);
+            1. If _starResolution_ is *undefined*, return ResolutionFailure(_resolveMode_).
             1. Otherwise, return _starResolution_.
           </emu-alg>
 
@@ -21711,7 +21711,7 @@
 
             <p>This abstract operation performs the following steps:</p>
             <emu-alg>
-              1. If _resolveMode_ is `"namespace"` or `"star"`: return *undefined*.
+              1. If _resolveMode_ is `"namespace"` or `"star"`, then return *undefined*.
               1. Assert: _resolveMode_ is `"normal"`.
               1. Throw a new *SyntaxError* exception.
             </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -21660,7 +21660,7 @@
             1. For each Record {[[Module]], [[ExportName]]} _r_ in _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
                 1. Assert: This is a circular import request.
-                1. Return _ResolutionFailure_(_module_, _resolveMode_).
+                1. Return ResolutionFailure(_module_, _resolveMode_).
             1. Append the Record {[[Module]]: _module_, [[ExportName]]: _exportName_} to _resolveSet_.
             1. For each ExportEntry Record _e_ in _module_.[[LocalExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
@@ -21674,7 +21674,7 @@
                 1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveMode_, _resolveSet_).
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
-              1. Return _ResolutionFailure_(_module_, _resolveMode_).
+              1. Return ResolutionFailure(_module_, _resolveMode_).
               1. NOTE: A `default` export cannot be provided by an `export *`.
             1. Let _starResolution_ be *undefined*.
             1. Let _newResolveMode_ be _resolveMode_.
@@ -21690,8 +21690,8 @@
                   1. If _resolution_.[[Module]] and _starResolution_.[[Module]]
                   are not the same Module Record or
                   SameValue(_resolution_.[[BindingName]],
-                  _starResolution_.[[BindingName]]) is *false*, return _ResolutionFailure_(_module_, _resolveMode_).
-            1. If _starResolution_ is *undefined*, return _ResolutionFailure_(_module_, _resolveMode_);
+                  _starResolution_.[[BindingName]]) is *false*, return ResolutionFailure(_module_, _resolveMode_).
+            1. If _starResolution_ is *undefined*, return ResolutionFailure(_module_, _resolveMode_);
             1. Otherwise, return _starResolution_.
           </emu-alg>
           <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -21638,16 +21638,24 @@
         </emu-clause>
 
         <emu-clause id="sec-resolutionfailure" aoid="ResolutionFailure">
-          <h1>Runtime Semantics: ResolutionFailure( _module_, _resolveMode_ )</h1>
+          <h1>Runtime Semantics: ResolutionFailure( _resolveMode_ )</h1>
           <p>The ResolutionFailure abstract operation performs the following steps:</p>
           <emu-alg>
-            1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
             1. If _resolveMode_ is `"namespace"` or `"star"`: return *undefined*.
             1. Assert: _resolveMode_ is `"normal"`.
-            1. Let _error_ be Completion{[[Type]]: ~throw~, [[Value]]: a newly created *SyntaxError* object, [[Target]]: ~empty~}.
-            1. Set _module_.[[ErrorCompletion]] to _error_.
-            1. Set _module_.[[Status]] to `"errored"`.
-            1. Return _error_.
+            1. Throw a new *SyntaxError* exception.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-propagateresolution" aoid="PropagateResolution">
+          <h1>Runtime Semantics: PropagateResolution( _module_, _resolution_ )</h1>
+          <p>The PropagateResolution abstract operation performs the following steps:</p>
+          <emu-alg>
+            1. If _resolution_ is an abrupt completion, then
+              1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
+              1. Set _module_.[[Status]] to `"errored"`.
+              1. Set _module_.[[ErrorCompletion]] to _resolution_.
+            1. Return _resolution_.
           </emu-alg>
         </emu-clause>
 
@@ -21661,7 +21669,7 @@
             1. For each Record {[[Module]], [[ExportName]]} _r_ in _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
                 1. Assert: This is a circular import request.
-                1. Return ResolutionFailure(_module_, _resolveMode_).
+                1. Return ResolutionFailure(_resolveMode_).
             1. Append the Record {[[Module]]: _module_, [[ExportName]]: _exportName_} to _resolveSet_.
             1. For each ExportEntry Record _e_ in _module_.[[LocalExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
@@ -21672,27 +21680,26 @@
                 1. Assert: _module_ imports a specific binding for this export.
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"normal"`.
-                1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveMode_, _resolveSet_).
+                1. Let _resolution_ be _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveMode_, _resolveSet_).
+                1. Return PropagateResolution(_module_, _resolution_).
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
-              1. Return ResolutionFailure(_module_, _resolveMode_).
+              1. Return ResolutionFailure(_resolveMode_).
               1. NOTE: A `default` export cannot be provided by an `export *`.
             1. Let _starResolution_ be *undefined*.
             1. Let _newResolveMode_ be _resolveMode_.
             1. If _resolveMode_ is `"normal"`, set _newResolveMode_ to `"star"`.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _newResolveMode_, _resolveSet_).
+              1. Let _resolution_ be _importedModule_.ResolveExport(_exportName_, _newResolveMode_, _resolveSet_).
+              1. Perform ? PropagateResolution(_module_, _resolution_).
               1. If _resolution_ is not *undefined*, then
                 1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
                   1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"normal"`.
-                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]]
-                  are not the same Module Record or
-                  SameValue(_resolution_.[[BindingName]],
-                  _starResolution_.[[BindingName]]) is *false*, return ResolutionFailure(_module_, _resolveMode_).
-            1. If _starResolution_ is *undefined*, return ResolutionFailure(_module_, _resolveMode_);
+                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return ResolutionFailure(_resolveMode_).
+            1. If _starResolution_ is *undefined*, return ResolutionFailure(_resolveMode_);
             1. Otherwise, return _starResolution_.
           </emu-alg>
           <emu-note>
@@ -21776,7 +21783,8 @@
                   1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
-                  1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], `"normal"`, &laquo; &raquo;).
+                  1. Let _resolution_ be _importedModule_.ResolveExport(_in_.[[ImportName]], `"normal"`, &laquo; &raquo;).
+                  1. Perform ? PropagateResolution(_module_, _resolution_).
                   1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
               1. Let _code_ be _module_.[[ECMAScriptCode]].
               1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.

--- a/spec.html
+++ b/spec.html
@@ -8301,7 +8301,7 @@
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _m_ be _O_.[[Module]].
-          1. Let _binding_ be ! _m_.ResolveExport(_P_, `"default"`, &laquo; &raquo;).
+          1. Let _binding_ be ! _m_.ResolveExport(_P_, `"normal"`, &laquo; &raquo;).
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.
           1. Let _targetEnv_ be _targetModule_.[[Environment]].
@@ -21643,7 +21643,7 @@
           <emu-alg>
             1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
             1. If _resolveMode_ is `"namespace"` or `"star"`: return *undefined*.
-            1. Assert: _resolveMode_ is `"default"`.
+            1. Assert: _resolveMode_ is `"normal"`.
             1. Let _error_ be Completion{[[Type]]: ~throw~, [[Value]]: a newly created *SyntaxError* object, [[Target]]: ~empty~}.
             1. Set _module_.[[ErrorCompletion]] to _error_.
             1. Set _module_.[[Status]] to `"errored"`.
@@ -21670,7 +21670,7 @@
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Assert: _module_ imports a specific binding for this export.
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-                1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"default"`.
+                1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"normal"`.
                 1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveMode_, _resolveSet_).
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
@@ -21678,7 +21678,7 @@
               1. NOTE: A `default` export cannot be provided by an `export *`.
             1. Let _starResolution_ be *undefined*.
             1. Let _newResolveMode_ be _resolveMode_.
-            1. If _resolveMode_ is `"default"`, set _newResolveMode_ to `"star"`.
+            1. If _resolveMode_ is `"normal"`, set _newResolveMode_ to `"star"`.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _newResolveMode_, _resolveSet_).
@@ -21686,7 +21686,7 @@
                 1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
-                  1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"default"`.
+                  1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"normal"`.
                   1. If _resolution_.[[Module]] and _starResolution_.[[Module]]
                   are not the same Module Record or
                   SameValue(_resolution_.[[BindingName]],
@@ -21760,7 +21760,7 @@
             <p>The ModuleDeclarationResolution abstract operation performs the following steps:</p>
             <emu-alg>
               1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
-                1. Perform ? _module_.ResolveExport(_e_.[[ExportName]], `"default"`, &laquo; &raquo;).
+                1. Perform ? _module_.ResolveExport(_e_.[[ExportName]], `"normal"`, &laquo; &raquo;).
               1. Assert: All named exports from _module_ are resolvable.
               1. Let _realm_ be _module_.[[Realm]].
               1. Assert: _realm_ is not *undefined*.
@@ -21775,7 +21775,7 @@
                   1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
-                  1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], `"default"`, &laquo; &raquo;).
+                  1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], `"normal"`, &laquo; &raquo;).
                   1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
               1. Let _code_ be _module_.[[ECMAScriptCode]].
               1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.

--- a/spec.html
+++ b/spec.html
@@ -21076,8 +21076,13 @@
       <!-- es6num="15.2.1.16" -->
       <emu-clause id="sec-source-text-module-records">
         <h1>Source Text Module Records</h1>
+
         <p>A <dfn>Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (10) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module.</p>
+
+        <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type. However, non-source text Module Records must not participate in dependency cycles with Source Text Module Records. Concretely, this is enforced below by assertions that non-source text Module Record dependencies do not have a [[Status]] of `"instantiating"` or `"evaluating"` during a call to ModuleDeclarationInstantiation or ModuleEvaluation on a Source Text Module Record.</p>
+
         <p>In addition to the fields, defined in <emu-xref href="#table-36"></emu-xref>, Source Text Module Records have the additional fields listed in <emu-xref href="#table-38"></emu-xref>. Each of these fields initially has the value *undefined*.</p>
+
         <emu-table id="table-38" caption="Additional Fields of Source Text Module Records">
           <table>
             <tbody>
@@ -21701,8 +21706,8 @@
             <p>The InnerModuleDeclarationInstantiation abstract operation performs the following steps:</p>
             <emu-alg>
               1. If _module_ is not a Source Text Module Record,
-                1. If _module_.[[Status]] is `"instantiating"`, throw a *TypeError* exception.
-                1. Otherwise, return _module_.ModuleDeclarationInstantiation().
+                1. Assert: _module_.[[Status]] is not `"instantiating"`.
+                1. Return _module_.ModuleDeclarationInstantiation().
               1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"`, or `"evaluated"`,
                 1. Return *undefined*.
               1. If _module_.[[Status]] is `"errored"`,
@@ -21803,8 +21808,8 @@
             <p>The InnerModuleEvaluation abstract operation performs the following steps:</p>
             <emu-alg>
               1. If _module_ is not a Source Text Module Record,
-                1. If _module_.[[Status]] is `"evaluating"`, throw a *TypeError* exception.
-                1. Otherwise, return _module_.ModuleEvaluation().
+                1. Assert: _module_.[[Status]] is not `"evaluating"`.
+                1. Return _module_.ModuleEvaluation().
               1. If _module_.[[Status]] is `"evaluating"` or `"evaluated"`,
                 1. Return *undefined*.
               1. If _module_.[[Status]] is `"errored"`,

--- a/spec.html
+++ b/spec.html
@@ -21916,7 +21916,7 @@
           1. Return _namespace_.
         </emu-alg>
         <emu-note>
-          <p>The only way GetModuleNamespace can throw is via one of the triggered HostResolveImportedModule calls.</p>
+          <p>The only way GetModuleNamespace can throw is via one of the triggered HostResolveImportedModule calls. Unresolvable names are simply excluded from the namespace at this point. They will lead to a real instantiation error later unless they are all ambiguous star exports that are not explicitly requested anywhere.</p>
         </emu-note>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -21035,7 +21035,7 @@
             </tr>
             <tr>
               <td>
-                GetExportedNames(exportStarSet)
+                GetExportedNames(_exportStarSet_)
               </td>
               <td>
                 Return a list of all names that are either directly or indirectly exported from this module.
@@ -21043,10 +21043,11 @@
             </tr>
             <tr>
               <td>
-                ResolveExport(exportName, resolveMode, resolveSet)
+                ResolveExport(_exportName_, _resolveMode_, _resolveSet_)
               </td>
               <td>
-                Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form {[[Module]]: Module Record, [[BindingName]]: String}. Return *null* if the name cannot be resolved, or `"ambiguous"` if multiple bindings were found.
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form {[[Module]]: Module Record, [[BindingName]]: String}. Return *null* if the name cannot be resolved, or `"ambiguous"` if multiple bindings were found.</p>
+                <p>The provided _resolveMode_ will be one of `"normal"` or `"namespace"`, indicating what type of export is being resolved.</p>
               </td>
             </tr>
             <tr>
@@ -21182,7 +21183,7 @@
                 Integer | *undefined*
               </td>
               <td>
-                Auxiliary field used during ModuleDeclarationInstantiation and ModuleEvaluation only. If [[Status]] is "`instantiating`" or "`evaluating`", this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly-connected component.
+                Auxiliary field used during ModuleDeclarationInstantiation and ModuleEvaluation only. If [[Status]] is "`instantiating`" or "`evaluating`", this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
               </td>
             </tr>
             </tbody>
@@ -21637,35 +21638,32 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-resolutionfailure" aoid="ResolutionFailure">
-          <h1>Runtime Semantics: ResolutionFailure( _resolveMode_ )</h1>
-          <p>The ResolutionFailure abstract operation performs the following steps:</p>
-          <emu-alg>
-            1. If _resolveMode_ is `"namespace"` or `"star"`: return *undefined*.
-            1. Assert: _resolveMode_ is `"normal"`.
-            1. Throw a new *SyntaxError* exception.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-propagateresolution" aoid="PropagateResolution">
-          <h1>Runtime Semantics: PropagateResolution( _module_, _resolution_ )</h1>
-          <p>The PropagateResolution abstract operation performs the following steps:</p>
-          <emu-alg>
-            1. If _resolution_ is an abrupt completion, then
-              1. If _module_.[[Status]] is `"errored"`, then
-                1. Assert: _module_.[[ErrorCompletion]] is _resolution_.
-              1. Otherwise,
-                1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
-                1. Set _module_.[[Status]] to `"errored"`.
-                1. Set _module_.[[ErrorCompletion]] to _resolution_.
-            1. Return _resolution_.
-          </emu-alg>
-        </emu-clause>
-
-        <!-- es6num="15.2.1.16.3" -->
         <emu-clause id="sec-resolveexport">
           <h1>ResolveExport( _exportName_, _resolveMode_, _resolveSet_ ) Concrete Method</h1>
-          <p>The ResolveExport concrete method of a Source Text Module Record with arguments _exportName_, _resolveMode_, and _resolveSet_ performs the following steps:</p>
+          <p>The ResolveExport concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
+
+          <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is use to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
+
+          <p>If a defining module is found, a ResolvedBinding Record {[[Module]], [[BindingName]]} is returned. This record identifies the resolved binding of the originally requested export. If no definition is found or the request is found to be circular or ambiguous, an error is thrown or *undefined* is returned, depending on _resolveMode_ (see below for more details).</p>
+
+          <p>In addition to the standard _resolveMode_ values of `"normal"` or `"namespace"`, ResolveExport for Source Text Module Records also accepts a third value, `"star"`. This is only used when it calls itself recursively, in order to help implement the semantics of the `"normal"` mode.</p>
+
+          <p>Its failure behavior, when the _exportName_ cannot be resolved, varies among the different _resolveMode_ values:</p>
+          <dl>
+            <dt>`"normal"`</dt>
+            <dd>Throws a *SyntaxError* exception, which is recorded in the culprit module when applicable.</dd>
+
+            <dt>`"namespace"`</dt>
+            <dd>Returns *undefined*.</dd>
+
+            <dt>`"star"`</dt>
+            <dd>If a culprit module responsible for the unresolved name can be found, and has a recorded exception, it is rethrown. Otherwise, returns *undefined*.</dd>
+          </dl>
+
+          <p>(Note that if HostResolveImportedModule throws, the above analysis does not apply; such errors will be rethrown before any mode-specific logic is involved.)</p>
+
+          <p>This abstract method performs the following steps:</p>
+
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. Assert: _module_.[[Status]] is not `"errored"`.
@@ -21705,16 +21703,49 @@
             1. If _starResolution_ is *undefined*, return ResolutionFailure(_resolveMode_);
             1. Otherwise, return _starResolution_.
           </emu-alg>
-          <emu-note>
-            <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is use to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
-            <p>If a defining module is found, a ResolvedBinding Record {[[Module]], [[BindingName]]} is returned. This record identifies the resolved binding of the originally requested export. If no definition is found or the request is found to be circular or ambiguous, an error is thrown or *undefined* is returned, depending on _resolveMode_.</p>
-          </emu-note>
+
+          <emu-clause id="sec-resolutionfailure" aoid="ResolutionFailure">
+            <h1>Runtime Semantics: ResolutionFailure( _resolveMode_ )</h1>
+
+            <p>The ResolutionFailure abstract operation is used by ResolveExport to react property to a module resolution failure in a given _resolveMode_.</p>
+
+            <p>This abstract operation performs the following steps:</p>
+            <emu-alg>
+              1. If _resolveMode_ is `"namespace"` or `"star"`: return *undefined*.
+              1. Assert: _resolveMode_ is `"normal"`.
+              1. Throw a new *SyntaxError* exception.
+            </emu-alg>
+          </emu-clause>
+
+          <emu-clause id="sec-propagateresolution" aoid="PropagateResolution">
+            <h1>Runtime Semantics: PropagateResolution( _module_, _resolution_ )</h1>
+
+            <p>The PropagateResolution abstract operation is used by ResolveExport to ensure any module resolution failures from indirect or star exports are correctly propagated to the Source Text Module Record in question.</p>
+
+            <p>This abstract operation performs the following steps:</p>
+            <emu-alg>
+              1. If _resolution_ is an abrupt completion, then
+                1. If _module_.[[Status]] is `"errored"`, then
+                  1. Assert: _module_.[[ErrorCompletion]] is _resolution_.
+                1. Otherwise,
+                  1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
+                  1. Set _module_.[[Status]] to `"errored"`.
+                  1. Set _module_.[[ErrorCompletion]] to _resolution_.
+              1. Return _resolution_.
+            </emu-alg>
+          </emu-clause>
         </emu-clause>
 
         <!-- es6num="15.2.1.16.4" -->
         <emu-clause id="sec-moduledeclarationinstantiation">
           <h1>ModuleDeclarationInstantiation( ) Concrete Method</h1>
-          <p>The ModuleDeclarationInstantiation concrete method of a Source Text Module Record performs the following steps:</p>
+
+          <p>The ModuleDeclarationInstantiation concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
+
+          <p>ModuleDeclarationInstantiation ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. Assert: _module_.[[Status]] is not `"instantiating"` or `"evaluating"`.
@@ -21734,7 +21765,11 @@
 
           <emu-clause id="sec-innermoduledeclarationinstantiation" aoid="InnerModuleDeclarationInstantiation">
             <h1>Runtime Semantics: InnerModuleDeclarationInstantiation( _module_, _stack_, _index_ )</h1>
-            <p>The InnerModuleDeclarationInstantiation abstract operation performs the following steps:</p>
+
+            <p>The InnerModuleDeclarationInstantiation abstract operation is used by ModuleDeclarationInstantiation to perform the actual instantiation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
+
+            <p>This abstract operation performs the following steps:</p>
+
             <emu-alg>
               1. If _module_ is not a Source Text Module Record,
                 1. Assert: _module_.[[Status]] is not `"instantiating"`.
@@ -21756,7 +21791,7 @@
                 1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is "`instantiating`" if and only if _requiredModule_ is in _stack_.
                 1. If _requiredModule_.[[Status]] is "`instantiating`", set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-              1. Perform ? ModuleDeclarationResolution(_module_).
+              1. Perform ? ModuleDeclarationEnvironmentSetup(_module_).
               1. Assert: _module_ occurs exactly once in _stack_.
               1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
               1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], repeat:
@@ -21768,9 +21803,13 @@
             </emu-alg>
           </emu-clause>
 
-          <emu-clause id="sec-moduledeclarationresolution" aoid="ModuleDeclarationResolution">
-            <h1>Runtime Semantics: ModuleDeclarationResolution( _module_ )</h1>
-            <p>The ModuleDeclarationResolution abstract operation performs the following steps:</p>
+          <emu-clause id="sec-moduledeclarationresolution" aoid="ModuleDeclarationEnvironmentSetup">
+            <h1>Runtime Semantics: ModuleDeclarationEnvironmentSetup( _module_ )</h1>
+
+            <p>The ModuleDeclarationEnvironmentSetup abstract operation is used by InnerModuleDeclarationInstantiation to initialize the Lexical Environment of the module, including resolving all imported bindings.</p>
+
+            <p>This abstract operation performs the following steps:</p>
+
             <emu-alg>
               1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
                 1. Perform ? _module_.ResolveExport(_e_.[[ExportName]], `"normal"`, &laquo; &raquo;).
@@ -21817,7 +21856,13 @@
         <!-- es6num="15.2.1.16.5" -->
         <emu-clause id="sec-moduleevaluation">
           <h1>ModuleEvaluation( ) Concrete Method</h1>
-          <p>The ModuleEvaluation concrete method of a Source Text Module Record performs the following steps:</p>
+
+          <p>The ModuleEvaluation concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
+
+          <p>ModuleEvaluation ensures that if evaluation (the actual work for which is performed by InnerModuleEvaluation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. Assert: _module_.[[Status]] is `"errored"`, `"instantiated"`, or `"evaluated"`.
@@ -21837,7 +21882,11 @@
 
           <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
             <h1>Runtime Semantics: InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
-            <p>The InnerModuleEvaluation abstract operation performs the following steps:</p>
+
+            <p>The InnerModuleEvaluation abstract operation is used by ModuleEvaluation to perform the actual evaluation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
+
+            <p>This abstract operation performs the following steps:</p>
+
             <emu-alg>
               1. If _module_ is not a Source Text Module Record,
                 1. Assert: _module_.[[Status]] is not `"evaluating"`.
@@ -21874,7 +21923,11 @@
 
           <emu-clause id="sec-moduleexecution" aoid="ModuleExecution">
             <h1>Runtime Semantics: ModuleExecution( _module_ )</h1>
-            <p>The ModuleExecution abstract operation performs the following steps:</p>
+
+            <p>The ModuleExecution abstract operation is used by InnerModuleEvaluation to initialize the execution context of the module and evaluate the module's code within it.</p>
+
+            <p>This abstract operation performs the following steps:</p>
+
             <emu-alg>
               1. Let _moduleCxt_ be a new ECMAScript code execution context.
               1. Set the Function of _moduleCxt_ to *null*.
@@ -21913,10 +21966,13 @@
         <p>Multiple different _referencingModule_, _specifier_ pairs may map to the same Module Record instance. The actual mapping semantic is implementation-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>
       </emu-clause>
 
-      <!-- es6num="15.2.1.18" -->
       <emu-clause id="sec-getmodulenamespace" aoid="GetModuleNamespace">
         <h1>Runtime Semantics: GetModuleNamespace( _module_ )</h1>
-        <p>The abstract operation GetModuleNamespace called with argument _module_ performs the following steps:</p>
+
+        <p>The GetModuleNamespace abstract operation retrieves the the Module Namespace Exotic object representing _module_'s exports, lazily creating it the first time it was requested, and storing it in _module_.[[Namespace]] for future retrieval.</p>
+
+        <p>This abstract operation performs the following steps:</p>
+
         <emu-alg>
           1. Assert: _module_ is an instance of a concrete subclass of Module Record.
           1. Assert: _module_.[[Status]] is neither `"uninstantiated"` nor `"errored"`.

--- a/spec.html
+++ b/spec.html
@@ -21006,7 +21006,7 @@
                 An abrupt completion | *undefined*
               </td>
               <td>
-                A completion of type `"throw"` representing the exception that occurred during instantiation or evaluation, if [[Status]] is `"errored"`. Otherwise *undefined*.
+                A completion of type ~throw~ representing the exception that occurred during instantiation or evaluation, if [[Status]] is `"errored"`. Otherwise *undefined*.
               </td>
             </tr>
             <tr>
@@ -21065,9 +21065,7 @@
               </td>
               <td>
                 <p>Transitively evaluate all module dependencies of this module and then evaluate this module.</p>
-                <p>Will transition this module's [[Status]] from
-                `"instantiated"` to either `"evaluated"` or `"errored"`. While
-                this is executing, this module's [[Status]] will be `"evaluating"`; this is observable through reentrant invocations via circular dependencies.</p>
+                <p>Will transition this module's [[Status]] from `"instantiated"` to either `"evaluated"` or `"errored"`. While this is executing, this module's [[Status]] will be `"evaluating"`; this is observable through reentrant invocations via circular dependencies.</p>
               </td>
             </tr>
             </tbody>
@@ -21180,7 +21178,7 @@
                 Integer | *undefined*
               </td>
               <td>
-                Auxiliary field used during ModuleDeclarationInstantiation and ModuleEvaluation only. If [[Status]] is "`instantiating`" or "`evaluating`", this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+                Auxiliary field used during ModuleDeclarationInstantiation and ModuleEvaluation only. If [[Status]] is "`instantiating`" or "`evaluating`", this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly-connected component.
               </td>
             </tr>
             </tbody>
@@ -21684,7 +21682,7 @@
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. Assert: _module_.[[Status]] is not `"instantiating"` or `"evaluating"`.
-            1. Let _stack_ be an empty list.
+            1. Let _stack_ be a new empty List.
             1. Let _result_ be InnerModuleDeclarationInstantiation(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion,
               1. For each module _m_ in _stack_,
@@ -21719,8 +21717,7 @@
                 1. Perform ? InnerModuleDeclarationInstantiation(_requiredModule_, _stack_, _index_+1).
                 1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is "`instantiating`" if and only if _requiredModule_ is in _stack_.
-                1. If _requiredModule_.[[Status]] is "`instantiating`",
-                  1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]].
+                1. If _requiredModule_.[[Status]] is "`instantiating`", set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? ModuleDeclarationResolution(_module_).
               1. Assert: _module_ occurs exactly once in _stack_.
               1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
@@ -21787,7 +21784,7 @@
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. Assert: _module_.[[Status]] is `"errored"`, `"instantiated"`, or `"evaluated"`.
-            1. Let _stack_ be an empty list.
+            1. Let _stack_ be a new empty List.
             1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion,
               1. For each module _m_ in _stack_,
@@ -21820,11 +21817,10 @@
               1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
                 1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
                 1. NOTE: ModuleDeclarationInstantiation must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-                1. Perform ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_+1).
+                1. Perform ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_ + 1).
                 1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is "`evaluating`" if and only if _requiredModule_ is in _stack_.
-                1. If _requiredModule_.[[Status]] is "`evaluating`",
-                  1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]].
+                1. If _requiredModule_.[[Status]] is "`evaluating`", set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? ModuleExecution(_module_).
               1. Assert: _module_ occurs exactly once in _stack_.
               1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].

--- a/spec.html
+++ b/spec.html
@@ -8301,7 +8301,8 @@
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _m_ be _O_.[[Module]].
-          1. Let _binding_ be ! _m_.ResolveExport(_P_, `"normal"`, &laquo; &raquo;).
+          1. Let _binding_ be ! _m_.ResolveExport(_P_, &laquo; &raquo;).
+          1. Assert: _binding_ is a ResolvedBinding Record.
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.
           1. Let _targetEnv_ be _targetModule_.[[Environment]].
@@ -21043,11 +21044,10 @@
             </tr>
             <tr>
               <td>
-                ResolveExport(_exportName_, _resolveMode_, _resolveSet_)
+                ResolveExport(_exportName_, _resolveSet_)
               </td>
               <td>
-                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form {[[Module]]: Module Record, [[BindingName]]: String}. Return *null* if the name cannot be resolved, or `"ambiguous"` if multiple bindings were found.</p>
-                <p>The provided _resolveMode_ will be one of `"normal"` or `"namespace"`, indicating what type of export is being resolved.</p>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form {[[Module]]: Module Record, [[BindingName]]: String}. If the name cannot be resolved, return either the module record that is to blame for the resolution failure or *null* in case there isn't any.</p>
               </td>
             </tr>
             <tr>
@@ -21639,26 +21639,14 @@
         </emu-clause>
 
         <emu-clause id="sec-resolveexport">
-          <h1>ResolveExport( _exportName_, _resolveMode_, _resolveSet_ ) Concrete Method</h1>
+          <h1>ResolveExport( _exportName_, _resolveSet_ ) Concrete Method</h1>
           <p>The ResolveExport concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
           <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is use to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
 
-          <p>If a defining module is found, a ResolvedBinding Record {[[Module]], [[BindingName]]} is returned. This record identifies the resolved binding of the originally requested export. If no definition is found or the request is found to be circular or ambiguous, an error is thrown or *undefined* is returned, depending on _resolveMode_ (see below for more details).</p>
-
-          <p>In addition to the standard _resolveMode_ values of `"normal"` or `"namespace"`, ResolveExport for Source Text Module Records also accepts a third value, `"star"`. This is only used when it calls itself recursively, in order to help implement the semantics of the `"normal"` mode.</p>
-
-          <p>Its failure behavior, when the _exportName_ cannot be resolved, varies among the different _resolveMode_ values:</p>
-          <dl>
-            <dt>`"normal"`</dt>
-            <dd>Throws a *SyntaxError* exception, which is recorded in the culprit module when applicable.</dd>
-
-            <dt>`"namespace"`</dt>
-            <dd>Returns *undefined*.</dd>
-
-            <dt>`"star"`</dt>
-            <dd>If a culprit module responsible for the unresolved name can be found, and has a recorded exception, it is rethrown. Otherwise, returns *undefined*.</dd>
-          </dl>
+          <p>If a defining module is found, a ResolvedBinding Record {[[Module]], [[BindingName]]} is returned. This record identifies the resolved binding of the originally requested export.</p>
+          
+          <p>If no definition is found or the request is detected to be circular or ambiguous and the resolution attempt yielded a culprit module record, then this module record is returned. If no culprit was found, *null* is returned instead. TODO: give examples.</p>
 
           <p>(Note that if HostResolveImportedModule throws, the above analysis does not apply; such errors will be rethrown before any mode-specific logic is involved.)</p>
 
@@ -21670,7 +21658,7 @@
             1. For each Record {[[Module]], [[ExportName]]} _r_ in _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
                 1. Assert: This is a circular import request.
-                1. Return ResolutionFailure(_resolveMode_).
+                1. Return *null*.
             1. Append the Record {[[Module]]: _module_, [[ExportName]]: _exportName_} to _resolveSet_.
             1. For each ExportEntry Record _e_ in _module_.[[LocalExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
@@ -21680,60 +21668,26 @@
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Assert: _module_ imports a specific binding for this export.
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-                1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"normal"`.
-                1. Let _resolution_ be _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveMode_, _resolveSet_).
-                1. Return PropagateResolution(_module_, _resolution_).
+                1. Let _resolution_ be ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
+                1. If _resolution_ is *null*, let _resolution_ be _module_.
+                1. Return _resolution_.
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
-              1. Return ResolutionFailure(_resolveMode_).
+              1. Return *null*.
               1. NOTE: A `default` export cannot be provided by an `export *`.
-            1. Let _starResolution_ be *undefined*.
-            1. Let _newResolveMode_ be _resolveMode_.
-            1. If _resolveMode_ is `"normal"`, set _newResolveMode_ to `"star"`.
+            1. Let _starResolution_ be *null*.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _resolution_ be _importedModule_.ResolveExport(_exportName_, _newResolveMode_, _resolveSet_).
-              1. Perform ? PropagateResolution(_module_, _resolution_).
-              1. If _resolution_ is not *undefined*, then
-                1. If _starResolution_ is *undefined*, set _starResolution_ to _resolution_.
+              1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
+              1. If _resolution_ is a Module Record, return _resolution_.
+              1. If _resolution_ is not *null*, then
+                1. Assert: _resolution_ is a ResolvedBinding Record.
+                1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
-                  1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"normal"`.
-                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return ResolutionFailure(_resolveMode_).
-            1. If _starResolution_ is *undefined*, return ResolutionFailure(_resolveMode_).
-            1. Otherwise, return _starResolution_.
+                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return _module_.
+            1. Return _starResolution_.
           </emu-alg>
-
-          <emu-clause id="sec-resolutionfailure" aoid="ResolutionFailure">
-            <h1>Runtime Semantics: ResolutionFailure( _resolveMode_ )</h1>
-
-            <p>The ResolutionFailure abstract operation is used by ResolveExport to react property to a module resolution failure in a given _resolveMode_.</p>
-
-            <p>This abstract operation performs the following steps:</p>
-            <emu-alg>
-              1. If _resolveMode_ is `"namespace"` or `"star"`, then return *undefined*.
-              1. Assert: _resolveMode_ is `"normal"`.
-              1. Throw a new *SyntaxError* exception.
-            </emu-alg>
-          </emu-clause>
-
-          <emu-clause id="sec-propagateresolution" aoid="PropagateResolution">
-            <h1>Runtime Semantics: PropagateResolution( _module_, _resolution_ )</h1>
-
-            <p>The PropagateResolution abstract operation is used by ResolveExport to ensure any module resolution failures from indirect or star exports are correctly propagated to the Source Text Module Record in question.</p>
-
-            <p>This abstract operation performs the following steps:</p>
-            <emu-alg>
-              1. If _resolution_ is an abrupt completion, then
-                1. If _module_.[[Status]] is `"errored"`, then
-                  1. Assert: _module_.[[ErrorCompletion]] is _resolution_.
-                1. Otherwise,
-                  1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
-                  1. Set _module_.[[Status]] to `"errored"`.
-                  1. Set _module_.[[ErrorCompletion]] to _resolution_.
-              1. Return _resolution_.
-            </emu-alg>
-          </emu-clause>
         </emu-clause>
 
         <!-- es6num="15.2.1.16.4" -->
@@ -21812,7 +21766,9 @@
 
             <emu-alg>
               1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
-                1. Perform ? _module_.ResolveExport(_e_.[[ExportName]], `"normal"`, &laquo; &raquo;).
+                1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
+                1. Assert: _resolution_ is not *null*.
+                1. If _resolution_ is a Module Record (i.e., not a ResolvedBinding Record), return ResolutionError(_resolution_).
               1. Assert: All named exports from _module_ are resolvable.
               1. Let _realm_ be _module_.[[Realm]].
               1. Assert: _realm_ is not *undefined*.
@@ -21827,8 +21783,9 @@
                   1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
-                  1. Let _resolution_ be _importedModule_.ResolveExport(_in_.[[ImportName]], `"normal"`, &laquo; &raquo;).
-                  1. Perform ? PropagateResolution(_module_, _resolution_).
+                  1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
+                  1. If _resolution_ is *null*, let _resolution_ be _module_.
+                  1. If _resolution_ is a Module Record, return ResolutionError(_resolution_).
                   1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
               1. Let _code_ be _module_.[[ECMAScriptCode]].
               1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
@@ -21849,6 +21806,20 @@
                   1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|, then
                     1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
                     1. Call _envRec_.InitializeBinding(_dn_, _fo_).
+            </emu-alg>
+          </emu-clause>
+
+          <emu-clause id="sec-resolutionerror" aoid="ResolutionError">
+            <h1>ResolutionError( _module_ )</h1>
+
+            <p>The ResolutionError abstract operation is used by ModuleDeclarationEnvironmentSetup to record and return an import/export resolution error. It performs the following steps:</p>
+
+            <emu-alg>
+              1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
+              1. Set _module_.[[Status]] to `"errored"`.
+              1. Let _completion_ be Completion{[[Type]]: ~throw~, [[Value]]: a newly created *SyntaxError* object, [[Target]]: ~empty~}.
+              1. Set _module_.[[ErrorCompletion]] to _completion_.
+              1. Return _completion_.
             </emu-alg>
           </emu-clause>
         </emu-clause>
@@ -22021,8 +21992,8 @@
             1. Let _exportedNames_ be ? _module_.GetExportedNames(&laquo; &raquo;).
             1. Let _unambiguousNames_ be a new empty List.
             1. For each _name_ that is an element of _exportedNames_, do
-              1. Let _resolution_ be ? _module_.ResolveExport(_name_, `"namespace"`, &laquo; &raquo;).
-              1. If _resolution_ is not *undefined*, append _name_ to _unambiguousNames_.
+              1. Let _resolution_ be ? _module_.ResolveExport(_name_, &laquo; &raquo;).
+              1. If _resolution_ is a ResolvedBinding Record, append _name_ to _unambiguousNames_.
             1. Set _namespace_ to ModuleNamespaceCreate(_module_, _unambiguousNames_).
           1. Return _namespace_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -21742,7 +21742,7 @@
 
           <p>The ModuleDeclarationInstantiation concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
-          <p>ModuleDeclarationInstantiation ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph.</p>
+          <p>ModuleDeclarationInstantiation ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller.</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -21764,7 +21764,7 @@
           </emu-alg>
 
           <emu-clause id="sec-innermoduledeclarationinstantiation" aoid="InnerModuleDeclarationInstantiation">
-            <h1>Runtime Semantics: InnerModuleDeclarationInstantiation( _module_, _stack_, _index_ )</h1>
+            <h1>InnerModuleDeclarationInstantiation( _module_, _stack_, _index_ )</h1>
 
             <p>The InnerModuleDeclarationInstantiation abstract operation is used by ModuleDeclarationInstantiation to perform the actual instantiation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
 
@@ -21803,8 +21803,8 @@
             </emu-alg>
           </emu-clause>
 
-          <emu-clause id="sec-moduledeclarationresolution" aoid="ModuleDeclarationEnvironmentSetup">
-            <h1>Runtime Semantics: ModuleDeclarationEnvironmentSetup( _module_ )</h1>
+          <emu-clause id="sec-moduledeclarationenvironmentsetup" aoid="ModuleDeclarationEnvironmentSetup">
+            <h1>ModuleDeclarationEnvironmentSetup( _module_ )</h1>
 
             <p>The ModuleDeclarationEnvironmentSetup abstract operation is used by InnerModuleDeclarationInstantiation to initialize the Lexical Environment of the module, including resolving all imported bindings.</p>
 
@@ -21859,7 +21859,7 @@
 
           <p>The ModuleEvaluation concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
-          <p>ModuleEvaluation ensures that if evaluation (the actual work for which is performed by InnerModuleEvaluation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph.</p>
+          <p>ModuleEvaluation ensures that if evaluation (the actual work for which is performed by InnerModuleEvaluation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller.</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -21881,7 +21881,7 @@
           </emu-alg>
 
           <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
-            <h1>Runtime Semantics: InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
+            <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
 
             <p>The InnerModuleEvaluation abstract operation is used by ModuleEvaluation to perform the actual evaluation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
 
@@ -21922,7 +21922,7 @@
           </emu-clause>
 
           <emu-clause id="sec-moduleexecution" aoid="ModuleExecution">
-            <h1>Runtime Semantics: ModuleExecution( _module_ )</h1>
+            <h1>ModuleExecution( _module_ )</h1>
 
             <p>The ModuleExecution abstract operation is used by InnerModuleEvaluation to initialize the execution context of the module and evaluate the module's code within it.</p>
 

--- a/spec.html
+++ b/spec.html
@@ -21772,7 +21772,7 @@
                 1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
                 1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
                 1. If _in_.[[ImportName]] is `"*"`, then
-                  1. Let _namespace_ be ! GetModuleNamespace(_importedModule_).
+                  1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
                   1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
@@ -21910,11 +21910,14 @@
             1. Let _exportedNames_ be ? _module_.GetExportedNames(&laquo; &raquo;).
             1. Let _unambiguousNames_ be a new empty List.
             1. For each _name_ that is an element of _exportedNames_, do
-              1. Let _resolution_ be ! _module_.ResolveExport(_name_, `"namespace"`, &laquo; &raquo;).
+              1. Let _resolution_ be ? _module_.ResolveExport(_name_, `"namespace"`, &laquo; &raquo;).
               1. If _resolution_ is not *undefined*, append _name_ to _unambiguousNames_.
             1. Set _namespace_ to ModuleNamespaceCreate(_module_, _unambiguousNames_).
           1. Return _namespace_.
         </emu-alg>
+        <emu-note>
+          <p>The only way GetModuleNamespace can throw is via one of the triggered HostResolveImportedModule calls.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="15.2.1.19" -->

--- a/spec.html
+++ b/spec.html
@@ -21694,7 +21694,7 @@
               1. Let _resolution_ be _importedModule_.ResolveExport(_exportName_, _newResolveMode_, _resolveSet_).
               1. Perform ? PropagateResolution(_module_, _resolution_).
               1. If _resolution_ is not *undefined*, then
-                1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
+                1. If _starResolution_ is *undefined*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
                   1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"normal"`.

--- a/spec.html
+++ b/spec.html
@@ -21697,7 +21697,7 @@
           </emu-alg>
           <emu-note>
             <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is use to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
-            <p>If a defining module is found, a ResolvedBinding Record {[[Module]], [[BindingName]]} is returned. This record identifies the resolved binding of the originally requested export. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string `"ambiguous"` is returned.</p>
+            <p>If a defining module is found, a ResolvedBinding Record {[[Module]], [[BindingName]]} is returned. This record identifies the resolved binding of the originally requested export. If no definition is found or the request is found to be circular or ambiguous, an error is thrown or *undefined* is returned, depending on _resolveMode_.</p>
           </emu-note>
         </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -21052,7 +21052,7 @@
             </tr>
             <tr>
               <td>
-                ModuleDeclarationInstantiation()
+                Instantiate()
               </td>
               <td>
                 <p>Transitively resolve all module dependencies and create a module Environment Record for the module.</p>
@@ -21061,7 +21061,7 @@
             </tr>
             <tr>
               <td>
-                ModuleEvaluation()
+                Evaluate()
               </td>
               <td>
                 <p>Transitively evaluate all module dependencies of this module and then evaluate this module.</p>
@@ -21079,7 +21079,7 @@
 
         <p>A <dfn id="sourctextmodule-record">Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (<emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module.</p>
 
-        <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type. However, non-source text Module Records must not participate in dependency cycles with Source Text Module Records. Concretely, this is enforced below by assertions that non-source text Module Record dependencies do not have a [[Status]] of `"instantiating"` or `"evaluating"` during a call to ModuleDeclarationInstantiation or ModuleEvaluation on a Source Text Module Record.</p>
+        <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type. However, non-source text Module Records must not participate in dependency cycles with Source Text Module Records. Concretely, this is enforced below by assertions that non-source text Module Record dependencies do not have a [[Status]] of `"instantiating"` or `"evaluating"` during a call to Instantiate or Evaluate on a Source Text Module Record.</p>
 
         <p>In addition to the fields, defined in <emu-xref href="#table-36"></emu-xref>, Source Text Module Records have the additional fields listed in <emu-xref href="#table-38"></emu-xref>. Each of these fields is initially set in ParseModule.</p>
 
@@ -21171,7 +21171,7 @@
                 Integer | *undefined*
               </td>
               <td>
-                Auxiliary field used during ModuleDeclarationInstantiation and ModuleEvaluation only.
+                Auxiliary field used during Instantiate and Evaluate only.
                 If [[Status]] is "`instantiating`" or "`evaluating`", this non-negative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
               </td>
             </tr>
@@ -21183,7 +21183,7 @@
                 Integer | *undefined*
               </td>
               <td>
-                Auxiliary field used during ModuleDeclarationInstantiation and ModuleEvaluation only. If [[Status]] is "`instantiating`" or "`evaluating`", this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+                Auxiliary field used during Instantiate and Evaluate only. If [[Status]] is "`instantiating`" or "`evaluating`", this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
               </td>
             </tr>
             </tbody>
@@ -21738,11 +21738,11 @@
 
         <!-- es6num="15.2.1.16.4" -->
         <emu-clause id="sec-moduledeclarationinstantiation">
-          <h1>ModuleDeclarationInstantiation( ) Concrete Method</h1>
+          <h1>Instantiate( ) Concrete Method</h1>
 
-          <p>The ModuleDeclarationInstantiation concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
+          <p>The Instantiate concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
-          <p>ModuleDeclarationInstantiation ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller. In particular, this will cause such failures to propagate to any parent modules in the graph, and thus to their strongly connected components.</p>
+          <p>Instantiate ensures that if instantiation (the actual work for which is performed by InnerModuleDeclarationInstantiation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller. In particular, this will cause such failures to propagate to any parent modules in the graph, and thus to their strongly connected components.</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -21766,14 +21766,14 @@
           <emu-clause id="sec-innermoduledeclarationinstantiation" aoid="InnerModuleDeclarationInstantiation">
             <h1>InnerModuleDeclarationInstantiation( _module_, _stack_, _index_ )</h1>
 
-            <p>The InnerModuleDeclarationInstantiation abstract operation is used by ModuleDeclarationInstantiation to perform the actual instantiation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
+            <p>The InnerModuleDeclarationInstantiation abstract operation is used by Instantiate to perform the actual instantiation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
 
             <p>This abstract operation performs the following steps:</p>
 
             <emu-alg>
               1. If _module_ is not a Source Text Module Record,
                 1. Assert: _module_.[[Status]] is not `"instantiating"`.
-                1. Perform ? _module_.ModuleDeclarationInstantiation().
+                1. Perform ? _module_.Instantiate().
                 1. Return _index_.
               1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"`, or `"evaluated"`,
                 1. Return _index_.
@@ -21855,11 +21855,11 @@
 
         <!-- es6num="15.2.1.16.5" -->
         <emu-clause id="sec-moduleevaluation">
-          <h1>ModuleEvaluation( ) Concrete Method</h1>
+          <h1>Evaluate( ) Concrete Method</h1>
 
-          <p>The ModuleEvaluation concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
+          <p>The Evaluate concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
-          <p>ModuleEvaluation ensures that if evaluation (the actual work for which is performed by InnerModuleEvaluation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller. In particular, this will cause such failures to propagate to any parent modules in the graph, and thus to their strongly connected components.</p>
+          <p>Evaluate ensures that if evaluation (the actual work for which is performed by InnerModuleEvaluation) fails, that fact is recorded in the module's [[Status]] and [[ErrorCompletion]] fields, and furthermore this failure is propagated to every other module in the same strongly connected component of the module graph. The exception that caused the failure is then re-thrown to the caller. In particular, this will cause such failures to propagate to any parent modules in the graph, and thus to their strongly connected components.</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -21883,14 +21883,14 @@
           <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
             <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
 
-            <p>The InnerModuleEvaluation abstract operation is used by ModuleEvaluation to perform the actual evaluation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
+            <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Source Text Module Record _module_, as well as recursively on all other modules in the same strongly connected component of the module graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used to track the traversal within the strongly connected component.</p>
 
             <p>This abstract operation performs the following steps:</p>
 
             <emu-alg>
               1. If _module_ is not a Source Text Module Record,
                 1. Assert: _module_.[[Status]] is not `"evaluating"`.
-                1. Perform ? _module_.ModuleEvaluation().
+                1. Perform ? _module_.Evaluate().
                 1. Return _index_.
               1. If _module_.[[Status]] is `"evaluating"` or `"evaluated"`,
                 1. Return _index_.
@@ -21904,7 +21904,7 @@
               1. Append _module_ to _stack_.
               1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
                 1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-                1. NOTE: ModuleDeclarationInstantiation must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+                1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
                 1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is "`evaluating`" if and only if _requiredModule_ is in _stack_.
@@ -21957,11 +21957,11 @@
             <img alt="A module graph in which module A depends on module B" width="121" height="121" src="img/module-graph-simple.svg">
           </emu-figure>
 
-          <p>Let's first assume that there are no error conditions. Then, a host will call _A_.ModuleDeclarationInstantiation(), which will complete successfully by assumption, and recursively instantiate module _B_ as well. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the module, it can call _A_.ModuleEvaluation(), which will complete successfully (again by assumption).</p>
+          <p>Let's first assume that there are no error conditions. Then, a host will call _A_.Instantiate(), which will complete successfully by assumption, and recursively instantiate module _B_ as well. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the module, it can call _A_.Evaluate(), which will complete successfully (again by assumption).</p>
 
-          <p>Consider then cases involving instantiation errors. If _B_ cannot be instantiated, for example because it imports itself, then _A_.ModuleDeclarationInstantiation() will fail, and the resulting exception will be recorded in both _A_ and _B_'s [[Status]] and [[ErrorCompletion]] fields. If the host then proceeds to call to _A_.ModuleEvaluation(), the exception will be re-thrown. Storing the exception also ensures that any time a host tries to reuse _A_ or _B_, it will encounter the same exception. (Hosts are not required to reuse Source Text Module Records; similarly, hosts are not required to expose the exception objects thrown by these methods. However, the specification enables such uses.)</p>
+          <p>Consider then cases involving instantiation errors. If _B_ cannot be instantiated, for example because it imports itself, then _A_.Instantiate() will fail, and the resulting exception will be recorded in both _A_ and _B_'s [[Status]] and [[ErrorCompletion]] fields. If the host then proceeds to call to _A_.Evaluate(), the exception will be re-thrown. Storing the exception also ensures that any time a host tries to reuse _A_ or _B_, it will encounter the same exception. (Hosts are not required to reuse Source Text Module Records; similarly, hosts are not required to expose the exception objects thrown by these methods. However, the specification enables such uses.)</p>
 
-          <p>Evaluation errors, such as throwing an exception at top-level, act much the same way as instantiation errors. Like instantiation errors, they are recorded in the [[Status]] and [[ErrorCompletion]] fields, thus preventing future instantiation or evaluation. They differ only in that detection will be delayed until _A_.ModuleEvaluation() is called.</p>
+          <p>Evaluation errors, such as throwing an exception at top-level, act much the same way as instantiation errors. Like instantiation errors, they are recorded in the [[Status]] and [[ErrorCompletion]] fields, thus preventing future instantiation or evaluation. They differ only in that detection will be delayed until _A_.Evaluate() is called.</p>
 
           <p>Note that if the instantiation or evaluation error occurs in _A_, _B_'s [[Status]] and [[ErrorCompletion]] remain unaffected. In other words, there is no propagation of errors to dependencies, only to dependents. (Unless the dependencies are in the same strongly connected component, i.e. are part of a cycle—see below for that case.)</p>
 
@@ -21979,9 +21979,9 @@
             <img alt="A module graph in which module A depends on module B and C, but module B also depends on module A" width="181" height="121" src="img/module-graph-cycle.svg">
           </emu-figure>
 
-          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.ModuleDeclarationInstantiation(). This in turn calls _B_.ModuleDeclarationInstantiation(). Because of the cycle, _B_.ModuleDeclarationInstantiation() calls _A_.ModuleDeclarationInstantiation(). In this case, _A_.[[Status]] is `"instantiating"`, so it returns the partially-instantiated _A_. This leaves _B_ as `"instantiating"` as well, i.e. the last steps of InnerModuleDeclarationInstantiation are not performed on _B_. But eventually, when we unwind back up and _C_ has become `"instantiated"`, both _A_ and _B_ then transition from `"instantiating"` to `"instantiated"` together; this is by design, since they are part of the same strongly connected component.</p>
+          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Instantiate(). This in turn calls _B_.Instantiate(). Because of the cycle, _B_.Instantiate() calls _A_.Instantiate(). In this case, _A_.[[Status]] is `"instantiating"`, so it returns the partially-instantiated _A_. This leaves _B_ as `"instantiating"` as well, i.e. the last steps of InnerModuleDeclarationInstantiation are not performed on _B_. But eventually, when we unwind back up and _C_ has become `"instantiated"`, both _A_ and _B_ then transition from `"instantiating"` to `"instantiated"` together; this is by design, since they are part of the same strongly connected component.</p>
 
-          <p>Now consider a case where _A_ has an instantiation error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to _A_.ModuleDeclarationInstantiation(). However, once we unwind back to the original call to _A_.ModuleDeclarationInstantiation(), it fails during ModuleDeclarationEnvironmentSetup, and in particular during a call to _C_.ResolveExport(). This exception propagates up to ModuleDeclarationInstantiation, which goes through everything in the depth-first search stack and propagates the exception to them. Since the stack at this point consists of both _A_ and _B_, this atomically transitions _A_ and _B_ to the `"errored"` status, as desired. Note that _C_ is left as `"uninstantiated"`.</p>
+          <p>Now consider a case where _A_ has an instantiation error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to _A_.Instantiate(). However, once we unwind back to the original call to _A_.Instantiate(), it fails during ModuleDeclarationEnvironmentSetup, and in particular during a call to _C_.ResolveExport(). This exception propagates up to Instantiate, which goes through everything in the depth-first search stack and propagates the exception to them. Since the stack at this point consists of both _A_ and _B_, this atomically transitions _A_ and _B_ to the `"errored"` status, as desired. Note that _C_ is left as `"uninstantiated"`.</p>
 
           <p>Analogous stories occur for evaluation of the cyclic module graph, both in the success and error cases.</p>
         </emu-clause>
@@ -22042,9 +22042,9 @@
           1. If _m_ is a List of errors, then
             1. Perform HostReportErrors(_m_).
             1. Return NormalCompletion(*undefined*).
-          1. Perform ? _m_.ModuleDeclarationInstantiation().
+          1. Perform ? _m_.Instantiate().
           1. Assert: All dependencies of _m_ have been transitively resolved and _m_ is ready for evaluation.
-          1. Return ? _m_.ModuleEvaluation().
+          1. Return ? _m_.Evaluate().
         </emu-alg>
         <emu-note>
           <p>An implementation may parse a _sourceText_ as a |Module|, analyse it for Early Error conditions, and instantiate it prior to the execution of the TopLevelModuleEvaluationJob for that _sourceText_. An implementation may also resolve, pre-parse and pre-analyse, and pre-instantiate module dependencies of _sourceText_. However, the reporting of any errors detected by these actions must be deferred until the TopLevelModuleEvaluationJob is actually executed.</p>

--- a/spec.html
+++ b/spec.html
@@ -21081,7 +21081,7 @@
 
         <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type. However, non-source text Module Records must not participate in dependency cycles with Source Text Module Records. Concretely, this is enforced below by assertions that non-source text Module Record dependencies do not have a [[Status]] of `"instantiating"` or `"evaluating"` during a call to ModuleDeclarationInstantiation or ModuleEvaluation on a Source Text Module Record.</p>
 
-        <p>In addition to the fields, defined in <emu-xref href="#table-36"></emu-xref>, Source Text Module Records have the additional fields listed in <emu-xref href="#table-38"></emu-xref>. Each of these fields initially has the value *undefined*.</p>
+        <p>In addition to the fields, defined in <emu-xref href="#table-36"></emu-xref>, Source Text Module Records have the additional fields listed in <emu-xref href="#table-38"></emu-xref>. Each of these fields is initially set in ParseModule.</p>
 
         <emu-table id="table-38" caption="Additional Fields of Source Text Module Records">
           <table>

--- a/spec.html
+++ b/spec.html
@@ -21657,6 +21657,7 @@
           <p>The ResolveExport concrete method of a Source Text Module Record with arguments _exportName_, _resolveMode_, and _resolveSet_ performs the following steps:</p>
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
+            1. Assert: _module_.[[Status]] is not `"errored"`.
             1. For each Record {[[Module]], [[ExportName]]} _r_ in _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
                 1. Assert: This is a circular import request.
@@ -21885,7 +21886,7 @@
         <p>The implementation of HostResolveImportedModule must conform to the following requirements:</p>
         <ul>
           <li>
-            The normal return value must be an instance of a concrete subclass of Module Record.
+            The normal return value must be an instance of a concrete subclass of Module Record, and its [[Status]] must not be `"errored"`.
           </li>
           <li>
             If a Module Record corresponding to the pair _referencingModule_, _specifier_ does not exist or cannot be created, an exception must be thrown.

--- a/spec.html
+++ b/spec.html
@@ -21624,8 +21624,8 @@
               1. Assert: _module_ imports a specific binding for this export.
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
-              1. Let _requestedModule_ be ! HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _starNames_ be ! _requestedModule_.GetExportedNames(_exportStarSet_).
+              1. Let _requestedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
+              1. Let _starNames_ be ? _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
                 1. If SameValue(_n_, `"default"`) is *false*, then
                   1. If _n_ is not an element of _exportedNames_, then
@@ -21669,7 +21669,7 @@
             1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Assert: _module_ imports a specific binding for this export.
-                1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
+                1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"default"`.
                 1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveMode_, _resolveSet_).
             1. If SameValue(_exportName_, `"default"`) is *true*, then
@@ -21680,7 +21680,7 @@
             1. Let _newResolveMode_ be _resolveMode_.
             1. If _resolveMode_ is `"default"`, set _newResolveMode_ to `"star"`.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
-              1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
+              1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _newResolveMode_, _resolveSet_).
               1. If _resolution_ is not *undefined*, then
                 1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
@@ -21738,7 +21738,7 @@
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Append _module_ to _stack_.
               1. For each String _required_ that is an element of _module_.[[RequestedModules]],
-                1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
+                1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
                 1. Perform ? InnerModuleDeclarationInstantiation(_requiredModule_, _stack_, _index_+1).
                 1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is "`instantiating`" if and only if _requiredModule_ is in _stack_.
@@ -21769,9 +21769,7 @@
               1. Let _envRec_ be _env_'s EnvironmentRecord.
               1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
                 1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
-                <!-- 1. NOTE: The above call cannot fail because imported module
-                     requests are a subset of _module_.[[RequestedModules]], and
-                     these have been resolved earlier in this algorithm. -->
+                1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
                 1. If _in_.[[ImportName]] is `"*"`, then
                   1. Let _namespace_ be ! GetModuleNamespace(_importedModule_).
                   1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
@@ -21908,7 +21906,7 @@
           1. Assert: _module_.[[Status]] is neither `"uninstantiated"` nor `"errored"`.
           1. Let _namespace_ be _module_.[[Namespace]].
           1. If _namespace_ is *undefined*, then
-            1. Let _exportedNames_ be ! _module_.GetExportedNames(&laquo; &raquo;).
+            1. Let _exportedNames_ be ? _module_.GetExportedNames(&laquo; &raquo;).
             1. Let _unambiguousNames_ be a new empty List.
             1. For each _name_ that is an element of _exportedNames_, do
               1. Let _resolution_ be ! _module_.ResolveExport(_name_, `"namespace"`, &laquo; &raquo;).

--- a/spec.html
+++ b/spec.html
@@ -20995,7 +20995,7 @@
                 String
               </td>
               <td>
-                Initially `"uninstantiated"`. Can become `"instantiated"`, `"instantiating"`, `"evaluated"`, or `"errored"` as the module progresses throughout its lifecycle.
+                Initially `"uninstantiated"`. Can become `"instantiating"`, `"instantiated"`, `"evaluating"`, `"evaluated"`, or `"errored"` as the module progresses throughout its lifecycle.
               </td>
             </tr>
             <tr>
@@ -21003,10 +21003,10 @@
                 [[ErrorCompletion]]
               </td>
               <td>
-                An abrupt completion
+                An abrupt completion | *undefined*
               </td>
               <td>
-                A completion record representing exception that occurred during instantiation or evaluation; meaningful only if [[Status]] is `"errored"`.
+                A completion of type `"throw"` representing the exception that occurred during instantiation or evaluation, if [[Status]] is `"errored"`. Otherwise *undefined*.
               </td>
             </tr>
             <tr>
@@ -21055,7 +21055,8 @@
                 ModuleDeclarationInstantiation()
               </td>
               <td>
-                Transitively resolve all module dependencies and create a module Environment Record for the module. Will transition this module's [[Status]] from `"uninstantiated"` to either `"instantiated"` or `"errored"`. While this is executing, this module's [[Status]] will be `"instantiating"`; this is observable through reentrant invocations via circular dependencies.
+                <p>Transitively resolve all module dependencies and create a module Environment Record for the module.</p>
+                <p>Will transition this module's [[Status]] from `"uninstantiated"` to either `"instantiated"` or `"errored"`. While this is executing, this module's [[Status]] will be `"instantiating"`; this is observable through reentrant invocations via circular dependencies.</p>
               </td>
             </tr>
             <tr>
@@ -21063,8 +21064,10 @@
                 ModuleEvaluation()
               </td>
               <td>
-                <p>Transitively evaluate all module dependences of this module and then evaluate this module.</p>
-                <p>Will transition this module's [[Status]] from `"instantiated"` to either `"evaluated"` or `"errored"`; if the status is already in one of those states, do nothing or return [[ErrorCompletion]] as appropriate. This method will never be invoked when the module's status is `"uninstantiated"`.</p>
+                <p>Transitively evaluate all module dependencies of this module and then evaluate this module.</p>
+                <p>Will transition this module's [[Status]] from
+                `"instantiated"` to either `"evaluated"` or `"errored"`. While
+                this is executing, this module's [[Status]] will be `"evaluating"`; this is observable through reentrant invocations via circular dependencies.</p>
               </td>
             </tr>
             </tbody>
@@ -21155,6 +21158,29 @@
               </td>
               <td>
                 A List of ExportEntry records derived from the code of this module that correspond to export * declarations that occur within the module.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[DFSIndex]]
+              </td>
+              <td>
+                Integer | *undefined*
+              </td>
+              <td>
+                Auxiliary field used during ModuleDeclarationInstantiation and ModuleEvaluation only.
+                If [[Status]] is "`instantiating`" or "`evaluating`", this non-negative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[DFSAncestorIndex]]
+              </td>
+              <td>
+                Integer | *undefined*
+              </td>
+              <td>
+                Auxiliary field used during ModuleDeclarationInstantiation and ModuleEvaluation only. If [[Status]] is "`instantiating`" or "`evaluating`", this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
               </td>
             </tr>
             </tbody>
@@ -21571,7 +21597,7 @@
                 1. Append _ee_ to _starExportEntries_.
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
-            1. Return Source Text Module Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[HostDefined]]: _hostDefined_, [[Namespace]]: *undefined*, [[Evaluated]]: *false*, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_}.
+            1. Return Source Text Module Record {[[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, [[Status]]: `"uninstantiated"`, [[ErrorCompletion]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*}.
           </emu-alg>
           <emu-note>
             <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -21657,40 +21683,68 @@
           <p>The ModuleDeclarationInstantiation concrete method of a Source Text Module Record performs the following steps:</p>
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
-            1. Let _result_ be InnerModuleDeclarationInstantiation(_module_).
+            1. Assert: _module_.[[Status]] is not `"instantiating"` or `"evaluating"`.
+            1. Let _stack_ be an empty list.
+            1. Let _result_ be InnerModuleDeclarationInstantiation(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion,
-              1. Set _module_.[[Status]] to `"errored"`.
-              1. Set _module_.[[ErrorCompletion]] to _result_.
-            1. Otherwise, set _module_.[[Status]] to `"instantiated"`.
+              1. For each module _m_ in _stack_,
+                1. Assert: _m_.[[Status]] is `"instantiating"`.
+                1. Set _m_.[[Status]] to `"errored"`.
+                1. Set _m_.[[ErrorCompletion]] to _result_.
+              1. Assert: _module_.[[Status]] is `"errored"` and _module_.[[ErrorCompletion]] is _result_.
+              1. Return _result_.
+            1. Assert: _module_.[[Status]] is `"instantiated"` or `"evaluated"`.
+            1. Assert: _stack_ is empty.
             1. Return _result_.
           </emu-alg>
 
           <emu-clause id="sec-innermoduledeclarationinstantiation" aoid="InnerModuleDeclarationInstantiation">
-            <h1>Runtime Semantics: InnerModuleDeclarationInstantiation( _module_ )</h1>
+            <h1>Runtime Semantics: InnerModuleDeclarationInstantiation( _module_, _stack_, _index_ )</h1>
             <p>The InnerModuleDeclarationInstantiation abstract operation performs the following steps:</p>
             <emu-alg>
-              1. Let _realm_ be _module_.[[Realm]].
-              1. Assert: _realm_ is not *undefined*.
-              1. Let _code_ be _module_.[[ECMAScriptCode]].
-              1. If _module_.[[Status]] is `"errored"`, return _module_.[[ErrorCompletion]].
-              1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"` or `"evaluated"`,
-                1. Assert: _module_.[[Environment]] is not *undefined*.
-                1. Return NormalCompletion(~empty~).
+              1. If _module_ is not a Source Text Module Record,
+                1. If _module_.[[Status]] is `"instantiating"`, throw a *TypeError* exception.
+                1. Otherwise, return _module_.ModuleDeclarationInstantiation().
+              1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"`, or `"evaluated"`,
+                1. Return *undefined*.
+              1. If _module_.[[Status]] is `"errored"`,
+                1. Return _module_.[[ErrorCompletion]].
               1. Assert: _module_.[[Status]] is `"uninstantiated"`.
-              1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
-              1. Set _module_.[[Environment]] to _env_.
               1. Set _module_.[[Status]] to `"instantiating"`.
+              1. Set _module_.[[DFSIndex]] to _index_.
+              1. Set _module_.[[DFSAncestorIndex]] to _index_.
+              1. Append _module_ to _stack_.
               1. For each String _required_ that is an element of _module_.[[RequestedModules]],
-                1. NOTE: Before instantiating a module, all of the modules it requested must be available. An implementation may perform this test at any time prior to this point.
-                1. Perform ? HostResolveImportedModule(_module_, _required_).
-              1. For each String _required_ that is an element of _module_.[[RequestedModules]],
-                1. NOTE: this loop is separate from the previous one to ensure that exceptions due to unresolvable modules are thrown before attempting to instantiate any modules.
-                1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-                1. Perform ? _requiredModule_.ModuleDeclarationInstantiation().
+                1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
+                1. Perform ? InnerModuleDeclarationInstantiation(_requiredModule_, _stack_, _index_+1).
+                1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
+                1. Assert: _requiredModule_.[[Status]] is "`instantiating`" if and only if _requiredModule_ is in _stack_.
+                1. If _requiredModule_.[[Status]] is "`instantiating`",
+                  1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]].
+              1. Perform ? ModuleDeclarationResolution(_module_).
+              1. Assert: _module_ occurs exactly once in _stack_.
+              1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
+              1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], repeat:
+                1. Let _requiredModule_ be the last element in _stack_.
+                1. Remove this element from _stack_.
+                1. Set _requiredModule_.[[Status]] to "`instantiated`".
+                1. If _requiredModule_ is _module_, end the repetition.
+              1. Return *undefined*.
+            </emu-alg>
+          </emu-clause>
+
+          <emu-clause id="sec-moduledeclarationresolution" aoid="ModuleDeclarationResolution">
+            <h1>Runtime Semantics: ModuleDeclarationResolution( _module_ )</h1>
+            <p>The ModuleDeclarationResolution abstract operation performs the following steps:</p>
+            <emu-alg>
               1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
                 1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
                 1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
               1. Assert: All named exports from _module_ are resolvable.
+              1. Let _realm_ be _module_.[[Realm]].
+              1. Assert: _realm_ is not *undefined*.
+              1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
+              1. Set _module_.[[Environment]] to _env_.
               1. Let _envRec_ be _env_'s EnvironmentRecord.
               1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
                 1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
@@ -21703,6 +21757,7 @@
                   1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
                   1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
                   1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
+              1. Let _code_ be _module_.[[ECMAScriptCode]].
               1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
               1. Let _declaredVarNames_ be a new empty List.
               1. For each element _d_ in _varDeclarations_, do
@@ -21721,7 +21776,6 @@
                   1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|, then
                     1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
                     1. Call _envRec_.InitializeBinding(_dn_, _fo_).
-              1. Return NormalCompletion(~empty~).
             </emu-alg>
           </emu-clause>
         </emu-clause>
@@ -21732,36 +21786,76 @@
           <p>The ModuleEvaluation concrete method of a Source Text Module Record performs the following steps:</p>
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
-            1. Assert: _module_.[[Realm]] is not *undefined*.
-            1. Assert: _module_.[[Status]] is not `"uninstantiated"` or `"instantiating"`.
-            1. If _module_.[[Status]] is `"evaluated"`, return *undefined*.
-            1. If _module_.[[Status]] is `"errored"`, return _module_.[[ErrorCompletion]].
-            1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
-              1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-              1. NOTE: ModuleDeclarationInstantiation must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-              1. Let _requiredModuleStatus_ be _requiredModule_.ModuleEvaluation().
-              1. If _requiredModuleStatus_ is an abrupt completion,
-                1. Set _module_.[[Status]] to `"errored"`.
-                1. Set _module_.[[ErrorCompletion]] to _requiredModuleStatus_.
-                1. Return _requiredModuleStatus_.
-            1. Let _moduleCxt_ be a new ECMAScript code execution context.
-            1. Set the Function of _moduleCxt_ to *null*.
-            1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
-            1. Set the ScriptOrModule of _moduleCxt_ to _module_.
-            1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
-            1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
-            1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
-            1. Suspend the currently running execution context.
-            1. Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.
-            1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
-            1. Suspend _moduleCxt_ and remove it from the execution context stack.
-            1. Resume the context that is now on the top of the execution context stack as the running execution context.
+            1. Assert: _module_.[[Status]] is `"errored"`, `"instantiated"`, or `"evaluated"`.
+            1. Let _stack_ be an empty list.
+            1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion,
-              1. Set _module_.[[Status]] to `"errored"`.
-              1. Set _module_.[[ErrorCompletion]] to _result_.
-            1. Otherwise, set _module_.[[Status]] to `"evaluated"`.
-            1. Return Completion(_result_).
+              1. For each module _m_ in _stack_,
+                1. Assert: _m_.[[Status]] is `"evaluating"`.
+                1. Set _m_.[[Status]] to `"errored"`.
+                1. Set _m_.[[ErrorCompletion]] to _result_.
+              1. Assert: _module_.[[Status]] is `"errored"` and _module_.[[ErrorCompletion]] is _result_.
+              1. Return _result_.
+            1. Assert: _module_.[[Status]] is `"evaluated"`.
+            1. Assert: _stack_ is empty.
+            1. Return _result_.
           </emu-alg>
+
+          <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
+            <h1>Runtime Semantics: InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
+            <p>The InnerModuleEvaluation abstract operation performs the following steps:</p>
+            <emu-alg>
+              1. If _module_ is not a Source Text Module Record,
+                1. If _module_.[[Status]] is `"evaluating"`, throw a *TypeError* exception.
+                1. Otherwise, return _module_.ModuleEvaluation().
+              1. If _module_.[[Status]] is `"evaluating"` or `"evaluated"`,
+                1. Return *undefined*.
+              1. If _module_.[[Status]] is `"errored"`,
+                1. Return _module_.[[ErrorCompletion]].
+              1. Assert: _module_.[[Status]] is `"instantiated"`.
+              1. Set _module_.[[Status]] to `"evaluating"`.
+              1. Set _module_.[[DFSIndex]] to _index_.
+              1. Set _module_.[[DFSAncestorIndex]] to _index_.
+              1. Append _module_ to _stack_.
+              1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+                1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
+                1. NOTE: ModuleDeclarationInstantiation must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+                1. Perform ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_+1).
+                1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
+                1. Assert: _requiredModule_.[[Status]] is "`evaluating`" if and only if _requiredModule_ is in _stack_.
+                1. If _requiredModule_.[[Status]] is "`evaluating`",
+                  1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]].
+              1. Perform ? ModuleExecution(_module_).
+              1. Assert: _module_ occurs exactly once in _stack_.
+              1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
+              1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], repeat:
+                1. Let _requiredModule_ be the last element in _stack_.
+                1. Remove this element from _stack_.
+                1. Set _requiredModule_.[[Status]] to "`evaluated`".
+                1. If _requiredModule_ is _module_, end the repetition.
+              1. Return *undefined*.
+            </emu-alg>
+          </emu-clause>
+
+          <emu-clause id="sec-moduleexecution" aoid="ModuleExecution">
+            <h1>Runtime Semantics: ModuleExecution( _module_ )</h1>
+            <p>The ModuleExecution abstract operation performs the following steps:</p>
+            <emu-alg>
+              1. Let _moduleCxt_ be a new ECMAScript code execution context.
+              1. Set the Function of _moduleCxt_ to *null*.
+              1. Assert: _module_.[[Realm]] is not *undefined*.
+              1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
+              1. Set the ScriptOrModule of _moduleCxt_ to _module_.
+              1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
+              1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
+              1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
+              1. Suspend the currently running execution context.
+              1. Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.
+              1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
+              1. Suspend _moduleCxt_ and remove it from the execution context stack.
+              1. Resume the context that is now on the top of the execution context stack as the running execution context.
+            </emu-alg>
+          </emu-clause>
         </emu-clause>
       </emu-clause>
 
@@ -21790,6 +21884,7 @@
         <p>The abstract operation GetModuleNamespace called with argument _module_ performs the following steps:</p>
         <emu-alg>
           1. Assert: _module_ is an instance of a concrete subclass of Module Record.
+          1. Assert: _module_.[[Status]] is neither `"uninstantiated"` nor `"errored"`.
           1. Let _namespace_ be _module_.[[Namespace]].
           1. If _namespace_ is *undefined*, then
             1. Let _exportedNames_ be ? _module_.GetExportedNames(&laquo; &raquo;).

--- a/spec.html
+++ b/spec.html
@@ -21077,7 +21077,7 @@
       <emu-clause id="sec-source-text-module-records">
         <h1>Source Text Module Records</h1>
 
-        <p>A <dfn>Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (<emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module.</p>
+        <p>A <dfn id="sourctextmodule-record">Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (<emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module.</p>
 
         <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type. However, non-source text Module Records must not participate in dependency cycles with Source Text Module Records. Concretely, this is enforced below by assertions that non-source text Module Record dependencies do not have a [[Status]] of `"instantiating"` or `"evaluating"` during a call to ModuleDeclarationInstantiation or ModuleEvaluation on a Source Text Module Record.</p>
 

--- a/spec.html
+++ b/spec.html
@@ -8301,8 +8301,7 @@
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _m_ be _O_.[[Module]].
-          1. Let _binding_ be ? _m_.ResolveExport(_P_, &laquo; &raquo;).
-          1. Assert: _binding_ is neither *null* nor `"ambiguous"`.
+          1. Let _binding_ be ! _m_.ResolveExport(_P_, `"default"`, &laquo; &raquo;).
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.
           1. Let _targetEnv_ be _targetModule_.[[Environment]].
@@ -21044,7 +21043,7 @@
             </tr>
             <tr>
               <td>
-                ResolveExport(exportName, resolveSet)
+                ResolveExport(exportName, resolveMode, resolveSet)
               </td>
               <td>
                 Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form {[[Module]]: Module Record, [[BindingName]]: String}. Return *null* if the name cannot be resolved, or `"ambiguous"` if multiple bindings were found.
@@ -21638,16 +21637,30 @@
           </emu-note>
         </emu-clause>
 
+        <emu-clause id="sec-resolutionfailure" aoid="ResolutionFailure">
+          <h1>Runtime Semantics: ResolutionFailure( _module_, _resolveMode_ )</h1>
+          <p>The ResolutionFailure abstract operation performs the following steps:</p>
+          <emu-alg>
+            1. Assert: _module_.[[Status]] is `"uninstantiated"` or `"instantiating"`.
+            1. If _resolveMode_ is `"namespace"` or `"star"`: return *undefined*.
+            1. Assert: _resolveMode_ is `"default"`.
+            1. Let _error_ be Completion{[[Type]]: ~throw~, [[Value]]: a newly created *SyntaxError* object, [[Target]]: ~empty~}.
+            1. Set _module_.[[ErrorCompletion]] to _error_.
+            1. Set _module_.[[Status]] to `"errored"`.
+            1. Return _error_.
+          </emu-alg>
+        </emu-clause>
+
         <!-- es6num="15.2.1.16.3" -->
         <emu-clause id="sec-resolveexport">
-          <h1>ResolveExport( _exportName_, _resolveSet_ ) Concrete Method</h1>
-          <p>The ResolveExport concrete method of a Source Text Module Record with arguments _exportName_, and _resolveSet_ performs the following steps:</p>
+          <h1>ResolveExport( _exportName_, _resolveMode_, _resolveSet_ ) Concrete Method</h1>
+          <p>The ResolveExport concrete method of a Source Text Module Record with arguments _exportName_, _resolveMode_, and _resolveSet_ performs the following steps:</p>
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. For each Record {[[Module]], [[ExportName]]} _r_ in _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
                 1. Assert: This is a circular import request.
-                1. Return *null*.
+                1. Return _ResolutionFailure_(_module_, _resolveMode_).
             1. Append the Record {[[Module]]: _module_, [[ExportName]]: _exportName_} to _resolveSet_.
             1. For each ExportEntry Record _e_ in _module_.[[LocalExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
@@ -21657,22 +21670,29 @@
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Assert: _module_ imports a specific binding for this export.
                 1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-                1. Return ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
+                1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"default"`.
+                1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveMode_, _resolveSet_).
             1. If SameValue(_exportName_, `"default"`) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
-              1. Return *null*.
+              1. Return _ResolutionFailure_(_module_, _resolveMode_).
               1. NOTE: A `default` export cannot be provided by an `export *`.
-            1. Let _starResolution_ be *null*.
+            1. Let _starResolution_ be *undefined*.
+            1. Let _newResolveMode_ be _resolveMode_.
+            1. If _resolveMode_ is `"default"`, set _newResolveMode_ to `"star"`.
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
-              1. If _resolution_ is `"ambiguous"`, return `"ambiguous"`.
-              1. If _resolution_ is not *null*, then
+              1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _newResolveMode_, _resolveSet_).
+              1. If _resolution_ is not *undefined*, then
                 1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
-                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return `"ambiguous"`.
-            1. Return _starResolution_.
+                  1. If _resolveMode_ is `"star"`, set _resolveMode_ to `"default"`.
+                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]]
+                  are not the same Module Record or
+                  SameValue(_resolution_.[[BindingName]],
+                  _starResolution_.[[BindingName]]) is *false*, return _ResolutionFailure_(_module_, _resolveMode_).
+            1. If _starResolution_ is *undefined*, return _ResolutionFailure_(_module_, _resolveMode_);
+            1. Otherwise, return _starResolution_.
           </emu-alg>
           <emu-note>
             <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is use to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
@@ -21691,7 +21711,7 @@
             1. Let _result_ be InnerModuleDeclarationInstantiation(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion,
               1. For each module _m_ in _stack_,
-                1. Assert: _m_.[[Status]] is `"instantiating"`.
+                1. Assert: _m_.[[Status]] is `"instantiating"` or `"errored"`.
                 1. Set _m_.[[Status]] to `"errored"`.
                 1. Set _m_.[[ErrorCompletion]] to _result_.
               1. Assert: _module_.[[Status]] is `"errored"` and _module_.[[ErrorCompletion]] is _result_.
@@ -21740,8 +21760,7 @@
             <p>The ModuleDeclarationResolution abstract operation performs the following steps:</p>
             <emu-alg>
               1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
-                1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
-                1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
+                1. Perform ? _module_.ResolveExport(_e_.[[ExportName]], `"default"`, &laquo; &raquo;).
               1. Assert: All named exports from _module_ are resolvable.
               1. Let _realm_ be _module_.[[Realm]].
               1. Assert: _realm_ is not *undefined*.
@@ -21754,12 +21773,11 @@
                      requests are a subset of _module_.[[RequestedModules]], and
                      these have been resolved earlier in this algorithm. -->
                 1. If _in_.[[ImportName]] is `"*"`, then
-                  1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
+                  1. Let _namespace_ be ! GetModuleNamespace(_importedModule_).
                   1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
-                  1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
-                  1. If _resolution_ is *null* or _resolution_ is `"ambiguous"`, throw a *SyntaxError* exception.
+                  1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], `"default"`, &laquo; &raquo;).
                   1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
               1. Let _code_ be _module_.[[ECMAScriptCode]].
               1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
@@ -21893,9 +21911,8 @@
             1. Let _exportedNames_ be ! _module_.GetExportedNames(&laquo; &raquo;).
             1. Let _unambiguousNames_ be a new empty List.
             1. For each _name_ that is an element of _exportedNames_, do
-              1. Let _resolution_ be ? _module_.ResolveExport(_name_, &laquo; &raquo;).
-              1. If _resolution_ is *null*, throw a *SyntaxError* exception.
-              1. If _resolution_ is not `"ambiguous"`, append _name_ to _unambiguousNames_.
+              1. Let _resolution_ be ! _module_.ResolveExport(_name_, `"namespace"`, &laquo; &raquo;).
+              1. If _resolution_ is not *undefined*, append _name_ to _unambiguousNames_.
             1. Set _namespace_ to ModuleNamespaceCreate(_module_, _unambiguousNames_).
           1. Return _namespace_.
         </emu-alg>


### PR DESCRIPTION
This addresses #862 by ensuring that repeated calls to ModuleDeclarationInstantiation() and ModuleEvaluation(), for Source Text Module Records, rethrow any exceptions they previously threw, instead of silently succeeding. This allows host environments to do top-down instantiation/evaluation of module graphs, instead of having to do bottom-up instantiation/evaluation in order to record individual failures and thus prevent future instantiation/evaluation.

In the process, this helps formalize some of the invariants previously stated in a vague way, such as "ModuleDeclarationInstantiation must have completed successfully", replacing them instead with an explicit [[Status]] field whose contents can be asserted against.

For background on the trouble caused by the previous approach of silent success, see:

- https://github.com/whatwg/html/issues/1545
- https://github.com/tc39/ecma262/issues/862
- https://github.com/whatwg/html/issues/2629
- https://github.com/whatwg/html/pull/2595#issuecomment-299242321

---

I've verified this works in some detail via [extensive case analysis](https://docs.google.com/document/d/19de8yileoNTOQEY_kQ_nI8bFY7DVU5-E59odZaglxds/edit?usp=sharing).

The corresponding HTML change is at https://github.com/whatwg/html/pull/2674

- [ES spec preview with these changes](https://dl.dropboxusercontent.com/u/20140634/es-spec-remember-modules/index.html)
- [HTML spec preview with the corresponding changes](https://dl.dropboxusercontent.com/u/20140634/modules-all-better/index.html)

---

I'd be thrilled if the editor/committee felt comfortable accepting this without needing to wait for the in-person meeting; that would certainly help us implement modules in Chrome and write valid web platform tests for them. We'd rather avoid a two-week delay in velocity, so we'll probably proceed assuming something with the same observable effects as this is acceptable, as I hope it will be.

The only potentially-opinionated thing here is rethrowing the same error, instead of some other way of "not completing successfully", but hosts who wanted a different error signal could easily do so by wrapping the calls to ModuleDeclarationInstantiation()/ModuleEvaluation(), so I don't think this limits expressive power. We also have strong signals from both Node and browsers that this is the behavior we'd prefer, and I think standardizing it across environments would be beneficial.

---

The alternative to this PR is to add more host hooks to allow hosts to accomplish the same thing. In particular, that would consist of something like:

- A hook called at the end of Source Text Module Records' ModuleDeclarationInstantiation() and ModuleEvaluation(), passed the completion value of the instantiation/evaluation process, which allows us to store thrown exceptions in [[HostDefined]] for later retrieval
- A hook called in the beginning of Source Text Module Records' ModuleDeclarationInstantiation() and ModuleEvaluation(), which allows us to throw the stored-in-[[HostDefined]] exceptions

Alternately, both Node.js and browsers could collaborate on a new spec for "For Realz Source Text Module Records" which are new implementations of the Abstract Module Records concept, wrapping Source Text Module Records and adding the appropriate before/after behavior.

Both of these options seem less good than having the behavior in 262. Especially given the nice bonus of the explicit [[Status]] field that this PR gives; I'd be sad to see 262 go back to vaguely asserting "ModuleDeclarationInstantiation must have completed successfully".

As such, I'd love a signal from the editor/committee as to whether I need to invest time in such alternate approaches, or if they think it's likely the strategy in this PR will be acceptable.