### PR TITLE
Editorial: remove `await` from FutureReservedWords in A.1.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37852,7 +37852,6 @@ THH:mm:ss.sss
     <emu-prodref name=ReservedWord></emu-prodref>
     <emu-prodref name=Keyword></emu-prodref>
     <emu-prodref name=FutureReservedWord></emu-prodref>
-    <p>`await` is only treated as a |FutureReservedWord| when |Module| is the goal symbol of the syntactic grammar.</p>
     <p>The following tokens are also considered to be |FutureReservedWord|s when parsing strict mode code:</p>
     <p><emu-t>implements</emu-t> &nbsp;<emu-t>package</emu-t> &nbsp;<emu-t>protected</emu-t><br>
       <emu-t>interface</emu-t> &nbsp;<emu-t>private</emu-t> &nbsp;<emu-t>public</emu-t>


### PR DESCRIPTION
`await` was removed as FutureReservedWord from [11.6.2.2](https://tc39.github.io/ecma262/#sec-future-reserved-words) in aec498db94dedbf31a930c6b09c2ae939d21890f but wasn't removed from [A.1](https://tc39.github.io/ecma262/#sec-lexical-grammar)

See #818 and #846 for context

Fixes #922 