### PR TITLE
Editorial: positive lookahead-restriction: use single-equal

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38185,7 +38185,7 @@ THH:mm:ss.sss
         ExtendedAtom ::
           `.`
           `\` AtomEscape[~U]
-          `\` [lookahead == `c`]
+          `\` [lookahead = `c`]
           CharacterClass[~U]
           `(` Disjunction[~U] `)`
           `(` `?` `:` Disjunction[~U] `)`
@@ -38256,7 +38256,7 @@ THH:mm:ss.sss
         <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) evaluation rules for the <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
 
         <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules are also added:</p>
-        <p>The production <emu-grammar>ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ExtendedAtom :: `\` [lookahead = `c`]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.


### PR DESCRIPTION
The definition says single-equal, but the uses say double-equal.
Change the uses to match the definition.