### PR TITLE
consistently use "is present" over "was supplied", "was provided", and other alternatives

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3257,7 +3257,7 @@
       <emu-alg>
         1. Assert: _input_ is an ECMAScript language value.
         1. If Type(_input_) is Object, then
-          1. If _PreferredType_ was not passed, let _hint_ be `"default"`.
+          1. If _PreferredType_ is not present, let _hint_ be `"default"`.
           1. Else if _PreferredType_ is hint String, let _hint_ be `"string"`.
           1. Else _PreferredType_ is hint Number, let _hint_ be `"number"`.
           1. Let _exoticToPrim_ be ? GetMethod(_input_, @@toPrimitive).
@@ -4443,7 +4443,7 @@
       <h1>Call ( _F_, _V_ [ , _argumentsList_ ] )</h1>
       <p>The abstract operation Call is used to call the [[Call]] internal method of a function object. The operation is called with arguments _F_, _V_, and optionally _argumentsList_ where _F_ is the function object, _V_ is an ECMAScript language value that is the *this* value of the [[Call]], and _argumentsList_ is the value passed to the corresponding argument of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. This abstract operation performs the following steps:</p>
       <emu-alg>
-        1. If _argumentsList_ was not passed, set _argumentsList_ to a new empty List.
+        1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
         1. If IsCallable(_F_) is *false*, throw a *TypeError* exception.
         1. Return ? _F_.[[Call]](_V_, _argumentsList_).
       </emu-alg>
@@ -4454,14 +4454,14 @@
       <h1>Construct ( _F_ [ , _argumentsList_ [ , _newTarget_ ]] )</h1>
       <p>The abstract operation Construct is used to call the [[Construct]] internal method of a function object. The operation is called with arguments _F_, and optionally _argumentsList_, and _newTarget_ where _F_ is the function object. _argumentsList_ and _newTarget_ are the values to be passed as the corresponding arguments of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. If _newTarget_ is not present, _F_ is used as its value. This abstract operation performs the following steps:</p>
       <emu-alg>
-        1. If _newTarget_ was not passed, set _newTarget_ to _F_.
-        1. If _argumentsList_ was not passed, set _argumentsList_ to a new empty List.
+        1. If _newTarget_ is not present, set _newTarget_ to _F_.
+        1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
         1. Assert: IsConstructor(_F_) is *true*.
         1. Assert: IsConstructor(_newTarget_) is *true*.
         1. Return ? _F_.[[Construct]](_argumentsList_, _newTarget_).
       </emu-alg>
       <emu-note>
-        <p>If _newTarget_ is not passed, this operation is equivalent to: `new F(...argumentsList)`</p>
+        <p>If _newTarget_ is not present, this operation is equivalent to: `new F(...argumentsList)`</p>
       </emu-note>
     </emu-clause>
 
@@ -4533,7 +4533,7 @@
       <h1>CreateListFromArrayLike ( _obj_ [ , _elementTypes_ ] )</h1>
       <p>The abstract operation CreateListFromArrayLike is used to create a List value whose elements are provided by the indexed properties of an array-like object, _obj_. The optional argument _elementTypes_ is a List containing the names of ECMAScript Language Types that are allowed for element values of the List that is created. This abstract operation performs the following steps:</p>
       <emu-alg>
-        1. If _elementTypes_ was not passed, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, Object &raquo;.
+        1. If _elementTypes_ is not present, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, Object &raquo;.
         1. If Type(_obj_) is not Object, throw a *TypeError* exception.
         1. Let _len_ be ? ToLength(? Get(_obj_, `"length"`)).
         1. Let _list_ be a new empty List.
@@ -4555,7 +4555,7 @@
 
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
-        1. If _argumentsList_ was not passed, set _argumentsList_ to a new empty List.
+        1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
         1. Let _func_ be ? GetV(_V_, _P_).
         1. Return ? Call(_func_, _V_, _argumentsList_).
       </emu-alg>
@@ -4653,7 +4653,7 @@
       <h1>GetIterator ( _obj_ [ , _method_ ] )</h1>
       <p>The abstract operation GetIterator with argument _obj_ and optional argument _method_ performs the following steps:</p>
       <emu-alg>
-        1. If _method_ was not passed, then
+        1. If _method_ is not present, then
           1. Set _method_ to ? GetMethod(_obj_, @@iterator).
         1. Let _iterator_ be ? Call(_method_, _obj_).
         1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
@@ -4666,7 +4666,7 @@
       <h1>IteratorNext ( _iterator_ [ , _value_ ] )</h1>
       <p>The abstract operation IteratorNext with argument _iterator_ and optional argument _value_ performs the following steps:</p>
       <emu-alg>
-        1. If _value_ was not passed, then
+        1. If _value_ is not present, then
           1. Let _result_ be ? Invoke(_iterator_, `"next"`, &laquo; &raquo;).
         1. Else,
           1. Let _result_ be ? Invoke(_iterator_, `"next"`, &laquo; _value_ &raquo;).
@@ -6204,7 +6204,7 @@
       <h1>ResolveBinding ( _name_ [ , _env_ ] )</h1>
       <p>The ResolveBinding abstract operation is used to determine the binding of _name_ passed as a String value. The optional argument _env_ can be used to explicitly provide the Lexical Environment that is to be searched for the binding. During execution of ECMAScript code, ResolveBinding is performed using the following algorithm:</p>
       <emu-alg>
-        1. If _env_ was not passed or if _env_ is *undefined*, then
+        1. If _env_ is not present or if _env_ is *undefined*, then
           1. Set _env_ to the running execution context's LexicalEnvironment.
         1. Assert: _env_ is a Lexical Environment.
         1. If the code matching the syntactic production that is being evaluated is contained in strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
@@ -6769,7 +6769,7 @@
         <h1>ValidateAndApplyPropertyDescriptor ( _O_, _P_, _extensible_, _Desc_, _current_ )</h1>
         <p>When the abstract operation ValidateAndApplyPropertyDescriptor is called with Object _O_, property key _P_, Boolean value _extensible_, and Property Descriptors _Desc_, and _current_, the following steps are taken:</p>
         <emu-note>
-          <p>If *undefined* is passed as the _O_ argument only validation is performed and no object updates are performed.</p>
+          <p>If *undefined* is passed as _O_, only validation is performed and no object updates are performed.</p>
         </emu-note>
         <emu-alg>
           1. Assert: If _O_ is not *undefined*, then IsPropertyKey(_P_) is *true*.
@@ -6956,7 +6956,7 @@
       <h1>ObjectCreate ( _proto_ [ , _internalSlotsList_ ] )</h1>
       <p>The abstract operation ObjectCreate with argument _proto_ (an object or null) is used to specify the runtime creation of new ordinary objects. The optional argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
       <emu-alg>
-        1. If _internalSlotsList_ was not provided, set _internalSlotsList_ to a new empty List.
+        1. If _internalSlotsList_ is not present, set _internalSlotsList_ to a new empty List.
         1. Let _obj_ be a newly created object with an internal slot for each name in _internalSlotsList_.
         1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
         1. Set _obj_.[[Prototype]] to _proto_.
@@ -7285,7 +7285,7 @@
       <h1>FunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_, _Strict_ [ , _prototype_ ] )</h1>
       <p>The abstract operation FunctionCreate requires the arguments: _kind_ which is one of (Normal, Method, Arrow), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, a Boolean flag _Strict_, and optionally, an object _prototype_. FunctionCreate performs the following steps:</p>
       <emu-alg>
-        1. If the _prototype_ argument was not passed, then
+        1. If _prototype_ is not present, then
           1. Set _prototype_ to the intrinsic object %FunctionPrototype%.
         1. If _kind_ is not ~Normal~, let _allocKind_ be `"non-constructor"`.
         1. Else, let _allocKind_ be `"normal"`.
@@ -7336,8 +7336,8 @@
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: _F_ has a [[Construct]] internal method.
         1. Assert: _F_ is an extensible object that does not have a `prototype` own property.
-        1. If the _writablePrototype_ argument was not provided, set _writablePrototype_ to *true*.
-        1. If the _prototype_ argument was not provided, then
+        1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
+        1. If _prototype_ is not present, then
           1. Set _prototype_ to ObjectCreate(%ObjectPrototype%).
           1. Perform ! DefinePropertyOrThrow(_prototype_, `"constructor"`, PropertyDescriptor{[[Value]]: _F_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Perform ! DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
@@ -7376,12 +7376,12 @@
       <emu-alg>
         1. Assert: _F_ is an extensible object that does not have a `name` own property.
         1. Assert: Type(_name_) is either Symbol or String.
-        1. Assert: If _prefix_ was passed, then Type(_prefix_) is String.
+        1. Assert: If _prefix_ is present, then Type(_prefix_) is String.
         1. If Type(_name_) is Symbol, then
           1. Let _description_ be _name_'s [[Description]] value.
           1. If _description_ is *undefined*, set _name_ to the empty String.
           1. Else, set _name_ to the concatenation of `"["`, _description_, and `"]"`.
-        1. If _prefix_ was passed, then
+        1. If _prefix_ is present, then
           1. Set _name_ to the concatenation of _prefix_, code unit 0x0020 (SPACE), and _name_.
         1. Return ! DefinePropertyOrThrow(_F_, `"name"`, PropertyDescriptor{[[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
       </emu-alg>
@@ -7728,7 +7728,7 @@
           1. Assert: _length_ is an integer Number &ge; 0.
           1. If _length_ is *-0*, set _length_ to *+0*.
           1. If _length_&gt;2<sup>32</sup>-1, throw a *RangeError* exception.
-          1. If the _proto_ argument was not passed, set _proto_ to the intrinsic object %ArrayPrototype%.
+          1. If _proto_ is not present, set _proto_ to the intrinsic object %ArrayPrototype%.
           1. Let _A_ be a newly created Array exotic object.
           1. Set _A_'s essential internal methods except for [[DefineOwnProperty]] to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
@@ -18836,7 +18836,7 @@
         1. ReturnIfAbrupt(_propKey_).
         1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. If _functionPrototype_ was passed as a parameter, then
+        1. If _functionPrototype_ is present as a parameter, then
           1. Let _kind_ be ~Normal~.
           1. Let _prototype_ be _functionPrototype_.
         1. Else,
@@ -26654,11 +26654,11 @@ THH:mm:ss.sss
           1. Else,
             1. Let _y_ be ? ToNumber(_year_).
             1. Let _m_ be ? ToNumber(_month_).
-            1. If _date_ is supplied, let _dt_ be ? ToNumber(_date_); else let _dt_ be 1.
-            1. If _hours_ is supplied, let _h_ be ? ToNumber(_hours_); else let _h_ be 0.
-            1. If _minutes_ is supplied, let _min_ be ? ToNumber(_minutes_); else let _min_ be 0.
-            1. If _seconds_ is supplied, let _s_ be ? ToNumber(_seconds_); else let _s_ be 0.
-            1. If _ms_ is supplied, let _milli_ be ? ToNumber(_ms_); else let _milli_ be 0.
+            1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 1.
+            1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be 0.
+            1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be 0.
+            1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be 0.
+            1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be 0.
             1. If _y_ is not *NaN* and 0 &le; ToInteger(_y_) &le; 99, let _yr_ be 1900+ToInteger(_y_); otherwise, let _yr_ be _y_.
             1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
             1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DatePrototype%"`, &laquo; [[DateValue]] &raquo;).
@@ -26756,12 +26756,12 @@ THH:mm:ss.sss
         <p>When the `UTC` function is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is supplied, let _m_ be ? ToNumber(_month_); else let _m_ be 0.
-          1. If _date_ is supplied, let _dt_ be ? ToNumber(_date_); else let _dt_ be 1.
-          1. If _hours_ is supplied, let _h_ be ? ToNumber(_hours_); else let _h_ be 0.
-          1. If _minutes_ is supplied, let _min_ be ? ToNumber(_minutes_); else let _min_ be 0.
-          1. If _seconds_ is supplied, let _s_ be ? ToNumber(_seconds_); else let _s_ be 0.
-          1. If _ms_ is supplied, let _milli_ be ? ToNumber(_ms_); else let _milli_ be 0.
+          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 0.
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 1.
+          1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be 0.
+          1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be 0.
+          1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be 0.
+          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be 0.
           1. If _y_ is not *NaN* and 0 &le; ToInteger(_y_) &le; 99, let _yr_ be 1900+ToInteger(_y_); otherwise, let _yr_ be _y_.
           1. Return TimeClip(MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_))).
         </emu-alg>
@@ -27010,8 +27010,8 @@ THH:mm:ss.sss
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, let _t_ be *+0*; otherwise, let _t_ be LocalTime(_t_).
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is not specified, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not specified, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
+          1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
+          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -27019,7 +27019,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setFullYear` method is 3.</p>
         <emu-note>
-          <p>If _month_ is not specified, this method behaves as if _month_ were specified with the value `getMonth()`. If _date_ is not specified, it behaves as if _date_ were specified with the value `getDate()`.</p>
+          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getDate()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27030,9 +27030,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
           1. Let _h_ be ? ToNumber(_hour_).
-          1. If _min_ is not specified, let _m_ be MinFromTime(_t_); otherwise, let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is not specified, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not specified, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
+          1. If _min_ is not present, let _m_ be MinFromTime(_t_); otherwise, let _m_ be ? ToNumber(_min_).
+          1. If _sec_ is not present, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -27040,7 +27040,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setHours` method is 4.</p>
         <emu-note>
-          <p>If _min_ is not specified, this method behaves as if _min_ were specified with the value `getMinutes()`. If _sec_ is not specified, it behaves as if _sec_ were specified with the value `getSeconds()`. If _ms_ is not specified, it behaves as if _ms_ were specified with the value `getMilliseconds()`.</p>
+          <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27065,8 +27065,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
           1. Let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is not specified, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not specified, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
+          1. If _sec_ is not present, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -27074,7 +27074,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setMinutes` method is 3.</p>
         <emu-note>
-          <p>If _sec_ is not specified, this method behaves as if _sec_ were specified with the value `getSeconds()`. If _ms_ is not specified, this behaves as if _ms_ were specified with the value `getMilliseconds()`.</p>
+          <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, this behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27085,7 +27085,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
           1. Let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not specified, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
+          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -27093,7 +27093,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setMonth` method is 2.</p>
         <emu-note>
-          <p>If _date_ is not specified, this method behaves as if _date_ were specified with the value `getDate()`.</p>
+          <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getDate()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27104,7 +27104,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
           1. Let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not specified, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -27112,7 +27112,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setSeconds` method is 2.</p>
         <emu-note>
-          <p>If _ms_ is not specified, this method behaves as if _ms_ were specified with the value `getMilliseconds()`.</p>
+          <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27150,8 +27150,8 @@ THH:mm:ss.sss
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, let _t_ be *+0*.
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is not specified, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not specified, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
+          1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
+          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
@@ -27159,7 +27159,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setUTCFullYear` method is 3.</p>
         <emu-note>
-          <p>If _month_ is not specified, this method behaves as if _month_ were specified with the value `getUTCMonth()`. If _date_ is not specified, it behaves as if _date_ were specified with the value `getUTCDate()`.</p>
+          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getUTCMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getUTCDate()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27170,9 +27170,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _h_ be ? ToNumber(_hour_).
-          1. If _min_ is not specified, let _m_ be MinFromTime(_t_); otherwise, let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is not specified, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not specified, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
+          1. If _min_ is not present, let _m_ be MinFromTime(_t_); otherwise, let _m_ be ? ToNumber(_min_).
+          1. If _sec_ is not present, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
           1. Let _newDate_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
@@ -27180,7 +27180,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setUTCHours` method is 4.</p>
         <emu-note>
-          <p>If _min_ is not specified, this method behaves as if _min_ were specified with the value `getUTCMinutes()`. If _sec_ is not specified, it behaves as if _sec_ were specified with the value `getUTCSeconds()`. If _ms_ is not specified, it behaves as if _ms_ were specified with the value `getUTCMilliseconds()`.</p>
+          <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getUTCMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27205,10 +27205,10 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is not specified, let _s_ be SecFromTime(_t_).
+          1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. Else,
             1. Let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not specified, let _milli_ be msFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Else,
             1. Let _milli_ be ? ToNumber(_ms_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
@@ -27218,7 +27218,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setUTCMinutes` method is 3.</p>
         <emu-note>
-          <p>If _sec_ is not specified, this method behaves as if _sec_ were specified with the value `getUTCSeconds()`. If _ms_ is not specified, it function behaves as if _ms_ were specified with the value return by `getUTCMilliseconds()`.</p>
+          <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it function behaves as if _ms_ was present with the value return by `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27229,7 +27229,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not specified, let _dt_ be DateFromTime(_t_).
+          1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
           1. Else,
             1. Let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
@@ -27239,7 +27239,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setUTCMonth` method is 2.</p>
         <emu-note>
-          <p>If _date_ is not specified, this method behaves as if _date_ were specified with the value `getUTCDate()`.</p>
+          <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getUTCDate()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27250,7 +27250,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not specified, let _milli_ be msFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Else,
             1. Let _milli_ be ? ToNumber(_ms_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
@@ -27260,7 +27260,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The `length` property of the `setUTCSeconds` method is 2.</p>
         <emu-note>
-          <p>If _ms_ is not specified, this method behaves as if _ms_ were specified with the value `getUTCMilliseconds()`.</p>
+          <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -28015,7 +28015,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. If _form_ is not provided or _form_ is *undefined*, let _form_ be `"NFC"`.
+          1. If _form_ is not present or _form_ is *undefined*, let _form_ be `"NFC"`.
           1. Let _f_ be ? ToString(_form_).
           1. If _f_ is not one of `"NFC"`, `"NFD"`, `"NFKC"`, or `"NFKD"`, throw a *RangeError* exception.
           1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="http://www.unicode.org/reports/tr15/">http://www.unicode.org/reports/tr15/</a>.
@@ -30616,7 +30616,7 @@ THH:mm:ss.sss
           1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
           1. Else,
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
-            1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+            1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_items_, @@iterator).
           1. If _usingIterator_ is not *undefined*, then
@@ -30863,7 +30863,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
@@ -30921,7 +30921,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
@@ -30958,7 +30958,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
@@ -30988,7 +30988,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
@@ -31017,7 +31017,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
@@ -31152,7 +31152,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If _len_ is 0, return -1.
-          1. If argument _fromIndex_ was passed, let _n_ be ? ToInteger(_fromIndex_); else let _n_ be _len_-1.
+          1. If _fromIndex_ is present, let _n_ be ? ToInteger(_fromIndex_); else let _n_ be _len_-1.
           1. If _n_ &ge; 0, then
             1. If _n_ is *-0*, let _k_ be *+0*; else let _k_ be min(_n_, _len_ - 1).
           1. Else _n_ &lt; 0,
@@ -31186,7 +31186,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
@@ -31261,7 +31261,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that takes four arguments. `reduce` calls the callback, as a function, once for each element after the first element present in the array, in ascending order.</p>
-          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time that callback is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was provided in the call to `reduce`, then _previousValue_ will be equal to _initialValue_ and _currentValue_ will be equal to the first value in the array. If no _initialValue_ was provided, then _previousValue_ will be equal to the first value in the array and _currentValue_ will be equal to the second. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
+          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time that callback is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduce`, then _previousValue_ will be equal to _initialValue_ and _currentValue_ will be equal to the first value in the array. If no _initialValue_ was supplied, then _previousValue_ will be equal to the first value in the array and _currentValue_ will be equal to the second. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
           <p>`reduce` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `reduce` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduce` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `reduce` visits them; elements that are deleted after the call to `reduce` begins and before being visited are not visited.</p>
         </emu-note>
@@ -31302,7 +31302,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that takes four arguments. `reduceRight` calls the callback, as a function, once for each element after the first element present in the array, in descending order.</p>
-          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time the function is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was provided in the call to `reduceRight`, then _previousValue_ will be equal to _initialValue_ and _currentValue_ will be equal to the last value in the array. If no _initialValue_ was provided, then _previousValue_ will be equal to the last value in the array and _currentValue_ will be equal to the second-to-last value. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
+          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time the function is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduceRight`, then _previousValue_ will be equal to _initialValue_ and _currentValue_ will be equal to the last value in the array. If no _initialValue_ was supplied, then _previousValue_ will be equal to the last value in the array and _currentValue_ will be equal to the second-to-last value. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
           <p>`reduceRight` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `reduceRight` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduceRight` begins will not be visited by _callbackfn_. If existing elements of the array are changed by _callbackfn_, their value as passed to _callbackfn_ will be the value at the time `reduceRight` visits them; elements that are deleted after the call to `reduceRight` begins and before being visited are not visited.</p>
         </emu-note>
@@ -31464,7 +31464,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
@@ -31595,7 +31595,7 @@ THH:mm:ss.sss
             1. If _x_ and _y_ are both *undefined*, return *+0*.
             1. If _x_ is *undefined*, return 1.
             1. If _y_ is *undefined*, return -1.
-            1. If the argument _comparefn_ is not *undefined*, then
+            1. If _comparefn_ is not *undefined*, then
               1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
               1. If _v_ is *NaN*, return *+0*.
               1. Return _v_.
@@ -32209,11 +32209,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
-          1. If _mapfn_ was supplied and _mapfn_ is not *undefined*, then
+          1. If _mapfn_ is present and _mapfn_ is not *undefined*, then
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Else, let _mapping_ be *false*.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _usingIterator_ be ? GetMethod(_source_, @@iterator).
           1. If _usingIterator_ is not *undefined*, then
             1. Let _values_ be ? IterableToList(_source_, _usingIterator_).
@@ -32471,7 +32471,7 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _kept_ be a new empty List.
           1. Let _k_ be 0.
           1. Let _captured_ be 0.
@@ -32579,7 +32579,7 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _len_ &raquo;).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
@@ -32782,7 +32782,7 @@ THH:mm:ss.sss
         <p>When the TypedArray SortCompare abstract operation is called with two arguments _x_ and _y_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Both Type(_x_) and Type(_y_) is Number.
-          1. If the argument _comparefn_ is not *undefined*, then
+          1. If _comparefn_ is not *undefined*, then
             1. Let _v_ be ? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. If _v_ is *NaN*, return *+0*.
@@ -32919,7 +32919,7 @@ THH:mm:ss.sss
             1. Let _obj_ be IntegerIndexedObjectCreate(_proto_, &laquo; [[ViewedArrayBuffer]], [[TypedArrayName]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;).
             1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
             1. Set _obj_.[[TypedArrayName]] to _constructorName_.
-            1. If _length_ was not passed, then
+            1. If _length_ is not present, then
               1. Set _obj_.[[ByteLength]] to 0.
               1. Set _obj_.[[ByteOffset]] to 0.
               1. Set _obj_.[[ArrayLength]] to 0.
@@ -33289,7 +33289,7 @@ THH:mm:ss.sss
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record {[[Key]], [[Value]]} _e_ that is an element of _entries_, in original key insertion order, do
             1. If _e_.[[Key]] is not ~empty~, then
@@ -33673,7 +33673,7 @@ THH:mm:ss.sss
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each _e_ that is an element of _entries_, in original insertion order, do
             1. If _e_ is not ~empty~, then
@@ -34990,7 +34990,7 @@ THH:mm:ss.sss
         <h1>ValidateSharedIntegerTypedArray(_typedArray_ [ , _onlyInt32_ ] )</h1>
         <p>The abstract operation ValidateSharedIntegerTypedArray takes one argument _typedArray_ and an optional Boolean _onlyInt32_. It performs the following steps:</p>
         <emu-alg>
-          1. If the _onlyInt32_ argument was not provided, set _onlyInt32_ to *false*.
+          1. If _onlyInt32_ is not present, set _onlyInt32_ to *false*.
           1. If Type(_typedArray_) is not Object, throw a *TypeError* exception.
           1. If _typedArray_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
           1. Let _typeName_ be _typedArray_.[[TypedArrayName]].


### PR DESCRIPTION
There were 4 occurrences of "was provided" and 14 occurrences of "was supplied", so I went with the latter.

Unfortunately, there's still 23 occurrences of "is provided" and 13 occurrences of "is supplied". 😕 Not sure what to do there.