### PR TITLE
Editorial: Refer to proleptic Gregorian calendar.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26225,7 +26225,7 @@
       <!-- es6num="20.3.1.3" -->
       <emu-clause id="sec-year-number">
         <h1>Year Number</h1>
-        <p>ECMAScript uses an extrapolated Gregorian system to map a day number to a year number and to determine the month and date within that year. In this system, leap years are precisely those which are (divisible by 4) and ((not divisible by 100) or (divisible by 400)). The number of days in year number _y_ is therefore defined by</p>
+        <p>ECMAScript uses a proleptic Gregorian calendar to map a day number to a year number and to determine the month and date within that year. In this calendar, leap years are precisely those which are (divisible by 4) and ((not divisible by 100) or (divisible by 400)). The number of days in year number _y_ is therefore defined by</p>
         <emu-eqn id="eqn-DaysInYear" aoid="DaysInYear">DaysInYear(_y_)
           = 365 if (_y_ modulo 4) &ne; 0
           = 366 if (_y_ modulo 4) = 0 and (_y_ modulo 100) &ne; 0
@@ -26422,7 +26422,7 @@
                 `YYYY`
               </td>
               <td>
-                is the decimal digits of the year 0000 to 9999 in the Gregorian calendar.
+                is the decimal digits of the year 0000 to 9999 in the proleptic Gregorian calendar.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
The spec currently refers to an "extrapolated Gregorian system",
but the term "proleptic Gregorian calendar" is more precise and is
the terminology used elsewhere in other standards and languages.
(e.g. ISO 8601:2004 3.2.1 "The use of this calendar for dates
preceding the introduction of the Gregorian calendar (also called
the proleptic Gregorian calendar) should only be by agreement of
the partners in information exchange.")