### PR TITLE
Editorial: fix the logo to not be humongous

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21,14 +21,14 @@
   margin: 0; padding: 0;
 }
 
-h1.version {
-  margin-right: 100px; /* width of logo */
+h1.version, h1.title {
+  margin-right: 350px; /* width of logo */
 }
 #ecma-logo {
   position: absolute;
   right: 0;
   top: 0;
-  width: 100px;
+  width: 350px;
 }
 </style>
 <script>

--- a/spec.html
+++ b/spec.html
@@ -21,7 +21,10 @@
   margin: 0; padding: 0;
 }
 #ecma-logo {
-  width: 100%;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100px;
 }
 </style>
 <script>

--- a/spec.html
+++ b/spec.html
@@ -21,7 +21,7 @@
   margin: 0; padding: 0;
 }
 
-h1.title {
+h1.version {
   margin-right: 100px; /* width of logo */
 }
 #ecma-logo {

--- a/spec.html
+++ b/spec.html
@@ -20,6 +20,10 @@
   list-style-type: none;
   margin: 0; padding: 0;
 }
+
+h1.title {
+  margin-right: 100px; /* width of logo */
+}
 #ecma-logo {
   position: absolute;
   right: 0;


### PR DESCRIPTION
This brings the logo in line with other standards organizations' logos on their specs, e.g. WHATWG (100px) or W3C (72px).