### PR TITLE
Normative: Clarify that case conversion is context-sensitve

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28417,7 +28417,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.touppercase">
         <h1>String.prototype.toUpperCase ( )</h1>
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
-        <p>This function behaves in exactly the same way as `String.prototype.toLowerCase`, except that the String is mapped using toe toUppercase algorithm of Unicode Default Case Conversion.</p>
+        <p>This function behaves in exactly the same way as `String.prototype.toLowerCase`, except that the String is mapped using to toUppercase algorithm of Unicode Default Case Conversion.</p>
         <emu-note>
           <p>The `toUpperCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>

--- a/spec.html
+++ b/spec.html
@@ -28388,10 +28388,8 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _cpList_ be a List containing in order the code points as defined in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref> of _S_, starting at the first element of _S_.
-          1. For each code point _c_ in _cpList_, if the Unicode Character Database provides a language insensitive lower case equivalent of _c_, then replace _c_ in _cpList_ with that equivalent code point(s).
-          1. Let _cuList_ be a new empty List.
-          1. For each code point _c_ in _cpList_, in order, append to _cuList_ the elements of the UTF16Encoding of _c_.
-          1. Let _L_ be a String whose elements are, in order, the elements of _cuList_.
+          1. Let _cuList_ be a List where the elements are the result of toLowercase(_cplist_), according to the Unicode Default Case Conversion algorithm.
+          1. Let _L_ be a String whose elements are the UTF16Encoding of the code points of _cuList_.
           1. Return _L_.
         </emu-alg>
         <p>The result must be derived according to the locale-insensitive case mappings in the Unicode Character Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive mappings in the SpecialCasings.txt file that accompanies it).</p>
@@ -28419,7 +28417,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.touppercase">
         <h1>String.prototype.toUpperCase ( )</h1>
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
-        <p>This function behaves in exactly the same way as `String.prototype.toLowerCase`, except that code points are mapped to their _uppercase_ equivalents as specified in the Unicode Character Database.</p>
+        <p>This function behaves in exactly the same way as `String.prototype.toLowerCase`, except that the String is mapped using toe toUppercase algorithm of Unicode Default Case Conversion.</p>
         <emu-note>
           <p>The `toUpperCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>


### PR DESCRIPTION
Previously, String.prototype.toUpperCase and
String.prototype.toLowerCase were specified with wording indicating
that Unicode case conversion was to be used, but code points should
be looked up one by one. The Unicode Default Case Conversion algorithm
is context-dependent, and a note alludes to this, but the normative
text seems to prohibit using the context. However, JSC, V8 and
ChakraCore do seem to pay attention to this context, at least when
it comes to final sigma.

This patch clarifies the spec text to make an explicit reference
to the Default Case Conversion algorithm.

These semantics are already tested by @anba's test262 test https://github.com/tc39/test262/blob/master/test/built-ins/String/prototype/toLowerCase/special_casing_conditional.js