### PR TITLE
Correct an axiom of strict total order

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2756,7 +2756,7 @@
       <p>A <dfn>strict total order</dfn> is a Relation value _R_ that satisfies the following conditions.</p>
       <emu-alg>
         1. For all _a_, _b_, and _c_ in _R_'s domain:
-          1. _a_ _R_ _b_ or _b_ _R_ _a_, and
+          1. _a_ is identical to _b_ or _a_ _R_ _b_ or _b_ _R_ _a_, and
           1. It is not the case that _a_ _R_ _a_, and
           1. If _a_ _R_ _b_ and _b_ _R_ _c_, then _a_ _R_ _c_.
       </emu-alg>


### PR DESCRIPTION
Dear Ecma-262 team,

I have noticed the following simple omission in the specification. The first axiom of the strict total order does not work when a = b. I have applied the necessary change. Please, let me know what other steps are necessary for this change to be applied. As this is a trivial change, I do not think it is necessary to pass any copyrights, but I am very happy to do so.

Yours faithfully,
Mateusz Grotek

For and on behalf of IdeaPiece Ltd.