### PR TITLE
Adds grammarkdown checking for emu-grammar elements

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3457,7 +3457,7 @@
           <p>The terminal symbols of this grammar are all composed of Unicode BMP code points so the result will be *NaN* if the string contains the UTF-16 encoding of any supplementary code points or any unpaired surrogate code points.</p>
         </emu-note>
         <h2>Syntax</h2>
-        <emu-grammar use="definition">
+        <emu-grammar>
           StringNumericLiteral :::
             StrWhiteSpace?
             StrWhiteSpace? StrNumericLiteral StrWhiteSpace?
@@ -9175,7 +9175,7 @@
   <emu-clause id="sec-source-text">
     <h1>Source Text</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       SourceCharacter ::
         &gt; any Unicode code point
     </emu-grammar>
@@ -9285,7 +9285,7 @@
     </code></pre>
   </emu-note>
   <h2>Syntax</h2>
-  <emu-grammar use="definition">
+  <emu-grammar>
     InputElementDiv ::
       WhiteSpace
       LineTerminator
@@ -9495,7 +9495,7 @@
       <p>Other than for the code points listed in <emu-xref href="#table-32"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       WhiteSpace ::
         &lt;TAB&gt;
         &lt;VT&gt;
@@ -9577,7 +9577,7 @@
     </emu-table>
     <p>Only the Unicode code points in <emu-xref href="#table-33"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-32"></emu-xref>. The sequence &lt;CR&gt;&lt;LF&gt; is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       LineTerminator ::
         &lt;LF&gt;
         &lt;CR&gt;
@@ -9600,7 +9600,7 @@
     <p>Because a single-line comment can contain any Unicode code point except a |LineTerminator| code point, and because of the general rule that a token is always as long as possible, a single-line comment always consists of all code points from the `//` marker to the end of the line. However, the |LineTerminator| at the end of the line is not considered to be part of the single-line comment; it is recognized separately by the lexical grammar and becomes part of the stream of input elements for the syntactic grammar. This point is very important, because it implies that the presence or absence of single-line comments does not affect the process of automatic semicolon insertion (see <emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>).</p>
     <p>Comments behave like white space and are discarded except that, if a |MultiLineComment| contains a line terminator code point, then the entire comment is considered to be a |LineTerminator| for purposes of parsing by the syntactic grammar.</p>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       Comment ::
         MultiLineComment
         SingleLineComment
@@ -9637,7 +9637,7 @@
   <emu-clause id="sec-tokens">
     <h1>Tokens</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       CommonToken ::
         IdentifierName
         Punctuator
@@ -9660,7 +9660,7 @@
     <p>Unicode escape sequences are permitted in an |IdentifierName|, where they contribute a single Unicode code point to the |IdentifierName|. The code point is expressed by the |HexDigits| of the |UnicodeEscapeSequence| (see <emu-xref href="#sec-literals-string-literals"></emu-xref>). The `\\` preceding the |UnicodeEscapeSequence| and the `u` and `{ }` code units, if they appear, do not contribute code points to the |IdentifierName|. A |UnicodeEscapeSequence| cannot be used to put a code point into an |IdentifierName| that would otherwise be illegal. In other words, if a `\\` |UnicodeEscapeSequence| sequence were replaced by the |SourceCharacter| it contributes, the result must still be a valid |IdentifierName| that has the exact same sequence of |SourceCharacter| elements as the original |IdentifierName|. All interpretations of |IdentifierName| within this specification are based upon their actual code points regardless of whether or not an escape sequence was used to contribute any particular code point.</p>
     <p>Two |IdentifierName|s that are canonically equivalent according to the Unicode standard are <em>not</em> equal unless, after replacement of each |UnicodeEscapeSequence|, they are represented by the exact same sequence of code points.</p>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       IdentifierName ::
         IdentifierStart
         IdentifierName IdentifierPart
@@ -9731,7 +9731,7 @@
       <h1>Reserved Words</h1>
       <p>A reserved word is an |IdentifierName| that cannot be used as an |Identifier|.</p>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         ReservedWord ::
           Keyword
           FutureReservedWord
@@ -9747,7 +9747,7 @@
         <h1>Keywords</h1>
         <p>The following tokens are ECMAScript keywords and may not be used as |Identifier|s in ECMAScript programs.</p>
         <h2>Syntax</h2>
-        <emu-grammar use="definition">
+        <emu-grammar>
           Keyword :: one of
             `await`
             `break`
@@ -9774,7 +9774,7 @@
         <h1>Future Reserved Words</h1>
         <p>The following tokens are reserved for use as keywords in future language extensions.</p>
         <h2>Syntax</h2>
-        <emu-grammar use="definition">
+        <emu-grammar>
           FutureReservedWord ::
             `enum`
         </emu-grammar>
@@ -9821,7 +9821,7 @@
   <emu-clause id="sec-punctuators">
     <h1>Punctuators</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       Punctuator :: one of
         `{` `(` `)` `[` `]`
         `.` `...` `;` `,`
@@ -9854,7 +9854,7 @@
     <emu-clause id="sec-null-literals">
       <h1>Null Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         NullLiteral ::
           `null`
       </emu-grammar>
@@ -9864,7 +9864,7 @@
     <emu-clause id="sec-boolean-literals">
       <h1>Boolean Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         BooleanLiteral ::
           `true`
           `false`
@@ -9875,7 +9875,7 @@
     <emu-clause id="sec-literals-numeric-literals">
       <h1>Numeric Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         NumericLiteral ::
           DecimalLiteral
           BinaryIntegerLiteral
@@ -10123,7 +10123,7 @@
         <p>A string literal is zero or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encoding"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         StringLiteral ::
           `"` DoubleStringCharacters? `"`
           `'` SingleStringCharacters? `'`
@@ -10154,7 +10154,7 @@
           UnicodeEscapeSequence
       </emu-grammar>
       <p>A conforming implementation, when processing strict mode code, must not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.</p>
-      <emu-grammar use="definition">
+      <emu-grammar>
         CharacterEscapeSequence ::
           SingleEscapeCharacter
           NonEscapeCharacter
@@ -10452,7 +10452,7 @@
       <p>The productions below describe the syntax for a regular expression literal and are used by the input element scanner to find the end of the regular expression literal. The source text comprising the |RegularExpressionBody| and the |RegularExpressionFlags| are subsequently parsed again using the more stringent ECMAScript Regular Expression grammar (<emu-xref href="#sec-patterns"></emu-xref>).</p>
       <p>An implementation may extend the ECMAScript Regular Expression grammar defined in <emu-xref href="#sec-patterns"></emu-xref>, but it must not extend the |RegularExpressionBody| and |RegularExpressionFlags| productions defined below or the productions used by these productions.</p>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         RegularExpressionLiteral ::
           `/` RegularExpressionBody `/` RegularExpressionFlags
 
@@ -10532,7 +10532,7 @@
     <emu-clause id="sec-template-literal-lexical-components">
       <h1>Template Literal Lexical Components</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         Template ::
           NoSubstitutionTemplate
           TemplateHead
@@ -10882,7 +10882,7 @@
   <emu-clause id="sec-identifiers">
     <h1>Identifiers</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       IdentifierReference[Yield, Await] :
         Identifier
         [~Yield] `yield`
@@ -11124,7 +11124,7 @@
   <emu-clause id="sec-primary-expression">
     <h1>Primary Expression</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       PrimaryExpression[Yield, Await] :
         `this`
         IdentifierReference[?Yield, ?Await]
@@ -11154,7 +11154,7 @@
       <emu-grammar>PrimaryExpression[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
       <br>
       the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ParenthesizedExpression[Yield, Await] :
         `(` Expression[+In, ?Yield, ?Await] `)`
     </emu-grammar>
@@ -11287,7 +11287,7 @@
     <emu-clause id="sec-primary-expression-literals">
       <h1>Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         Literal :
           NullLiteral
           BooleanLiteral
@@ -11326,7 +11326,7 @@
       </emu-note>
       <p>Array elements may be elided at the beginning, middle or end of the element list. Whenever a comma in the element list is not preceded by an |AssignmentExpression| (i.e., a comma at the beginning or after another comma), the missing array element contributes to the length of the Array and increases the index of subsequent elements. Elided array elements are not defined. If an element is elided at the end of an array, that element does not contribute to the length of the Array.</p>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         ArrayLiteral[Yield, Await] :
           `[` Elision? `]`
           `[` ElementList[?Yield, ?Await] `]`
@@ -11454,7 +11454,7 @@
         <p>An object initializer is an expression describing the initialization of an Object, written in a form resembling a literal. It is a list of zero or more pairs of property keys and associated values, enclosed in curly brackets. The values need not be literals; they are evaluated each time the object initializer is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         ObjectLiteral[Yield, Await] :
           `{` `}`
           `{` PropertyDefinitionList[?Yield, ?Await] `}`
@@ -11732,7 +11732,7 @@
     <emu-clause id="sec-template-literals">
       <h1>Template Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         TemplateLiteral[Yield, Await] :
           NoSubstitutionTemplate
           TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await]
@@ -12030,7 +12030,7 @@
   <emu-clause id="sec-left-hand-side-expressions">
     <h1>Left-Hand-Side Expressions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       MemberExpression[Yield, Await] :
         PrimaryExpression[?Yield, ?Await]
         MemberExpression[?Yield, ?Await] `[` Expression[+In, ?Yield, ?Await] `]`
@@ -12082,7 +12082,7 @@
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
     <p>When processing an instance of the production <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
-    <emu-grammar use="definition">
+    <emu-grammar>
       CallMemberExpression[Yield, Await] :
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
     </emu-grammar>
@@ -12594,7 +12594,7 @@
   <emu-clause id="sec-update-expressions">
     <h1>Update Expressions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       UpdateExpression[Yield, Await] :
         LeftHandSideExpression[?Yield, ?Await]
         LeftHandSideExpression[?Yield, ?Await] [no LineTerminator here] `++`
@@ -12738,7 +12738,7 @@
   <emu-clause id="sec-unary-operators">
     <h1>Unary Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       UnaryExpression[Yield, Await] :
         UpdateExpression[?Yield, ?Await]
         `delete` UnaryExpression[?Yield, ?Await]
@@ -13054,7 +13054,7 @@
     <h1>Exponentiation Operator</h1>
     <h2>Syntax</h2>
 
-    <emu-grammar use="definition">
+    <emu-grammar>
       ExponentiationExpression[Yield, Await] :
         UnaryExpression[?Yield, ?Await]
         UpdateExpression[?Yield, ?Await] `**` ExponentiationExpression[?Yield, ?Await]
@@ -13140,7 +13140,7 @@
   <emu-clause id="sec-multiplicative-operators">
     <h1>Multiplicative Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       MultiplicativeExpression[Yield, Await] :
         ExponentiationExpression[?Yield, ?Await]
         MultiplicativeExpression[?Yield, ?Await] MultiplicativeOperator ExponentiationExpression[?Yield, ?Await]
@@ -13282,7 +13282,7 @@
   <emu-clause id="sec-additive-operators">
     <h1>Additive Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       AdditiveExpression[Yield, Await] :
         MultiplicativeExpression[?Yield, ?Await]
         AdditiveExpression[?Yield, ?Await] `+` MultiplicativeExpression[?Yield, ?Await]
@@ -13414,7 +13414,7 @@
   <emu-clause id="sec-bitwise-shift-operators">
     <h1>Bitwise Shift Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ShiftExpression[Yield, Await] :
         AdditiveExpression[?Yield, ?Await]
         ShiftExpression[?Yield, ?Await] `&lt;&lt;` AdditiveExpression[?Yield, ?Await]
@@ -13532,7 +13532,7 @@
       <p>The result of evaluating a relational operator is always of type Boolean, reflecting whether the relationship named by the operator holds between its two operands.</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       RelationalExpression[In, Yield, Await] :
         ShiftExpression[?Yield, ?Await]
         RelationalExpression[?In, ?Yield, ?Await] `&lt;` ShiftExpression[?Yield, ?Await]
@@ -13669,7 +13669,7 @@
       <p>The result of evaluating an equality operator is always of type Boolean, reflecting whether the relationship named by the operator holds between its two operands.</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       EqualityExpression[In, Yield, Await] :
         RelationalExpression[?In, ?Yield, ?Await]
         EqualityExpression[?In, ?Yield, ?Await] `==` RelationalExpression[?In, ?Yield, ?Await]
@@ -13793,7 +13793,7 @@
   <emu-clause id="sec-binary-bitwise-operators">
     <h1>Binary Bitwise Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       BitwiseANDExpression[In, Yield, Await] :
         EqualityExpression[?In, ?Yield, ?Await]
         BitwiseANDExpression[?In, ?Yield, ?Await] `&amp;` EqualityExpression[?In, ?Yield, ?Await]
@@ -13859,7 +13859,7 @@
   <emu-clause id="sec-binary-logical-operators">
     <h1>Binary Logical Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       LogicalANDExpression[In, Yield, Await] :
         BitwiseORExpression[?In, ?Yield, ?Await]
         LogicalANDExpression[?In, ?Yield, ?Await] `&amp;&amp;` BitwiseORExpression[?In, ?Yield, ?Await]
@@ -13928,7 +13928,7 @@
   <emu-clause id="sec-conditional-operator">
     <h1>Conditional Operator ( `? :` )</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ConditionalExpression[In, Yield, Await] :
         LogicalORExpression[?In, ?Yield, ?Await]
         LogicalORExpression[?In, ?Yield, ?Await] `?` AssignmentExpression[+In, ?Yield, ?Await] `:` AssignmentExpression[?In, ?Yield, ?Await]
@@ -13978,7 +13978,7 @@
   <emu-clause id="sec-assignment-operators">
     <h1>Assignment Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       AssignmentExpression[In, Yield, Await] :
         ConditionalExpression[?In, ?Yield, ?Await]
         [+Yield] YieldExpression[?In, ?Await]
@@ -14093,7 +14093,7 @@
       <h1>Destructuring Assignment</h1>
       <h2>Supplemental Syntax</h2>
       <p>In certain circumstances when processing an instance of the production <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar> the following grammar is used to refine the interpretation of |LeftHandSideExpression|.</p>
-      <emu-grammar use="definition">
+      <emu-grammar>
         AssignmentPattern[Yield, Await] :
           ObjectAssignmentPattern[?Yield, ?Await]
           ArrayAssignmentPattern[?Yield, ?Await]
@@ -14374,7 +14374,7 @@
   <emu-clause id="sec-comma-operator">
     <h1>Comma Operator ( `,` )</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       Expression[In, Yield, Await] :
         AssignmentExpression[?In, ?Yield, ?Await]
         Expression[?In, ?Yield, ?Await] `,` AssignmentExpression[?In, ?Yield, ?Await]
@@ -14421,7 +14421,7 @@
 <emu-clause id="sec-ecmascript-language-statements-and-declarations">
   <h1>ECMAScript Language: Statements and Declarations</h1>
   <h2>Syntax</h2>
-  <emu-grammar use="definition">
+  <emu-grammar>
     Statement[Yield, Await, Return] :
       BlockStatement[?Yield, ?Await, ?Return]
       VariableStatement[?Yield, ?Await]
@@ -14651,7 +14651,7 @@
   <emu-clause id="sec-block">
     <h1>Block</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       BlockStatement[Yield, Await, Return] :
         Block[?Yield, ?Await, ?Return]
 
@@ -15017,7 +15017,7 @@
         <p>`let` and `const` declarations define variables that are scoped to the running execution context's LexicalEnvironment. The variables are created when their containing Lexical Environment is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         LexicalDeclaration[In, Yield, Await] :
           LetOrConst BindingList[?In, ?Yield, ?Await] `;`
 
@@ -15147,7 +15147,7 @@
         <p>A `var` statement declares variables that are scoped to the running execution context's VariableEnvironment. Var variables are created when their containing Lexical Environment is instantiated and are initialized to *undefined* when created. Within the scope of any VariableEnvironment a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         VariableStatement[Yield, Await] :
           `var` VariableDeclarationList[+In, ?Yield, ?Await] `;`
 
@@ -15252,7 +15252,7 @@
     <emu-clause id="sec-destructuring-binding-patterns">
       <h1>Destructuring Binding Patterns</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         BindingPattern[Yield, Await] :
           ObjectBindingPattern[?Yield, ?Await]
           ArrayBindingPattern[?Yield, ?Await]
@@ -15690,7 +15690,7 @@
   <emu-clause id="sec-empty-statement">
     <h1>Empty Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       EmptyStatement :
         `;`
     </emu-grammar>
@@ -15709,7 +15709,7 @@
   <emu-clause id="sec-expression-statement">
     <h1>Expression Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ExpressionStatement[Yield, Await] :
         [lookahead &lt;! {`{`, `function`, `async` [no |LineTerminator| here] `function`, `class`, `let [`}] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
@@ -15732,7 +15732,7 @@
   <emu-clause id="sec-if-statement">
     <h1>The `if` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       IfStatement[Yield, Await, Return] :
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` Statement[?Yield, ?Await, ?Return]
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -15870,7 +15870,7 @@
   <emu-clause id="sec-iteration-statements">
     <h1>Iteration Statements</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       IterationStatement[Yield, Await, Return] :
         `do` Statement[?Yield, ?Await, ?Return] `while` `(` Expression[+In, ?Yield, ?Await] `)` `;`
         `while` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -16712,7 +16712,7 @@
   <emu-clause id="sec-continue-statement">
     <h1>The `continue` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ContinueStatement[Yield, Await] :
         `continue` `;`
         `continue` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
@@ -16768,7 +16768,7 @@
   <emu-clause id="sec-break-statement">
     <h1>The `break` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       BreakStatement[Yield, Await] :
         `break` `;`
         `break` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
@@ -16820,7 +16820,7 @@
   <emu-clause id="sec-return-statement">
     <h1>The `return` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ReturnStatement[Yield, Await] :
         `return` `;`
         `return` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
@@ -16849,7 +16849,7 @@
   <emu-clause id="sec-with-statement">
     <h1>The `with` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       WithStatement[Yield, Await, Return] :
         `with` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     </emu-grammar>
@@ -16952,7 +16952,7 @@
   <emu-clause id="sec-switch-statement">
     <h1>The `switch` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       SwitchStatement[Yield, Await, Return] :
         `switch` `(` Expression[+In, ?Yield, ?Await] `)` CaseBlock[?Yield, ?Await, ?Return]
 
@@ -17374,7 +17374,7 @@
   <emu-clause id="sec-labelled-statements">
     <h1>Labelled Statements</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       LabelledStatement[Yield, Await, Return] :
         LabelIdentifier[?Yield, ?Await] `:` LabelledItem[?Yield, ?Await, ?Return]
 
@@ -17629,7 +17629,7 @@
   <emu-clause id="sec-throw-statement">
     <h1>The `throw` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ThrowStatement[Yield, Await] :
         `throw` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
@@ -17650,7 +17650,7 @@
   <emu-clause id="sec-try-statement">
     <h1>The `try` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       TryStatement[Yield, Await, Return] :
         `try` Block[?Yield, ?Await, ?Return] Catch[?Yield, ?Await, ?Return]
         `try` Block[?Yield, ?Await, ?Return] Finally[?Yield, ?Await, ?Return]
@@ -17899,7 +17899,7 @@
   <emu-clause id="sec-debugger-statement">
     <h1>The `debugger` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       DebuggerStatement :
         `debugger` `;`
     </emu-grammar>
@@ -17934,7 +17934,7 @@
   <emu-clause id="sec-function-definitions">
     <h1>Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       FunctionDeclaration[Yield, Await, Default] :
         `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         [+Default] `function` `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
@@ -18450,7 +18450,7 @@
   <emu-clause id="sec-arrow-function-definitions">
     <h1>Arrow Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ArrowFunction[In, Yield, Await] :
         ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=&gt;` ConciseBody[?In]
 
@@ -18468,7 +18468,7 @@
       <emu-grammar>ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
       <br>
       is recognized the following grammar is used to refine the interpretation of |CoverParenthesizedExpressionAndArrowParameterList|:</p>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ArrowFormalParameters[Yield, Await] :
         `(` UniqueFormalParameters[?Yield, ?Await] `)`
     </emu-grammar>
@@ -18708,7 +18708,7 @@
   <emu-clause id="sec-method-definitions">
     <h1>Method Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       MethodDefinition[Yield, Await] :
         PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         GeneratorMethod[?Yield, ?Await]
@@ -18894,7 +18894,7 @@
   <emu-clause id="sec-generator-function-definitions">
     <h1>Generator Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       GeneratorMethod[Yield, Await] :
         `*` PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, ~Await] `)` `{` GeneratorBody `}`
 
@@ -19236,7 +19236,7 @@
   <emu-clause id="sec-class-definitions">
     <h1>Class Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       ClassDeclaration[Yield, Await, Default] :
         `class` BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
         [+Default] `class` ClassTail[?Yield, ?Await]
@@ -19610,7 +19610,7 @@
   <emu-clause id="sec-async-function-definitions">
     <h1>Async Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       AsyncFunctionDeclaration[Yield, Await, Default] :
         `async` [no LineTerminator here] `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
         [+Default] `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
@@ -19900,7 +19900,7 @@
   <emu-clause id="sec-async-arrow-function-definitions">
     <h1>Async Arrow Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       AsyncArrowFunction[In, Yield, Await] :
         `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
         CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
@@ -19918,7 +19918,7 @@
     <h2>Supplemental Syntax</h2>
     <p>When processing an instance of the production <emu-grammar>AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
 
-    <emu-grammar use="definition">
+    <emu-grammar>
       AsyncArrowHead :
         `async` [no LineTerminator here] ArrowFormalParameters[~Yield, +Await]
     </emu-grammar>
@@ -20478,7 +20478,7 @@
   <emu-clause id="sec-scripts">
     <h1>Scripts</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       Script :
         ScriptBody?
 
@@ -20781,7 +20781,7 @@
   <emu-clause id="sec-modules">
     <h1>Modules</h1>
     <h2>Syntax</h2>
-    <emu-grammar use="definition">
+    <emu-grammar>
       Module :
         ModuleBody?
 
@@ -22025,7 +22025,7 @@
     <emu-clause id="sec-imports">
       <h1>Imports</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         ImportDeclaration :
           `import` ImportClause FromClause `;`
           `import` ModuleSpecifier `;`
@@ -22204,7 +22204,7 @@
     <emu-clause id="sec-exports">
       <h1>Exports</h1>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         ExportDeclaration :
           `export` `*` FromClause `;`
           `export` ExportClause FromClause `;`
@@ -23061,7 +23061,7 @@
         <p>where the italicized names represent components and &ldquo;`:`&rdquo;, &ldquo;`/`&rdquo;, &ldquo;`;`&rdquo; and &ldquo;`?`&rdquo; are reserved for use as separators. The `encodeURI` and `decodeURI` functions are intended to work with complete URIs; they assume that any reserved code units in the URI are intended to have special meaning and so are not encoded. The `encodeURIComponent` and `decodeURIComponent` functions are intended to work with the individual component parts of a URI; they assume that any reserved code units represent text and so must be encoded so that they are not interpreted as reserved code units when the component is part of a complete URI.</p>
         <p>The following lexical grammar specifies the form of encoded URIs.</p>
         <h2>Syntax</h2>
-        <emu-grammar use="definition">
+        <emu-grammar>
           uri :::
             uriCharacters?
 
@@ -28640,7 +28640,7 @@ THH:mm:ss.sss
       <h1>Patterns</h1>
       <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         Pattern[U] ::
           Disjunction[?U]
 
@@ -28720,7 +28720,7 @@ THH:mm:ss.sss
           [+U] `u{` HexDigits `}`
       </emu-grammar>
       <p>Each `\\u` |TrailSurrogate| for which the choice of associated `u` |LeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |LeadSurrogate| that would otherwise have no corresponding `\\u` |TrailSurrogate|.</p>
-      <emu-grammar use="definition">
+      <emu-grammar>
         LeadSurrogate ::
           Hex4Digits [> but only if the SV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
 
@@ -35363,7 +35363,7 @@ THH:mm:ss.sss
       </emu-alg>
       <p>The `length` property of the `parse` function is 2.</p>
       <p>JSON allows Unicode code units 0x2028 (LINE SEPARATOR) and 0x2029 (PARAGRAPH SEPARATOR) to directly appear in String literals without using an escape sequence. This is enabled by using the following alternative definition of |DoubleStringCharacter| when parsing _scriptText_ in step 4:</p>
-      <emu-grammar use="definition">
+      <emu-grammar>
         DoubleStringCharacter ::
           SourceCharacter but not one of `"` or `\` or U+0000 through U+001F
           `\` EscapeSequence
@@ -38357,7 +38357,7 @@ THH:mm:ss.sss
       <h1>Numeric Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-numeric-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         NumericLiteral ::
           DecimalLiteral
           BinaryIntegerLiteral
@@ -38430,7 +38430,7 @@ THH:mm:ss.sss
       <h1>String Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-string-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         EscapeSequence ::
           CharacterEscapeSequence
           LegacyOctalEscapeSequence
@@ -38503,7 +38503,7 @@ THH:mm:ss.sss
       <h1>HTML-like Comments</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source code using the goal symbol |Module|:</p>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         Comment ::
           MultiLineComment
           SingleLineComment
@@ -38558,7 +38558,7 @@ THH:mm:ss.sss
       <p>The syntax of <emu-xref href="#sec-patterns"></emu-xref> is modified and extended as follows. These changes introduce ambiguities that are broken by the ordering of grammar productions and by contextual information. When parsing using the following grammar, each alternative is considered only if previous production alternatives do not match.</p>
       <p>This alternative pattern grammar and semantics only changes the syntax and semantics of BMP patterns. The following grammar extensions include productions parameterized with the [U] parameter. However, none of these extensions change the syntax of Unicode patterns recognized when parsing with the [U] parameter present on the goal symbol.</p>
       <h2>Syntax</h2>
-      <emu-grammar use="definition">
+      <emu-grammar>
         Term[U] ::
           [+U] Assertion[+U]
           [+U] Atom[+U]
@@ -39450,7 +39450,7 @@ THH:mm:ss.sss
     <emu-annex id="sec-functiondeclarations-in-ifstatement-statement-clauses">
       <h1>FunctionDeclarations in IfStatement Statement Clauses</h1>
       <p>The following augments the |IfStatement| production in <emu-xref href="#sec-if-statement"></emu-xref>:</p>
-      <emu-grammar use="definition">
+      <emu-grammar>
         IfStatement[Yield, Await, Return] :
           `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` Statement[?Yield, ?Await, ?Return]
           `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
@@ -39495,7 +39495,7 @@ THH:mm:ss.sss
     <emu-annex id="sec-initializers-in-forin-statement-heads">
       <h1>Initializers in ForIn Statement Heads</h1>
       <p>The following augments the |IterationStatement| production in <emu-xref href="#sec-iteration-statements"></emu-xref>:</p>
-      <emu-grammar use="definition">
+      <emu-grammar>
         IterationStatement[Yield, Await, Return] :
           `for` `(` `var` BindingIdentifier[?Yield, ?Await] Initializer[~In, ?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
       </emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -491,41 +491,41 @@
       <h1>Grammar Notation</h1>
       <p>Terminal symbols of the lexical, RegExp, and numeric string grammars are shown in `fixed width` font, both in the productions of the grammars and throughout this specification whenever the text directly refers to such a terminal symbol. These are to appear in a script exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin range, as opposed to any similar-looking code points from other Unicode ranges.</p>
       <p>Nonterminal symbols are shown in <i>italic</i> type. The definition of a nonterminal (also called a &ldquo;production&rdquo;) is introduced by the name of the nonterminal being defined followed by one or more colons. (The number of colons indicates to which grammar the production belongs.) One or more alternative right-hand sides for the nonterminal then follow on succeeding lines. For example, the syntactic definition:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         WhileStatement :
           `while` `(` Expression `)` Statement
       </emu-grammar>
       <p>states that the nonterminal |WhileStatement| represents the token `while`, followed by a left parenthesis token, followed by an |Expression|, followed by a right parenthesis token, followed by a |Statement|. The occurrences of |Expression| and |Statement| are themselves nonterminals. As another example, the syntactic definition:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         ArgumentList :
           AssignmentExpression
           ArgumentList `,` AssignmentExpression
       </emu-grammar>
       <p>states that an |ArgumentList| may represent either a single |AssignmentExpression| or an |ArgumentList|, followed by a comma, followed by an |AssignmentExpression|. This definition of |ArgumentList| is recursive, that is, it is defined in terms of itself. The result is that an |ArgumentList| may contain any positive number of arguments, separated by commas, where each argument expression is an |AssignmentExpression|. Such recursive definitions of nonterminals are common.</p>
       <p>The subscripted suffix &ldquo;<sub>opt</sub>&rdquo;, which may appear after a terminal or nonterminal, indicates an optional symbol. The alternative containing the optional symbol actually specifies two right-hand sides, one that omits the optional element and one that includes it. This means that:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         VariableDeclaration :
           BindingIdentifier Initializer?
       </emu-grammar>
       <p>is a convenient abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         VariableDeclaration :
           BindingIdentifier
           BindingIdentifier Initializer
       </emu-grammar>
       <p>and that:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         IterationStatement :
           `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
       </emu-grammar>
       <p>is a convenient abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         IterationStatement :
           `for` `(` LexicalDeclaration `;` Expression? `)` Statement
           `for` `(` LexicalDeclaration Expression `;` Expression? `)` Statement
       </emu-grammar>
       <p>which in turn is an abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         IterationStatement :
           `for` `(` LexicalDeclaration `;` `)` Statement
           `for` `(` LexicalDeclaration `;` Expression `)` Statement
@@ -534,13 +534,13 @@
       </emu-grammar>
       <p>so, in this example, the nonterminal |IterationStatement| actually has four alternative right-hand sides.</p>
       <p>A production may be parameterized by a subscripted annotation of the form &ldquo;<sub>[parameters]</sub>&rdquo;, which may appear as a suffix to the nonterminal symbol defined by the production. &ldquo;<sub>parameters</sub>&rdquo; may be either a single name or a comma separated list of names. A parameterized production is shorthand for a set of productions defining all combinations of the parameter names, preceded by an underscore, appended to the parameterized nonterminal symbol. This means that:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList[Return] :
           ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>is a convenient abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList :
           ReturnStatement
           ExpressionStatement
@@ -550,13 +550,13 @@
           ExpressionStatement
       </emu-grammar>
       <p>and that:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList[Return, In] :
           ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList :
           ReturnStatement
           ExpressionStatement
@@ -575,47 +575,47 @@
       </emu-grammar>
       <p>Multiple parameters produce a combinatory number of productions, not all of which are necessarily referenced in a complete grammar.</p>
       <p>References to nonterminals on the right-hand side of a production can also be parameterized. For example:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList :
           ReturnStatement
           ExpressionStatement[+In]
       </emu-grammar>
       <p>is equivalent to saying:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList :
           ReturnStatement
           ExpressionStatement_In
       </emu-grammar>
       <p>and:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList :
           ReturnStatement
           ExpressionStatement[~In]
       </emu-grammar>
       <p>is equivalent to:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList :
           ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>A nonterminal reference may have both a parameter list and an &ldquo;<sub>opt</sub>&rdquo; suffix. For example:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         VariableDeclaration :
           BindingIdentifier Initializer[+In]?
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         VariableDeclaration :
           BindingIdentifier
           BindingIdentifier Initializer_In
       </emu-grammar>
       <p>Prefixing a parameter name with &ldquo;<sub>?</sub>&rdquo; on a right-hand side nonterminal reference makes that parameter value dependent upon the occurrence of the parameter name on the reference to the current production's left-hand side symbol. For example:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         VariableDeclaration[In] :
           BindingIdentifier Initializer[?In]
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         VariableDeclaration :
           BindingIdentifier Initializer
 
@@ -623,13 +623,13 @@
           BindingIdentifier Initializer_In
       </emu-grammar>
       <p>If a right-hand side alternative is prefixed with &ldquo;[+parameter]&rdquo; that alternative is only available if the named parameter was used in referencing the production's nonterminal symbol. If a right-hand side alternative is prefixed with &ldquo;[\~parameter]&rdquo; that alternative is only available if the named parameter was <em>not</em> used in referencing the production's nonterminal symbol. This means that:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList[Return] :
           [+Return] ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList :
           ExpressionStatement
 
@@ -638,13 +638,13 @@
           ExpressionStatement
       </emu-grammar>
       <p>and that:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList[Return] :
           [~Return] ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         StatementList :
           ReturnStatement
           ExpressionStatement
@@ -653,12 +653,12 @@
           ExpressionStatement
       </emu-grammar>
       <p>When the words &ldquo;<b>one of</b>&rdquo; follow the colon(s) in a grammar definition, they signify that each of the terminal symbols on the following line or lines is an alternative definition. For example, the lexical grammar for ECMAScript contains the production:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         NonZeroDigit :: one of
           `1` `2` `3` `4` `5` `6` `7` `8` `9`
       </emu-grammar>
       <p>which is merely a convenient abbreviation for:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         NonZeroDigit ::
           `1`
           `2`
@@ -673,7 +673,7 @@
       <p>If the phrase &ldquo;[empty]&rdquo; appears as the right-hand side of a production, it indicates that the production's right-hand side contains no terminals or nonterminals.</p>
       <p>If the phrase &ldquo;[lookahead &notin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may not be used if the immediately following input token sequence is a member of the given _set_. The _set_ can be written as a comma separated list of one or two element terminal sequences enclosed in curly brackets. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all terminals to which that nonterminal could expand. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead &ne; _terminal_]&rdquo; may be used.</p>
       <p>For example, given the definitions:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         DecimalDigit :: one of
           `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
@@ -682,7 +682,7 @@
           DecimalDigits DecimalDigit
       </emu-grammar>
       <p>the definition:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         LookaheadExample ::
           `n` [lookahead &lt;! {`1`, `3`, `5`, `7`, `9`}] DecimalDigits
           DecimalDigit [lookahead &lt;! DecimalDigit]
@@ -690,7 +690,7 @@
       <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
       <p>Similarly, if the phrase &ldquo;[lookahead &isin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the immediately following input token sequence is a member of the given _set_. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead == _terminal_]&rdquo; may be used.</p>
       <p>If the phrase &ldquo;[no |LineTerminator| here]&rdquo; appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a |LineTerminator| occurs in the input stream at the indicated position. For example, the production:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         ThrowStatement :
           `throw` [no LineTerminator here] Expression `;`
       </emu-grammar>
@@ -698,13 +698,13 @@
       <p>Unless the presence of a |LineTerminator| is forbidden by a restricted production, any number of occurrences of |LineTerminator| may appear between any two consecutive tokens in the stream of input elements without affecting the syntactic acceptability of the script.</p>
       <p>When an alternative in a production of the lexical grammar or the numeric string grammar appears to be a multi-code point token, it represents the sequence of code points that would make up such a token.</p>
       <p>The right-hand side of a production may specify that certain expansions are not permitted by using the phrase &ldquo;<b>but not</b>&rdquo; and then indicating the expansions to be excluded. For example, the production:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         Identifier ::
           IdentifierName but not ReservedWord
       </emu-grammar>
       <p>means that the nonterminal |Identifier| may be replaced by any sequence of code points that could replace |IdentifierName| provided that the same sequence of code points could not replace |ReservedWord|.</p>
       <p>Finally, a few nonterminal symbols are described by a descriptive phrase in sans-serif type in cases where it would be impractical to list all the alternatives:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         SourceCharacter ::
           &gt; any Unicode code point
       </emu-grammar>
@@ -749,13 +749,13 @@
         2. Perform SyntaxDirectedOperation of _someParseNode_ passing `"value"` as the argument.
       </emu-alg>
       <p>Unless explicitly specified otherwise, all chain productions have an implicit definition for every operation that might be applied to that production's left-hand side nonterminal. The implicit definition simply reapplies the same operation with the same parameters, if any, to the chain production's sole right-hand side nonterminal and then returns the result. For example, assume that some algorithm has a step of the form: &ldquo;Return the result of evaluating |Block|&rdquo; and that there is a production:</p>
-      <emu-grammar>
+      <emu-grammar use="example">
         Block :
           `{` StatementList `}`
       </emu-grammar>
       <p>but the Evaluation operation does not associate an algorithm with that production. In that case, the Evaluation operation implicitly includes an association of the form:</p>
       <p><b>Runtime Semantics: Evaluation</b></p>
-      <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
+      <emu-grammar use="example">Block : `{` StatementList `}`</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
@@ -3457,7 +3457,7 @@
           <p>The terminal symbols of this grammar are all composed of Unicode BMP code points so the result will be *NaN* if the string contains the UTF-16 encoding of any supplementary code points or any unpaired surrogate code points.</p>
         </emu-note>
         <h2>Syntax</h2>
-        <emu-grammar definition>
+        <emu-grammar use="definition">
           StringNumericLiteral :::
             StrWhiteSpace?
             StrWhiteSpace? StrNumericLiteral StrWhiteSpace?
@@ -3514,61 +3514,61 @@
           <p>The conversion of a String to a Number value is similar overall to the determination of the Number value for a numeric literal (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different, so the process for converting a String numeric literal to a value of Number type is given here. This value is determined in two steps: first, a mathematical value (MV) is derived from the String numeric literal; second, this mathematical value is rounded as described below. The MV on any grammar symbol, not provided below, is the MV for that symbol defined in <emu-xref href="#sec-static-semantics-mv"></emu-xref>.</p>
           <ul>
             <li>
-              The MV of <emu-grammar>StringNumericLiteral ::: [empty]</emu-grammar> is 0.
+              The MV of <emu-grammar use="reference">StringNumericLiteral ::: [empty]</emu-grammar> is 0.
             </li>
             <li>
-              The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace</emu-grammar> is 0.
+              The MV of <emu-grammar use="reference">StringNumericLiteral ::: StrWhiteSpace</emu-grammar> is 0.
             </li>
             <li>
-              The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar> is the MV of |StrNumericLiteral|, no matter whether white space is present or not.
+              The MV of <emu-grammar use="reference">StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar> is the MV of |StrNumericLiteral|, no matter whether white space is present or not.
             </li>
             <li>
-              The MV of <emu-grammar>StrNumericLiteral ::: StrDecimalLiteral</emu-grammar> is the MV of |StrDecimalLiteral|.
+              The MV of <emu-grammar use="reference">StrNumericLiteral ::: StrDecimalLiteral</emu-grammar> is the MV of |StrDecimalLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar>StrNumericLiteral ::: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
+              The MV of <emu-grammar use="reference">StrNumericLiteral ::: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar>StrNumericLiteral ::: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
+              The MV of <emu-grammar use="reference">StrNumericLiteral ::: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar>StrNumericLiteral ::: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
+              The MV of <emu-grammar use="reference">StrNumericLiteral ::: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar>StrDecimalLiteral ::: StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
+              The MV of <emu-grammar use="reference">StrDecimalLiteral ::: StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar>StrDecimalLiteral ::: `+` StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
+              The MV of <emu-grammar use="reference">StrDecimalLiteral ::: `+` StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar> is the negative of the MV of |StrUnsignedDecimalLiteral|. (Note that if the MV of |StrUnsignedDecimalLiteral| is 0, the negative of this MV is also 0. The rounding rule described below handles the conversion of this signless mathematical zero to a floating-point *+0* or *-0* as appropriate.)
+              The MV of <emu-grammar use="reference">StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar> is the negative of the MV of |StrUnsignedDecimalLiteral|. (Note that if the MV of |StrUnsignedDecimalLiteral| is 0, the negative of this MV is also 0. The rounding rule described below handles the conversion of this signless mathematical zero to a floating-point *+0* or *-0* as appropriate.)
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sup>10000</sup> (a value so large that it will round to *+&infin;*).
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sup>10000</sup> (a value so large that it will round to *+&infin;*).
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.`</emu-grammar> is the MV of |DecimalDigits|.
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits `.`</emu-grammar> is the MV of |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>), where _n_ is the number of code points in the second |DecimalDigits|.
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>), where _n_ is the number of code points in the second |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>)) times 10<sup>_e_</sup>, where _n_ is the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>)) times 10<sup>_e_</sup>, where _n_ is the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
           </ul>
           <p>Once the exact MV for a String numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0* unless the first non white space code point in the String numeric literal is `"-"`, in which case the rounded value is *-0*. Otherwise, the rounded value must be the Number value for the MV (in the sense defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal includes a |StrUnsignedDecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit and then incrementing the literal at the 20th digit position. A digit is significant if it is not part of an |ExponentPart| and</p>
@@ -9175,7 +9175,7 @@
   <emu-clause id="sec-source-text">
     <h1>Source Text</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       SourceCharacter ::
         &gt; any Unicode code point
     </emu-grammar>
@@ -9285,7 +9285,7 @@
     </code></pre>
   </emu-note>
   <h2>Syntax</h2>
-  <emu-grammar definition>
+  <emu-grammar use="definition">
     InputElementDiv ::
       WhiteSpace
       LineTerminator
@@ -9495,7 +9495,7 @@
       <p>Other than for the code points listed in <emu-xref href="#table-32"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       WhiteSpace ::
         &lt;TAB&gt;
         &lt;VT&gt;
@@ -9577,7 +9577,7 @@
     </emu-table>
     <p>Only the Unicode code points in <emu-xref href="#table-33"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-32"></emu-xref>. The sequence &lt;CR&gt;&lt;LF&gt; is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       LineTerminator ::
         &lt;LF&gt;
         &lt;CR&gt;
@@ -9600,7 +9600,7 @@
     <p>Because a single-line comment can contain any Unicode code point except a |LineTerminator| code point, and because of the general rule that a token is always as long as possible, a single-line comment always consists of all code points from the `//` marker to the end of the line. However, the |LineTerminator| at the end of the line is not considered to be part of the single-line comment; it is recognized separately by the lexical grammar and becomes part of the stream of input elements for the syntactic grammar. This point is very important, because it implies that the presence or absence of single-line comments does not affect the process of automatic semicolon insertion (see <emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>).</p>
     <p>Comments behave like white space and are discarded except that, if a |MultiLineComment| contains a line terminator code point, then the entire comment is considered to be a |LineTerminator| for purposes of parsing by the syntactic grammar.</p>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       Comment ::
         MultiLineComment
         SingleLineComment
@@ -9637,7 +9637,7 @@
   <emu-clause id="sec-tokens">
     <h1>Tokens</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       CommonToken ::
         IdentifierName
         Punctuator
@@ -9660,7 +9660,7 @@
     <p>Unicode escape sequences are permitted in an |IdentifierName|, where they contribute a single Unicode code point to the |IdentifierName|. The code point is expressed by the |HexDigits| of the |UnicodeEscapeSequence| (see <emu-xref href="#sec-literals-string-literals"></emu-xref>). The `\\` preceding the |UnicodeEscapeSequence| and the `u` and `{ }` code units, if they appear, do not contribute code points to the |IdentifierName|. A |UnicodeEscapeSequence| cannot be used to put a code point into an |IdentifierName| that would otherwise be illegal. In other words, if a `\\` |UnicodeEscapeSequence| sequence were replaced by the |SourceCharacter| it contributes, the result must still be a valid |IdentifierName| that has the exact same sequence of |SourceCharacter| elements as the original |IdentifierName|. All interpretations of |IdentifierName| within this specification are based upon their actual code points regardless of whether or not an escape sequence was used to contribute any particular code point.</p>
     <p>Two |IdentifierName|s that are canonically equivalent according to the Unicode standard are <em>not</em> equal unless, after replacement of each |UnicodeEscapeSequence|, they are represented by the exact same sequence of code points.</p>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       IdentifierName ::
         IdentifierStart
         IdentifierName IdentifierPart
@@ -9697,13 +9697,13 @@
       <!-- es6num="11.6.1.1" -->
       <emu-clause id="sec-identifier-names-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
+        <emu-grammar use="reference">IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
-        <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
+        <emu-grammar use="reference">IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
@@ -9715,7 +9715,7 @@
       <emu-clause id="sec-identifier-names-static-semantics-stringvalue">
         <h1>Static Semantics: StringValue</h1>
         <emu-see-also-para op="StringValue"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IdentifierName ::
             IdentifierStart
             IdentifierName IdentifierPart
@@ -9731,7 +9731,7 @@
       <h1>Reserved Words</h1>
       <p>A reserved word is an |IdentifierName| that cannot be used as an |Identifier|.</p>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         ReservedWord ::
           Keyword
           FutureReservedWord
@@ -9747,7 +9747,7 @@
         <h1>Keywords</h1>
         <p>The following tokens are ECMAScript keywords and may not be used as |Identifier|s in ECMAScript programs.</p>
         <h2>Syntax</h2>
-        <emu-grammar definition>
+        <emu-grammar use="definition">
           Keyword :: one of
             `await`
             `break`
@@ -9774,7 +9774,7 @@
         <h1>Future Reserved Words</h1>
         <p>The following tokens are reserved for use as keywords in future language extensions.</p>
         <h2>Syntax</h2>
-        <emu-grammar definition>
+        <emu-grammar use="definition">
           FutureReservedWord ::
             `enum`
         </emu-grammar>
@@ -9821,7 +9821,7 @@
   <emu-clause id="sec-punctuators">
     <h1>Punctuators</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       Punctuator :: one of
         `{` `(` `)` `[` `]`
         `.` `...` `;` `,`
@@ -9854,7 +9854,7 @@
     <emu-clause id="sec-null-literals">
       <h1>Null Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         NullLiteral ::
           `null`
       </emu-grammar>
@@ -9864,7 +9864,7 @@
     <emu-clause id="sec-boolean-literals">
       <h1>Boolean Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         BooleanLiteral ::
           `true`
           `false`
@@ -9875,7 +9875,7 @@
     <emu-clause id="sec-literals-numeric-literals">
       <h1>Numeric Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         NumericLiteral ::
           DecimalLiteral
           BinaryIntegerLiteral
@@ -9957,151 +9957,151 @@
         <p>A numeric literal stands for a value of the Number type. This value is determined in two steps: first, a mathematical value (MV) is derived from the literal; second, this mathematical value is rounded as described below.</p>
         <ul>
           <li>
-            The MV of <emu-grammar>NumericLiteral :: DecimalLiteral</emu-grammar> is the MV of |DecimalLiteral|.
+            The MV of <emu-grammar use="reference">NumericLiteral :: DecimalLiteral</emu-grammar> is the MV of |DecimalLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>NumericLiteral :: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
+            The MV of <emu-grammar use="reference">NumericLiteral :: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>NumericLiteral :: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
+            The MV of <emu-grammar use="reference">NumericLiteral :: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>NumericLiteral :: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
+            The MV of <emu-grammar use="reference">NumericLiteral :: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.`</emu-grammar> is the MV of |DecimalIntegerLiteral|.
+            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral `.`</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>), where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>), where _n_ is the number of code points in |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>)) &times; 10<sup>_e_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>)) &times; 10<sup>_e_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar use="reference">DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar use="reference">DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral</emu-grammar> is the MV of |DecimalIntegerLiteral|.
+            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalIntegerLiteral :: `0`</emu-grammar> is 0.
+            The MV of <emu-grammar use="reference">DecimalIntegerLiteral :: `0`</emu-grammar> is 0.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit</emu-grammar> is the MV of |NonZeroDigit|.
+            The MV of <emu-grammar use="reference">DecimalIntegerLiteral :: NonZeroDigit</emu-grammar> is the MV of |NonZeroDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar use="reference">DecimalIntegerLiteral :: NonZeroDigit DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the number of code points in |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigits :: DecimalDigit</emu-grammar> is the MV of |DecimalDigit|.
+            The MV of <emu-grammar use="reference">DecimalDigits :: DecimalDigit</emu-grammar> is the MV of |DecimalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10) plus the MV of |DecimalDigit|.
+            The MV of <emu-grammar use="reference">DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10) plus the MV of |DecimalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>ExponentPart :: ExponentIndicator SignedInteger</emu-grammar> is the MV of |SignedInteger|.
+            The MV of <emu-grammar use="reference">ExponentPart :: ExponentIndicator SignedInteger</emu-grammar> is the MV of |SignedInteger|.
           </li>
           <li>
-            The MV of <emu-grammar>SignedInteger :: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
+            The MV of <emu-grammar use="reference">SignedInteger :: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>SignedInteger :: `+` DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
+            The MV of <emu-grammar use="reference">SignedInteger :: `+` DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>SignedInteger :: `-` DecimalDigits</emu-grammar> is the negative of the MV of |DecimalDigits|.
+            The MV of <emu-grammar use="reference">SignedInteger :: `-` DecimalDigits</emu-grammar> is the negative of the MV of |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `0`</emu-grammar> or of <emu-grammar>HexDigit :: `0`</emu-grammar> or of <emu-grammar>OctalDigit :: `0`</emu-grammar> or of <emu-grammar>BinaryDigit :: `0`</emu-grammar> is 0.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `0`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `0`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `0`</emu-grammar> or of <emu-grammar use="reference">BinaryDigit :: `0`</emu-grammar> is 0.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `1`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `1`</emu-grammar> or of <emu-grammar>HexDigit :: `1`</emu-grammar> or of <emu-grammar>OctalDigit :: `1`</emu-grammar> or of <emu-grammar>BinaryDigit :: `1`</emu-grammar> is 1.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `1`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `1`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `1`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `1`</emu-grammar> or of <emu-grammar use="reference">BinaryDigit :: `1`</emu-grammar> is 1.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `2`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `2`</emu-grammar> or of <emu-grammar>HexDigit :: `2`</emu-grammar> or of <emu-grammar>OctalDigit :: `2`</emu-grammar> is 2.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `2`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `2`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `2`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `2`</emu-grammar> is 2.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `3`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `3`</emu-grammar> or of <emu-grammar>HexDigit :: `3`</emu-grammar> or of <emu-grammar>OctalDigit :: `3`</emu-grammar> is 3.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `3`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `3`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `3`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `3`</emu-grammar> is 3.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `4`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `4`</emu-grammar> or of <emu-grammar>HexDigit :: `4`</emu-grammar> or of <emu-grammar>OctalDigit :: `4`</emu-grammar> is 4.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `4`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `4`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `4`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `4`</emu-grammar> is 4.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `5`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `5`</emu-grammar> or of <emu-grammar>HexDigit :: `5`</emu-grammar> or of <emu-grammar>OctalDigit :: `5`</emu-grammar> is 5.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `5`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `5`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `5`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `5`</emu-grammar> is 5.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `6`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `6`</emu-grammar> or of <emu-grammar>HexDigit :: `6`</emu-grammar> or of <emu-grammar>OctalDigit :: `6`</emu-grammar> is 6.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `6`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `6`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `6`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `6`</emu-grammar> is 6.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `7`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `7`</emu-grammar> or of <emu-grammar>HexDigit :: `7`</emu-grammar> or of <emu-grammar>OctalDigit :: `7`</emu-grammar> is 7.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `7`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `7`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `7`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `7`</emu-grammar> is 7.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `8`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `8`</emu-grammar> or of <emu-grammar>HexDigit :: `8`</emu-grammar> is 8.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `8`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `8`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `8`</emu-grammar> is 8.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `9`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `9`</emu-grammar> or of <emu-grammar>HexDigit :: `9`</emu-grammar> is 9.
+            The MV of <emu-grammar use="reference">DecimalDigit :: `9`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `9`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `9`</emu-grammar> is 9.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `a`</emu-grammar> or of <emu-grammar>HexDigit :: `A`</emu-grammar> is 10.
+            The MV of <emu-grammar use="reference">HexDigit :: `a`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `A`</emu-grammar> is 10.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `b`</emu-grammar> or of <emu-grammar>HexDigit :: `B`</emu-grammar> is 11.
+            The MV of <emu-grammar use="reference">HexDigit :: `b`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `B`</emu-grammar> is 11.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `c`</emu-grammar> or of <emu-grammar>HexDigit :: `C`</emu-grammar> is 12.
+            The MV of <emu-grammar use="reference">HexDigit :: `c`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `C`</emu-grammar> is 12.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `d`</emu-grammar> or of <emu-grammar>HexDigit :: `D`</emu-grammar> is 13.
+            The MV of <emu-grammar use="reference">HexDigit :: `d`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `D`</emu-grammar> is 13.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `e`</emu-grammar> or of <emu-grammar>HexDigit :: `E`</emu-grammar> is 14.
+            The MV of <emu-grammar use="reference">HexDigit :: `e`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `E`</emu-grammar> is 14.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `f`</emu-grammar> or of <emu-grammar>HexDigit :: `F`</emu-grammar> is 15.
+            The MV of <emu-grammar use="reference">HexDigit :: `f`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `F`</emu-grammar> is 15.
           </li>
           <li>
-            The MV of <emu-grammar>BinaryIntegerLiteral :: `0b` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
+            The MV of <emu-grammar use="reference">BinaryIntegerLiteral :: `0b` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>BinaryIntegerLiteral :: `0B` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
+            The MV of <emu-grammar use="reference">BinaryIntegerLiteral :: `0B` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>BinaryDigits :: BinaryDigit</emu-grammar> is the MV of |BinaryDigit|.
+            The MV of <emu-grammar use="reference">BinaryDigits :: BinaryDigit</emu-grammar> is the MV of |BinaryDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2) plus the MV of |BinaryDigit|.
+            The MV of <emu-grammar use="reference">BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2) plus the MV of |BinaryDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>OctalIntegerLiteral :: `0o` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
+            The MV of <emu-grammar use="reference">OctalIntegerLiteral :: `0o` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>OctalIntegerLiteral :: `0O` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
+            The MV of <emu-grammar use="reference">OctalIntegerLiteral :: `0O` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>OctalDigits :: OctalDigit</emu-grammar> is the MV of |OctalDigit|.
+            The MV of <emu-grammar use="reference">OctalDigits :: OctalDigit</emu-grammar> is the MV of |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8) plus the MV of |OctalDigit|.
+            The MV of <emu-grammar use="reference">OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8) plus the MV of |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>HexIntegerLiteral :: `0x` HexDigits</emu-grammar> is the MV of |HexDigits|.
+            The MV of <emu-grammar use="reference">HexIntegerLiteral :: `0x` HexDigits</emu-grammar> is the MV of |HexDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>HexIntegerLiteral :: `0X` HexDigits</emu-grammar> is the MV of |HexDigits|.
+            The MV of <emu-grammar use="reference">HexIntegerLiteral :: `0X` HexDigits</emu-grammar> is the MV of |HexDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigits :: HexDigit</emu-grammar> is the MV of |HexDigit|.
+            The MV of <emu-grammar use="reference">HexDigits :: HexDigit</emu-grammar> is the MV of |HexDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16) plus the MV of |HexDigit|.
+            The MV of <emu-grammar use="reference">HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16) plus the MV of |HexDigit|.
           </li>
         </ul>
         <p>Once the exact MV for a numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0*; otherwise, the rounded value must be the Number value for the MV (as specified in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal is a |DecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit and then incrementing the literal at the 20th significant digit position. A digit is <em>significant</em> if it is not part of an |ExponentPart| and</p>
@@ -10123,7 +10123,7 @@
         <p>A string literal is zero or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encoding"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         StringLiteral ::
           `"` DoubleStringCharacters? `"`
           `'` SingleStringCharacters? `'`
@@ -10154,7 +10154,7 @@
           UnicodeEscapeSequence
       </emu-grammar>
       <p>A conforming implementation, when processing strict mode code, must not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.</p>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         CharacterEscapeSequence ::
           SingleEscapeCharacter
           NonEscapeCharacter
@@ -10189,7 +10189,7 @@
       <!-- es6num="11.8.4.1" -->
       <emu-clause id="sec-string-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
+        <emu-grammar use="reference">UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the MV of |HexDigits| &gt; 0x10FFFF.
@@ -10201,7 +10201,7 @@
       <emu-clause id="sec-string-literals-static-semantics-stringvalue">
         <h1>Static Semantics: StringValue</h1>
         <emu-see-also-para op="StringValue"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           StringLiteral ::
             `"` DoubleStringCharacters? `"`
             `'` SingleStringCharacters? `'`
@@ -10217,61 +10217,61 @@
         <p>A string literal stands for a value of the String type. The String value (SV) of the literal is described in terms of code unit values contributed by the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value (MV), as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
         <ul>
           <li>
-            The SV of <emu-grammar>StringLiteral :: `"` `"`</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar use="reference">StringLiteral :: `"` `"`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar>StringLiteral :: `'` `'`</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar use="reference">StringLiteral :: `'` `'`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar>StringLiteral :: `"` DoubleStringCharacters `"`</emu-grammar> is the SV of |DoubleStringCharacters|.
+            The SV of <emu-grammar use="reference">StringLiteral :: `"` DoubleStringCharacters `"`</emu-grammar> is the SV of |DoubleStringCharacters|.
           </li>
           <li>
-            The SV of <emu-grammar>StringLiteral :: `'` SingleStringCharacters `'`</emu-grammar> is the SV of |SingleStringCharacters|.
+            The SV of <emu-grammar use="reference">StringLiteral :: `'` SingleStringCharacters `'`</emu-grammar> is the SV of |SingleStringCharacters|.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacters :: DoubleStringCharacter</emu-grammar> is a sequence of one or two code units that is the SV of |DoubleStringCharacter|.
+            The SV of <emu-grammar use="reference">DoubleStringCharacters :: DoubleStringCharacter</emu-grammar> is a sequence of one or two code units that is the SV of |DoubleStringCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacters :: DoubleStringCharacter DoubleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |DoubleStringCharacter| followed by all the code units in the SV of |DoubleStringCharacters| in order.
+            The SV of <emu-grammar use="reference">DoubleStringCharacters :: DoubleStringCharacter DoubleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |DoubleStringCharacter| followed by all the code units in the SV of |DoubleStringCharacters| in order.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter|.
+            The SV of <emu-grammar use="reference">SingleStringCharacters :: SingleStringCharacter</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter| followed by all the code units in the SV of |SingleStringCharacters| in order.
+            The SV of <emu-grammar use="reference">SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter| followed by all the code units in the SV of |SingleStringCharacters| in order.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar use="reference">DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
+            The SV of <emu-grammar use="reference">DoubleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar use="reference">DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar use="reference">SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
+            The SV of <emu-grammar use="reference">SingleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar use="reference">SingleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the SV of the |CharacterEscapeSequence|.
+            The SV of <emu-grammar use="reference">EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the SV of the |CharacterEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit value 0.
+            The SV of <emu-grammar use="reference">EscapeSequence :: `0`</emu-grammar> is the code unit value 0.
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: HexEscapeSequence</emu-grammar> is the SV of the |HexEscapeSequence|.
+            The SV of <emu-grammar use="reference">EscapeSequence :: HexEscapeSequence</emu-grammar> is the SV of the |HexEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the SV of the |UnicodeEscapeSequence|.
+            The SV of <emu-grammar use="reference">EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the SV of the |UnicodeEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-34"></emu-xref>.
+            The SV of <emu-grammar use="reference">CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-34"></emu-xref>.
           </li>
         </ul>
         <emu-table id="table-34" caption="String Single Character Escape Sequences">
@@ -10422,22 +10422,22 @@
         </emu-table>
         <ul>
           <li>
-            The SV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
+            The SV of <emu-grammar use="reference">CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar use="reference">NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit value that is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
+            The SV of <emu-grammar use="reference">HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit value that is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the SV of |Hex4Digits|.
+            The SV of <emu-grammar use="reference">UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the SV of |Hex4Digits|.
           </li>
           <li>
-            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit value that is (0x1000 times the MV of the first |HexDigit|) plus (0x100 times the MV of the second |HexDigit|) plus (0x10 times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
+            The SV of <emu-grammar use="reference">Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit value that is (0x1000 times the MV of the first |HexDigit|) plus (0x100 times the MV of the second |HexDigit|) plus (0x10 times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the UTF16Encoding of the MV of |HexDigits|.
+            The SV of <emu-grammar use="reference">UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the UTF16Encoding of the MV of |HexDigits|.
           </li>
         </ul>
       </emu-clause>
@@ -10452,7 +10452,7 @@
       <p>The productions below describe the syntax for a regular expression literal and are used by the input element scanner to find the end of the regular expression literal. The source text comprising the |RegularExpressionBody| and the |RegularExpressionFlags| are subsequently parsed again using the more stringent ECMAScript Regular Expression grammar (<emu-xref href="#sec-patterns"></emu-xref>).</p>
       <p>An implementation may extend the ECMAScript Regular Expression grammar defined in <emu-xref href="#sec-patterns"></emu-xref>, but it must not extend the |RegularExpressionBody| and |RegularExpressionFlags| productions defined below or the productions used by these productions.</p>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         RegularExpressionLiteral ::
           `/` RegularExpressionBody `/` RegularExpressionFlags
 
@@ -10501,7 +10501,7 @@
       <!-- es6num="11.8.5.1" -->
       <emu-clause id="sec-literals-regular-expression-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>RegularExpressionFlags :: RegularExpressionFlags IdentifierPart</emu-grammar>
+        <emu-grammar use="reference">RegularExpressionFlags :: RegularExpressionFlags IdentifierPart</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if |IdentifierPart| contains a Unicode escape sequence.
@@ -10512,7 +10512,7 @@
       <!-- es6num="11.8.5.2" -->
       <emu-clause id="sec-static-semantics-bodytext">
         <h1>Static Semantics: BodyText</h1>
-        <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
+        <emu-grammar use="reference">RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
         <emu-alg>
           1. Return the source text that was recognized as |RegularExpressionBody|.
         </emu-alg>
@@ -10521,7 +10521,7 @@
       <!-- es6num="11.8.5.3" -->
       <emu-clause id="sec-static-semantics-flagtext">
         <h1>Static Semantics: FlagText</h1>
-        <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
+        <emu-grammar use="reference">RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
         <emu-alg>
           1. Return the source text that was recognized as |RegularExpressionFlags|.
         </emu-alg>
@@ -10532,7 +10532,7 @@
     <emu-clause id="sec-template-literal-lexical-components">
       <h1>Template Literal Lexical Components</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         Template ::
           NoSubstitutionTemplate
           TemplateHead
@@ -10574,145 +10574,145 @@
         <p>A template literal component is interpreted as a sequence of Unicode code points. The Template Value (TV) of a literal component is described in terms of code unit values (SV, <emu-xref href="#sec-literals-string-literals"></emu-xref>) contributed by the various parts of the template literal component. As part of this process, some Unicode code points within the template component are interpreted as having a mathematical value (MV, <emu-xref href="#sec-literals-numeric-literals"></emu-xref>). In determining a TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence. The Template Raw Value (TRV) is similar to a Template Value with the difference that in TRVs escape sequences are interpreted literally.</p>
         <ul>
           <li>
-            The TV and TRV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar use="reference">NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateHead :: ``` `${`</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar use="reference">TemplateHead :: ``` `${`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateMiddle :: `}` `${`</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar use="reference">TemplateMiddle :: `}` `${`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateTail :: `}` ```</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar use="reference">TemplateTail :: `}` ```</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TV of <emu-grammar>NoSubstitutionTemplate :: ``` TemplateCharacters ```</emu-grammar> is the TV of |TemplateCharacters|.
+            The TV of <emu-grammar use="reference">NoSubstitutionTemplate :: ``` TemplateCharacters ```</emu-grammar> is the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateHead :: ``` TemplateCharacters `${`</emu-grammar> is the TV of |TemplateCharacters|.
+            The TV of <emu-grammar use="reference">TemplateHead :: ``` TemplateCharacters `${`</emu-grammar> is the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateMiddle :: `}` TemplateCharacters `${`</emu-grammar> is the TV of |TemplateCharacters|.
+            The TV of <emu-grammar use="reference">TemplateMiddle :: `}` TemplateCharacters `${`</emu-grammar> is the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateTail :: `}` TemplateCharacters ```</emu-grammar> is the TV of |TemplateCharacters|.
+            The TV of <emu-grammar use="reference">TemplateTail :: `}` TemplateCharacters ```</emu-grammar> is the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter</emu-grammar> is the TV of |TemplateCharacter|.
+            The TV of <emu-grammar use="reference">TemplateCharacters :: TemplateCharacter</emu-grammar> is the TV of |TemplateCharacter|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TV of |TemplateCharacter| followed by all the code units in the TV of |TemplateCharacters| in order.
+            The TV of <emu-grammar use="reference">TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TV of |TemplateCharacter| followed by all the code units in the TV of |TemplateCharacters| in order.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The TV of <emu-grammar use="reference">TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
+            The TV of <emu-grammar use="reference">TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the SV of |EscapeSequence|.
+            The TV of <emu-grammar use="reference">TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the SV of |EscapeSequence|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: LineContinuation</emu-grammar> is the TV of |LineContinuation|.
+            The TV of <emu-grammar use="reference">TemplateCharacter :: LineContinuation</emu-grammar> is the TV of |LineContinuation|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
+            The TV of <emu-grammar use="reference">TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the empty code unit sequence.
+            The TV of <emu-grammar use="reference">LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TRV of <emu-grammar>NoSubstitutionTemplate :: ``` TemplateCharacters ```</emu-grammar> is the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar use="reference">NoSubstitutionTemplate :: ``` TemplateCharacters ```</emu-grammar> is the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateHead :: ``` TemplateCharacters `${`</emu-grammar> is the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar use="reference">TemplateHead :: ``` TemplateCharacters `${`</emu-grammar> is the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateMiddle :: `}` TemplateCharacters `${`</emu-grammar> is the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar use="reference">TemplateMiddle :: `}` TemplateCharacters `${`</emu-grammar> is the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateTail :: `}` TemplateCharacters ```</emu-grammar> is the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar use="reference">TemplateTail :: `}` TemplateCharacters ```</emu-grammar> is the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter</emu-grammar> is the TRV of |TemplateCharacter|.
+            The TRV of <emu-grammar use="reference">TemplateCharacters :: TemplateCharacter</emu-grammar> is the TRV of |TemplateCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TRV of |TemplateCharacter| followed by all the code units in the TRV of |TemplateCharacters|, in order.
+            The TRV of <emu-grammar use="reference">TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TRV of |TemplateCharacter| followed by all the code units in the TRV of |TemplateCharacters|, in order.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The TRV of <emu-grammar use="reference">TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
+            The TRV of <emu-grammar use="reference">TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the sequence consisting of the code unit value 0x005C followed by the code units of TRV of |EscapeSequence|.
+            The TRV of <emu-grammar use="reference">TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the sequence consisting of the code unit value 0x005C followed by the code units of TRV of |EscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: LineContinuation</emu-grammar> is the TRV of |LineContinuation|.
+            The TRV of <emu-grammar use="reference">TemplateCharacter :: LineContinuation</emu-grammar> is the TRV of |LineContinuation|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
+            The TRV of <emu-grammar use="reference">TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the TRV of the |CharacterEscapeSequence|.
+            The TRV of <emu-grammar use="reference">EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the TRV of the |CharacterEscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit value 0x0030 (DIGIT ZERO).
+            The TRV of <emu-grammar use="reference">EscapeSequence :: `0`</emu-grammar> is the code unit value 0x0030 (DIGIT ZERO).
           </li>
           <li>
-            The TRV of <emu-grammar>EscapeSequence :: HexEscapeSequence</emu-grammar> is the TRV of the |HexEscapeSequence|.
+            The TRV of <emu-grammar use="reference">EscapeSequence :: HexEscapeSequence</emu-grammar> is the TRV of the |HexEscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the TRV of the |UnicodeEscapeSequence|.
+            The TRV of <emu-grammar use="reference">EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the TRV of the |UnicodeEscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the TRV of the |SingleEscapeCharacter|.
+            The TRV of <emu-grammar use="reference">CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the TRV of the |SingleEscapeCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
+            The TRV of <emu-grammar use="reference">CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar>SingleEscapeCharacter :: one of `'` `"` `\` `b` `f` `n` `r` `t` `v`</emu-grammar> is the SV of the |SourceCharacter| that is that single code point.
+            The TRV of <emu-grammar use="reference">SingleEscapeCharacter :: one of `'` `"` `\` `b` `f` `n` `r` `t` `v`</emu-grammar> is the SV of the |SourceCharacter| that is that single code point.
           </li>
           <li>
-            The TRV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the sequence consisting of code unit value 0x0078 followed by TRV of the first |HexDigit| followed by the TRV of the second |HexDigit|.
+            The TRV of <emu-grammar use="reference">HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the sequence consisting of code unit value 0x0078 followed by TRV of the first |HexDigit| followed by the TRV of the second |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the sequence consisting of code unit value 0x0075 followed by TRV of |Hex4Digits|.
+            The TRV of <emu-grammar use="reference">UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the sequence consisting of code unit value 0x0075 followed by TRV of |Hex4Digits|.
           </li>
           <li>
-            The TRV of <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the sequence consisting of code unit value 0x0075 followed by code unit value 0x007B followed by TRV of |HexDigits| followed by code unit value 0x007D.
+            The TRV of <emu-grammar use="reference">UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the sequence consisting of code unit value 0x0075 followed by code unit value 0x007B followed by TRV of |HexDigits| followed by code unit value 0x007D.
           </li>
           <li>
-            The TRV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the sequence consisting of the TRV of the first |HexDigit| followed by the TRV of the second |HexDigit| followed by the TRV of the third |HexDigit| followed by the TRV of the fourth |HexDigit|.
+            The TRV of <emu-grammar use="reference">Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the sequence consisting of the TRV of the first |HexDigit| followed by the TRV of the second |HexDigit| followed by the TRV of the third |HexDigit| followed by the TRV of the fourth |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>HexDigits :: HexDigit</emu-grammar> is the TRV of |HexDigit|.
+            The TRV of <emu-grammar use="reference">HexDigits :: HexDigit</emu-grammar> is the TRV of |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is the sequence consisting of TRV of |HexDigits| followed by TRV of |HexDigit|.
+            The TRV of <emu-grammar use="reference">HexDigits :: HexDigits HexDigit</emu-grammar> is the sequence consisting of TRV of |HexDigits| followed by TRV of |HexDigit|.
           </li>
           <li>
             The TRV of a |HexDigit| is the SV of the |SourceCharacter| that is that |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the sequence consisting of the code unit value 0x005C followed by the code units of TRV of |LineTerminatorSequence|.
+            The TRV of <emu-grammar use="reference">LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the sequence consisting of the code unit value 0x005C followed by the code units of TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;LF&gt;</emu-grammar> is the code unit value 0x000A.
+            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;LF&gt;</emu-grammar> is the code unit value 0x000A.
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt;</emu-grammar> is the code unit value 0x000A.
+            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;CR&gt;</emu-grammar> is the code unit value 0x000A.
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;LS&gt;</emu-grammar> is the code unit value 0x2028.
+            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;LS&gt;</emu-grammar> is the code unit value 0x2028.
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;PS&gt;</emu-grammar> is the code unit value 0x2029.
+            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;PS&gt;</emu-grammar> is the code unit value 0x2029.
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt;&lt;LF&gt;</emu-grammar> is the sequence consisting of the code unit value 0x000A.
+            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;CR&gt;&lt;LF&gt;</emu-grammar> is the sequence consisting of the code unit value 0x000A.
           </li>
         </ul>
         <emu-note>
@@ -10757,7 +10757,7 @@
       <p>However, there is an additional overriding condition on the preceding rules: a semicolon is never inserted automatically if the semicolon would then be parsed as an empty statement or if that semicolon would become one of the two semicolons in the header of a `for` statement (see <emu-xref href="#sec-for-statement"></emu-xref>).</p>
       <emu-note>
         <p>The following are the only restricted productions in the grammar:</p>
-        <emu-grammar>
+        <emu-grammar use="reference">
           UpdateExpression[Yield, Await] :
             LeftHandSideExpression[?Yield, ?Await] [no LineTerminator here] `++`
             LeftHandSideExpression[?Yield, ?Await] [no LineTerminator here] `--`
@@ -10882,7 +10882,7 @@
   <emu-clause id="sec-identifiers">
     <h1>Identifiers</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       IdentifierReference[Yield, Await] :
         Identifier
         [~Yield] `yield`
@@ -10913,13 +10913,13 @@
     <!-- es6num="12.1.1" -->
     <emu-clause id="sec-identifiers-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
+      <emu-grammar use="reference">BindingIdentifier : Identifier</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the code matched by this production is contained in strict mode code and the StringValue of |Identifier| is `"arguments"` or `"eval"`.
         </li>
       </ul>
-      <emu-grammar>
+      <emu-grammar use="reference">
         IdentifierReference : `yield`
 
         BindingIdentifier : `yield`
@@ -10931,7 +10931,7 @@
           It is a Syntax Error if the code matched by this production is contained in strict mode code.
         </li>
       </ul>
-      <emu-grammar>
+      <emu-grammar use="reference">
         IdentifierReference : `await`
 
         BindingIdentifier : `await`
@@ -10943,7 +10943,7 @@
           It is a Syntax Error if the goal symbol of the syntactic grammar is |Module|.
         </li>
       </ul>
-      <emu-grammar>
+      <emu-grammar use="reference">
         BindingIdentifier : `yield`
       </emu-grammar>
       <ul>
@@ -10951,7 +10951,7 @@
           It is a Syntax Error if this production has a <sub>[Yield]</sub> parameter.
         </li>
       </ul>
-      <emu-grammar>
+      <emu-grammar use="reference">
         BindingIdentifier : `await`
       </emu-grammar>
       <ul>
@@ -10959,7 +10959,7 @@
           It is a Syntax Error if this production has an <sub>[Await]</sub> parameter.
         </li>
       </ul>
-      <emu-grammar>
+      <emu-grammar use="reference">
         IdentifierReference[Yield, Await] : Identifier
 
         BindingIdentifier[Yield, Await] : Identifier
@@ -10974,7 +10974,7 @@
           It is a Syntax Error if this production has an <sub>[Await]</sub> parameter and StringValue of |Identifier| is `"await"`.
         </li>
       </ul>
-      <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
+      <emu-grammar use="reference">Identifier : IdentifierName but not ReservedWord</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, `"static"`, or `"yield"`.
@@ -10995,15 +10995,15 @@
     <emu-clause id="sec-identifiers-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
+      <emu-grammar use="reference">BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
         1. Return a new List containing the StringValue of |Identifier|.
       </emu-alg>
-      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
+      <emu-grammar use="reference">BindingIdentifier : `yield`</emu-grammar>
       <emu-alg>
         1. Return a new List containing `"yield"`.
       </emu-alg>
-      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
+      <emu-grammar use="reference">BindingIdentifier : `await`</emu-grammar>
       <emu-alg>
         1. Return a new List containing `"await"`.
       </emu-alg>
@@ -11013,16 +11013,16 @@
     <emu-clause id="sec-identifiers-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>IdentifierReference : Identifier</emu-grammar>
+      <emu-grammar use="reference">IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
         1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is `"eval"` or `"arguments"`, return *false*.
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>IdentifierReference : `yield`</emu-grammar>
+      <emu-grammar use="reference">IdentifierReference : `yield`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>IdentifierReference : `await`</emu-grammar>
+      <emu-grammar use="reference">IdentifierReference : `await`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -11032,7 +11032,7 @@
     <emu-clause id="sec-identifiers-static-semantics-stringvalue">
       <h1>Static Semantics: StringValue</h1>
       <emu-see-also-para op="StringValue"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         IdentifierReference : `yield`
 
         BindingIdentifier : `yield`
@@ -11042,7 +11042,7 @@
       <emu-alg>
         1. Return `"yield"`.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         IdentifierReference : `await`
 
         BindingIdentifier : `await`
@@ -11052,7 +11052,7 @@
       <emu-alg>
         1. Return `"await"`.
       </emu-alg>
-      <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
+      <emu-grammar use="reference">Identifier : IdentifierName but not ReservedWord</emu-grammar>
       <emu-alg>
         1. Return the StringValue of |IdentifierName|.
       </emu-alg>
@@ -11066,16 +11066,16 @@
       <emu-note>
         <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and formal parameter lists of some non-strict functions (See <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
       </emu-note>
-      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
+      <emu-grammar use="reference">BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |Identifier|.
         1. Return ? InitializeBoundName(_name_, _value_, _environment_).
       </emu-alg>
-      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
+      <emu-grammar use="reference">BindingIdentifier : `yield`</emu-grammar>
       <emu-alg>
         1. Return ? InitializeBoundName(`"yield"`, _value_, _environment_).
       </emu-alg>
-      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
+      <emu-grammar use="reference">BindingIdentifier : `await`</emu-grammar>
       <emu-alg>
         1. Return ? InitializeBoundName(`"await"`, _value_, _environment_).
       </emu-alg>
@@ -11099,15 +11099,15 @@
     <!-- es6num="12.1.6" -->
     <emu-clause id="sec-identifiers-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>IdentifierReference : Identifier</emu-grammar>
+      <emu-grammar use="reference">IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
         1. Return ? ResolveBinding(StringValue of |Identifier|).
       </emu-alg>
-      <emu-grammar>IdentifierReference : `yield`</emu-grammar>
+      <emu-grammar use="reference">IdentifierReference : `yield`</emu-grammar>
       <emu-alg>
         1. Return ? ResolveBinding(`"yield"`).
       </emu-alg>
-      <emu-grammar>IdentifierReference : `await`</emu-grammar>
+      <emu-grammar use="reference">IdentifierReference : `await`</emu-grammar>
       <emu-alg>
         1. Return ? ResolveBinding(`"await"`).
       </emu-alg>
@@ -11124,7 +11124,7 @@
   <emu-clause id="sec-primary-expression">
     <h1>Primary Expression</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       PrimaryExpression[Yield, Await] :
         `this`
         IdentifierReference[?Yield, ?Await]
@@ -11151,10 +11151,10 @@
     <h2>Supplemental Syntax</h2>
     <p>When processing an instance of the production
       <br>
-      <emu-grammar>PrimaryExpression[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
+      <emu-grammar use="reference">PrimaryExpression[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
       <br>
       the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
-    <emu-grammar>
+    <emu-grammar use="definition">
       ParenthesizedExpression[Yield, Await] :
         `(` Expression[+In, ?Yield, ?Await] `)`
     </emu-grammar>
@@ -11166,7 +11166,7 @@
       <!-- es6num="12.2.1.1" -->
       <emu-clause id="sec-static-semantics-coveredparenthesizedexpression">
         <h1>Static Semantics: CoveredParenthesizedExpression</h1>
-        <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] : `(` Expression[+In, ?Yield, ?Await] `)`</emu-grammar>
+        <emu-grammar use="reference">CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] : `(` Expression[+In, ?Yield, ?Await] `)`</emu-grammar>
         <emu-alg>
           1. Return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList| using |ParenthesizedExpression| as the goal symbol with its <sub>[Yield]</sub> and <sub>[Await]</sub> parameters set to the values used when parsing this |CoverParenthesizedExpressionAndArrowParameterList|.
         </emu-alg>
@@ -11176,7 +11176,7 @@
       <emu-clause id="sec-semantics-static-semantics-hasname">
         <h1>Static Semantics: HasName</h1>
         <emu-see-also-para op="HasName"></emu-see-also-para>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
@@ -11188,7 +11188,7 @@
       <emu-clause id="sec-semantics-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           PrimaryExpression :
             `this`
             IdentifierReference
@@ -11201,7 +11201,7 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return IsFunctionDefinition of _expr_.
@@ -11212,11 +11212,11 @@
       <emu-clause id="sec-semantics-static-semantics-isidentifierref">
         <h1>Static Semantics: IsIdentifierRef</h1>
         <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
-        <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : IdentifierReference</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           PrimaryExpression :
             `this`
             Literal
@@ -11239,7 +11239,7 @@
       <emu-clause id="sec-semantics-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           PrimaryExpression :
             `this`
             Literal
@@ -11255,7 +11255,7 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return IsValidSimpleAssignmentTarget of _expr_.
@@ -11270,7 +11270,7 @@
       <!-- es6num="12.2.2.1" -->
       <emu-clause id="sec-this-keyword-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>PrimaryExpression : `this`</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : `this`</emu-grammar>
         <emu-alg>
           1. Return ? ResolveThisBinding( ).
         </emu-alg>
@@ -11287,7 +11287,7 @@
     <emu-clause id="sec-primary-expression-literals">
       <h1>Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         Literal :
           NullLiteral
           BooleanLiteral
@@ -11298,20 +11298,20 @@
       <!-- es6num="12.2.4.1" -->
       <emu-clause id="sec-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>Literal : NullLiteral</emu-grammar>
+        <emu-grammar use="reference">Literal : NullLiteral</emu-grammar>
         <emu-alg>
           1. Return *null*.
         </emu-alg>
-        <emu-grammar>Literal : BooleanLiteral</emu-grammar>
+        <emu-grammar use="reference">Literal : BooleanLiteral</emu-grammar>
         <emu-alg>
           1. If |BooleanLiteral| is the token `false`, return *false*.
           1. If |BooleanLiteral| is the token `true`, return *true*.
         </emu-alg>
-        <emu-grammar>Literal : NumericLiteral</emu-grammar>
+        <emu-grammar use="reference">Literal : NumericLiteral</emu-grammar>
         <emu-alg>
           1. Return the number whose value is MV of |NumericLiteral| as defined in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.
         </emu-alg>
-        <emu-grammar>Literal : StringLiteral</emu-grammar>
+        <emu-grammar use="reference">Literal : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return the StringValue of |StringLiteral| as defined in <emu-xref href="#sec-string-literals-static-semantics-stringvalue"></emu-xref>.
         </emu-alg>
@@ -11326,7 +11326,7 @@
       </emu-note>
       <p>Array elements may be elided at the beginning, middle or end of the element list. Whenever a comma in the element list is not preceded by an |AssignmentExpression| (i.e., a comma at the beginning or after another comma), the missing array element contributes to the length of the Array and increases the index of subsequent elements. Elided array elements are not defined. If an element is elided at the end of an array, that element does not contribute to the length of the Array.</p>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         ArrayLiteral[Yield, Await] :
           `[` Elision? `]`
           `[` ElementList[?Yield, ?Await] `]`
@@ -11349,11 +11349,11 @@
       <!-- es6num="12.2.5.1" -->
       <emu-clause id="sec-static-semantics-elisionwidth">
         <h1>Static Semantics: ElisionWidth</h1>
-        <emu-grammar>Elision : `,`</emu-grammar>
+        <emu-grammar use="reference">Elision : `,`</emu-grammar>
         <emu-alg>
           1. Return the numeric value 1.
         </emu-alg>
-        <emu-grammar>Elision : Elision `,`</emu-grammar>
+        <emu-grammar use="reference">Elision : Elision `,`</emu-grammar>
         <emu-alg>
           1. Let _preceding_ be the ElisionWidth of |Elision|.
           1. Return _preceding_+1.
@@ -11364,7 +11364,7 @@
       <emu-clause id="sec-runtime-semantics-arrayaccumulation">
         <h1>Runtime Semantics: ArrayAccumulation</h1>
         <p>With parameters _array_ and _nextIndex_.</p>
-        <emu-grammar>ElementList : Elision? AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">ElementList : Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
@@ -11373,12 +11373,12 @@
           1. Assert: _created_ is *true*.
           1. Return _nextIndex_+_padding_+1.
         </emu-alg>
-        <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
+        <emu-grammar use="reference">ElementList : Elision? SpreadElement</emu-grammar>
         <emu-alg>
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _nextIndex_+_padding_.
         </emu-alg>
-        <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _postIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
           1. ReturnIfAbrupt(_postIndex_).
@@ -11389,14 +11389,14 @@
           1. Assert: _created_ is *true*.
           1. Return _postIndex_+_padding_+1.
         </emu-alg>
-        <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
+        <emu-grammar use="reference">ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
         <emu-alg>
           1. Let _postIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
           1. ReturnIfAbrupt(_postIndex_).
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _postIndex_+_padding_.
         </emu-alg>
-        <emu-grammar>SpreadElement : `...` AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">SpreadElement : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
@@ -11417,7 +11417,7 @@
       <!-- es6num="12.2.5.3" -->
       <emu-clause id="sec-array-initializer-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>ArrayLiteral : `[` Elision? `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayLiteral : `[` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. Let _pad_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
@@ -11425,7 +11425,7 @@
           1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
           1. Return _array_.
         </emu-alg>
-        <emu-grammar>ArrayLiteral : `[` ElementList `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayLiteral : `[` ElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. Let _len_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
@@ -11434,7 +11434,7 @@
           1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
           1. Return _array_.
         </emu-alg>
-        <emu-grammar>ArrayLiteral : `[` ElementList `,` Elision? `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayLiteral : `[` ElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. Let _len_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
@@ -11454,7 +11454,7 @@
         <p>An object initializer is an expression describing the initialization of an Object, written in a form resembling a literal. It is a list of zero or more pairs of property keys and associated values, enclosed in curly brackets. The values need not be literals; they are evaluated each time the object initializer is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         ObjectLiteral[Yield, Await] :
           `{` `}`
           `{` PropertyDefinitionList[?Yield, ?Await] `}`
@@ -11498,14 +11498,14 @@
       <!-- es6num="12.2.6.1" -->
       <emu-clause id="sec-object-initializer-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinition : MethodDefinition</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
           </li>
         </ul>
         <p>In addition to describing an actual object initializer the |ObjectLiteral| productions are also used as a cover grammar for |ObjectAssignmentPattern| and may be recognized as part of a |CoverParenthesizedExpressionAndArrowParameterList|. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the following Early Error rules are <b>not</b> applied. In addition, they are not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or |CoverCallExpressionAndAsyncArrowHead|.</p>
-        <emu-grammar>PropertyDefinition : CoverInitializedName</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinition : CoverInitializedName</emu-grammar>
         <ul>
           <li>
             Always throw a Syntax Error if code matches this production.
@@ -11521,11 +11521,11 @@
         <h1>Static Semantics: ComputedPropertyContains</h1>
         <p>With parameter _symbol_.</p>
         <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-        <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
+        <emu-grammar use="reference">PropertyName : LiteralPropertyName</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>PropertyName : ComputedPropertyName</emu-grammar>
+        <emu-grammar use="reference">PropertyName : ComputedPropertyName</emu-grammar>
         <emu-alg>
           1. Return the result of |ComputedPropertyName| Contains _symbol_.
         </emu-alg>
@@ -11536,7 +11536,7 @@
         <h1>Static Semantics: Contains</h1>
         <p>With parameter _symbol_.</p>
         <emu-see-also-para op="Contains"></emu-see-also-para>
-        <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinition : MethodDefinition</emu-grammar>
         <emu-alg>
           1. If _symbol_ is |MethodDefinition|, return *true*.
           1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
@@ -11544,7 +11544,7 @@
         <emu-note>
           <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
         </emu-note>
-        <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
+        <emu-grammar use="reference">LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
           1. If _symbol_ is a |ReservedWord|, return *false*.
           1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
@@ -11555,11 +11555,11 @@
       <!-- es6num="12.2.6.5" -->
       <emu-clause id="sec-static-semantics-iscomputedpropertykey">
         <h1>Static Semantics: IsComputedPropertyKey</h1>
-        <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
+        <emu-grammar use="reference">PropertyName : LiteralPropertyName</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>PropertyName : ComputedPropertyName</emu-grammar>
+        <emu-grammar use="reference">PropertyName : ComputedPropertyName</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -11569,28 +11569,28 @@
       <emu-clause id="sec-object-initializer-static-semantics-propname">
         <h1>Static Semantics: PropName</h1>
         <emu-see-also-para op="PropName"></emu-see-also-para>
-        <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinition : IdentifierReference</emu-grammar>
         <emu-alg>
           1. Return StringValue of |IdentifierReference|.
         </emu-alg>
-        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Return PropName of |PropertyName|.
         </emu-alg>
-        <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
+        <emu-grammar use="reference">LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return StringValue of |IdentifierName|.
         </emu-alg>
-        <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
+        <emu-grammar use="reference">LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return a String value whose code units are the SV of the |StringLiteral|.
         </emu-alg>
-        <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
+        <emu-grammar use="reference">LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
           1. Let _nbr_ be the result of forming the value of the |NumericLiteral|.
           1. Return ! ToString(_nbr_).
         </emu-alg>
-        <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
+        <emu-grammar use="reference">ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
         <emu-alg>
           1. Return ~empty~.
         </emu-alg>
@@ -11599,12 +11599,12 @@
       <!-- es6num="12.2.6.7" -->
       <emu-clause id="sec-static-semantics-propertynamelist">
         <h1>Static Semantics: PropertyNameList</h1>
-        <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinitionList : PropertyDefinition</emu-grammar>
         <emu-alg>
           1. If PropName of |PropertyDefinition| is ~empty~, return a new empty List.
           1. Return a new List containing PropName of |PropertyDefinition|.
         </emu-alg>
-        <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
           1. Let _list_ be PropertyNameList of |PropertyDefinitionList|.
           1. If PropName of |PropertyDefinition| is ~empty~, return _list_.
@@ -11616,11 +11616,11 @@
       <!-- es6num="12.2.6.8" -->
       <emu-clause id="sec-object-initializer-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>ObjectLiteral : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ObjectLiteral : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return ObjectCreate(%ObjectPrototype%).
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ObjectLiteral :
             `{` PropertyDefinitionList `}`
             `{` PropertyDefinitionList `,` `}`
@@ -11630,20 +11630,20 @@
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_ and *true*.
           1. Return _obj_.
         </emu-alg>
-        <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
+        <emu-grammar use="reference">LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return StringValue of |IdentifierName|.
         </emu-alg>
-        <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
+        <emu-grammar use="reference">LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return a String value whose code units are the SV of the |StringLiteral|.
         </emu-alg>
-        <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
+        <emu-grammar use="reference">LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
           1. Let _nbr_ be the result of forming the value of the |NumericLiteral|.
           1. Return ! ToString(_nbr_).
         </emu-alg>
-        <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
+        <emu-grammar use="reference">ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
         <emu-alg>
           1. Let _exprValue_ be the result of evaluating |AssignmentExpression|.
           1. Let _propName_ be ? GetValue(_exprValue_).
@@ -11656,12 +11656,12 @@
         <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
         <p>With parameters _object_ and _enumerable_.</p>
         <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-        <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _object_ and _enumerable_.
           1. Return the result of performing PropertyDefinitionEvaluation of |PropertyDefinition| with arguments _object_ and _enumerable_.
         </emu-alg>
-        <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinition : IdentifierReference</emu-grammar>
         <emu-alg>
           1. Let _propName_ be StringValue of |IdentifierReference|.
           1. Let _exprValue_ be the result of evaluating |IdentifierReference|.
@@ -11669,7 +11669,7 @@
           1. Assert: _enumerable_ is *true*.
           1. Return CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
         </emu-alg>
-        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _propKey_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_propKey_).
@@ -11690,10 +11690,10 @@
     <!-- es6num="12.2.7" -->
     <emu-clause id="sec-function-defining-expressions">
       <h1>Function Defining Expressions</h1>
-      <p>See <emu-xref href="#sec-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : FunctionExpression</emu-grammar>.</p>
-      <p>See <emu-xref href="#sec-generator-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : GeneratorExpression</emu-grammar>.</p>
-      <p>See <emu-xref href="#sec-class-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : ClassExpression</emu-grammar>.</p>
-      <p>See <emu-xref href="#sec-async-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : AsyncFunctionExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-function-definitions"></emu-xref> for <emu-grammar use="reference">PrimaryExpression : FunctionExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-generator-function-definitions"></emu-xref> for <emu-grammar use="reference">PrimaryExpression : GeneratorExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-class-definitions"></emu-xref> for <emu-grammar use="reference">PrimaryExpression : ClassExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-async-function-definitions"></emu-xref> for <emu-grammar use="reference">PrimaryExpression : AsyncFunctionExpression</emu-grammar>.</p>
     </emu-clause>
 
     <!-- es6num="12.2.8" -->
@@ -11705,7 +11705,7 @@
       <!-- es6num="12.2.8.1" -->
       <emu-clause id="sec-primary-expression-regular-expression-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : RegularExpressionLiteral</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if BodyText of |RegularExpressionLiteral| cannot be recognized using the goal symbol |Pattern| of the ECMAScript RegExp grammar specified in <emu-xref href="#sec-patterns"></emu-xref>.
@@ -11719,7 +11719,7 @@
       <!-- es6num="12.2.8.2" -->
       <emu-clause id="sec-regular-expression-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : RegularExpressionLiteral</emu-grammar>
         <emu-alg>
           1. Let _pattern_ be the String value consisting of the UTF16Encoding of each code point of BodyText of |RegularExpressionLiteral|.
           1. Let _flags_ be the String value consisting of the UTF16Encoding of each code point of FlagText of |RegularExpressionLiteral|.
@@ -11732,7 +11732,7 @@
     <emu-clause id="sec-template-literals">
       <h1>Template Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         TemplateLiteral[Yield, Await] :
           NoSubstitutionTemplate
           TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await]
@@ -11748,7 +11748,7 @@
 
       <emu-clause id="sec-primary-expression-template-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>
+        <emu-grammar use="reference">
           TemplateLiteral :
             NoSubstitutionTemplate
             TemplateHead Expression TemplateSpans
@@ -11764,7 +11764,7 @@
       <emu-clause id="sec-static-semantics-templatestrings">
         <h1>Static Semantics: TemplateStrings</h1>
         <p>With parameter _raw_.</p>
-        <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
+        <emu-grammar use="reference">TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
             1. Let _string_ be the TV of |NoSubstitutionTemplate|.
@@ -11772,7 +11772,7 @@
             1. Let _string_ be the TRV of |NoSubstitutionTemplate|.
           1. Return a List containing the single element, _string_.
         </emu-alg>
-        <emu-grammar>TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-grammar use="reference">TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
             1. Let _head_ be the TV of |TemplateHead|.
@@ -11781,7 +11781,7 @@
           1. Let _tail_ be TemplateStrings of |TemplateSpans| with argument _raw_.
           1. Return a List containing _head_ followed by the elements, in order, of _tail_.
         </emu-alg>
-        <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
+        <emu-grammar use="reference">TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
             1. Let _tail_ be the TV of |TemplateTail|.
@@ -11789,7 +11789,7 @@
             1. Let _tail_ be the TRV of |TemplateTail|.
           1. Return a List containing the single element, _tail_.
         </emu-alg>
-        <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
+        <emu-grammar use="reference">TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _middle_ be TemplateStrings of |TemplateMiddleList| with argument _raw_.
           1. If _raw_ is *false*, then
@@ -11798,7 +11798,7 @@
             1. Let _tail_ be the TRV of |TemplateTail|.
           1. Return a List containing the elements, in order, of _middle_ followed by _tail_.
         </emu-alg>
-        <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
+        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
             1. Let _string_ be the TV of |TemplateMiddle|.
@@ -11806,7 +11806,7 @@
             1. Let _string_ be the TRV of |TemplateMiddle|.
           1. Return a List containing the single element, _string_.
         </emu-alg>
-        <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
+        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _front_ be TemplateStrings of |TemplateMiddleList| with argument _raw_.
           1. If _raw_ is *false*, then
@@ -11822,13 +11822,13 @@
       <emu-clause id="sec-template-literals-runtime-semantics-argumentlistevaluation">
         <h1>Runtime Semantics: ArgumentListEvaluation</h1>
         <emu-see-also-para op="ArgumentListEvaluation"></emu-see-also-para>
-        <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
+        <emu-grammar use="reference">TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
           1. Let _templateLiteral_ be this |TemplateLiteral|.
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
           1. Return a List containing the one element which is _siteObj_.
         </emu-alg>
-        <emu-grammar>TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-grammar use="reference">TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. Let _templateLiteral_ be this |TemplateLiteral|.
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
@@ -11885,21 +11885,21 @@
       <!-- es6num="12.2.9.4" -->
       <emu-clause id="sec-runtime-semantics-substitutionevaluation">
         <h1>Runtime Semantics: SubstitutionEvaluation</h1>
-        <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
+        <emu-grammar use="reference">TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
+        <emu-grammar use="reference">TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
           1. Return the result of SubstitutionEvaluation of |TemplateMiddleList|.
         </emu-alg>
-        <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
+        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _subRef_ be the result of evaluating |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Return a List containing only _sub_.
         </emu-alg>
-        <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
+        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _preceding_ be the result of SubstitutionEvaluation of |TemplateMiddleList|.
           1. ReturnIfAbrupt(_preceding_).
@@ -11913,11 +11913,11 @@
       <!-- es6num="12.2.9.5" -->
       <emu-clause id="sec-template-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
+        <emu-grammar use="reference">TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
           1. Return the String value whose code units are the elements of the TV of |NoSubstitutionTemplate| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
         </emu-alg>
-        <emu-grammar>TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-grammar use="reference">TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateHead| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Let _sub_ be the result of evaluating |Expression|.
@@ -11930,19 +11930,19 @@
         <emu-note>
           <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
         </emu-note>
-        <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
+        <emu-grammar use="reference">TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Return the String consisting of the code units of _tail_.
         </emu-alg>
-        <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
+        <emu-grammar use="reference">TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _head_ be the result of evaluating |TemplateMiddleList|.
           1. ReturnIfAbrupt(_head_).
           1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Return the String value whose code units are the elements of _head_ followed by the elements of _tail_.
         </emu-alg>
-        <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
+        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Let _sub_ be the result of evaluating |Expression|.
@@ -11953,7 +11953,7 @@
         <emu-note>
           <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
         </emu-note>
-        <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
+        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _rest_ be the result of evaluating |TemplateMiddleList|.
           1. ReturnIfAbrupt(_rest_).
@@ -11976,7 +11976,7 @@
       <!-- es6num="12.2.10.1" -->
       <emu-clause id="sec-grouping-operator-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the lexical token sequence matched by |CoverParenthesizedExpressionAndArrowParameterList| cannot be parsed with no tokens left over using |ParenthesizedExpression| as the goal symbol.
@@ -11991,7 +11991,7 @@
       <emu-clause id="sec-grouping-operator-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
+        <emu-grammar use="reference">ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
           1. Return IsFunctionDefinition of |Expression|.
         </emu-alg>
@@ -12001,7 +12001,7 @@
       <emu-clause id="sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
+        <emu-grammar use="reference">ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
           1. Return IsValidSimpleAssignmentTarget of |Expression|.
         </emu-alg>
@@ -12010,12 +12010,12 @@
       <!-- es6num="12.2.10.4" -->
       <emu-clause id="sec-grouping-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return the result of evaluating _expr_.
         </emu-alg>
-        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
+        <emu-grammar use="reference">ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
           1. Return the result of evaluating |Expression|. This may be of type Reference.
         </emu-alg>
@@ -12030,7 +12030,7 @@
   <emu-clause id="sec-left-hand-side-expressions">
     <h1>Left-Hand-Side Expressions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       MemberExpression[Yield, Await] :
         PrimaryExpression[?Yield, ?Await]
         MemberExpression[?Yield, ?Await] `[` Expression[+In, ?Yield, ?Await] `]`
@@ -12081,8 +12081,8 @@
         CallExpression[?Yield, ?Await]
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
-    <p>When processing an instance of the production <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
-    <emu-grammar>
+    <p>When processing an instance of the production <emu-grammar use="reference">CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
+    <emu-grammar use="definition">
       CallMemberExpression[Yield, Await] :
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
     </emu-grammar>
@@ -12093,7 +12093,7 @@
 
       <emu-clause id="sec-left-hand-side-expressions-static-semantics-coveredcallexpression">
         <h1>Static Semantics: CoveredCallExpression</h1>
-        <emu-grammar>
+        <emu-grammar use="reference">
           CallExpression : CoverCallExpressionAndAsyncArrowHead
         </emu-grammar>
         <emu-alg>
@@ -12106,21 +12106,21 @@
         <h1>Static Semantics: Contains</h1>
         <p>With parameter _symbol_.</p>
         <emu-see-also-para op="Contains"></emu-see-also-para>
-        <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If |MemberExpression| Contains _symbol_ is *true*, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
           1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">SuperProperty : `super` `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If _symbol_ is the |ReservedWord| `super`, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
           1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If |CallExpression| Contains _symbol_ is *true*, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
@@ -12133,7 +12133,7 @@
       <emu-clause id="sec-static-semantics-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           MemberExpression :
             MemberExpression `[` Expression `]`
             MemberExpression `.` IdentifierName
@@ -12157,12 +12157,12 @@
       <emu-clause id="sec-static-semantics-static-semantics-isdestructuring">
         <h1>Static Semantics: IsDestructuring</h1>
         <emu-see-also-para op="IsDestructuring"></emu-see-also-para>
-        <emu-grammar>MemberExpression : PrimaryExpression</emu-grammar>
+        <emu-grammar use="reference">MemberExpression : PrimaryExpression</emu-grammar>
         <emu-alg>
           1. If |PrimaryExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           MemberExpression :
             MemberExpression `[` Expression `]`
             MemberExpression `.` IdentifierName
@@ -12186,7 +12186,7 @@
       <emu-clause id="sec-static-semantics-static-semantics-isidentifierref">
         <h1>Static Semantics: IsIdentifierRef</h1>
         <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           MemberExpression :
             MemberExpression `[` Expression `]`
             MemberExpression `.` IdentifierName
@@ -12210,7 +12210,7 @@
       <emu-clause id="sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           CallExpression :
             CallExpression `[` Expression `]`
             CallExpression `.` IdentifierName
@@ -12223,7 +12223,7 @@
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           CallExpression :
             CoverCallExpressionAndAsyncArrowHead
             SuperCall
@@ -12284,7 +12284,7 @@
       <!-- es6num="12.3.2.1" -->
       <emu-clause id="sec-property-accessors-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>MemberExpression : MemberExpression `[` Expression `]`</emu-grammar>
+        <emu-grammar use="reference">MemberExpression : MemberExpression `[` Expression `]`</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
@@ -12295,7 +12295,7 @@
           1. If the code matched by this |MemberExpression| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return a value of type Reference whose base value component is _bv_, whose referenced name component is _propertyKey_, and whose strict reference flag is _strict_.
         </emu-alg>
-        <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
@@ -12304,10 +12304,10 @@
           1. If the code matched by this |MemberExpression| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return a value of type Reference whose base value component is _bv_, whose referenced name component is _propertyNameString_, and whose strict reference flag is _strict_.
         </emu-alg>
-        <emu-grammar>CallExpression : CallExpression `[` Expression `]`</emu-grammar>
-        <p>Is evaluated in exactly the same manner as <emu-grammar>MemberExpression : MemberExpression `[` Expression `]`</emu-grammar> except that the contained |CallExpression| is evaluated in step 1.</p>
-        <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
-        <p>Is evaluated in exactly the same manner as <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar> except that the contained |CallExpression| is evaluated in step 1.</p>
+        <emu-grammar use="reference">CallExpression : CallExpression `[` Expression `]`</emu-grammar>
+        <p>Is evaluated in exactly the same manner as <emu-grammar use="reference">MemberExpression : MemberExpression `[` Expression `]`</emu-grammar> except that the contained |CallExpression| is evaluated in step 1.</p>
+        <emu-grammar use="reference">CallExpression : CallExpression `.` IdentifierName</emu-grammar>
+        <p>Is evaluated in exactly the same manner as <emu-grammar use="reference">MemberExpression : MemberExpression `.` IdentifierName</emu-grammar> except that the contained |CallExpression| is evaluated in step 1.</p>
       </emu-clause>
     </emu-clause>
 
@@ -12318,11 +12318,11 @@
       <!-- es6num="12.3.3.1" -->
       <emu-clause id="sec-new-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>NewExpression : `new` NewExpression</emu-grammar>
+        <emu-grammar use="reference">NewExpression : `new` NewExpression</emu-grammar>
         <emu-alg>
           1. Return ? EvaluateNew(|NewExpression|, ~empty~).
         </emu-alg>
-        <emu-grammar>MemberExpression : `new` MemberExpression Arguments</emu-grammar>
+        <emu-grammar use="reference">MemberExpression : `new` MemberExpression Arguments</emu-grammar>
         <emu-alg>
           1. Return ? EvaluateNew(|MemberExpression|, |Arguments|).
         </emu-alg>
@@ -12354,7 +12354,7 @@
       <!-- es6num="12.3.4.1" -->
       <emu-clause id="sec-function-calls-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
+        <emu-grammar use="reference">CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredCallExpression of |CoverCallExpressionAndAsyncArrowHead|.
           1. Let _memberExpr_ be the |MemberExpression| of _expr_.
@@ -12383,7 +12383,7 @@
           1. Return ? EvaluateDirectCall(_func_, _thisValue_, _arguments_, _tailCall_).
         </emu-alg>
         <p>A |CallExpression| evaluation that executes step 6.a.vii is a <dfn>direct eval</dfn>.</p>
-        <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
+        <emu-grammar use="reference">CallExpression : CallExpression Arguments</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |CallExpression|.
           1. Let _thisCall_ be this |CallExpression|.
@@ -12434,7 +12434,7 @@
       <!-- es6num="12.3.5.1" -->
       <emu-clause id="sec-super-keyword-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>SuperProperty : `super` `[` Expression `]`</emu-grammar>
+        <emu-grammar use="reference">SuperProperty : `super` `[` Expression `]`</emu-grammar>
         <emu-alg>
           1. Let _propertyNameReference_ be the result of evaluating |Expression|.
           1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
@@ -12442,13 +12442,13 @@
           1. If the code matched by this |SuperProperty| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? MakeSuperPropertyReference(_propertyKey_, _strict_).
         </emu-alg>
-        <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">SuperProperty : `super` `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _propertyKey_ be StringValue of |IdentifierName|.
           1. If the code matched by this |SuperProperty| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? MakeSuperPropertyReference(_propertyKey_, _strict_).
         </emu-alg>
-        <emu-grammar>SuperCall : `super` Arguments</emu-grammar>
+        <emu-grammar use="reference">SuperCall : `super` Arguments</emu-grammar>
         <emu-alg>
           1. Let _newTarget_ be GetNewTarget().
           1. Assert: Type(_newTarget_) is Object.
@@ -12502,17 +12502,17 @@
       <emu-clause id="sec-argument-lists-runtime-semantics-argumentlistevaluation">
         <h1>Runtime Semantics: ArgumentListEvaluation</h1>
         <emu-see-also-para op="ArgumentListEvaluation"></emu-see-also-para>
-        <emu-grammar>Arguments : `(` `)`</emu-grammar>
+        <emu-grammar use="reference">Arguments : `(` `)`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ArgumentList : AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">ArgumentList : AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
           1. Return a List whose sole item is _arg_.
         </emu-alg>
-        <emu-grammar>ArgumentList : `...` AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">ArgumentList : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _list_ be a new empty List.
           1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
@@ -12524,7 +12524,7 @@
             1. Let _nextArg_ be ? IteratorValue(_next_).
             1. Append _nextArg_ as the last element of _list_.
         </emu-alg>
-        <emu-grammar>ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _precedingArgs_ be ArgumentListEvaluation of |ArgumentList|.
           1. ReturnIfAbrupt(_precedingArgs_).
@@ -12533,7 +12533,7 @@
           1. Append _arg_ to the end of _precedingArgs_.
           1. Return _precedingArgs_.
         </emu-alg>
-        <emu-grammar>ArgumentList : ArgumentList `,` `...` AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">ArgumentList : ArgumentList `,` `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _precedingArgs_ be ArgumentListEvaluation of |ArgumentList|.
           1. ReturnIfAbrupt(_precedingArgs_).
@@ -12558,14 +12558,14 @@
       <!-- es6num="12.3.7.1" -->
       <emu-clause id="sec-tagged-templates-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
+        <emu-grammar use="reference">MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
         <emu-alg>
           1. Let _tagRef_ be the result of evaluating |MemberExpression|.
           1. Let _thisCall_ be this |MemberExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_tagRef_, |TemplateLiteral|, _tailCall_).
         </emu-alg>
-        <emu-grammar>CallExpression : CallExpression TemplateLiteral</emu-grammar>
+        <emu-grammar use="reference">CallExpression : CallExpression TemplateLiteral</emu-grammar>
         <emu-alg>
           1. Let _tagRef_ be the result of evaluating |CallExpression|.
           1. Let _thisCall_ be this |CallExpression|.
@@ -12582,7 +12582,7 @@
       <!-- es6num="12.3.8.1" -->
       <emu-clause id="sec-meta-properties-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>NewTarget : `new` `.` `target`</emu-grammar>
+        <emu-grammar use="reference">NewTarget : `new` `.` `target`</emu-grammar>
         <emu-alg>
           1. Return GetNewTarget().
         </emu-alg>
@@ -12594,7 +12594,7 @@
   <emu-clause id="sec-update-expressions">
     <h1>Update Expressions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       UpdateExpression[Yield, Await] :
         LeftHandSideExpression[?Yield, ?Await]
         LeftHandSideExpression[?Yield, ?Await] [no LineTerminator here] `++`
@@ -12606,7 +12606,7 @@
     <!-- es6num="12.4.1" -->
     <emu-clause id="sec-update-expressions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         UpdateExpression :
           LeftHandSideExpression `++`
           LeftHandSideExpression `--`
@@ -12617,7 +12617,7 @@
         </li>
       </ul>
 
-      <emu-grammar>
+      <emu-grammar use="reference">
         UpdateExpression :
           `++` UnaryExpression
           `--` UnaryExpression
@@ -12633,7 +12633,7 @@
     <emu-clause id="sec-update-expressions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         UpdateExpression :
           LeftHandSideExpression `++`
           LeftHandSideExpression `--`
@@ -12649,7 +12649,7 @@
     <emu-clause id="sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         UpdateExpression :
           LeftHandSideExpression `++`
           LeftHandSideExpression `--`
@@ -12668,7 +12668,7 @@
       <!-- es6num="12.4.4.1" -->
       <emu-clause id="sec-postfix-increment-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
+        <emu-grammar use="reference">UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_lhs_)).
@@ -12686,7 +12686,7 @@
       <!-- es6num="12.4.5.1" -->
       <emu-clause id="sec-postfix-decrement-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
+        <emu-grammar use="reference">UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_lhs_)).
@@ -12704,7 +12704,7 @@
       <!-- es6num="12.5.7.1" -->
       <emu-clause id="sec-prefix-increment-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UpdateExpression : `++` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UpdateExpression : `++` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
@@ -12722,7 +12722,7 @@
       <!-- es6num="12.5.8.1" -->
       <emu-clause id="sec-prefix-decrement-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UpdateExpression : `--` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UpdateExpression : `--` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
@@ -12738,7 +12738,7 @@
   <emu-clause id="sec-unary-operators">
     <h1>Unary Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       UnaryExpression[Yield, Await] :
         UpdateExpression[?Yield, ?Await]
         `delete` UnaryExpression[?Yield, ?Await]
@@ -12755,7 +12755,7 @@
     <emu-clause id="sec-unary-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         UnaryExpression :
           `delete` UnaryExpression
           `void` UnaryExpression
@@ -12775,7 +12775,7 @@
     <emu-clause id="sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         UnaryExpression :
           `delete` UnaryExpression
           `void` UnaryExpression
@@ -12798,15 +12798,15 @@
       <!-- es6num="12.5.4.1" -->
       <emu-clause id="sec-delete-operator-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UnaryExpression : `delete` UnaryExpression</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the |UnaryExpression| is contained in strict mode code and the derived |UnaryExpression| is <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>.
+            It is a Syntax Error if the |UnaryExpression| is contained in strict mode code and the derived |UnaryExpression| is <emu-grammar use="reference">PrimaryExpression : IdentifierReference</emu-grammar>.
           </li>
           <li>
             <p>It is a Syntax Error if the derived |UnaryExpression| is
               <br>
-              <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+              <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
               <br>
               and |CoverParenthesizedExpressionAndArrowParameterList| ultimately derives a phrase that, if used in place of |UnaryExpression|, would produce a Syntax Error according to these rules. This rule is recursively applied.</p>
           </li>
@@ -12819,7 +12819,7 @@
       <!-- es6num="12.5.4.2" -->
       <emu-clause id="sec-delete-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UnaryExpression : `delete` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |UnaryExpression|.
           1. ReturnIfAbrupt(_ref_).
@@ -12850,7 +12850,7 @@
       <!-- es6num="12.5.5.1" -->
       <emu-clause id="sec-void-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UnaryExpression : `void` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UnaryExpression : `void` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Perform ? GetValue(_expr_).
@@ -12869,7 +12869,7 @@
       <!-- es6num="12.5.6.1" -->
       <emu-clause id="sec-typeof-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UnaryExpression : `typeof` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UnaryExpression : `typeof` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _val_ be the result of evaluating |UnaryExpression|.
           1. If Type(_val_) is Reference, then
@@ -12988,7 +12988,7 @@
       <!-- es6num="12.5.9.1" -->
       <emu-clause id="sec-unary-plus-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UnaryExpression : `+` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UnaryExpression : `+` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Return ? ToNumber(? GetValue(_expr_)).
@@ -13006,7 +13006,7 @@
       <!-- es6num="12.5.10.1" -->
       <emu-clause id="sec-unary-minus-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UnaryExpression : `-` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
@@ -13023,7 +13023,7 @@
       <!-- es6num="12.5.11.1" -->
       <emu-clause id="sec-bitwise-not-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UnaryExpression : `~` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UnaryExpression : `~` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToInt32(? GetValue(_expr_)).
@@ -13039,7 +13039,7 @@
       <!-- es6num="12.5.12.1" -->
       <emu-clause id="sec-logical-not-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>UnaryExpression : `!` UnaryExpression</emu-grammar>
+        <emu-grammar use="reference">UnaryExpression : `!` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ToBoolean(? GetValue(_expr_)).
@@ -13054,7 +13054,7 @@
     <h1>Exponentiation Operator</h1>
     <h2>Syntax</h2>
 
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ExponentiationExpression[Yield, Await] :
         UnaryExpression[?Yield, ?Await]
         UpdateExpression[?Yield, ?Await] `**` ExponentiationExpression[?Yield, ?Await]
@@ -13063,7 +13063,7 @@
     <emu-clause id="sec-exp-operator-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         ExponentiationExpression :
           UpdateExpression `**` ExponentiationExpression
       </emu-grammar>
@@ -13075,7 +13075,7 @@
     <emu-clause id="sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         ExponentiationExpression :
           UpdateExpression `**` ExponentiationExpression
       </emu-grammar>
@@ -13086,7 +13086,7 @@
 
     <emu-clause id="sec-exp-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         ExponentiationExpression : UpdateExpression `**` ExponentiationExpression
       </emu-grammar>
       <emu-alg>
@@ -13140,7 +13140,7 @@
   <emu-clause id="sec-multiplicative-operators">
     <h1>Multiplicative Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       MultiplicativeExpression[Yield, Await] :
         ExponentiationExpression[?Yield, ?Await]
         MultiplicativeExpression[?Yield, ?Await] MultiplicativeOperator ExponentiationExpression[?Yield, ?Await]
@@ -13153,7 +13153,7 @@
     <emu-clause id="sec-multiplicative-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
+      <emu-grammar use="reference">MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -13163,7 +13163,7 @@
     <emu-clause id="sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
+      <emu-grammar use="reference">MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -13172,7 +13172,7 @@
     <!-- es6num="12.6.3" -->
     <emu-clause id="sec-multiplicative-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
+      <emu-grammar use="reference">MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
         1. Let _left_ be the result of evaluating |MultiplicativeExpression|.
         1. Let _leftValue_ be ? GetValue(_left_).
@@ -13282,7 +13282,7 @@
   <emu-clause id="sec-additive-operators">
     <h1>Additive Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       AdditiveExpression[Yield, Await] :
         MultiplicativeExpression[?Yield, ?Await]
         AdditiveExpression[?Yield, ?Await] `+` MultiplicativeExpression[?Yield, ?Await]
@@ -13293,7 +13293,7 @@
     <emu-clause id="sec-additive-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AdditiveExpression :
           AdditiveExpression `+` MultiplicativeExpression
           AdditiveExpression `-` MultiplicativeExpression
@@ -13307,7 +13307,7 @@
     <emu-clause id="sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AdditiveExpression :
           AdditiveExpression `+` MultiplicativeExpression
           AdditiveExpression `-` MultiplicativeExpression
@@ -13327,7 +13327,7 @@
       <!-- es6num="12.7.3.1" -->
       <emu-clause id="sec-addition-operator-plus-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>AdditiveExpression : AdditiveExpression `+` MultiplicativeExpression</emu-grammar>
+        <emu-grammar use="reference">AdditiveExpression : AdditiveExpression `+` MultiplicativeExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |AdditiveExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13359,7 +13359,7 @@
       <!-- es6num="12.7.4.1" -->
       <emu-clause id="sec-subtraction-operator-minus-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>AdditiveExpression : AdditiveExpression `-` MultiplicativeExpression</emu-grammar>
+        <emu-grammar use="reference">AdditiveExpression : AdditiveExpression `-` MultiplicativeExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |AdditiveExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13414,7 +13414,7 @@
   <emu-clause id="sec-bitwise-shift-operators">
     <h1>Bitwise Shift Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ShiftExpression[Yield, Await] :
         AdditiveExpression[?Yield, ?Await]
         ShiftExpression[?Yield, ?Await] `&lt;&lt;` AdditiveExpression[?Yield, ?Await]
@@ -13426,7 +13426,7 @@
     <emu-clause id="sec-bitwise-shift-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         ShiftExpression :
           ShiftExpression `&lt;&lt;` AdditiveExpression
           ShiftExpression `&gt;&gt;` AdditiveExpression
@@ -13441,7 +13441,7 @@
     <emu-clause id="sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         ShiftExpression :
           ShiftExpression `&lt;&lt;` AdditiveExpression
           ShiftExpression `&gt;&gt;` AdditiveExpression
@@ -13462,7 +13462,7 @@
       <!-- es6num="12.8.3.1" -->
       <emu-clause id="sec-left-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>ShiftExpression : ShiftExpression `&lt;&lt;` AdditiveExpression</emu-grammar>
+        <emu-grammar use="reference">ShiftExpression : ShiftExpression `&lt;&lt;` AdditiveExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |ShiftExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13486,7 +13486,7 @@
       <!-- es6num="12.8.4.1" -->
       <emu-clause id="sec-signed-right-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;` AdditiveExpression</emu-grammar>
+        <emu-grammar use="reference">ShiftExpression : ShiftExpression `&gt;&gt;` AdditiveExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |ShiftExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13510,7 +13510,7 @@
       <!-- es6num="12.8.5.1" -->
       <emu-clause id="sec-unsigned-right-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;&gt;` AdditiveExpression</emu-grammar>
+        <emu-grammar use="reference">ShiftExpression : ShiftExpression `&gt;&gt;&gt;` AdditiveExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |ShiftExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13532,7 +13532,7 @@
       <p>The result of evaluating a relational operator is always of type Boolean, reflecting whether the relationship named by the operator holds between its two operands.</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       RelationalExpression[In, Yield, Await] :
         ShiftExpression[?Yield, ?Await]
         RelationalExpression[?In, ?Yield, ?Await] `&lt;` ShiftExpression[?Yield, ?Await]
@@ -13550,7 +13550,7 @@
     <emu-clause id="sec-relational-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         RelationalExpression :
           RelationalExpression `&lt;` ShiftExpression
           RelationalExpression `&gt;` ShiftExpression
@@ -13568,7 +13568,7 @@
     <emu-clause id="sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         RelationalExpression :
           RelationalExpression `&lt;` ShiftExpression
           RelationalExpression `&gt;` ShiftExpression
@@ -13585,7 +13585,7 @@
     <!-- es6num="12.9.3" -->
     <emu-clause id="sec-relational-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
+      <emu-grammar use="reference">RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13595,7 +13595,7 @@
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
-      <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
+      <emu-grammar use="reference">RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13605,7 +13605,7 @@
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
-      <emu-grammar>RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
+      <emu-grammar use="reference">RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13615,7 +13615,7 @@
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
-      <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
+      <emu-grammar use="reference">RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13625,7 +13625,7 @@
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
-      <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
+      <emu-grammar use="reference">RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13633,7 +13633,7 @@
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return ? InstanceofOperator(_lval_, _rval_).
       </emu-alg>
-      <emu-grammar>RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
+      <emu-grammar use="reference">RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13669,7 +13669,7 @@
       <p>The result of evaluating an equality operator is always of type Boolean, reflecting whether the relationship named by the operator holds between its two operands.</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       EqualityExpression[In, Yield, Await] :
         RelationalExpression[?In, ?Yield, ?Await]
         EqualityExpression[?In, ?Yield, ?Await] `==` RelationalExpression[?In, ?Yield, ?Await]
@@ -13682,7 +13682,7 @@
     <emu-clause id="sec-equality-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         EqualityExpression :
           EqualityExpression `==` RelationalExpression
           EqualityExpression `!=` RelationalExpression
@@ -13698,7 +13698,7 @@
     <emu-clause id="sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         EqualityExpression :
           EqualityExpression `==` RelationalExpression
           EqualityExpression `!=` RelationalExpression
@@ -13713,7 +13713,7 @@
     <!-- es6num="12.10.3" -->
     <emu-clause id="sec-equality-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
+      <emu-grammar use="reference">EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13721,7 +13721,7 @@
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return the result of performing Abstract Equality Comparison _rval_ == _lval_.
       </emu-alg>
-      <emu-grammar>EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
+      <emu-grammar use="reference">EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13730,7 +13730,7 @@
         1. Let _r_ be the result of performing Abstract Equality Comparison _rval_ == _lval_.
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
-      <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
+      <emu-grammar use="reference">EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13738,7 +13738,7 @@
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return the result of performing Strict Equality Comparison _rval_ === _lval_.
       </emu-alg>
-      <emu-grammar>EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
+      <emu-grammar use="reference">EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13793,7 +13793,7 @@
   <emu-clause id="sec-binary-bitwise-operators">
     <h1>Binary Bitwise Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       BitwiseANDExpression[In, Yield, Await] :
         EqualityExpression[?In, ?Yield, ?Await]
         BitwiseANDExpression[?In, ?Yield, ?Await] `&amp;` EqualityExpression[?In, ?Yield, ?Await]
@@ -13811,7 +13811,7 @@
     <emu-clause id="sec-binary-bitwise-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
 
         BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression
@@ -13827,7 +13827,7 @@
     <emu-clause id="sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
 
         BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression
@@ -13842,7 +13842,7 @@
     <!-- es6num="12.11.3" -->
     <emu-clause id="sec-binary-bitwise-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <p>The production <emu-grammar>A : A @ B</emu-grammar>, where @ is one of the bitwise operators in the productions above, is evaluated as follows:</p>
+      <p>The production <emu-grammar use="example">A : A @ B</emu-grammar>, where @ is one of the bitwise operators in the productions above, is evaluated as follows:</p>
       <emu-alg>
         1. Let _lref_ be the result of evaluating _A_.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13859,7 +13859,7 @@
   <emu-clause id="sec-binary-logical-operators">
     <h1>Binary Logical Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       LogicalANDExpression[In, Yield, Await] :
         BitwiseORExpression[?In, ?Yield, ?Await]
         LogicalANDExpression[?In, ?Yield, ?Await] `&amp;&amp;` BitwiseORExpression[?In, ?Yield, ?Await]
@@ -13876,7 +13876,7 @@
     <emu-clause id="sec-binary-logical-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression
 
         LogicalORExpression : LogicalORExpression `||` LogicalANDExpression
@@ -13890,7 +13890,7 @@
     <emu-clause id="sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression
 
         LogicalORExpression : LogicalORExpression `||` LogicalANDExpression
@@ -13903,7 +13903,7 @@
     <!-- es6num="12.12.3" -->
     <emu-clause id="sec-binary-logical-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
+      <emu-grammar use="reference">LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalANDExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13912,7 +13912,7 @@
         1. Let _rref_ be the result of evaluating |BitwiseORExpression|.
         1. Return ? GetValue(_rref_).
       </emu-alg>
-      <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
+      <emu-grammar use="reference">LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalORExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13928,7 +13928,7 @@
   <emu-clause id="sec-conditional-operator">
     <h1>Conditional Operator ( `? :` )</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ConditionalExpression[In, Yield, Await] :
         LogicalORExpression[?In, ?Yield, ?Await]
         LogicalORExpression[?In, ?Yield, ?Await] `?` AssignmentExpression[+In, ?Yield, ?Await] `:` AssignmentExpression[?In, ?Yield, ?Await]
@@ -13941,7 +13941,7 @@
     <emu-clause id="sec-conditional-operator-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -13951,7 +13951,7 @@
     <emu-clause id="sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -13960,7 +13960,7 @@
     <!-- es6num="12.13.3" -->
     <emu-clause id="sec-conditional-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalORExpression|.
         1. Let _lval_ be ToBoolean(? GetValue(_lref_)).
@@ -13978,7 +13978,7 @@
   <emu-clause id="sec-assignment-operators">
     <h1>Assignment Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       AssignmentExpression[In, Yield, Await] :
         ConditionalExpression[?In, ?Yield, ?Await]
         [+Yield] YieldExpression[?In, ?Await]
@@ -13994,7 +13994,7 @@
     <!-- es6num="12.14.1" -->
     <emu-clause id="sec-assignment-operators-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and the lexical token sequence matched by |LeftHandSideExpression| cannot be parsed with no tokens left over using |AssignmentPattern| as the goal symbol.
@@ -14003,7 +14003,7 @@
           It is an early Reference Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
         </li>
       </ul>
-      <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <ul>
         <li>
           It is an early Reference Error if IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
@@ -14015,7 +14015,7 @@
     <emu-clause id="sec-assignment-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AssignmentExpression :
           ArrowFunction
           AsyncArrowFunction
@@ -14023,7 +14023,7 @@
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AssignmentExpression :
           YieldExpression
           LeftHandSideExpression `=` AssignmentExpression
@@ -14038,7 +14038,7 @@
     <emu-clause id="sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AssignmentExpression :
           YieldExpression
           ArrowFunction
@@ -14054,7 +14054,7 @@
     <!-- es6num="12.14.4" -->
     <emu-clause id="sec-assignment-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>AssignmentExpression[In, Yield, Await] : LeftHandSideExpression[?Yield, ?Await] `=` AssignmentExpression[?In, ?Yield, ?Await]</emu-grammar>
+      <emu-grammar use="reference">AssignmentExpression[In, Yield, Await] : LeftHandSideExpression[?Yield, ?Await] `=` AssignmentExpression[?In, ?Yield, ?Await]</emu-grammar>
       <emu-alg>
         1. If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
           1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
@@ -14072,7 +14072,7 @@
         1. Perform ? DestructuringAssignmentEvaluation of _assignmentPattern_ using _rval_ as the argument.
         1. Return _rval_.
       </emu-alg>
-      <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -14092,8 +14092,8 @@
     <emu-clause id="sec-destructuring-assignment">
       <h1>Destructuring Assignment</h1>
       <h2>Supplemental Syntax</h2>
-      <p>In certain circumstances when processing an instance of the production <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar> the following grammar is used to refine the interpretation of |LeftHandSideExpression|.</p>
-      <emu-grammar>
+      <p>In certain circumstances when processing an instance of the production <emu-grammar use="reference">AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar> the following grammar is used to refine the interpretation of |LeftHandSideExpression|.</p>
+      <emu-grammar use="definition">
         AssignmentPattern[Yield, Await] :
           ObjectAssignmentPattern[?Yield, ?Await]
           ArrayAssignmentPattern[?Yield, ?Await]
@@ -14136,13 +14136,13 @@
       <!-- es6num="12.14.5.1" -->
       <emu-clause id="sec-destructuring-assignment-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
+        <emu-grammar use="reference">AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if IsValidSimpleAssignmentTarget of |IdentifierReference| is *false*.
           </li>
         </ul>
-        <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
+        <emu-grammar use="reference">DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and if the lexical token sequence matched by |LeftHandSideExpression| cannot be parsed with no tokens left over using |AssignmentPattern| as the goal symbol.
@@ -14157,12 +14157,12 @@
       <emu-clause id="sec-runtime-semantics-destructuringassignmentevaluation">
         <h1>Runtime Semantics: DestructuringAssignmentEvaluation</h1>
         <p>With parameter _value_.</p>
-        <emu-grammar>ObjectAssignmentPattern : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ObjectAssignmentPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ObjectAssignmentPattern :
             `{` AssignmentPropertyList `}`
             `{` AssignmentPropertyList `,` `}`
@@ -14171,12 +14171,12 @@
           1. Perform ? RequireObjectCoercible(_value_).
           1. Return the result of performing DestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
         </emu-alg>
-        <emu-grammar>ArrayAssignmentPattern : `[` `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayAssignmentPattern : `[` `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Return ? IteratorClose(_iterator_, NormalCompletion(~empty~)).
         </emu-alg>
-        <emu-grammar>ArrayAssignmentPattern : `[` Elision `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayAssignmentPattern : `[` Elision `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -14184,7 +14184,7 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _result_).
           1. Return _result_.
         </emu-alg>
-        <emu-grammar>ArrayAssignmentPattern : `[` Elision? AssignmentRestElement `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayAssignmentPattern : `[` Elision? AssignmentRestElement `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -14196,7 +14196,7 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _result_).
           1. Return _result_.
         </emu-alg>
-        <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayAssignmentPattern : `[` AssignmentElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -14204,7 +14204,7 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _result_).
           1. Return _result_.
         </emu-alg>
-        <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `,` Elision? AssignmentRestElement? `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayAssignmentPattern : `[` AssignmentElementList `,` Elision? AssignmentRestElement? `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -14221,12 +14221,12 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _status_).
           1. Return Completion(_status_).
         </emu-alg>
-        <emu-grammar>AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
+        <emu-grammar use="reference">AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
         <emu-alg>
           1. Perform ? DestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
           1. Return the result of performing DestructuringAssignmentEvaluation for |AssignmentProperty| using _value_ as the argument.
         </emu-alg>
-        <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
+        <emu-grammar use="reference">AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
         <emu-alg>
           1. Let _P_ be StringValue of |IdentifierReference|.
           1. Let _lref_ be ? ResolveBinding(_P_).
@@ -14239,7 +14239,7 @@
               1. If _hasNameProperty_ is *false*, perform SetFunctionName(_v_, _P_).
           1. Return ? PutValue(_lref_, _v_).
         </emu-alg>
-        <emu-grammar>AssignmentProperty : PropertyName `:` AssignmentElement</emu-grammar>
+        <emu-grammar use="reference">AssignmentProperty : PropertyName `:` AssignmentElement</emu-grammar>
         <emu-alg>
           1. Let _name_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_name_).
@@ -14251,25 +14251,25 @@
       <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation">
         <h1>Runtime Semantics: IteratorDestructuringAssignmentEvaluation</h1>
         <p>With parameter _iteratorRecord_.</p>
-        <emu-grammar>AssignmentElementList : AssignmentElisionElement</emu-grammar>
+        <emu-grammar use="reference">AssignmentElementList : AssignmentElisionElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| using _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar>AssignmentElementList : AssignmentElementList `,` AssignmentElisionElement</emu-grammar>
+        <emu-grammar use="reference">AssignmentElementList : AssignmentElementList `,` AssignmentElisionElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| using _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| using _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar>AssignmentElisionElement : AssignmentElement</emu-grammar>
+        <emu-grammar use="reference">AssignmentElisionElement : AssignmentElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar>AssignmentElisionElement : Elision AssignmentElement</emu-grammar>
+        <emu-grammar use="reference">AssignmentElisionElement : Elision AssignmentElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar>Elision : `,`</emu-grammar>
+        <emu-grammar use="reference">Elision : `,`</emu-grammar>
         <emu-alg>
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be IteratorStep(_iteratorRecord_.[[Iterator]]).
@@ -14278,7 +14278,7 @@
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>Elision : Elision `,`</emu-grammar>
+        <emu-grammar use="reference">Elision : Elision `,`</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. If _iteratorRecord_.[[Done]] is *false*, then
@@ -14288,7 +14288,7 @@
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>AssignmentElement[Yield, Await] : DestructuringAssignmentTarget Initializer?</emu-grammar>
+        <emu-grammar use="reference">AssignmentElement[Yield, Await] : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
@@ -14318,7 +14318,7 @@
         <emu-note>
           <p>Left to right evaluation order is maintained by evaluating a |DestructuringAssignmentTarget| that is not a destructuring pattern prior to accessing the iterator or evaluating the |Initializer|.</p>
         </emu-note>
-        <emu-grammar>AssignmentRestElement[Yield, Await] : `...` DestructuringAssignmentTarget</emu-grammar>
+        <emu-grammar use="reference">AssignmentRestElement[Yield, Await] : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
@@ -14348,7 +14348,7 @@
       <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation">
         <h1>Runtime Semantics: KeyedDestructuringAssignmentEvaluation</h1>
         <p>With parameters _value_ and _propertyName_.</p>
-        <emu-grammar>AssignmentElement[Yield, Await] : DestructuringAssignmentTarget Initializer?</emu-grammar>
+        <emu-grammar use="reference">AssignmentElement[Yield, Await] : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
@@ -14374,7 +14374,7 @@
   <emu-clause id="sec-comma-operator">
     <h1>Comma Operator ( `,` )</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       Expression[In, Yield, Await] :
         AssignmentExpression[?In, ?Yield, ?Await]
         Expression[?In, ?Yield, ?Await] `,` AssignmentExpression[?In, ?Yield, ?Await]
@@ -14384,7 +14384,7 @@
     <emu-clause id="sec-comma-operator-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14394,7 +14394,7 @@
     <emu-clause id="sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14403,7 +14403,7 @@
     <!-- es6num="12.15.3" -->
     <emu-clause id="sec-comma-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |Expression|.
         1. Perform ? GetValue(_lref_).
@@ -14421,7 +14421,7 @@
 <emu-clause id="sec-ecmascript-language-statements-and-declarations">
   <h1>ECMAScript Language: Statements and Declarations</h1>
   <h2>Syntax</h2>
-  <emu-grammar definition>
+  <emu-grammar use="definition">
     Statement[Yield, Await, Return] :
       BlockStatement[?Yield, ?Await, ?Return]
       VariableStatement[?Yield, ?Await]
@@ -14462,7 +14462,7 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         Statement :
           VariableStatement
           EmptyStatement
@@ -14483,7 +14483,7 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         Statement :
           VariableStatement
           EmptyStatement
@@ -14503,7 +14503,7 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         Statement :
           VariableStatement
           EmptyStatement
@@ -14516,7 +14516,7 @@
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
+      <emu-grammar use="reference">BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
         1. Let _newIterationSet_ be a copy of _iterationSet_ with all the elements of _labelSet_ appended.
         1. Return ContainsUndefinedContinueTarget of |IterationStatement| with arguments _newIterationSet_ and &laquo; &raquo;.
@@ -14526,23 +14526,23 @@
     <!-- es6num="13.1.4" -->
     <emu-clause id="sec-static-semantics-declarationpart">
       <h1>Static Semantics: DeclarationPart</h1>
-      <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">HoistableDeclaration : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return |FunctionDeclaration|.
       </emu-alg>
-      <emu-grammar>HoistableDeclaration : GeneratorDeclaration</emu-grammar>
+      <emu-grammar use="reference">HoistableDeclaration : GeneratorDeclaration</emu-grammar>
       <emu-alg>
         1. Return |GeneratorDeclaration|.
       </emu-alg>
-      <emu-grammar>HoistableDeclaration : AsyncFunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">HoistableDeclaration : AsyncFunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return |AsyncFunctionDeclaration|.
       </emu-alg>
-      <emu-grammar>Declaration : ClassDeclaration</emu-grammar>
+      <emu-grammar use="reference">Declaration : ClassDeclaration</emu-grammar>
       <emu-alg>
         1. Return |ClassDeclaration|.
       </emu-alg>
-      <emu-grammar>Declaration : LexicalDeclaration</emu-grammar>
+      <emu-grammar use="reference">Declaration : LexicalDeclaration</emu-grammar>
       <emu-alg>
         1. Return |LexicalDeclaration|.
       </emu-alg>
@@ -14552,7 +14552,7 @@
     <emu-clause id="sec-statement-semantics-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         Statement :
           EmptyStatement
           ExpressionStatement
@@ -14571,7 +14571,7 @@
     <emu-clause id="sec-statement-semantics-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         Statement :
           EmptyStatement
           ExpressionStatement
@@ -14591,7 +14591,7 @@
       <h1>Runtime Semantics: LabelledEvaluation</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-      <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
+      <emu-grammar use="reference">BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
         1. Let _stmtResult_ be the result of performing LabelledEvaluation of |IterationStatement| with argument _labelSet_.
         1. If _stmtResult_.[[Type]] is ~break~, then
@@ -14600,7 +14600,7 @@
             1. Else, set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
         1. Return Completion(_stmtResult_).
       </emu-alg>
-      <emu-grammar>BreakableStatement : SwitchStatement</emu-grammar>
+      <emu-grammar use="reference">BreakableStatement : SwitchStatement</emu-grammar>
       <emu-alg>
         1. Let _stmtResult_ be the result of evaluating |SwitchStatement|.
         1. If _stmtResult_.[[Type]] is ~break~, then
@@ -14617,25 +14617,25 @@
     <!-- es6num="13.1.8" -->
     <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         HoistableDeclaration : GeneratorDeclaration
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         HoistableDeclaration : AsyncFunctionDeclaration
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         HoistableDeclaration : FunctionDeclaration
       </emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |FunctionDeclaration|.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         BreakableStatement :
           IterationStatement
           SwitchStatement
@@ -14651,7 +14651,7 @@
   <emu-clause id="sec-block">
     <h1>Block</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       BlockStatement[Yield, Await, Return] :
         Block[?Yield, ?Await, ?Return]
 
@@ -14670,7 +14670,7 @@
     <!-- es6num="13.2.1" -->
     <emu-clause id="sec-block-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` StatementList `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries.
@@ -14686,17 +14686,17 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |StatementListItem| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14707,17 +14707,17 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |StatementListItem| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14728,17 +14728,17 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |StatementListItem| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14748,22 +14748,22 @@
     <emu-clause id="sec-block-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names_ be LexicallyDeclaredNames of |StatementList|.
         1. Append to _names_ the elements of the LexicallyDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyDeclaredNames of |LabelledStatement|.
+        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return LexicallyDeclaredNames of |LabelledStatement|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |Declaration|.
       </emu-alg>
@@ -14773,18 +14773,18 @@
     <emu-clause id="sec-block-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be LexicallyScopedDeclarations of |StatementList|.
         1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyScopedDeclarations of |LabelledStatement|.
+        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return LexicallyScopedDeclarations of |LabelledStatement|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return a new List containing DeclarationPart of |Declaration|.
       </emu-alg>
@@ -14794,19 +14794,19 @@
     <emu-clause id="sec-block-static-semantics-toplevellexicallydeclarednames">
       <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
       <emu-see-also-para op="TopLevelLexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names_ be TopLevelLexicallyDeclaredNames of |StatementList|.
         1. Append to _names_ the elements of the TopLevelLexicallyDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
+        1. If |Declaration| is <emu-grammar use="reference">Declaration : HoistableDeclaration</emu-grammar> , then
           1. Return &laquo; &raquo;.
         1. Return the BoundNames of |Declaration|.
       </emu-alg>
@@ -14819,23 +14819,23 @@
     <emu-clause id="sec-block-static-semantics-toplevellexicallyscopeddeclarations">
       <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelLexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be TopLevelLexicallyScopedDeclarations of |StatementList|.
         1. Append to _declarations_ the elements of the TopLevelLexicallyScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
+        1. If |Declaration| is <emu-grammar use="reference">Declaration : HoistableDeclaration</emu-grammar> , then
           1. Return &laquo; &raquo;.
         1. Return a new List containing |Declaration|.
       </emu-alg>
@@ -14845,25 +14845,25 @@
     <emu-clause id="sec-block-static-semantics-toplevelvardeclarednames">
       <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
       <emu-see-also-para op="TopLevelVarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names_ be TopLevelVarDeclaredNames of |StatementList|.
         1. Append to _names_ the elements of the TopLevelVarDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
+        1. If |Declaration| is <emu-grammar use="reference">Declaration : HoistableDeclaration</emu-grammar> , then
           1. Return the BoundNames of |HoistableDeclaration|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
+        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
         1. Return VarDeclaredNames of |Statement|.
       </emu-alg>
       <emu-note>
@@ -14875,24 +14875,24 @@
     <emu-clause id="sec-block-static-semantics-toplevelvarscopeddeclarations">
       <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelVarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be TopLevelVarScopedDeclarations of |StatementList|.
         1. Append to _declarations_ the elements of the TopLevelVarScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
+        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
         1. Return VarScopedDeclarations of |Statement|.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
+        1. If |Declaration| is <emu-grammar use="reference">Declaration : HoistableDeclaration</emu-grammar> , then
           1. Let _declaration_ be DeclarationPart of |HoistableDeclaration|.
           1. Return &laquo; _declaration_ &raquo;.
         1. Return a new empty List.
@@ -14903,17 +14903,17 @@
     <emu-clause id="sec-block-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |StatementList|.
         1. Append to _names_ the elements of the VarDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -14923,17 +14923,17 @@
     <emu-clause id="sec-block-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |StatementList|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -14942,11 +14942,11 @@
     <!-- es6num="13.2.13" -->
     <emu-clause id="sec-block-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
+      <emu-grammar use="reference">Block : `{` StatementList `}`</emu-grammar>
       <emu-alg>
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -14959,7 +14959,7 @@
       <emu-note>
         <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
       </emu-note>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _sl_ be the result of evaluating |StatementList|.
         1. ReturnIfAbrupt(_sl_).
@@ -15017,7 +15017,7 @@
         <p>`let` and `const` declarations define variables that are scoped to the running execution context's LexicalEnvironment. The variables are created when their containing Lexical Environment is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         LexicalDeclaration[In, Yield, Await] :
           LetOrConst BindingList[?In, ?Yield, ?Await] `;`
 
@@ -15037,7 +15037,7 @@
       <!-- es6num="13.3.1.1" -->
       <emu-clause id="sec-let-and-const-declarations-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+        <emu-grammar use="reference">LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the BoundNames of |BindingList| contains `"let"`.
@@ -15046,7 +15046,7 @@
             It is a Syntax Error if the BoundNames of |BindingList| contains any duplicate entries.
           </li>
         </ul>
-        <emu-grammar>LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar use="reference">LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if |Initializer| is not present and IsConstantDeclaration of the |LexicalDeclaration| containing this |LexicalBinding| is *true*.
@@ -15058,21 +15058,21 @@
       <emu-clause id="sec-let-and-const-declarations-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+        <emu-grammar use="reference">LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingList|.
         </emu-alg>
-        <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
+        <emu-grammar use="reference">BindingList : BindingList `,` LexicalBinding</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |BindingList|.
           1. Append to _names_ the elements of the BoundNames of |LexicalBinding|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar use="reference">LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingIdentifier|.
         </emu-alg>
-        <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
+        <emu-grammar use="reference">LexicalBinding : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingPattern|.
         </emu-alg>
@@ -15082,15 +15082,15 @@
       <emu-clause id="sec-let-and-const-declarations-static-semantics-isconstantdeclaration">
         <h1>Static Semantics: IsConstantDeclaration</h1>
         <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+        <emu-grammar use="reference">LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
           1. Return IsConstantDeclaration of |LetOrConst|.
         </emu-alg>
-        <emu-grammar>LetOrConst : `let`</emu-grammar>
+        <emu-grammar use="reference">LetOrConst : `let`</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>LetOrConst : `const`</emu-grammar>
+        <emu-grammar use="reference">LetOrConst : `const`</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -15099,19 +15099,19 @@
       <!-- es6num="13.3.1.4" -->
       <emu-clause id="sec-let-and-const-declarations-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+        <emu-grammar use="reference">LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
           1. Let _next_ be the result of evaluating |BindingList|.
           1. ReturnIfAbrupt(_next_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
+        <emu-grammar use="reference">BindingList : BindingList `,` LexicalBinding</emu-grammar>
         <emu-alg>
           1. Let _next_ be the result of evaluating |BindingList|.
           1. ReturnIfAbrupt(_next_).
           1. Return the result of evaluating |LexicalBinding|.
         </emu-alg>
-        <emu-grammar>LexicalBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">LexicalBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ResolveBinding(StringValue of |BindingIdentifier|).
           1. Return InitializeReferencedBinding(_lhs_, *undefined*).
@@ -15119,7 +15119,7 @@
         <emu-note>
           <p>A static semantics rule ensures that this form of |LexicalBinding| never occurs in a `const` declaration.</p>
         </emu-note>
-        <emu-grammar>LexicalBinding : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar use="reference">LexicalBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ResolveBinding(_bindingId_).
@@ -15130,7 +15130,7 @@
             1. If _hasNameProperty_ is *false*, perform SetFunctionName(_value_, _bindingId_).
           1. Return InitializeReferencedBinding(_lhs_, _value_).
         </emu-alg>
-        <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
+        <emu-grammar use="reference">LexicalBinding : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
@@ -15147,7 +15147,7 @@
         <p>A `var` statement declares variables that are scoped to the running execution context's VariableEnvironment. Var variables are created when their containing Lexical Environment is instantiated and are initialized to *undefined* when created. Within the scope of any VariableEnvironment a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         VariableStatement[Yield, Await] :
           `var` VariableDeclarationList[+In, ?Yield, ?Await] `;`
 
@@ -15164,17 +15164,17 @@
       <emu-clause id="sec-variable-statement-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
+        <emu-grammar use="reference">VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |VariableDeclarationList|.
           1. Append to _names_ the elements of BoundNames of |VariableDeclaration|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>VariableDeclaration : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar use="reference">VariableDeclaration : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingIdentifier|.
         </emu-alg>
-        <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
+        <emu-grammar use="reference">VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingPattern|.
         </emu-alg>
@@ -15184,7 +15184,7 @@
       <emu-clause id="sec-variable-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
+        <emu-grammar use="reference">VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
         <emu-alg>
           1. Return BoundNames of |VariableDeclarationList|.
         </emu-alg>
@@ -15194,11 +15194,11 @@
       <emu-clause id="sec-variable-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>VariableDeclarationList : VariableDeclaration</emu-grammar>
+        <emu-grammar use="reference">VariableDeclarationList : VariableDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new List containing |VariableDeclaration|.
         </emu-alg>
-        <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
+        <emu-grammar use="reference">VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
           1. Append |VariableDeclaration| to _declarations_.
@@ -15209,23 +15209,23 @@
       <!-- es6num="13.3.2.4" -->
       <emu-clause id="sec-variable-statement-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
+        <emu-grammar use="reference">VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
         <emu-alg>
           1. Let _next_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_next_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
+        <emu-grammar use="reference">VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _next_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_next_).
           1. Return the result of evaluating |VariableDeclaration|.
         </emu-alg>
-        <emu-grammar>VariableDeclaration : BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">VariableDeclaration : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>VariableDeclaration : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar use="reference">VariableDeclaration : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_).
@@ -15239,7 +15239,7 @@
         <emu-note>
           <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's object Environment Record, then step 6 will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
         </emu-note>
-        <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
+        <emu-grammar use="reference">VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _rval_ be ? GetValue(_rhs_).
@@ -15252,7 +15252,7 @@
     <emu-clause id="sec-destructuring-binding-patterns">
       <h1>Destructuring Binding Patterns</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         BindingPattern[Yield, Await] :
           ObjectBindingPattern[?Yield, ?Await]
           ArrayBindingPattern[?Yield, ?Await]
@@ -15298,53 +15298,53 @@
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ObjectBindingPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingRestElement|.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingElementList|.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |BindingElementList|.
           1. Append to _names_ the elements of BoundNames of |BindingRestElement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
+        <emu-grammar use="reference">BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |BindingPropertyList|.
           1. Append to _names_ the elements of BoundNames of |BindingProperty|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+        <emu-grammar use="reference">BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |BindingElementList|.
           1. Append to _names_ the elements of BoundNames of |BindingElisionElement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
+        <emu-grammar use="reference">BindingElisionElement : Elision? BindingElement</emu-grammar>
         <emu-alg>
           1. Return BoundNames of |BindingElement|.
         </emu-alg>
-        <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
+        <emu-grammar use="reference">BindingProperty : PropertyName `:` BindingElement</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingElement|.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingIdentifier|.
         </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
+        <emu-grammar use="reference">BindingElement : BindingPattern Initializer?</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingPattern|.
         </emu-alg>
@@ -15354,67 +15354,67 @@
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-containsexpression">
         <h1>Static Semantics: ContainsExpression</h1>
         <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-        <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ObjectBindingPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Return ContainsExpression of |BindingRestElement|.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Return ContainsExpression of |BindingElementList|.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Let _has_ be ContainsExpression of |BindingElementList|.
           1. If _has_ is *true*, return *true*.
           1. Return ContainsExpression of |BindingRestElement|.
         </emu-alg>
-        <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
+        <emu-grammar use="reference">BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
           1. Let _has_ be ContainsExpression of |BindingPropertyList|.
           1. If _has_ is *true*, return *true*.
           1. Return ContainsExpression of |BindingProperty|.
         </emu-alg>
-        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+        <emu-grammar use="reference">BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
         <emu-alg>
           1. Let _has_ be ContainsExpression of |BindingElementList|.
           1. If _has_ is *true*, return *true*.
           1. Return ContainsExpression of |BindingElisionElement|.
         </emu-alg>
-        <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
+        <emu-grammar use="reference">BindingElisionElement : Elision? BindingElement</emu-grammar>
         <emu-alg>
           1. Return ContainsExpression of |BindingElement|.
         </emu-alg>
-        <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
+        <emu-grammar use="reference">BindingProperty : PropertyName `:` BindingElement</emu-grammar>
         <emu-alg>
           1. Let _has_ be IsComputedPropertyKey of |PropertyName|.
           1. If _has_ is *true*, return *true*.
           1. Return ContainsExpression of |BindingElement|.
         </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
+        <emu-grammar use="reference">BindingElement : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">BindingRestElement : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
+        <emu-grammar use="reference">BindingRestElement : `...` BindingPattern</emu-grammar>
         <emu-alg>
           1. Return ContainsExpression of |BindingPattern|.
         </emu-alg>
@@ -15424,19 +15424,19 @@
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-hasinitializer">
         <h1>Static Semantics: HasInitializer</h1>
         <emu-see-also-para op="HasInitializer"></emu-see-also-para>
-        <emu-grammar>BindingElement : BindingPattern</emu-grammar>
+        <emu-grammar use="reference">BindingElement : BindingPattern</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
+        <emu-grammar use="reference">BindingElement : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -15446,19 +15446,19 @@
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-issimpleparameterlist">
         <h1>Static Semantics: IsSimpleParameterList</h1>
         <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-        <emu-grammar>BindingElement : BindingPattern</emu-grammar>
+        <emu-grammar use="reference">BindingElement : BindingPattern</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
+        <emu-grammar use="reference">BindingElement : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
@@ -15472,12 +15472,12 @@
         <emu-note>
           <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
         </emu-note>
-        <emu-grammar>BindingPattern : ObjectBindingPattern</emu-grammar>
+        <emu-grammar use="reference">BindingPattern : ObjectBindingPattern</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
           1. Return the result of performing BindingInitialization for |ObjectBindingPattern| using _value_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
+        <emu-grammar use="reference">BindingPattern : ArrayBindingPattern</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -15485,21 +15485,21 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _result_).
           1. Return _result_.
         </emu-alg>
-        <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ObjectBindingPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
+        <emu-grammar use="reference">BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
           1. Perform ? BindingInitialization for |BindingPropertyList| using _value_ and _environment_ as arguments.
           1. Return the result of performing BindingInitialization for |BindingProperty| using _value_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>BindingProperty : SingleNameBinding</emu-grammar>
+        <emu-grammar use="reference">BindingProperty : SingleNameBinding</emu-grammar>
         <emu-alg>
           1. Let _name_ be the string that is the only element of BoundNames of |SingleNameBinding|.
           1. Return the result of performing KeyedBindingInitialization for |SingleNameBinding| using _value_, _environment_, and _name_ as the arguments.
         </emu-alg>
-        <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
+        <emu-grammar use="reference">BindingProperty : PropertyName `:` BindingElement</emu-grammar>
         <emu-alg>
           1. Let _P_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_P_).
@@ -15515,63 +15515,63 @@
         <emu-note>
           <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
         </emu-note>
-        <emu-grammar>ArrayBindingPattern : `[` `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` `]`</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision `]`</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. If |Elision| is present, then
             1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `]`</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` `]`</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
           1. If |Elision| is present, then
             1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>BindingElementList : BindingElisionElement</emu-grammar>
+        <emu-grammar use="reference">BindingElementList : BindingElisionElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization for |BindingElisionElement| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+        <emu-grammar use="reference">BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
           1. Return the result of performing IteratorBindingInitialization for |BindingElisionElement| using _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>BindingElisionElement : BindingElement</emu-grammar>
+        <emu-grammar use="reference">BindingElisionElement : BindingElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization of |BindingElement| with _iteratorRecord_ and _environment_ as the arguments.
         </emu-alg>
-        <emu-grammar>BindingElisionElement : Elision BindingElement</emu-grammar>
+        <emu-grammar use="reference">BindingElisionElement : Elision BindingElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorBindingInitialization of |BindingElement| with _iteratorRecord_ and _environment_ as the arguments.
         </emu-alg>
-        <emu-grammar>BindingElement : SingleNameBinding</emu-grammar>
+        <emu-grammar use="reference">BindingElement : SingleNameBinding</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization for |SingleNameBinding| with _iteratorRecord_ and _environment_ as the arguments.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
@@ -15594,7 +15594,7 @@
           1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
           1. Return InitializeReferencedBinding(_lhs_, _v_).
         </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
+        <emu-grammar use="reference">BindingElement : BindingPattern Initializer?</emu-grammar>
         <emu-alg>
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be IteratorStep(_iteratorRecord_.[[Iterator]]).
@@ -15611,7 +15611,7 @@
             1. Set _v_ to ? GetValue(_defaultValue_).
           1. Return the result of performing BindingInitialization of |BindingPattern| with _v_ and _environment_ as the arguments.
         </emu-alg>
-        <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">BindingRestElement : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
           1. Let _A_ be ! ArrayCreate(0).
@@ -15632,7 +15632,7 @@
             1. Assert: _status_ is *true*.
             1. Increment _n_ by 1.
         </emu-alg>
-        <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
+        <emu-grammar use="reference">BindingRestElement : `...` BindingPattern</emu-grammar>
         <emu-alg>
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
@@ -15660,7 +15660,7 @@
         <emu-note>
           <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
         </emu-note>
-        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
+        <emu-grammar use="reference">BindingElement : BindingPattern Initializer?</emu-grammar>
         <emu-alg>
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
@@ -15668,7 +15668,7 @@
             1. Set _v_ to ? GetValue(_defaultValue_).
           1. Return the result of performing BindingInitialization for |BindingPattern| passing _v_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
@@ -15690,7 +15690,7 @@
   <emu-clause id="sec-empty-statement">
     <h1>Empty Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       EmptyStatement :
         `;`
     </emu-grammar>
@@ -15698,7 +15698,7 @@
     <!-- es6num="13.4.1" -->
     <emu-clause id="sec-empty-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>EmptyStatement : `;`</emu-grammar>
+      <emu-grammar use="reference">EmptyStatement : `;`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
@@ -15709,7 +15709,7 @@
   <emu-clause id="sec-expression-statement">
     <h1>Expression Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ExpressionStatement[Yield, Await] :
         [lookahead &lt;! {`{`, `function`, `async` [no |LineTerminator| here] `function`, `class`, `let [`}] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
@@ -15720,7 +15720,7 @@
     <!-- es6num="13.5.1" -->
     <emu-clause id="sec-expression-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ExpressionStatement : Expression `;`</emu-grammar>
+      <emu-grammar use="reference">ExpressionStatement : Expression `;`</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Return ? GetValue(_exprRef_).
@@ -15732,7 +15732,7 @@
   <emu-clause id="sec-if-statement">
     <h1>The `if` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       IfStatement[Yield, Await, Return] :
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` Statement[?Yield, ?Await, ?Return]
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -15742,7 +15742,7 @@
     <!-- es6num="13.6.1" -->
     <emu-clause id="sec-if-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         IfStatement :
           `if` `(` Expression `)` Statement `else` Statement
           `if` `(` Expression `)` Statement
@@ -15762,13 +15762,13 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicate_ be ContainsDuplicateLabels of the first |Statement| with argument _labelSet_.
         1. If _hasDuplicate_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of the second |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -15779,13 +15779,13 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |Statement| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of the second |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -15796,13 +15796,13 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of the second |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -15812,13 +15812,13 @@
     <emu-clause id="sec-if-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of the first |Statement|.
         1. Append to _names_ the elements of the VarDeclaredNames of the second |Statement|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
@@ -15828,13 +15828,13 @@
     <emu-clause id="sec-if-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of the first |Statement|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of the second |Statement|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
@@ -15843,7 +15843,7 @@
     <!-- es6num="13.6.7" -->
     <emu-clause id="sec-if-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
@@ -15853,7 +15853,7 @@
           1. Let _stmtCompletion_ be the result of evaluating the second |Statement|.
         1. Return Completion(UpdateEmpty(_stmtCompletion_, *undefined*)).
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
@@ -15870,7 +15870,7 @@
   <emu-clause id="sec-iteration-statements">
     <h1>Iteration Statements</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       IterationStatement[Yield, Await, Return] :
         `do` Statement[?Yield, ?Await, ?Return] `while` `(` Expression[+In, ?Yield, ?Await] `)` `;`
         `while` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -15902,7 +15902,7 @@
       <!-- es6num="13.7.1.1" -->
       <emu-clause id="sec-semantics-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `do` Statement `while` `(` Expression `)` `;`
             `while` `(` Expression `)` Statement
@@ -15952,7 +15952,7 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
         </emu-alg>
@@ -15963,7 +15963,7 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
         </emu-alg>
@@ -15974,7 +15974,7 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
@@ -15984,7 +15984,7 @@
       <emu-clause id="sec-do-while-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -15994,7 +15994,7 @@
       <emu-clause id="sec-do-while-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16005,7 +16005,7 @@
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
@@ -16028,7 +16028,7 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
         </emu-alg>
@@ -16039,7 +16039,7 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
         </emu-alg>
@@ -16050,7 +16050,7 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
@@ -16060,7 +16060,7 @@
       <emu-clause id="sec-while-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -16070,7 +16070,7 @@
       <emu-clause id="sec-while-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16081,7 +16081,7 @@
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
@@ -16102,7 +16102,7 @@
       <!-- es6num="13.7.4.1" -->
       <emu-clause id="sec-for-statement-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if any element of the BoundNames of |LexicalDeclaration| also occurs in the VarDeclaredNames of |Statement|.
@@ -16115,7 +16115,7 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
             `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
@@ -16131,7 +16131,7 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
             `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
@@ -16147,7 +16147,7 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
             `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
@@ -16162,17 +16162,17 @@
       <emu-clause id="sec-for-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |VariableDeclarationList|.
           1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -16182,17 +16182,17 @@
       <emu-clause id="sec-for-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16203,20 +16203,20 @@
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. If the first |Expression| is present, then
             1. Let _exprRef_ be the result of evaluating the first |Expression|.
             1. Perform ? GetValue(_exprRef_).
           1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _varDcl_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_varDcl_).
           1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -16291,7 +16291,7 @@
       <!-- es6num="13.7.5.1" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
@@ -16307,13 +16307,13 @@
             It is a Syntax Error if IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
           </li>
           <li>
-            It is a Syntax Error if the |LeftHandSideExpression| is <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar> and |Expression| derives a phrase that would produce a Syntax Error according to these rules if that phrase were substituted for |LeftHandSideExpression|. This rule is recursively applied.
+            It is a Syntax Error if the |LeftHandSideExpression| is <emu-grammar use="reference">CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar> and |Expression| derives a phrase that would produce a Syntax Error according to these rules if that phrase were substituted for |LeftHandSideExpression|. This rule is recursively applied.
           </li>
         </ul>
         <emu-note>
           <p>The last rule means that the other rules are applied even if parentheses surround |Expression|.</p>
         </emu-note>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `for` `(` ForDeclaration `in` Expression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
@@ -16335,7 +16335,7 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
+        <emu-grammar use="reference">ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |ForBinding|.
         </emu-alg>
@@ -16346,7 +16346,7 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` `var` ForBinding `in` Expression `)` Statement
@@ -16368,7 +16368,7 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` `var` ForBinding `in` Expression `)` Statement
@@ -16390,7 +16390,7 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` `var` ForBinding `in` Expression `)` Statement
@@ -16411,15 +16411,15 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-isdestructuring">
         <h1>Static Semantics: IsDestructuring</h1>
         <emu-see-also-para op="IsDestructuring"></emu-see-also-para>
-        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
+        <emu-grammar use="reference">ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Return IsDestructuring of |ForBinding|.
         </emu-alg>
-        <emu-grammar>ForBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">ForBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>ForBinding : BindingPattern</emu-grammar>
+        <emu-grammar use="reference">ForBinding : BindingPattern</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -16432,31 +16432,31 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ForBinding|.
           1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ForBinding|.
           1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -16469,31 +16469,31 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be a List containing |ForBinding|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be a List containing |ForBinding|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16510,7 +16510,7 @@
         <emu-note>
           <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and the formal parameter lists of some non-strict functions (see <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
         </emu-note>
-        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
+        <emu-grammar use="reference">ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Return the result of performing BindingInitialization for |ForBinding| passing _value_ and _environment_ as the arguments.
         </emu-alg>
@@ -16520,7 +16520,7 @@
       <emu-clause id="sec-runtime-semantics-bindinginstantiation">
         <h1>Runtime Semantics: BindingInstantiation</h1>
         <p>With parameter _environment_.</p>
-        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
+        <emu-grammar use="reference">ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Let _envRec_ be _environment_'s EnvironmentRecord.
           1. Assert: _envRec_ is a declarative Environment Record.
@@ -16537,32 +16537,32 @@
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
           1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~enumerate~, ~assignment~, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~enumerate~, ~varBinding~, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |Expression|, ~enumerate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~enumerate~, ~lexicalBinding~, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
@@ -16666,7 +16666,7 @@
       <!-- es6num="13.7.5.14" -->
       <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>ForBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar use="reference">ForBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Return ? ResolveBinding(_bindingId_).
@@ -16712,7 +16712,7 @@
   <emu-clause id="sec-continue-statement">
     <h1>The `continue` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ContinueStatement[Yield, Await] :
         `continue` `;`
         `continue` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
@@ -16721,7 +16721,7 @@
     <!-- es6num="13.8.1" -->
     <emu-clause id="sec-continue-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         ContinueStatement : `continue` `;`
 
         ContinueStatement : `continue` LabelIdentifier `;`
@@ -16738,11 +16738,11 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
+      <emu-grammar use="reference">ContinueStatement : `continue` `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
+      <emu-grammar use="reference">ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. If the StringValue of |LabelIdentifier| is not an element of _iterationSet_, return *true*.
         1. Return *false*.
@@ -16752,11 +16752,11 @@
     <!-- es6num="13.8.3" -->
     <emu-clause id="sec-continue-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
+      <emu-grammar use="reference">ContinueStatement : `continue` `;`</emu-grammar>
       <emu-alg>
         1. Return Completion{[[Type]]: ~continue~, [[Value]]: ~empty~, [[Target]]: ~empty~}.
       </emu-alg>
-      <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
+      <emu-grammar use="reference">ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Return Completion{[[Type]]: ~continue~, [[Value]]: ~empty~, [[Target]]: _label_ }.
@@ -16768,7 +16768,7 @@
   <emu-clause id="sec-break-statement">
     <h1>The `break` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       BreakStatement[Yield, Await] :
         `break` `;`
         `break` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
@@ -16777,7 +16777,7 @@
     <!-- es6num="13.9.1" -->
     <emu-clause id="sec-break-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
+      <emu-grammar use="reference">BreakStatement : `break` `;`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if this |BreakStatement| is not nested, directly or indirectly (but not crossing function boundaries), within an |IterationStatement| or a |SwitchStatement|.
@@ -16790,11 +16790,11 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
+      <emu-grammar use="reference">BreakStatement : `break` `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
+      <emu-grammar use="reference">BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. If the StringValue of |LabelIdentifier| is not an element of _labelSet_, return *true*.
         1. Return *false*.
@@ -16804,11 +16804,11 @@
     <!-- es6num="13.9.3" -->
     <emu-clause id="sec-break-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
+      <emu-grammar use="reference">BreakStatement : `break` `;`</emu-grammar>
       <emu-alg>
         1. Return Completion{[[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~}.
       </emu-alg>
-      <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
+      <emu-grammar use="reference">BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Return Completion{[[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: _label_ }.
@@ -16820,7 +16820,7 @@
   <emu-clause id="sec-return-statement">
     <h1>The `return` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ReturnStatement[Yield, Await] :
         `return` `;`
         `return` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
@@ -16832,11 +16832,11 @@
     <!-- es6num="13.10.1" -->
     <emu-clause id="sec-return-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ReturnStatement : `return` `;`</emu-grammar>
+      <emu-grammar use="reference">ReturnStatement : `return` `;`</emu-grammar>
       <emu-alg>
         1. Return Completion{[[Type]]: ~return~, [[Value]]: *undefined*, [[Target]]: ~empty~}.
       </emu-alg>
-      <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
+      <emu-grammar use="reference">ReturnStatement : `return` Expression `;`</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
@@ -16849,7 +16849,7 @@
   <emu-clause id="sec-with-statement">
     <h1>The `with` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       WithStatement[Yield, Await, Return] :
         `with` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     </emu-grammar>
@@ -16860,7 +16860,7 @@
     <!-- es6num="13.11.1" -->
     <emu-clause id="sec-with-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the code that matches this production is contained in strict mode code.
@@ -16879,7 +16879,7 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -16890,7 +16890,7 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -16901,7 +16901,7 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -16911,7 +16911,7 @@
     <emu-clause id="sec-with-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
@@ -16921,7 +16921,7 @@
     <emu-clause id="sec-with-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
@@ -16930,7 +16930,7 @@
     <!-- es6num="13.11.7" -->
     <emu-clause id="sec-with-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _val_ be the result of evaluating |Expression|.
         1. Let _obj_ be ? ToObject(? GetValue(_val_)).
@@ -16952,7 +16952,7 @@
   <emu-clause id="sec-switch-statement">
     <h1>The `switch` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       SwitchStatement[Yield, Await, Return] :
         `switch` `(` Expression[+In, ?Yield, ?Await] `)` CaseBlock[?Yield, ?Await, ?Return]
 
@@ -16974,7 +16974,7 @@
     <!-- es6num="13.12.1" -->
     <emu-clause id="sec-switch-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries.
@@ -16990,15 +16990,15 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |CaseBlock| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
           1. Let _hasDuplicates_ be ContainsDuplicateLabels of the first |CaseClauses| with argument _labelSet_.
@@ -17008,18 +17008,18 @@
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsDuplicateLabels of the second |CaseClauses| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |CaseClauses| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |CaseClause| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
         1. Return *false*.
@@ -17031,15 +17031,15 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |CaseBlock| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
           1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |CaseClauses| with argument _labelSet_.
@@ -17049,18 +17049,18 @@
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsUndefinedBreakTarget of the second |CaseClauses| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |CaseClauses| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |CaseClause| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
         1. Return *false*.
@@ -17072,15 +17072,15 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |CaseBlock| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
           1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
@@ -17090,18 +17090,18 @@
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsUndefinedContinueTarget of the second |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |CaseClause| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
         1. Return *false*.
@@ -17112,11 +17112,11 @@
     <emu-clause id="sec-switch-statement-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, let _names_ be the LexicallyDeclaredNames of the first |CaseClauses|.
         1. Else, let _names_ be a new empty List.
@@ -17124,18 +17124,18 @@
         1. If the second |CaseClauses| is not present, return _names_.
         1. Return the result of appending to _names_ the elements of the LexicallyDeclaredNames of the second |CaseClauses|.
       </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _names_ be LexicallyDeclaredNames of |CaseClauses|.
         1. Append to _names_ the elements of the LexicallyDeclaredNames of |CaseClause|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
         1. Return a new empty List.
@@ -17146,11 +17146,11 @@
     <emu-clause id="sec-switch-statement-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, let _declarations_ be the LexicallyScopedDeclarations of the first |CaseClauses|.
         1. Else, let _declarations_ be a new empty List.
@@ -17158,18 +17158,18 @@
         1. If the second |CaseClauses| is not present, return _declarations_.
         1. Return the result of appending to _declarations_ the elements of the LexicallyScopedDeclarations of the second |CaseClauses|.
       </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be LexicallyScopedDeclarations of |CaseClauses|.
         1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |CaseClause|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
         1. Return a new empty List.
@@ -17180,15 +17180,15 @@
     <emu-clause id="sec-switch-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |CaseBlock|.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, let _names_ be the VarDeclaredNames of the first |CaseClauses|.
         1. Else, let _names_ be a new empty List.
@@ -17196,18 +17196,18 @@
         1. If the second |CaseClauses| is not present, return _names_.
         1. Return the result of appending to _names_ the elements of the VarDeclaredNames of the second |CaseClauses|.
       </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |CaseClauses|.
         1. Append to _names_ the elements of the VarDeclaredNames of |CaseClause|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
         1. Return a new empty List.
@@ -17218,15 +17218,15 @@
     <emu-clause id="sec-switch-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |CaseBlock|.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, let _declarations_ be the VarScopedDeclarations of the first |CaseClauses|.
         1. Else, let _declarations_ be a new empty List.
@@ -17234,18 +17234,18 @@
         1. If the second |CaseClauses| is not present, return _declarations_.
         1. Return the result of appending to _declarations_ the elements of the VarScopedDeclarations of the second |CaseClauses|.
       </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |CaseClauses|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |CaseClause|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
         1. Return a new empty List.
@@ -17256,11 +17256,11 @@
     <emu-clause id="sec-runtime-semantics-caseblockevaluation">
       <h1>Runtime Semantics: CaseBlockEvaluation</h1>
       <p>With parameter _input_.</p>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses `}`</emu-grammar>
       <emu-alg>
         1. Let _V_ be *undefined*.
         1. Let _A_ be the List of |CaseClause| items in |CaseClauses|, in source text order.
@@ -17276,7 +17276,7 @@
             1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
         1. Return NormalCompletion(_V_).
       </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. Let _V_ be *undefined*.
         1. If the first |CaseClauses| is present, then
@@ -17323,7 +17323,7 @@
     <!-- es6num="13.12.10" -->
     <emu-clause id="sec-runtime-semantics-caseselectorevaluation">
       <h1>Runtime Semantics: CaseSelectorEvaluation</h1>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Return ? GetValue(_exprRef_).
@@ -17336,7 +17336,7 @@
     <!-- es6num="13.12.11" -->
     <emu-clause id="sec-switch-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _switchValue_ be ? GetValue(_exprRef_).
@@ -17351,19 +17351,19 @@
       <emu-note>
         <p>No matter how control leaves the |SwitchStatement| the LexicalEnvironment is always restored to its former state.</p>
       </emu-note>
-      <emu-grammar>CaseClause : `case` Expression `:`</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList</emu-grammar>
+      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:`</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList</emu-grammar>
+      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
@@ -17374,7 +17374,7 @@
   <emu-clause id="sec-labelled-statements">
     <h1>Labelled Statements</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       LabelledStatement[Yield, Await, Return] :
         LabelIdentifier[?Yield, ?Await] `:` LabelledItem[?Yield, ?Await, ?Return]
 
@@ -17389,7 +17389,7 @@
     <!-- es6num="13.13.1" -->
     <emu-clause id="sec-labelled-statements-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if any source text matches this rule.
@@ -17405,14 +17405,14 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. If _label_ is an element of _labelSet_, return *true*.
         1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
         1. Return ContainsDuplicateLabels of |LabelledItem| with argument _newLabelSet_.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -17423,13 +17423,13 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
         1. Return ContainsUndefinedBreakTarget of |LabelledItem| with argument _newLabelSet_.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -17440,13 +17440,13 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
         1. Return ContainsUndefinedContinueTarget of |LabelledItem| with arguments _iterationSet_ and _newLabelSet_.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -17459,7 +17459,7 @@
       <emu-alg>
         1. If _stmt_ is not a |LabelledStatement|, return *false*.
         1. Let _item_ be the |LabelledItem| of _stmt_.
-        1. If _item_ is <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar> , return *true*.
+        1. If _item_ is <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar> , return *true*.
         1. Let _subStmt_ be the |Statement| of _item_.
         1. Return IsLabelledFunction(_subStmt_).
       </emu-alg>
@@ -17469,15 +17469,15 @@
     <emu-clause id="sec-labelled-statements-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the LexicallyDeclaredNames of |LabelledItem|.
       </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return BoundNames of |FunctionDeclaration|.
       </emu-alg>
@@ -17487,15 +17487,15 @@
     <emu-clause id="sec-labelled-statements-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the LexicallyScopedDeclarations of |LabelledItem|.
       </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return a new List containing |FunctionDeclaration|.
       </emu-alg>
@@ -17505,7 +17505,7 @@
     <emu-clause id="sec-labelled-statements-static-semantics-toplevellexicallydeclarednames">
       <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
       <emu-see-also-para op="TopLevelLexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -17515,7 +17515,7 @@
     <emu-clause id="sec-labelled-statements-static-semantics-toplevellexicallyscopeddeclarations">
       <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelLexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -17525,16 +17525,16 @@
     <emu-clause id="sec-labelled-statements-static-semantics-toplevelvardeclarednames">
       <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
       <emu-see-also-para op="TopLevelVarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the TopLevelVarDeclaredNames of |LabelledItem|.
       </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
+        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
         1. Return VarDeclaredNames of |Statement|.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return BoundNames of |FunctionDeclaration|.
       </emu-alg>
@@ -17544,16 +17544,16 @@
     <emu-clause id="sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations">
       <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelVarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the TopLevelVarScopedDeclarations of |LabelledItem|.
       </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
+        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
         1. Return VarScopedDeclarations of |Statement|.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return a new List containing |FunctionDeclaration|.
       </emu-alg>
@@ -17563,11 +17563,11 @@
     <emu-clause id="sec-labelled-statements-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |LabelledItem|.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -17577,11 +17577,11 @@
     <emu-clause id="sec-labelled-statements-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |LabelledItem|.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -17592,7 +17592,7 @@
       <h1>Runtime Semantics: LabelledEvaluation</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Append _label_ as an element of _labelSet_.
@@ -17601,14 +17601,14 @@
           1. Set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
         1. Return Completion(_stmtResult_).
       </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
       <emu-alg>
         1. If |Statement| is either a |LabelledStatement| or a |BreakableStatement|, then
           1. Return LabelledEvaluation of |Statement| with argument _labelSet_.
         1. Else,
           1. Return the result of evaluating |Statement|.
       </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |FunctionDeclaration|.
       </emu-alg>
@@ -17617,7 +17617,7 @@
     <!-- es6num="13.13.15" -->
     <emu-clause id="sec-labelled-statements-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _newLabelSet_ be a new empty List.
         1. Return LabelledEvaluation of this |LabelledStatement| with argument _newLabelSet_.
@@ -17629,7 +17629,7 @@
   <emu-clause id="sec-throw-statement">
     <h1>The `throw` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ThrowStatement[Yield, Await] :
         `throw` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
@@ -17637,7 +17637,7 @@
     <!-- es6num="13.14.1" -->
     <emu-clause id="sec-throw-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ThrowStatement : `throw` Expression `;`</emu-grammar>
+      <emu-grammar use="reference">ThrowStatement : `throw` Expression `;`</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
@@ -17650,7 +17650,7 @@
   <emu-clause id="sec-try-statement">
     <h1>The `try` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       TryStatement[Yield, Await, Return] :
         `try` Block[?Yield, ?Await, ?Return] Catch[?Yield, ?Await, ?Return]
         `try` Block[?Yield, ?Await, ?Return] Finally[?Yield, ?Await, ?Return]
@@ -17673,7 +17673,7 @@
     <!-- es6num="13.15.1" -->
     <emu-clause id="sec-try-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |CatchParameter| contains any duplicate elements.
@@ -17695,19 +17695,19 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |Catch| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
@@ -17715,7 +17715,7 @@
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Block| with argument _labelSet_.
       </emu-alg>
@@ -17726,19 +17726,19 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |Catch| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
@@ -17746,7 +17746,7 @@
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
       </emu-alg>
@@ -17757,19 +17757,19 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |Catch| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
@@ -17777,7 +17777,7 @@
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -17787,26 +17787,26 @@
     <emu-clause id="sec-try-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |Block|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Catch|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |Block|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Finally|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |Block|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Catch|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Finally|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Block|.
       </emu-alg>
@@ -17816,26 +17816,26 @@
     <emu-clause id="sec-try-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |Block|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Catch|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |Block|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Finally|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |Block|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Catch|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Finally|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Block|.
       </emu-alg>
@@ -17845,7 +17845,7 @@
     <emu-clause id="sec-runtime-semantics-catchclauseevaluation">
       <h1>Runtime Semantics: CatchClauseEvaluation</h1>
       <p>With parameter _thrownValue_.</p>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
         1. Let _catchEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -17869,21 +17869,21 @@
     <!-- es6num="13.15.8" -->
     <emu-clause id="sec-try-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
         1. If _B_.[[Type]] is ~throw~, let _C_ be CatchClauseEvaluation of |Catch| with argument _B_.[[Value]].
         1. Else, let _C_ be _B_.
         1. Return Completion(UpdateEmpty(_C_, *undefined*)).
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
         1. Let _F_ be the result of evaluating |Finally|.
         1. If _F_.[[Type]] is ~normal~, set _F_ to _B_.
         1. Return Completion(UpdateEmpty(_F_, *undefined*)).
       </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
         1. If _B_.[[Type]] is ~throw~, let _C_ be CatchClauseEvaluation of |Catch| with argument _B_.[[Value]].
@@ -17899,7 +17899,7 @@
   <emu-clause id="sec-debugger-statement">
     <h1>The `debugger` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       DebuggerStatement :
         `debugger` `;`
     </emu-grammar>
@@ -17910,7 +17910,7 @@
       <emu-note>
         <p>Evaluating a |DebuggerStatement| may allow an implementation to cause a breakpoint when run under a debugger. If a debugger is not present or active this statement has no observable effect.</p>
       </emu-note>
-      <emu-grammar>DebuggerStatement : `debugger` `;`</emu-grammar>
+      <emu-grammar use="reference">DebuggerStatement : `debugger` `;`</emu-grammar>
       <emu-alg>
         1. If an implementation-defined debugging facility is available and enabled, then
           1. Perform an implementation-defined debugging action.
@@ -17934,7 +17934,7 @@
   <emu-clause id="sec-function-definitions">
     <h1>Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       FunctionDeclaration[Yield, Await, Default] :
         `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         [+Default] `function` `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
@@ -17983,7 +17983,7 @@
     <!-- es6num="14.1.2" -->
     <emu-clause id="sec-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
 
         FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
@@ -17992,7 +17992,7 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
           If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
@@ -18019,13 +18019,13 @@
       <emu-note>
         <p>The LexicallyDeclaredNames of a |FunctionBody| does not include identifiers bound using var or function declarations.</p>
       </emu-note>
-      <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar>
+      <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |FormalParameters| contains any duplicate elements.
         </li>
       </ul>
-      <emu-grammar>FormalParameters : FormalParameterList</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : FormalParameterList</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if IsSimpleParameterList of |FormalParameterList| is *false* and BoundNames of |FormalParameterList| contains any duplicate elements.
@@ -18034,7 +18034,7 @@
       <emu-note>
         <p>Multiple occurrences of the same |BindingIdentifier| in a |FormalParameterList| is only allowed for functions which have simple parameter lists and which are not defined in strict mode code.</p>
       </emu-note>
-      <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
+      <emu-grammar use="reference">FunctionBody : FunctionStatementList</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the LexicallyDeclaredNames of |FunctionStatementList| contains any duplicate entries.
@@ -18058,28 +18058,28 @@
     <emu-clause id="sec-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return &laquo; `"*default*"` &raquo;.
       </emu-alg>
       <emu-note>
         <p>`"*default*"` is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
       </emu-note>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Let _names_ be BoundNames of |FormalParameterList|.
         1. Append to _names_ the BoundNames of |FunctionRestParameter|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. Let _names_ be BoundNames of |FormalParameterList|.
         1. Append to _names_ the BoundNames of |FormalParameter|.
@@ -18092,7 +18092,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
 
         FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
@@ -18111,16 +18111,16 @@
     <emu-clause id="sec-function-definitions-static-semantics-containsexpression">
       <h1>Static Semantics: ContainsExpression</h1>
       <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. If ContainsExpression of |FormalParameterList| is *true*, return *true*.
         1. Return ContainsExpression of |FunctionRestParameter|.
       </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. If ContainsExpression of |FormalParameterList| is *true*, return *true*.
         1. Return ContainsExpression of |FormalParameter|.
@@ -18130,7 +18130,7 @@
     <emu-clause id="sec-function-definitions-static-semantics-containsusestrict">
       <h1>Static Semantics: ContainsUseStrict</h1>
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
-      <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
+      <emu-grammar use="reference">FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. If the Directive Prologue of |FunctionStatementList| contains a Use Strict Directive, return *true*; otherwise, return *false*.
       </emu-alg>
@@ -18140,18 +18140,18 @@
     <emu-clause id="sec-function-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return 0.
       </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Return ExpectedArgumentCount of |FormalParameterList|.
       </emu-alg>
       <emu-note>
         <p>The ExpectedArgumentCount of a |FormalParameterList| is the number of |FormalParameters| to the left of either the rest parameter or the first |FormalParameter| with an Initializer. A |FormalParameter| without an initializer is allowed after the first parameter with an initializer but such parameters are considered to be optional with *undefined* as their default value.</p>
       </emu-note>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. Let _count_ be ExpectedArgumentCount of |FormalParameterList|.
         1. If HasInitializer of |FormalParameterList| is *true* or HasInitializer of |FormalParameter| is *true*, return _count_.
@@ -18163,7 +18163,7 @@
     <emu-clause id="sec-function-definitions-static-semantics-hasinitializer">
       <h1>Static Semantics: HasInitializer</h1>
       <emu-see-also-para op="HasInitializer"></emu-see-also-para>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. If HasInitializer of |FormalParameterList| is *true*, return *true*.
         1. Return HasInitializer of |FormalParameter|.
@@ -18174,11 +18174,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -18200,7 +18200,7 @@
     <emu-clause id="sec-function-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
 
         FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
@@ -18214,7 +18214,7 @@
     <emu-clause id="sec-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -18224,20 +18224,20 @@
     <emu-clause id="sec-function-definitions-static-semantics-issimpleparameterlist">
       <h1>Static Semantics: IsSimpleParameterList</h1>
       <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. If IsSimpleParameterList of |FormalParameterList| is *false*, return *false*.
         1. Return IsSimpleParameterList of |FormalParameter|.
       </emu-alg>
-      <emu-grammar>FormalParameter : BindingElement</emu-grammar>
+      <emu-grammar use="reference">FormalParameter : BindingElement</emu-grammar>
       <emu-alg>
         1. Return IsSimpleParameterList of |BindingElement|.
       </emu-alg>
@@ -18247,11 +18247,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
       </emu-alg>
@@ -18261,11 +18261,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Return the TopLevelLexicallyScopedDeclarations of |StatementList|.
       </emu-alg>
@@ -18275,11 +18275,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelVarDeclaredNames of |StatementList|.
       </emu-alg>
@@ -18289,11 +18289,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Return the TopLevelVarScopedDeclarations of |StatementList|.
       </emu-alg>
@@ -18304,7 +18304,7 @@
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
       <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
-      <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
+      <emu-grammar use="reference">FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Return the result of evaluating |FunctionStatementList|.
@@ -18319,21 +18319,21 @@
         <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
       </emu-note>
       <emu-see-also-para op="IteratorBindingInitialization"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
         1. Return the result of performing IteratorBindingInitialization for |FunctionRestParameter| using _iteratorRecord_ and _environment_ as the arguments.
       </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
         1. Return the result of performing IteratorBindingInitialization for |FormalParameter| using _iteratorRecord_ and _environment_ as the arguments.
       </emu-alg>
-      <emu-grammar>FormalParameter : BindingElement</emu-grammar>
+      <emu-grammar use="reference">FormalParameter : BindingElement</emu-grammar>
       <emu-alg>
         1. If ContainsExpression of |BindingElement| is *false*, return the result of performing IteratorBindingInitialization for |BindingElement| using _iteratorRecord_ and _environment_ as the arguments.
         1. Let _currentContext_ be the running execution context.
@@ -18351,7 +18351,7 @@
       <emu-note>
         <p>The new Environment Record created in step 6 is only used if the |BindingElement| contains a direct eval.</p>
       </emu-note>
-      <emu-grammar>FunctionRestParameter : BindingRestElement</emu-grammar>
+      <emu-grammar use="reference">FunctionRestParameter : BindingRestElement</emu-grammar>
       <emu-alg>
         1. If ContainsExpression of |BindingRestElement| is *false*, return the result of performing IteratorBindingInitialization for |BindingRestElement| using _iteratorRecord_ and _environment_ as the arguments.
         1. Let _currentContext_ be the running execution context.
@@ -18376,7 +18376,7 @@
       <h1>Runtime Semantics: InstantiateFunctionObject</h1>
       <p>With parameter _scope_.</p>
       <emu-see-also-para op="InstantiateFunctionObject"></emu-see-also-para>
-      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for |FunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _name_ be StringValue of |BindingIdentifier|.
@@ -18385,7 +18385,7 @@
         1. Perform SetFunctionName(_F_, _name_).
         1. Return _F_.
       </emu-alg>
-      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _F_ be FunctionCreate(~Normal~, |FormalParameters|, |FunctionBody|, _scope_, *true*).
         1. Perform MakeConstructor(_F_).
@@ -18400,18 +18400,18 @@
     <!-- es6num="14.1.20" -->
     <emu-clause id="sec-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
       <emu-note>
         <p>An alternative semantics is provided in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
       </emu-note>
-      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for |FunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
@@ -18419,7 +18419,7 @@
         1. Perform MakeConstructor(_closure_).
         1. Return _closure_.
       </emu-alg>
-      <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for |FunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
@@ -18439,7 +18439,7 @@
       <emu-note>
         <p>A `prototype` property is automatically created for every function defined using a |FunctionDeclaration| or |FunctionExpression|, to allow for the possibility that the function will be used as a constructor.</p>
       </emu-note>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
@@ -18450,7 +18450,7 @@
   <emu-clause id="sec-arrow-function-definitions">
     <h1>Arrow Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ArrowFunction[In, Yield, Await] :
         ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=&gt;` ConciseBody[?In]
 
@@ -18465,10 +18465,10 @@
     <h2>Supplemental Syntax</h2>
     <p>When the production
       <br>
-      <emu-grammar>ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
       <br>
       is recognized the following grammar is used to refine the interpretation of |CoverParenthesizedExpressionAndArrowParameterList|:</p>
-    <emu-grammar>
+    <emu-grammar use="definition">
       ArrowFormalParameters[Yield, Await] :
         `(` UniqueFormalParameters[?Yield, ?Await] `)`
     </emu-grammar>
@@ -18476,7 +18476,7 @@
     <!-- es6num="14.2.1" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar use="reference">ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if |ArrowParameters| Contains |YieldExpression| is *true*.
@@ -18491,7 +18491,7 @@
           It is a Syntax Error if any element of the BoundNames of |ArrowParameters| also occurs in the LexicallyDeclaredNames of |ConciseBody|.
         </li>
       </ul>
-      <emu-grammar>ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the lexical token sequence matched by |CoverParenthesizedExpressionAndArrowParameterList| cannot be parsed with no tokens left over using |ArrowFormalParameters| as the goal symbol with its <sub>[Yield]</sub> and <sub>[Await]</sub> parameters set to the values used when parsing this |CoverParenthesizedExpressionAndArrowParameterList|.
@@ -18506,7 +18506,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return the BoundNames of _formals_.
@@ -18518,7 +18518,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar use="reference">ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
         1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super` or `this`, return *false*.
         1. If |ArrowParameters| Contains _symbol_ is *true*, return *true*.
@@ -18527,7 +18527,7 @@
       <emu-note>
         <p>Normally, Contains does not look inside most function forms. However, Contains is used to detect `new.target`, `this`, and `super` usage within an |ArrowFunction|.</p>
       </emu-note>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return _formals_ Contains _symbol_.
@@ -18538,7 +18538,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-containsexpression">
       <h1>Static Semantics: ContainsExpression</h1>
       <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -18547,7 +18547,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-containsusestrict">
       <h1>Static Semantics: ContainsUseStrict</h1>
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -18557,7 +18557,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return 1.
       </emu-alg>
@@ -18567,7 +18567,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar use="reference">ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -18577,11 +18577,11 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-issimpleparameterlist">
       <h1>Static Semantics: IsSimpleParameterList</h1>
       <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return IsSimpleParameterList of _formals_.
@@ -18591,11 +18591,11 @@
     <!-- es6num="14.2.9" -->
     <emu-clause id="sec-static-semantics-coveredformalslist">
       <h1>Static Semantics: CoveredFormalsList</h1>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return this |ArrowParameters|.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] :
           `(` Expression `)`
           `(` `)`
@@ -18613,7 +18613,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -18623,7 +18623,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -18633,7 +18633,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -18643,7 +18643,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -18657,7 +18657,7 @@
       <emu-note>
         <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
       </emu-note>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Assert: _iteratorRecord_.[[Done]] is *false*.
         1. Let _next_ be IteratorStep(_iteratorRecord_.[[Iterator]]).
@@ -18678,7 +18678,7 @@
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
       <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
@@ -18690,7 +18690,7 @@
     <!-- es6num="14.2.16" -->
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar use="reference">ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
         1. If the function code for this |ArrowFunction| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
@@ -18708,7 +18708,7 @@
   <emu-clause id="sec-method-definitions">
     <h1>Method Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       MethodDefinition[Yield, Await] :
         PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         GeneratorMethod[?Yield, ?Await]
@@ -18723,7 +18723,7 @@
     <!-- es6num="14.3.1" -->
     <emu-clause id="sec-method-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.
@@ -18732,7 +18732,7 @@
           It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
         </li>
       </ul>
-      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |PropertySetParameterList| contains any duplicate elements.
@@ -18751,7 +18751,7 @@
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         MethodDefinition :
           PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
           `get` PropertyName `(` `)` `{` FunctionBody `}`
@@ -18766,7 +18766,7 @@
     <emu-clause id="sec-method-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar>PropertySetParameterList : FormalParameter</emu-grammar>
+      <emu-grammar use="reference">PropertySetParameterList : FormalParameter</emu-grammar>
       <emu-alg>
         1. If HasInitializer of |FormalParameter| is *true*, return 0.
         1. Return 1.
@@ -18777,16 +18777,16 @@
     <emu-clause id="sec-method-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |FunctionBody| Contains |SuperCall|.
       </emu-alg>
-      <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return |FunctionBody| Contains |SuperCall|.
       </emu-alg>
-      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If |PropertySetParameterList| Contains |SuperCall| is *true*, return *true*.
         1. Return |FunctionBody| Contains |SuperCall|.
@@ -18797,7 +18797,7 @@
     <emu-clause id="sec-method-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         MethodDefinition :
           PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
           `get` PropertyName `(` `)` `{` FunctionBody `}`
@@ -18811,11 +18811,11 @@
     <!-- es6num="14.3.7" -->
     <emu-clause id="sec-static-semantics-specialmethod">
       <h1>Static Semantics: SpecialMethod</h1>
-      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         MethodDefinition :
           GeneratorMethod
           AsyncMethod
@@ -18831,7 +18831,7 @@
     <emu-clause id="sec-runtime-semantics-definemethod">
       <h1>Runtime Semantics: DefineMethod</h1>
       <p>With parameters _object_ and optional parameter _functionPrototype_.</p>
-      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
@@ -18854,7 +18854,7 @@
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
       <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _methodDef_ be DefineMethod of |MethodDefinition| with argument _object_.
         1. ReturnIfAbrupt(_methodDef_).
@@ -18862,20 +18862,20 @@
         1. Let _desc_ be the PropertyDescriptor{[[Value]]: _methodDef_.[[Closure]], [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
         1. Return ? DefinePropertyOrThrow(_object_, _methodDef_.[[Key]], _desc_).
       </emu-alg>
-      <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
+        1. Let _formalParameterList_ be an instance of the production <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>.
         1. Let _closure_ be FunctionCreate(~Method~, _formalParameterList_, |FunctionBody|, _scope_, _strict_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_, `"get"`).
         1. Let _desc_ be the PropertyDescriptor{[[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
-      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar use="reference">MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
@@ -18894,7 +18894,7 @@
   <emu-clause id="sec-generator-function-definitions">
     <h1>Generator Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       GeneratorMethod[Yield, Await] :
         `*` PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, ~Await] `)` `{` GeneratorBody `}`
 
@@ -18926,7 +18926,7 @@
     <!-- es6num="14.4.1" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if HasDirectSuper of |GeneratorMethod| is *true*.
@@ -18941,7 +18941,7 @@
           It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
         </li>
       </ul>
-      <emu-grammar>
+      <emu-grammar use="reference">
         GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
 
         GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
@@ -18950,7 +18950,7 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
           If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
@@ -18983,11 +18983,11 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return &laquo; `"*default*"` &raquo;.
       </emu-alg>
@@ -19001,7 +19001,7 @@
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
       </emu-alg>
@@ -19012,7 +19012,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
 
         GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
@@ -19031,7 +19031,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |GeneratorBody| Contains |SuperCall|.
@@ -19042,11 +19042,11 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19056,7 +19056,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
 
         GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
@@ -19070,7 +19070,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19080,7 +19080,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return PropName of |PropertyName|.
       </emu-alg>
@@ -19091,7 +19091,7 @@
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
       <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
-      <emu-grammar>GeneratorBody : FunctionBody</emu-grammar>
+      <emu-grammar use="reference">GeneratorBody : FunctionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, `"%GeneratorPrototype%"`, &laquo; [[GeneratorState]], [[GeneratorContext]] &raquo;).
@@ -19105,7 +19105,7 @@
       <h1>Runtime Semantics: InstantiateFunctionObject</h1>
       <p>With parameter _scope_.</p>
       <emu-see-also-para op="InstantiateFunctionObject"></emu-see-also-para>
-      <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for |GeneratorDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _name_ be StringValue of |BindingIdentifier|.
@@ -19115,7 +19115,7 @@
         1. Perform SetFunctionName(_F_, _name_).
         1. Return _F_.
       </emu-alg>
-      <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _F_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_, *true*).
         1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
@@ -19133,7 +19133,7 @@
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
       <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
@@ -19152,7 +19152,7 @@
     <!-- es6num="14.4.14" -->
     <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for this |GeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
@@ -19161,7 +19161,7 @@
         1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
         1. Return _closure_.
       </emu-alg>
-      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar use="reference">GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for this |GeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
@@ -19179,17 +19179,17 @@
       <emu-note>
         <p>The |BindingIdentifier| in a |GeneratorExpression| can be referenced from inside the |GeneratorExpression|'s |FunctionBody| to allow the generator code to call itself recursively. However, unlike in a |GeneratorDeclaration|, the |BindingIdentifier| in a |GeneratorExpression| cannot be referenced from and does not affect the scope enclosing the |GeneratorExpression|.</p>
       </emu-note>
-      <emu-grammar>YieldExpression : `yield`</emu-grammar>
+      <emu-grammar use="reference">YieldExpression : `yield`</emu-grammar>
       <emu-alg>
         1. Return ? GeneratorYield(CreateIterResultObject(*undefined*, *false*)).
       </emu-alg>
-      <emu-grammar>YieldExpression : `yield` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">YieldExpression : `yield` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
       </emu-alg>
-      <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
@@ -19236,7 +19236,7 @@
   <emu-clause id="sec-class-definitions">
     <h1>Class Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       ClassDeclaration[Yield, Await, Default] :
         `class` BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
         [+Default] `class` ClassTail[?Yield, ?Await]
@@ -19269,7 +19269,7 @@
     <!-- es6num="14.5.1" -->
     <emu-clause id="sec-class-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
+      <emu-grammar use="reference">ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
       <ul>
         <li>
           <p>It is a Syntax Error if |ClassHeritage| is not present and the following algorithm evaluates to *true*:</p>
@@ -19280,13 +19280,13 @@
           </emu-alg>
         </li>
       </ul>
-      <emu-grammar>ClassBody : ClassElementList</emu-grammar>
+      <emu-grammar use="reference">ClassBody : ClassElementList</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if PrototypePropertyNameList of |ClassElementList| contains more than one occurrence of `"constructor"`.
         </li>
       </ul>
-      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar use="reference">ClassElement : MethodDefinition</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if PropName of |MethodDefinition| is not `"constructor"` and HasDirectSuper of |MethodDefinition| is *true*.
@@ -19295,7 +19295,7 @@
           It is a Syntax Error if PropName of |MethodDefinition| is `"constructor"` and SpecialMethod of |MethodDefinition| is *true*.
         </li>
       </ul>
-      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-grammar use="reference">ClassElement : `static` MethodDefinition</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
@@ -19310,11 +19310,11 @@
     <emu-clause id="sec-class-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassDeclaration : `class` ClassTail</emu-grammar>
       <emu-alg>
         1. Return &laquo; `"*default*"` &raquo;.
       </emu-alg>
@@ -19323,18 +19323,18 @@
     <!-- es6num="14.5.3" -->
     <emu-clause id="sec-static-semantics-constructormethod">
       <h1>Static Semantics: ConstructorMethod</h1>
-      <emu-grammar>ClassElementList : ClassElement</emu-grammar>
+      <emu-grammar use="reference">ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return ~empty~.
+        1. If |ClassElement| is <emu-grammar use="reference">ClassElement : `;`</emu-grammar> , return ~empty~.
         1. If IsStatic of |ClassElement| is *true*, return ~empty~.
         1. If PropName of |ClassElement| is not `"constructor"`, return ~empty~.
         1. Return |ClassElement|.
       </emu-alg>
-      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-grammar use="reference">ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _head_ be ConstructorMethod of |ClassElementList|.
         1. If _head_ is not ~empty~, return _head_.
-        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return ~empty~.
+        1. If |ClassElement| is <emu-grammar use="reference">ClassElement : `;`</emu-grammar> , return ~empty~.
         1. If IsStatic of |ClassElement| is *true*, return ~empty~.
         1. If PropName of |ClassElement| is not `"constructor"`, return ~empty~.
         1. Return |ClassElement|.
@@ -19349,7 +19349,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
+      <emu-grammar use="reference">ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
       <emu-alg>
         1. If _symbol_ is |ClassBody|, return *true*.
         1. If _symbol_ is |ClassHeritage|, then
@@ -19368,21 +19368,21 @@
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-grammar use="reference">ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _inList_ be the result of ComputedPropertyContains for |ClassElementList| with argument _symbol_.
         1. If _inList_ is *true*, return *true*.
         1. Return the result of ComputedPropertyContains for |ClassElement| with argument _symbol_.
       </emu-alg>
-      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar use="reference">ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
       </emu-alg>
-      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-grammar use="reference">ClassElement : `static` MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
       </emu-alg>
-      <emu-grammar>ClassElement : `;`</emu-grammar>
+      <emu-grammar use="reference">ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -19392,11 +19392,11 @@
     <emu-clause id="sec-class-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassExpression : `class` ClassTail</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19406,7 +19406,7 @@
     <emu-clause id="sec-class-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar>
+      <emu-grammar use="reference">
         ClassDeclaration : `class` BindingIdentifier ClassTail
 
         ClassDeclaration : `class` ClassTail
@@ -19420,7 +19420,7 @@
     <emu-clause id="sec-class-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19429,15 +19429,15 @@
     <!-- es6num="14.5.9" -->
     <emu-clause id="sec-static-semantics-isstatic">
       <h1>Static Semantics: IsStatic</h1>
-      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar use="reference">ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-grammar use="reference">ClassElement : `static` MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>ClassElement : `;`</emu-grammar>
+      <emu-grammar use="reference">ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -19446,16 +19446,16 @@
     <!-- es6num="14.5.10" -->
     <emu-clause id="sec-static-semantics-nonconstructormethoddefinitions">
       <h1>Static Semantics: NonConstructorMethodDefinitions</h1>
-      <emu-grammar>ClassElementList : ClassElement</emu-grammar>
+      <emu-grammar use="reference">ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return a new empty List.
+        1. If |ClassElement| is <emu-grammar use="reference">ClassElement : `;`</emu-grammar> , return a new empty List.
         1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is `"constructor"`, return a new empty List.
         1. Return a List containing |ClassElement|.
       </emu-alg>
-      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-grammar use="reference">ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _list_ be NonConstructorMethodDefinitions of |ClassElementList|.
-        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return _list_.
+        1. If |ClassElement| is <emu-grammar use="reference">ClassElement : `;`</emu-grammar> , return _list_.
         1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is `"constructor"`, return _list_.
         1. Append |ClassElement| to the end of _list_.
         1. Return _list_.
@@ -19465,13 +19465,13 @@
     <!-- es6num="14.5.11" -->
     <emu-clause id="sec-static-semantics-prototypepropertynamelist">
       <h1>Static Semantics: PrototypePropertyNameList</h1>
-      <emu-grammar>ClassElementList : ClassElement</emu-grammar>
+      <emu-grammar use="reference">ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
         1. If PropName of |ClassElement| is ~empty~, return a new empty List.
         1. If IsStatic of |ClassElement| is *true*, return a new empty List.
         1. Return a List containing PropName of |ClassElement|.
       </emu-alg>
-      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-grammar use="reference">ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _list_ be PrototypePropertyNameList of |ClassElementList|.
         1. If PropName of |ClassElement| is ~empty~, return _list_.
@@ -19485,7 +19485,7 @@
     <emu-clause id="sec-class-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>ClassElement : `;`</emu-grammar>
+      <emu-grammar use="reference">ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return ~empty~.
       </emu-alg>
@@ -19495,7 +19495,7 @@
     <emu-clause id="sec-runtime-semantics-classdefinitionevaluation">
       <h1>Runtime Semantics: ClassDefinitionEvaluation</h1>
       <p>With parameter _className_.</p>
-      <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody? `}`</emu-grammar>
+      <emu-grammar use="reference">ClassTail : ClassHeritage? `{` ClassBody? `}`</emu-grammar>
       <emu-alg>
         1. Let _lex_ be the LexicalEnvironment of the running execution context.
         1. Let _classScope_ be NewDeclarativeEnvironment(_lex_).
@@ -19558,7 +19558,7 @@
     <!-- es6num="14.5.15" -->
     <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation">
       <h1>Runtime Semantics: BindingClassDeclarationEvaluation</h1>
-      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Let _className_ be StringValue of |BindingIdentifier|.
         1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with argument _className_.
@@ -19569,27 +19569,27 @@
         1. Perform ? InitializeBoundName(_className_, _value_, _env_).
         1. Return _value_.
       </emu-alg>
-      <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassDeclaration : `class` ClassTail</emu-grammar>
       <emu-alg>
         1. Return the result of ClassDefinitionEvaluation of |ClassTail| with argument *undefined*.
       </emu-alg>
       <emu-note>
-        <p><emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and the setting of a name property and establishing its binding are handled as part of the evaluation action for that production. See <emu-xref href="#sec-exports-runtime-semantics-evaluation"></emu-xref>.</p>
+        <p><emu-grammar use="reference">ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and the setting of a name property and establishing its binding are handled as part of the evaluation action for that production. See <emu-xref href="#sec-exports-runtime-semantics-evaluation"></emu-xref>.</p>
       </emu-note>
     </emu-clause>
 
     <!-- es6num="14.5.16" -->
     <emu-clause id="sec-class-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Perform ? BindingClassDeclarationEvaluation of this |ClassDeclaration|.
         1. Return NormalCompletion(~empty~).
       </emu-alg>
       <emu-note>
-        <p><emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and is never directly evaluated.</p>
+        <p><emu-grammar use="reference">ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and is never directly evaluated.</p>
       </emu-note>
-      <emu-grammar>ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
+      <emu-grammar use="reference">ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
       <emu-alg>
         1. If |BindingIdentifier_opt| is not present, let _className_ be *undefined*.
         1. Else, let _className_ be StringValue of |BindingIdentifier|.
@@ -19610,7 +19610,7 @@
   <emu-clause id="sec-async-function-definitions">
     <h1>Async Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       AsyncFunctionDeclaration[Yield, Await, Default] :
         `async` [no LineTerminator here] `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
         [+Default] `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
@@ -19648,7 +19648,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <ul>
@@ -19657,7 +19657,7 @@
         <li>It is a Syntax Error if |UniqueFormalParameters| Contains |AwaitExpression| is *true*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
       </ul>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -19669,7 +19669,7 @@
       <ul>
         <li>It is a Syntax Error if ContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
-        <li>If the source code matching this production is strict code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If the source code matching this production is strict code, the Early Error rules for <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
         <li>If the source code matching this production is strict code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
@@ -19681,13 +19681,13 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-BoundNames">
       <h1>Static Semantics: BoundNames</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19699,7 +19699,7 @@
     <emu-clause id="sec-async-function-definitions-static-semantics-ComputedPropertyContains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19710,7 +19710,7 @@
     <emu-clause id="sec-async-function-definitions-static-semantics-Contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -19726,7 +19726,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-HasDirectSuper">
       <h1>Static Semantics: HasDirectSuper</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19737,13 +19737,13 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-HasName">
       <h1>Static Semantics: HasName</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19753,7 +19753,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-IsConstantDeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -19765,7 +19765,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-IsFunctionDefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -19777,7 +19777,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-PropName">
       <h1>Static Semantics: PropName</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19788,7 +19788,7 @@
     <emu-clause id="sec-async-function-definitions-InstantiateFunctionObject">
       <h1>Runtime Semantics: InstantiateFunctionObject</h1>
       <p>With parameter _scope_.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19798,7 +19798,7 @@
         1. Perform ! SetFunctionName(_F_, _name_).
         1. Return _F_.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19812,7 +19812,7 @@
     <emu-clause id="sec-async-function-definitions-EvaluateBody">
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionBody : FunctionBody
       </emu-grammar>
       <emu-alg>
@@ -19829,7 +19829,7 @@
     <emu-clause id="sec-async-function-definitions-PropertyDefinitionEvaluation">
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19846,21 +19846,21 @@
     </emu-clause>
     <emu-clause id="sec-async-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
 
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
 
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19870,7 +19870,7 @@
         1. Return _closure_.
       </emu-alg>
 
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19886,7 +19886,7 @@
         1. Return _closure_.
       </emu-alg>
 
-      <emu-grammar>
+      <emu-grammar use="reference">
         AwaitExpression : `await` UnaryExpression
       </emu-grammar>
       <emu-alg>
@@ -19900,7 +19900,7 @@
   <emu-clause id="sec-async-arrow-function-definitions">
     <h1>Async Arrow Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       AsyncArrowFunction[In, Yield, Await] :
         `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
         CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
@@ -19916,22 +19916,22 @@
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
-    <p>When processing an instance of the production <emu-grammar>AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
+    <p>When processing an instance of the production <emu-grammar use="reference">AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
 
-    <emu-grammar>
+    <emu-grammar use="definition">
       AsyncArrowHead :
         `async` [no LineTerminator here] ArrowFormalParameters[~Yield, +Await]
     </emu-grammar>
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <ul>
         <li>It is a Syntax Error if any element of the BoundNames of |AsyncArrowBindingIdentifier| also occurs in the LexicallyDeclaredNames of |AsyncConciseBody|.</li>
       </ul>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <ul>
@@ -19946,7 +19946,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-CoveredAsyncArrowHead">
       <h1>Static Semantics: CoveredAsyncArrowHead</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>
       <emu-alg>
@@ -19956,7 +19956,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-BoundNames">
       <h1>Static Semantics: BoundNames</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>
       <emu-alg>
@@ -19968,14 +19968,14 @@
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-Contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
         1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
         1. Return |AsyncConciseBody| Contains _symbol_.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
@@ -19989,7 +19989,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-ContainsExpression">
       <h1>Static Semantics: ContainsExpression</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
@@ -19999,7 +19999,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
@@ -20009,7 +20009,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-HasName">
       <h1>Static Semantics: HasName</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
 
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
@@ -20021,13 +20021,13 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-IsSimpleParameterList">
       <h1>Static Semantics: IsSimpleParameterList</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowBindingIdentifier[Yield] : BindingIdentifier[?Yield, +Await]
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>
       <emu-alg>
@@ -20038,7 +20038,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-LexicallyDeclaredNames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20048,7 +20048,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-LexicallyScopedDeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20058,7 +20058,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-VarDeclaredNames">
       <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20068,7 +20068,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-VarScopedDeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20079,7 +20079,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-IteratorBindingInitialization">
       <h1>Runtime Semantics: IteratorBindingInitialization</h1>
       <p>With parameters _iteratorRecord_ and _environment_.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
@@ -20100,7 +20100,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-EvaluateBody">
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20112,7 +20112,7 @@
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_declResult_.[[Value]]&raquo;).
         1. Return Completion{[[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~}.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncConciseBody : `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -20122,7 +20122,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
@@ -20132,7 +20132,7 @@
         1. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
         1. Return _closure_.
       </emu-alg>
-      <emu-grammar>
+      <emu-grammar use="reference">
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
@@ -20180,17 +20180,17 @@
       <!-- es6num="14.6.2.1" -->
       <emu-clause id="sec-statement-rules">
         <h1>Statement Rules</h1>
-        <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |AssignmentExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+        <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of |StatementList| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of |StatementListItem| with argument _call_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           FunctionStatementList : [empty]
 
           StatementListItem : Declaration
@@ -20220,13 +20220,13 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+        <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of the first |Statement| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of the second |Statement| with argument _call_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           IfStatement : `if` `(` Expression `)` Statement
 
           IterationStatement :
@@ -20244,22 +20244,22 @@
         <emu-alg>
           1. Return HasCallInTailPosition of |Statement| with argument _call_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           LabelledStatement :
             LabelIdentifier `:` LabelledItem
         </emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |LabelledItem| with argument _call_.
         </emu-alg>
-        <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
+        <emu-grammar use="reference">ReturnStatement : `return` Expression `;`</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Expression| with argument _call_.
         </emu-alg>
-        <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+        <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |CaseBlock| with argument _call_.
         </emu-alg>
-        <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+        <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
         <emu-alg>
           1. Let _has_ be *false*.
           1. If the first |CaseClauses| is present, let _has_ be HasCallInTailPosition of the first |CaseClauses| with argument _call_.
@@ -20269,13 +20269,13 @@
           1. If the second |CaseClauses| is present, let _has_ be HasCallInTailPosition of the second |CaseClauses| with argument _call_.
           1. Return _has_.
         </emu-alg>
-        <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+        <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of |CaseClauses| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of |CaseClause| with argument _call_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           CaseClause : `case` Expression `:` StatementList?
 
           DefaultClause : `default` `:` StatementList?
@@ -20284,11 +20284,11 @@
           1. If |StatementList| is present, return HasCallInTailPosition of |StatementList| with argument _call_.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+        <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Catch| with argument _call_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           TryStatement : `try` Block Finally
 
           TryStatement : `try` Block Catch Finally
@@ -20296,7 +20296,7 @@
         <emu-alg>
           1. Return HasCallInTailPosition of |Finally| with argument _call_.
         </emu-alg>
-        <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+        <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Block| with argument _call_.
         </emu-alg>
@@ -20308,7 +20308,7 @@
         <emu-note>
           <p>A potential tail position call that is immediately followed by return GetValue of the call result is also a possible tail position call. Function calls cannot return reference values, so such a GetValue operation will always return the same value as the actual function call result.</p>
         </emu-note>
-        <emu-grammar>
+        <emu-grammar use="reference">
           AssignmentExpression :
             YieldExpression
             ArrowFunction
@@ -20397,7 +20397,7 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           Expression :
             AssignmentExpression
             Expression `,` AssignmentExpression
@@ -20405,21 +20405,21 @@
         <emu-alg>
           1. Return HasCallInTailPosition of |AssignmentExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of the first |AssignmentExpression| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of the second |AssignmentExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
+        <emu-grammar use="reference">LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |BitwiseORExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
+        <emu-grammar use="reference">LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |LogicalANDExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           CallExpression :
             CoverCallExpressionAndAsyncArrowHead
             CallExpression Arguments
@@ -20429,7 +20429,7 @@
           1. If this |CallExpression| is _call_, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           MemberExpression :
             MemberExpression TemplateLiteral
         </emu-grammar>
@@ -20437,12 +20437,12 @@
           1. If this |MemberExpression| is _call_, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return HasCallInTailPosition of _expr_ with argument _call_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ParenthesizedExpression :
             `(` Expression `)`
         </emu-grammar>
@@ -20478,7 +20478,7 @@
   <emu-clause id="sec-scripts">
     <h1>Scripts</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       Script :
         ScriptBody?
 
@@ -20489,7 +20489,7 @@
     <!-- es6num="15.1.1" -->
     <emu-clause id="sec-scripts-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>Script : ScriptBody</emu-grammar>
+      <emu-grammar use="reference">Script : ScriptBody</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the LexicallyDeclaredNames of |ScriptBody| contains any duplicate entries.
@@ -20498,7 +20498,7 @@
           It is a Syntax Error if any element of the LexicallyDeclaredNames of |ScriptBody| also occurs in the VarDeclaredNames of |ScriptBody|.
         </li>
       </ul>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if |StatementList| Contains `super` unless the source code containing `super` is eval code that is being processed by a direct eval. Additional early error rules for `super` within direct eval are defined in <emu-xref href="#sec-performeval"></emu-xref>.
@@ -20521,7 +20521,7 @@
     <!-- es6num="15.1.2" -->
     <emu-clause id="sec-static-semantics-isstrict">
       <h1>Static Semantics: IsStrict</h1>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. If the Directive Prologue of |StatementList| contains a Use Strict Directive, return *true*; otherwise, return *false*.
       </emu-alg>
@@ -20531,7 +20531,7 @@
     <emu-clause id="sec-scripts-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
       </emu-alg>
@@ -20544,7 +20544,7 @@
     <emu-clause id="sec-scripts-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelLexicallyScopedDeclarations of |StatementList|.
       </emu-alg>
@@ -20554,7 +20554,7 @@
     <emu-clause id="sec-scripts-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelVarDeclaredNames of |StatementList|.
       </emu-alg>
@@ -20564,7 +20564,7 @@
     <emu-clause id="sec-scripts-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelVarScopedDeclarations of |StatementList|.
       </emu-alg>
@@ -20572,7 +20572,7 @@
 
     <emu-clause id="sec-script-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>Script : [empty]</emu-grammar>
+      <emu-grammar use="reference">Script : [empty]</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
@@ -20781,7 +20781,7 @@
   <emu-clause id="sec-modules">
     <h1>Modules</h1>
     <h2>Syntax</h2>
-    <emu-grammar definition>
+    <emu-grammar use="definition">
       Module :
         ModuleBody?
 
@@ -20805,7 +20805,7 @@
       <!-- es6num="15.2.1.1" -->
       <emu-clause id="sec-module-semantics-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
+        <emu-grammar use="reference">ModuleBody : ModuleItemList</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the LexicallyDeclaredNames of |ModuleItemList| contains any duplicate entries.
@@ -20845,13 +20845,13 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _hasDuplicates_ be ContainsDuplicateLabels of |ModuleItemList| with argument _labelSet_.
           1. If _hasDuplicates_ is *true*, return *true*.
           1. Return ContainsDuplicateLabels of |ModuleItem| with argument _labelSet_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ModuleItem :
             ImportDeclaration
             ExportDeclaration
@@ -20866,13 +20866,13 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |ModuleItemList| with argument _labelSet_.
           1. If _hasUndefinedLabels_ is *true*, return *true*.
           1. Return ContainsUndefinedBreakTarget of |ModuleItem| with argument _labelSet_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ModuleItem :
             ImportDeclaration
             ExportDeclaration
@@ -20887,13 +20887,13 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |ModuleItemList| with arguments _iterationSet_ and &laquo; &raquo;.
           1. If _hasUndefinedLabels_ is *true*, return *true*.
           1. Return ContainsUndefinedContinueTarget of |ModuleItem| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ModuleItem :
             ImportDeclaration
             ExportDeclaration
@@ -20910,13 +20910,13 @@
         <emu-note>
           <p>ExportedBindings are the locally bound names that are explicitly associated with a |Module|'s ExportedNames.</p>
         </emu-note>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _names_ be ExportedBindings of |ModuleItemList|.
           1. Append to _names_ the elements of the ExportedBindings of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ModuleItem :
             ImportDeclaration
             StatementListItem
@@ -20933,17 +20933,17 @@
         <emu-note>
           <p>ExportedNames are the externally visible names that a |Module| explicitly maps to one of its local name bindings.</p>
         </emu-note>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _names_ be ExportedNames of |ModuleItemList|.
           1. Append to _names_ the elements of the ExportedNames of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. Return the ExportedNames of |ExportDeclaration|.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ModuleItem :
             ImportDeclaration
             StatementListItem
@@ -20957,17 +20957,17 @@
       <emu-clause id="sec-module-semantics-static-semantics-exportentries">
         <h1>Static Semantics: ExportEntries</h1>
         <emu-see-also-para op="ExportEntries"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-grammar use="reference">Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _entries_ be ExportEntries of |ModuleItemList|.
           1. Append to _entries_ the elements of the ExportEntries of |ModuleItem|.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ModuleItem :
             ImportDeclaration
             StatementListItem
@@ -20981,17 +20981,17 @@
       <emu-clause id="sec-module-semantics-static-semantics-importentries">
         <h1>Static Semantics: ImportEntries</h1>
         <emu-see-also-para op="ImportEntries"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-grammar use="reference">Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _entries_ be ImportEntries of |ModuleItemList|.
           1. Append to _entries_ the elements of the ImportEntries of |ModuleItem|.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ModuleItem :
             ExportDeclaration
             StatementListItem
@@ -21017,22 +21017,22 @@
       <emu-clause id="sec-module-semantics-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-grammar use="reference">Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItem</emu-grammar>
         <emu-alg>
           1. Return ModuleRequests of |ModuleItem|.
         </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _moduleNames_ be ModuleRequests of |ModuleItemList|.
           1. Let _additionalNames_ be ModuleRequests of |ModuleItem|.
           1. Append to _moduleNames_ each element of _additionalNames_ that is not already an element of _moduleNames_.
           1. Return _moduleNames_.
         </emu-alg>
-        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -21045,22 +21045,22 @@
         <emu-note>
           <p>The LexicallyDeclaredNames of a |Module| includes the names of all of its imported bindings.</p>
         </emu-note>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _names_ be LexicallyDeclaredNames of |ModuleItemList|.
           1. Append to _names_ the elements of the LexicallyDeclaredNames of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |ImportDeclaration|.
         </emu-alg>
-        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. If |ExportDeclaration| is `export` |VariableStatement|, return a new empty List.
           1. Return the BoundNames of |ExportDeclaration|.
         </emu-alg>
-        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return LexicallyDeclaredNames of |StatementListItem|.
         </emu-alg>
@@ -21073,17 +21073,17 @@
       <emu-clause id="sec-module-semantics-static-semantics-lexicallyscopeddeclarations">
         <h1>Static Semantics: LexicallyScopedDeclarations</h1>
         <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-grammar use="reference">Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be LexicallyScopedDeclarations of |ModuleItemList|.
           1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |ModuleItem|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -21093,21 +21093,21 @@
       <emu-clause id="sec-module-semantics-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-grammar use="reference">Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _names_ be VarDeclaredNames of |ModuleItemList|.
           1. Append to _names_ the elements of the VarDeclaredNames of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. If |ExportDeclaration| is `export` |VariableStatement|, return BoundNames of |ExportDeclaration|.
           1. Return a new empty List.
@@ -21118,21 +21118,21 @@
       <emu-clause id="sec-module-semantics-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-grammar use="reference">Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be VarScopedDeclarations of |ModuleItemList|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |ModuleItem|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. If |ExportDeclaration| is `export` |VariableStatement|, return VarScopedDeclarations of |VariableStatement|.
           1. Return a new empty List.
@@ -21993,18 +21993,18 @@
       <!-- es6num="15.2.1.20" -->
       <emu-clause id="sec-module-semantics-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-grammar use="reference">Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(*undefined*).
         </emu-alg>
-        <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
+        <emu-grammar use="reference">ModuleBody : ModuleItemList</emu-grammar>
         <emu-alg>
           1. Let _result_ be the result of evaluating |ModuleItemList|.
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
             1. Return NormalCompletion(*undefined*).
           1. Return Completion(_result_).
         </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _sl_ be the result of evaluating |ModuleItemList|.
           1. ReturnIfAbrupt(_sl_).
@@ -22014,7 +22014,7 @@
         <emu-note>
           <p>The value of a |ModuleItemList| is the value of the last value-producing item in the |ModuleItemList|.</p>
         </emu-note>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
@@ -22025,7 +22025,7 @@
     <emu-clause id="sec-imports">
       <h1>Imports</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         ImportDeclaration :
           `import` ImportClause FromClause `;`
           `import` ModuleSpecifier `;`
@@ -22069,7 +22069,7 @@
       <!-- es6num="15.2.2.1" -->
       <emu-clause id="sec-imports-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the BoundNames of |ImportDeclaration| contains any duplicate entries.
@@ -22081,37 +22081,37 @@
       <emu-clause id="sec-imports-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-grammar use="reference">ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |ImportClause|.
         </emu-alg>
-        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+        <emu-grammar use="reference">ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
+        <emu-grammar use="reference">ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ImportedDefaultBinding|.
           1. Append to _names_ the elements of the BoundNames of |NameSpaceImport|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
+        <emu-grammar use="reference">ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ImportedDefaultBinding|.
           1. Append to _names_ the elements of the BoundNames of |NamedImports|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>NamedImports : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">NamedImports : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
+        <emu-grammar use="reference">ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ImportsList|.
           1. Append to _names_ the elements of the BoundNames of |ImportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
+        <emu-grammar use="reference">ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |ImportedBinding|.
         </emu-alg>
@@ -22121,12 +22121,12 @@
       <emu-clause id="sec-imports-static-semantics-importentries">
         <h1>Static Semantics: ImportEntries</h1>
         <emu-see-also-para op="ImportEntries"></emu-see-also-para>
-        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-grammar use="reference">ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
           1. Return ImportEntriesForModule of |ImportClause| with argument _module_.
         </emu-alg>
-        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+        <emu-grammar use="reference">ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -22136,47 +22136,47 @@
       <emu-clause id="sec-static-semantics-importentriesformodule">
         <h1>Static Semantics: ImportEntriesForModule</h1>
         <p>With parameter _module_.</p>
-        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
+        <emu-grammar use="reference">ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
         <emu-alg>
           1. Let _entries_ be ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
           1. Append to _entries_ the elements of the ImportEntriesForModule of |NameSpaceImport| with argument _module_.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
+        <emu-grammar use="reference">ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
         <emu-alg>
           1. Let _entries_ be ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
           1. Append to _entries_ the elements of the ImportEntriesForModule of |NamedImports| with argument _module_.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar>ImportedDefaultBinding : ImportedBinding</emu-grammar>
+        <emu-grammar use="reference">ImportedDefaultBinding : ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
           1. Let _defaultEntry_ be the ImportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: `"default"`, [[LocalName]]: _localName_ }.
           1. Return a new List containing _defaultEntry_.
         </emu-alg>
-        <emu-grammar>NameSpaceImport : `*` `as` ImportedBinding</emu-grammar>
+        <emu-grammar use="reference">NameSpaceImport : `*` `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the StringValue of |ImportedBinding|.
           1. Let _entry_ be the ImportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: `"*"`, [[LocalName]]: _localName_ }.
           1. Return a new List containing _entry_.
         </emu-alg>
-        <emu-grammar>NamedImports : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">NamedImports : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
+        <emu-grammar use="reference">ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _specs_ be the ImportEntriesForModule of |ImportsList| with argument _module_.
           1. Append to _specs_ the elements of the ImportEntriesForModule of |ImportSpecifier| with argument _module_.
           1. Return _specs_.
         </emu-alg>
-        <emu-grammar>ImportSpecifier : ImportedBinding</emu-grammar>
+        <emu-grammar use="reference">ImportSpecifier : ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
           1. Let _entry_ be the ImportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: _localName_, [[LocalName]]: _localName_ }.
           1. Return a new List containing _entry_.
         </emu-alg>
-        <emu-grammar>ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
+        <emu-grammar use="reference">ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _importName_ be the StringValue of |IdentifierName|.
           1. Let _localName_ be the StringValue of |ImportedBinding|.
@@ -22189,11 +22189,11 @@
       <emu-clause id="sec-imports-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
-        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-grammar use="reference">ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Return ModuleRequests of |FromClause|.
         </emu-alg>
-        <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
+        <emu-grammar use="reference">ModuleSpecifier : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |StringLiteral|.
         </emu-alg>
@@ -22204,7 +22204,7 @@
     <emu-clause id="sec-exports">
       <h1>Exports</h1>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         ExportDeclaration :
           `export` `*` FromClause `;`
           `export` ExportClause FromClause `;`
@@ -22232,7 +22232,7 @@
       <!-- es6num="15.2.3.1" -->
       <emu-clause id="sec-exports-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` ExportClause `;`</emu-grammar>
         <ul>
           <li>
             For each |IdentifierName| _n_ in ReferencedBindings of |ExportClause|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or if the StringValue of _n_ is one of: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, or `"static"`.
@@ -22247,7 +22247,7 @@
       <emu-clause id="sec-exports-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration :
             `export` `*` FromClause `;`
             `export` ExportClause FromClause `;`
@@ -22256,27 +22256,27 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |VariableStatement|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |Declaration|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _declarationNames_ be the BoundNames of |HoistableDeclaration|.
           1. If _declarationNames_ does not include the element `"*default*"`, append `"*default*"` to _declarationNames_.
           1. Return _declarationNames_.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _declarationNames_ be the BoundNames of |ClassDeclaration|.
           1. If _declarationNames_ does not include the element `"*default*"`, append `"*default*"` to _declarationNames_.
           1. Return _declarationNames_.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Return &laquo; `"*default*"` &raquo;.
         </emu-alg>
@@ -22286,7 +22286,7 @@
       <emu-clause id="sec-exports-static-semantics-exportedbindings">
         <h1>Static Semantics: ExportedBindings</h1>
         <emu-see-also-para op="ExportedBindings"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration :
             `export` ExportClause FromClause `;`
             `export` `*` FromClause `;`
@@ -22294,19 +22294,19 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` ExportClause `;`</emu-grammar>
         <emu-alg>
           1. Return the ExportedBindings of |ExportClause|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |VariableStatement|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |Declaration|.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration : `export` `default` HoistableDeclaration
 
           ExportDeclaration : `export` `default` ClassDeclaration
@@ -22316,21 +22316,21 @@
         <emu-alg>
           1. Return the BoundNames of this |ExportDeclaration|.
         </emu-alg>
-        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ExportClause : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
+        <emu-grammar use="reference">ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _names_ be the ExportedBindings of |ExportsList|.
           1. Append to _names_ the elements of the ExportedBindings of |ExportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar use="reference">ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |IdentifierName|.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of the first |IdentifierName|.
         </emu-alg>
@@ -22340,11 +22340,11 @@
       <emu-clause id="sec-exports-static-semantics-exportednames">
         <h1>Static Semantics: ExportedNames</h1>
         <emu-see-also-para op="ExportedNames"></emu-see-also-para>
-        <emu-grammar>ExportDeclaration : `export` `*` FromClause `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `*` FromClause `;`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration : `export` ExportClause FromClause `;`
 
           ExportDeclaration : `export` ExportClause `;`
@@ -22352,15 +22352,15 @@
         <emu-alg>
           1. Return the ExportedNames of |ExportClause|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |VariableStatement|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |Declaration|.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration : `export` `default` HoistableDeclaration
 
           ExportDeclaration : `export` `default` ClassDeclaration
@@ -22370,21 +22370,21 @@
         <emu-alg>
           1. Return &laquo; `"default"` &raquo;.
         </emu-alg>
-        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ExportClause : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
+        <emu-grammar use="reference">ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _names_ be the ExportedNames of |ExportsList|.
           1. Append to _names_ the elements of the ExportedNames of |ExportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar use="reference">ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |IdentifierName|.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of the second |IdentifierName|.
         </emu-alg>
@@ -22394,22 +22394,22 @@
       <emu-clause id="sec-exports-static-semantics-exportentries">
         <h1>Static Semantics: ExportEntries</h1>
         <emu-see-also-para op="ExportEntries"></emu-see-also-para>
-        <emu-grammar>ExportDeclaration : `export` `*` FromClause `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `*` FromClause `;`</emu-grammar>
         <emu-alg>
           1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
           1. Let _entry_ be the ExportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: `"*"`, [[LocalName]]: *null*, [[ExportName]]: *null* }.
           1. Return a new List containing _entry_.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` ExportClause FromClause `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` ExportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
           1. Return ExportEntriesForModule of |ExportClause| with argument _module_.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` ExportClause `;`</emu-grammar>
         <emu-alg>
           1. Return ExportEntriesForModule of |ExportClause| with argument *null*.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Let _entries_ be a new empty List.
           1. Let _names_ be the BoundNames of |VariableStatement|.
@@ -22417,7 +22417,7 @@
             1. Append the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _name_, [[ExportName]]: _name_ } to _entries_.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Let _entries_ be a new empty List.
           1. Let _names_ be the BoundNames of |Declaration|.
@@ -22425,19 +22425,19 @@
             1. Append the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _name_, [[ExportName]]: _name_ } to _entries_.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |HoistableDeclaration|.
           1. Let _localName_ be the sole element of _names_.
           1. Return a new List containing the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: `"default"`}.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |ClassDeclaration|.
           1. Let _localName_ be the sole element of _names_.
           1. Return a new List containing the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: `"default"`}.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Let _entry_ be the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: `"*default*"`, [[ExportName]]: `"default"`}.
           1. Return a new List containing _entry_.
@@ -22451,17 +22451,17 @@
       <emu-clause id="sec-static-semantics-exportentriesformodule">
         <h1>Static Semantics: ExportEntriesForModule</h1>
         <p>With parameter _module_.</p>
-        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ExportClause : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
+        <emu-grammar use="reference">ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _specs_ be the ExportEntriesForModule of |ExportsList| with argument _module_.
           1. Append to _specs_ the elements of the ExportEntriesForModule of |ExportSpecifier| with argument _module_.
           1. Return _specs_.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar use="reference">ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _sourceName_ be the StringValue of |IdentifierName|.
           1. If _module_ is *null*, then
@@ -22472,7 +22472,7 @@
             1. Let _importName_ be _sourceName_.
           1. Return a new List containing the ExportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _sourceName_ }.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _sourceName_ be the StringValue of the first |IdentifierName|.
           1. Let _exportName_ be the StringValue of the second |IdentifierName|.
@@ -22490,7 +22490,7 @@
       <emu-clause id="sec-exports-static-semantics-isconstantdeclaration">
         <h1>Static Semantics: IsConstantDeclaration</h1>
         <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration :
             `export` `*` FromClause `;`
             `export` ExportClause FromClause `;`
@@ -22509,7 +22509,7 @@
       <emu-clause id="sec-exports-static-semantics-lexicallyscopeddeclarations">
         <h1>Static Semantics: LexicallyScopedDeclarations</h1>
         <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration :
             `export` `*` FromClause `;`
             `export` ExportClause FromClause `;`
@@ -22519,19 +22519,19 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return a new List containing DeclarationPart of |Declaration|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new List containing DeclarationPart of |HoistableDeclaration|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new List containing |ClassDeclaration|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Return a new List containing this |ExportDeclaration|.
         </emu-alg>
@@ -22541,7 +22541,7 @@
       <emu-clause id="sec-exports-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration : `export` `*` FromClause `;`
 
           ExportDeclaration : `export` ExportClause FromClause `;`
@@ -22549,7 +22549,7 @@
         <emu-alg>
           1. Return the ModuleRequests of |FromClause|.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration :
             `export` ExportClause `;`
             `export` VariableStatement
@@ -22566,21 +22566,21 @@
       <!-- es6num="15.2.3.10" -->
       <emu-clause id="sec-static-semantics-referencedbindings">
         <h1>Static Semantics: ReferencedBindings</h1>
-        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
+        <emu-grammar use="reference">ExportClause : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
+        <emu-grammar use="reference">ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _names_ be the ReferencedBindings of |ExportsList|.
           1. Append to _names_ the elements of the ReferencedBindings of |ExportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar use="reference">ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the |IdentifierName|.
         </emu-alg>
-        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
+        <emu-grammar use="reference">ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the first |IdentifierName|.
         </emu-alg>
@@ -22589,7 +22589,7 @@
       <!-- es6num="15.2.3.11" -->
       <emu-clause id="sec-exports-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>
+        <emu-grammar use="reference">
           ExportDeclaration :
             `export` `*` FromClause `;`
             `export` ExportClause FromClause `;`
@@ -22598,19 +22598,19 @@
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Return the result of evaluating |VariableStatement|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return the result of evaluating |Declaration|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Return the result of evaluating |HoistableDeclaration|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _value_ be the result of BindingClassDeclarationEvaluation of |ClassDeclaration|.
           1. ReturnIfAbrupt(_value_).
@@ -22622,7 +22622,7 @@
             1. Perform ? InitializeBoundName(`"*default*"`, _value_, _env_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+        <emu-grammar use="reference">ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
           1. Let _value_ be ? GetValue(_rhs_).
@@ -22835,7 +22835,7 @@
         <emu-clause id="sec-performeval-rules-outside-functions">
           <h1>Additional Early Error Rules for Eval Outside Functions</h1>
           <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of any function.</p>
-          <emu-grammar>ScriptBody : StatementList</emu-grammar>
+          <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
           <ul>
             <li>It is a Syntax Error if |StatementList| Contains |NewTarget|.</li>
           </ul>
@@ -22844,7 +22844,7 @@
         <emu-clause id="sec-performeval-rules-outside-methods">
           <h1>Additional Early Error Rules for Eval Outside Methods</h1>
           <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of a |MethodDefinition|.</p>
-          <emu-grammar>ScriptBody : StatementList</emu-grammar>
+          <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
           <ul>
             <li>It is a Syntax Error if |StatementList| Contains |SuperProperty|.</li>
           </ul>
@@ -22853,7 +22853,7 @@
         <emu-clause id="sec-performeval-rules-outside-constructors">
           <h1>Additional Early Error Rules for Eval Outside Constructor Methods</h1>
           <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of the <emu-xref href="#sec-static-semantics-constructormethod">constructor method</emu-xref> of a |ClassDeclaration| or |ClassExpression|.</p>
-          <emu-grammar>ScriptBody : StatementList</emu-grammar>
+          <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
           <ul>
             <li>It is a Syntax Error if |StatementList| Contains |SuperCall|.</li>
           </ul>
@@ -23061,7 +23061,7 @@
         <p>where the italicized names represent components and &ldquo;`:`&rdquo;, &ldquo;`/`&rdquo;, &ldquo;`;`&rdquo; and &ldquo;`?`&rdquo; are reserved for use as separators. The `encodeURI` and `decodeURI` functions are intended to work with complete URIs; they assume that any reserved code units in the URI are intended to have special meaning and so are not encoded. The `encodeURIComponent` and `decodeURIComponent` functions are intended to work with the individual component parts of a URI; they assume that any reserved code units represent text and so must be encoded so that they are not interpreted as reserved code units when the component is part of a complete URI.</p>
         <p>The following lexical grammar specifies the form of encoded URIs.</p>
         <h2>Syntax</h2>
-        <emu-grammar definition>
+        <emu-grammar use="definition">
           uri :::
             uriCharacters?
 
@@ -24166,7 +24166,7 @@
             1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
             1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
             1. Let _strict_ be ContainsUseStrict of _body_.
-            1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied. Parsing and early error detection may be interweaved in an implementation-dependent manner.
+            1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar> are applied. Parsing and early error detection may be interweaved in an implementation-dependent manner.
             1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
             1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.
             1. If _body_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
@@ -28640,7 +28640,7 @@ THH:mm:ss.sss
       <h1>Patterns</h1>
       <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         Pattern[U] ::
           Disjunction[?U]
 
@@ -28720,7 +28720,7 @@ THH:mm:ss.sss
           [+U] `u{` HexDigits `}`
       </emu-grammar>
       <p>Each `\\u` |TrailSurrogate| for which the choice of associated `u` |LeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |LeadSurrogate| that would otherwise have no corresponding `\\u` |TrailSurrogate|.</p>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         LeadSurrogate ::
           Hex4Digits [> but only if the SV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
 
@@ -28777,13 +28777,13 @@ THH:mm:ss.sss
       <!-- es6num="21.2.1.1" -->
       <emu-clause id="sec-patterns-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>Pattern :: Disjunction</emu-grammar>
+        <emu-grammar use="reference">Pattern :: Disjunction</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if _NcapturingParens_ &ge; 2<sup>32</sup>-1.
           </li>
         </ul>
-        <emu-grammar>RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
+        <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the MV of |HexDigits| &gt; 0x10FFFF.
@@ -28816,7 +28816,7 @@ THH:mm:ss.sss
             _InputLength_ is the number of characters in _Input_.
           </li>
           <li>
-            _NcapturingParens_ is the total number of left-capturing parentheses (i.e. the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes) in the pattern. A left-capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production.
+            _NcapturingParens_ is the total number of left-capturing parentheses (i.e. the total number of <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes) in the pattern. A left-capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> production.
           </li>
           <li>
             _IgnoreCase_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains `"i"` and otherwise is *false*.
@@ -28854,7 +28854,7 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.2" -->
       <emu-clause id="sec-pattern">
         <h1>Pattern</h1>
-        <p>The production <emu-grammar>Pattern :: Disjunction</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Pattern :: Disjunction</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
           1. Return an internal closure that takes two arguments, a String _str_ and an integer _index_, and performs the following steps:
@@ -28875,12 +28875,12 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.3" -->
       <emu-clause id="sec-disjunction">
         <h1>Disjunction</h1>
-        <p>The production <emu-grammar>Disjunction :: Alternative</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Disjunction :: Alternative</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Alternative| to obtain a Matcher _m_.
           1. Return _m_.
         </emu-alg>
-        <p>The production <emu-grammar>Disjunction :: Alternative `|` Disjunction</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Disjunction :: Alternative `|` Disjunction</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Alternative| to obtain a Matcher _m1_.
           1. Evaluate |Disjunction| to obtain a Matcher _m2_.
@@ -28904,11 +28904,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.4" -->
       <emu-clause id="sec-alternative">
         <h1>Alternative</h1>
-        <p>The production <emu-grammar>Alternative :: [empty]</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Alternative :: [empty]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return a Matcher that takes two arguments, a State _x_ and a Continuation _c_, and returns the result of calling _c_(_x_).
         </emu-alg>
-        <p>The production <emu-grammar>Alternative :: Alternative Term</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Alternative :: Alternative Term</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Alternative| to obtain a Matcher _m1_.
           1. Evaluate |Term| to obtain a Matcher _m2_.
@@ -28924,7 +28924,7 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.5" -->
       <emu-clause id="sec-term">
         <h1>Term</h1>
-        <p>The production <emu-grammar>Term :: Assertion</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Term :: Assertion</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps when evaluated:
             1. Evaluate |Assertion| to obtain an AssertionTester _t_.
@@ -28932,17 +28932,17 @@ THH:mm:ss.sss
             1. If _r_ is *false*, return ~failure~.
             1. Call _c_(_x_) and return its result.
         </emu-alg>
-        <p>The production <emu-grammar>Term :: Atom</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Term :: Atom</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Atom|.
         </emu-alg>
-        <p>The production <emu-grammar>Term :: Atom Quantifier</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Term :: Atom Quantifier</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Atom| to obtain a Matcher _m_.
           1. Evaluate |Quantifier| to obtain the three results: an integer _min_, an integer (or &infin;) _max_, and Boolean _greedy_.
           1. If _max_ is finite and less than _min_, throw a *SyntaxError* exception.
-          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Term|. This is the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Term|.
-          1. Let _parenCount_ be the number of left-capturing parentheses in |Atom|. This is the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes enclosed by |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Term|. This is the total number of <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Term|.
+          1. Let _parenCount_ be the number of left-capturing parentheses in |Atom|. This is the total number of <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes enclosed by |Atom|.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps when evaluated:
             1. Call RepeatMatcher(_m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_) and return its result.
         </emu-alg>
@@ -29017,7 +29017,7 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.6" -->
       <emu-clause id="sec-assertion">
         <h1>Assertion</h1>
-        <p>The production <emu-grammar>Assertion :: `^`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Assertion :: `^`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal AssertionTester closure that takes a State argument _x_ and performs the following steps when evaluated:
             1. Let _e_ be _x_'s _endIndex_.
@@ -29029,7 +29029,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>Even when the `y` flag is used with a pattern, `^` always matches only at the beginning of _Input_, or (if _Multiline_ is *true*) at the beginning of a line.</p>
         </emu-note>
-        <p>The production <emu-grammar>Assertion :: `$`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Assertion :: `$`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal AssertionTester closure that takes a State argument _x_ and performs the following steps when evaluated:
             1. Let _e_ be _x_'s _endIndex_.
@@ -29038,7 +29038,7 @@ THH:mm:ss.sss
             1. If the character _Input_[_e_] is one of |LineTerminator|, return *true*.
             1. Return *false*.
         </emu-alg>
-        <p>The production <emu-grammar>Assertion :: `\` `b`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Assertion :: `\` `b`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal AssertionTester closure that takes a State argument _x_ and performs the following steps when evaluated:
             1. Let _e_ be _x_'s _endIndex_.
@@ -29048,7 +29048,7 @@ THH:mm:ss.sss
             1. If _a_ is *false* and _b_ is *true*, return *true*.
             1. Return *false*.
         </emu-alg>
-        <p>The production <emu-grammar>Assertion :: `\` `B`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Assertion :: `\` `B`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal AssertionTester closure that takes a State argument _x_ and performs the following steps when evaluated:
             1. Let _e_ be _x_'s _endIndex_.
@@ -29058,7 +29058,7 @@ THH:mm:ss.sss
             1. If _a_ is *false* and _b_ is *true*, return *false*.
             1. Return *true*.
         </emu-alg>
-        <p>The production <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps:
@@ -29071,7 +29071,7 @@ THH:mm:ss.sss
             1. Let _z_ be the State (_xe_, _cap_).
             1. Call _c_(_z_) and return its result.
         </emu-alg>
-        <p>The production <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps:
@@ -29341,39 +29341,39 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.7" -->
       <emu-clause id="sec-quantifier">
         <h1>Quantifier</h1>
-        <p>The production <emu-grammar>Quantifier :: QuantifierPrefix</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Quantifier :: QuantifierPrefix</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |QuantifierPrefix| to obtain the two results: an integer _min_ and an integer (or &infin;) _max_.
           1. Return the three results _min_, _max_, and *true*.
         </emu-alg>
-        <p>The production <emu-grammar>Quantifier :: QuantifierPrefix `?`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Quantifier :: QuantifierPrefix `?`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |QuantifierPrefix| to obtain the two results: an integer _min_ and an integer (or &infin;) _max_.
           1. Return the three results _min_, _max_, and *false*.
         </emu-alg>
-        <p>The production <emu-grammar>QuantifierPrefix :: `*`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `*`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the two results 0 and &infin;.
         </emu-alg>
-        <p>The production <emu-grammar>QuantifierPrefix :: `+`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `+`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the two results 1 and &infin;.
         </emu-alg>
-        <p>The production <emu-grammar>QuantifierPrefix :: `?`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `?`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the two results 0 and 1.
         </emu-alg>
-        <p>The production <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `{` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _i_ be the MV of |DecimalDigits| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>).
           1. Return the two results _i_ and _i_.
         </emu-alg>
-        <p>The production <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` `}`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `{` DecimalDigits `,` `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _i_ be the MV of |DecimalDigits|.
           1. Return the two results _i_ and &infin;.
         </emu-alg>
-        <p>The production <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _i_ be the MV of the first |DecimalDigits|.
           1. Let _j_ be the MV of the second |DecimalDigits|.
@@ -29384,30 +29384,30 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.8" -->
       <emu-clause id="sec-atom">
         <h1>Atom</h1>
-        <p>The production <emu-grammar>Atom :: PatternCharacter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Atom :: PatternCharacter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character matched by |PatternCharacter|.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: `.`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Atom :: `.`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _A_ be the set of all characters except |LineTerminator|.
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: `\` AtomEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Atom :: `\` AtomEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |AtomEscape|.
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: CharacterClass</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Atom :: CharacterClass</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterClass| to obtain a CharSet _A_ and a Boolean _invert_.
           1. Call CharacterSetMatcher(_A_, _invert_) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
-          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Atom|. This is the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Atom|. This is the total number of <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Atom|.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps:
             1. Let _d_ be an internal Continuation closure that takes one State argument _y_ and performs the following steps:
               1. Let _cap_ be a fresh copy of _y_'s _captures_ List.
@@ -29419,7 +29419,7 @@ THH:mm:ss.sss
               1. Call _c_(_z_) and return its result.
             1. Call _m_(_x_, _d_) and return its result.
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: `(` `?` `:` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Atom :: `(` `?` `:` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Disjunction|.
         </emu-alg>
@@ -29494,7 +29494,7 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.9" -->
       <emu-clause id="sec-atomescape">
         <h1>AtomEscape</h1>
-        <p>The production <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">AtomEscape :: DecimalEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |DecimalEscape| to obtain an integer _n_.
           1. If _n_&gt;_NcapturingParens_, throw a *SyntaxError* exception.
@@ -29510,13 +29510,13 @@ THH:mm:ss.sss
             1. Let _y_ be the State (_f_, _cap_).
             1. Call _c_(_y_) and return its result.
         </emu-alg>
-        <p>The production <emu-grammar>AtomEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">AtomEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterEscape| to obtain a character _ch_.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar>AtomEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">AtomEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterClassEscape| to obtain a CharSet _A_.
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
@@ -29529,14 +29529,14 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.10" -->
       <emu-clause id="sec-characterescape">
         <h1>CharacterEscape</h1>
-        <p>The production <emu-grammar>CharacterEscape :: `0`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterEscape :: `0`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character U+0000 (NULL).
         </emu-alg>
         <emu-note>
           <p>`\\0` represents the &lt;NUL&gt; character and cannot be followed by a decimal digit.</p>
         </emu-note>
-        <p>The production <emu-grammar>CharacterEscape :: ControlEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterEscape :: ControlEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character according to <emu-xref href="#table-47"></emu-xref>.
         </emu-alg>
@@ -29648,61 +29648,61 @@ THH:mm:ss.sss
             </tbody>
           </table>
         </emu-table>
-        <p>The production <emu-grammar>CharacterEscape :: `c` ControlLetter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterEscape :: `c` ControlLetter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character matched by |ControlLetter|.
           1. Let _i_ be _ch_'s character value.
           1. Let _j_ be the remainder of dividing _i_ by 32.
           1. Return the character whose character value is _j_.
         </emu-alg>
-        <p>The production <emu-grammar>CharacterEscape :: HexEscapeSequence</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterEscape :: HexEscapeSequence</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |HexEscapeSequence|.
         </emu-alg>
-        <p>The production <emu-grammar>CharacterEscape :: RegExpUnicodeEscapeSequence</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterEscape :: RegExpUnicodeEscapeSequence</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the result of evaluating |RegExpUnicodeEscapeSequence|.
         </emu-alg>
-        <p>The production <emu-grammar>CharacterEscape :: IdentityEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterEscape :: IdentityEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character matched by |IdentityEscape|.
         </emu-alg>
-        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` LeadSurrogate `\u` TrailSurrogate</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` LeadSurrogate `\u` TrailSurrogate</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _lead_ be the result of evaluating |LeadSurrogate|.
           1. Let _trail_ be the result of evaluating |TrailSurrogate|.
           1. Let _cp_ be UTF16Decode(_lead_, _trail_).
           1. Return the character whose character value is _cp_.
         </emu-alg>
-        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` LeadSurrogate</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` LeadSurrogate</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the result of evaluating |LeadSurrogate|.
         </emu-alg>
-        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` TrailSurrogate</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` TrailSurrogate</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the result of evaluating |TrailSurrogate|.
         </emu-alg>
-        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` NonSurrogate</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` NonSurrogate</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the result of evaluating |NonSurrogate|.
         </emu-alg>
-        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |Hex4Digits|.
         </emu-alg>
-        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the MV of |HexDigits|.
         </emu-alg>
-        <p>The production <emu-grammar>LeadSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">LeadSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |Hex4Digits|.
         </emu-alg>
-        <p>The production <emu-grammar>TrailSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">TrailSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |Hex4Digits|.
         </emu-alg>
-        <p>The production <emu-grammar>NonSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |Hex4Digits|.
         </emu-alg>
@@ -29711,11 +29711,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.11" -->
       <emu-clause id="sec-decimalescape">
         <h1>DecimalEscape</h1>
-        <p>The production <emu-grammar>DecimalEscape :: NonZeroDigit</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">DecimalEscape :: NonZeroDigit</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the MV of |NonZeroDigit|.
         </emu-alg>
-        <p>The production <emu-grammar>DecimalEscape :: NonZeroDigit DecimalDigits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">DecimalEscape :: NonZeroDigit DecimalDigits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _n_ be the number of code points in |DecimalDigits|.
           1. Return (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|.
@@ -29729,41 +29729,41 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.12" -->
       <emu-clause id="sec-characterclassescape">
         <h1>CharacterClassEscape</h1>
-        <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `d`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the ten-element set of characters containing the characters `0` through `9` inclusive.
         </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `D`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar>.
+          1. Return the set of all characters not included in the set returned by <emu-grammar use="reference">CharacterClassEscape :: `d`</emu-grammar>.
         </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `s`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the set of characters containing the characters that are on the right-hand side of the |WhiteSpace| or |LineTerminator| productions.
         </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `S`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> .
+          1. Return the set of all characters not included in the set returned by <emu-grammar use="reference">CharacterClassEscape :: `s`</emu-grammar> .
         </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `w`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the set of all characters returned by WordCharacters().
         </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `W`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> .
+          1. Return the set of all characters not included in the set returned by <emu-grammar use="reference">CharacterClassEscape :: `w`</emu-grammar> .
         </emu-alg>
       </emu-clause>
 
       <!-- es6num="21.2.2.13" -->
       <emu-clause id="sec-characterclass">
         <h1>CharacterClass</h1>
-        <p>The production <emu-grammar>CharacterClass :: `[` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterClass :: `[` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassRanges| to obtain a CharSet _A_.
           1. Return the two results _A_ and *false*.
         </emu-alg>
-        <p>The production <emu-grammar>CharacterClass :: `[` `^` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterClass :: `[` `^` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassRanges| to obtain a CharSet _A_.
           1. Return the two results _A_ and *true*.
@@ -29773,11 +29773,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.14" -->
       <emu-clause id="sec-classranges">
         <h1>ClassRanges</h1>
-        <p>The production <emu-grammar>ClassRanges :: [empty]</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassRanges :: [empty]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the empty CharSet.
         </emu-alg>
-        <p>The production <emu-grammar>ClassRanges :: NonemptyClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassRanges :: NonemptyClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |NonemptyClassRanges| to obtain a CharSet _A_.
           1. Return _A_.
@@ -29787,17 +29787,17 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.15" -->
       <emu-clause id="sec-nonemptyclassranges">
         <h1>NonemptyClassRanges</h1>
-        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonemptyClassRanges :: ClassAtom</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |ClassAtom|.
         </emu-alg>
-        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom NonemptyClassRangesNoDash</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonemptyClassRanges :: ClassAtom NonemptyClassRangesNoDash</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtom| to obtain a CharSet _A_.
           1. Evaluate |NonemptyClassRangesNoDash| to obtain a CharSet _B_.
           1. Return the union of CharSets _A_ and _B_.
         </emu-alg>
-        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate the first |ClassAtom| to obtain a CharSet _A_.
           1. Evaluate the second |ClassAtom| to obtain a CharSet _B_.
@@ -29825,17 +29825,17 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.16" -->
       <emu-clause id="sec-nonemptyclassrangesnodash">
         <h1>NonemptyClassRangesNoDash</h1>
-        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtom</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonemptyClassRangesNoDash :: ClassAtom</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |ClassAtom|.
         </emu-alg>
-        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash NonemptyClassRangesNoDash</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonemptyClassRangesNoDash :: ClassAtomNoDash NonemptyClassRangesNoDash</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Evaluate |NonemptyClassRangesNoDash| to obtain a CharSet _B_.
           1. Return the union of CharSets _A_ and _B_.
         </emu-alg>
-        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Evaluate |ClassAtom| to obtain a CharSet _B_.
@@ -29857,11 +29857,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.17" -->
       <emu-clause id="sec-classatom">
         <h1>ClassAtom</h1>
-        <p>The production <emu-grammar>ClassAtom :: `-`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassAtom :: `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
         </emu-alg>
-        <p>The production <emu-grammar>ClassAtom :: ClassAtomNoDash</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassAtom :: ClassAtomNoDash</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Return _A_.
@@ -29871,11 +29871,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.18" -->
       <emu-clause id="sec-classatomnodash">
         <h1>ClassAtomNoDash</h1>
-        <p>The production <emu-grammar>ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the character matched by |SourceCharacter|.
         </emu-alg>
-        <p>The production <emu-grammar>ClassAtomNoDash :: `\` ClassEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassAtomNoDash :: `\` ClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |ClassEscape|.
         </emu-alg>
@@ -29884,19 +29884,19 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.19" -->
       <emu-clause id="sec-classescape">
         <h1>ClassEscape</h1>
-        <p>The production <emu-grammar>ClassEscape :: `b`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassEscape :: `b`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character &lt;BS&gt; U+0008 (BACKSPACE).
         </emu-alg>
-        <p>The production <emu-grammar>ClassEscape :: `-`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassEscape :: `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
         </emu-alg>
-        <p>The production <emu-grammar>ClassEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character that is the result of evaluating |CharacterEscape|.
         </emu-alg>
-        <p>The production <emu-grammar>ClassEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |CharacterClassEscape|.
         </emu-alg>
@@ -35363,14 +35363,14 @@ THH:mm:ss.sss
       </emu-alg>
       <p>The `length` property of the `parse` function is 2.</p>
       <p>JSON allows Unicode code units 0x2028 (LINE SEPARATOR) and 0x2029 (PARAGRAPH SEPARATOR) to directly appear in String literals without using an escape sequence. This is enabled by using the following alternative definition of |DoubleStringCharacter| when parsing _scriptText_ in step 4:</p>
-      <emu-grammar>
+      <emu-grammar use="definition">
         DoubleStringCharacter ::
           SourceCharacter but not one of `"` or `\` or U+0000 through U+001F
           `\` EscapeSequence
       </emu-grammar>
       <ul>
         <li>
-          The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or U+0000 through U+001F</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+          The SV of <emu-grammar use="reference">DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or U+0000 through U+001F</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
         </li>
       </ul>
       <emu-note>
@@ -38357,7 +38357,7 @@ THH:mm:ss.sss
       <h1>Numeric Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-numeric-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         NumericLiteral ::
           DecimalLiteral
           BinaryIntegerLiteral
@@ -38392,34 +38392,34 @@ THH:mm:ss.sss
       <h1>Static Semantics</h1>
       <ul>
         <li>
-          The MV of <emu-grammar>LegacyOctalIntegerLiteral :: `0` OctalDigit</emu-grammar> is the MV of |OctalDigit|.
+          The MV of <emu-grammar use="reference">LegacyOctalIntegerLiteral :: `0` OctalDigit</emu-grammar> is the MV of |OctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar>LegacyOctalIntegerLiteral :: LegacyOctalIntegerLiteral OctalDigit</emu-grammar> is (the MV of |LegacyOctalIntegerLiteral| times 8) plus the MV of |OctalDigit|.
+          The MV of <emu-grammar use="reference">LegacyOctalIntegerLiteral :: LegacyOctalIntegerLiteral OctalDigit</emu-grammar> is (the MV of |LegacyOctalIntegerLiteral| times 8) plus the MV of |OctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar>DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral</emu-grammar> is the MV of |NonOctalDecimalIntegerLiteral|.
+          The MV of <emu-grammar use="reference">DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral</emu-grammar> is the MV of |NonOctalDecimalIntegerLiteral|.
         </li>
         <li>
-          The MV of <emu-grammar>NonOctalDecimalIntegerLiteral :: `0` NonOctalDigit</emu-grammar> is the MV of |NonOctalDigit|.
+          The MV of <emu-grammar use="reference">NonOctalDecimalIntegerLiteral :: `0` NonOctalDigit</emu-grammar> is the MV of |NonOctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar>NonOctalDecimalIntegerLiteral :: LegacyOctalLikeDecimalIntegerLiteral NonOctalDigit</emu-grammar> is (the MV of |LegacyOctalLikeDecimalIntegerLiteral| times 10) plus the MV of |NonOctalDigit|.
+          The MV of <emu-grammar use="reference">NonOctalDecimalIntegerLiteral :: LegacyOctalLikeDecimalIntegerLiteral NonOctalDigit</emu-grammar> is (the MV of |LegacyOctalLikeDecimalIntegerLiteral| times 10) plus the MV of |NonOctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar>NonOctalDecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral DecimalDigit</emu-grammar> is (the MV of |NonOctalDecimalIntegerLiteral| times 10) plus the MV of |DecimalDigit|.
+          The MV of <emu-grammar use="reference">NonOctalDecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral DecimalDigit</emu-grammar> is (the MV of |NonOctalDecimalIntegerLiteral| times 10) plus the MV of |DecimalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar>LegacyOctalLikeDecimalIntegerLiteral :: `0` OctalDigit</emu-grammar> is the MV of |OctalDigit|.
+          The MV of <emu-grammar use="reference">LegacyOctalLikeDecimalIntegerLiteral :: `0` OctalDigit</emu-grammar> is the MV of |OctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar>LegacyOctalLikeDecimalIntegerLiteral :: LegacyOctalLikeDecimalIntegerLiteral OctalDigit</emu-grammar> is (the MV of |LegacyOctalLikeDecimalIntegerLiteral| times 10) plus the MV of |OctalDigit|.
+          The MV of <emu-grammar use="reference">LegacyOctalLikeDecimalIntegerLiteral :: LegacyOctalLikeDecimalIntegerLiteral OctalDigit</emu-grammar> is (the MV of |LegacyOctalLikeDecimalIntegerLiteral| times 10) plus the MV of |OctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar>NonOctalDigit :: `8`</emu-grammar> is 8.
+          The MV of <emu-grammar use="reference">NonOctalDigit :: `8`</emu-grammar> is 8.
         </li>
         <li>
-          The MV of <emu-grammar>NonOctalDigit :: `9`</emu-grammar> is 9.
+          The MV of <emu-grammar use="reference">NonOctalDigit :: `9`</emu-grammar> is 9.
         </li>
       </ul>
       </emu-annex>
@@ -38430,7 +38430,7 @@ THH:mm:ss.sss
       <h1>String Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-string-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         EscapeSequence ::
           CharacterEscapeSequence
           LegacyOctalEscapeSequence
@@ -38456,43 +38456,43 @@ THH:mm:ss.sss
         <h1>Static Semantics</h1>
         <ul>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the SV of the |LegacyOctalEscapeSequence|.
+            The SV of <emu-grammar use="reference">EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the SV of the |LegacyOctalEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: OctalDigit</emu-grammar> is the code unit whose value is the MV of the |OctalDigit|.
+            The SV of <emu-grammar use="reference">LegacyOctalEscapeSequence :: OctalDigit</emu-grammar> is the code unit whose value is the MV of the |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |ZeroToThree|) plus the MV of the |OctalDigit|.
+            The SV of <emu-grammar use="reference">LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |ZeroToThree|) plus the MV of the |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: FourToSeven OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |FourToSeven|) plus the MV of the |OctalDigit|.
+            The SV of <emu-grammar use="reference">LegacyOctalEscapeSequence :: FourToSeven OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |FourToSeven|) plus the MV of the |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is the code unit whose value is (64 (that is, 8<sup>2</sup>) times the MV of the |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
+            The SV of <emu-grammar use="reference">LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is the code unit whose value is (64 (that is, 8<sup>2</sup>) times the MV of the |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>ZeroToThree :: `0`</emu-grammar> is 0.
+            The MV of <emu-grammar use="reference">ZeroToThree :: `0`</emu-grammar> is 0.
           </li>
           <li>
-            The MV of <emu-grammar>ZeroToThree :: `1`</emu-grammar> is 1.
+            The MV of <emu-grammar use="reference">ZeroToThree :: `1`</emu-grammar> is 1.
           </li>
           <li>
-            The MV of <emu-grammar>ZeroToThree :: `2`</emu-grammar> is 2.
+            The MV of <emu-grammar use="reference">ZeroToThree :: `2`</emu-grammar> is 2.
           </li>
           <li>
-            The MV of <emu-grammar>ZeroToThree :: `3`</emu-grammar> is 3.
+            The MV of <emu-grammar use="reference">ZeroToThree :: `3`</emu-grammar> is 3.
           </li>
           <li>
-            The MV of <emu-grammar>FourToSeven :: `4`</emu-grammar> is 4.
+            The MV of <emu-grammar use="reference">FourToSeven :: `4`</emu-grammar> is 4.
           </li>
           <li>
-            The MV of <emu-grammar>FourToSeven :: `5`</emu-grammar> is 5.
+            The MV of <emu-grammar use="reference">FourToSeven :: `5`</emu-grammar> is 5.
           </li>
           <li>
-            The MV of <emu-grammar>FourToSeven :: `6`</emu-grammar> is 6.
+            The MV of <emu-grammar use="reference">FourToSeven :: `6`</emu-grammar> is 6.
           </li>
           <li>
-            The MV of <emu-grammar>FourToSeven :: `7`</emu-grammar> is 7.
+            The MV of <emu-grammar use="reference">FourToSeven :: `7`</emu-grammar> is 7.
           </li>
         </ul>
       </emu-annex>
@@ -38503,7 +38503,7 @@ THH:mm:ss.sss
       <h1>HTML-like Comments</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source code using the goal symbol |Module|:</p>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         Comment ::
           MultiLineComment
           SingleLineComment
@@ -38558,7 +38558,7 @@ THH:mm:ss.sss
       <p>The syntax of <emu-xref href="#sec-patterns"></emu-xref> is modified and extended as follows. These changes introduce ambiguities that are broken by the ordering of grammar productions and by contextual information. When parsing using the following grammar, each alternative is considered only if previous production alternatives do not match.</p>
       <p>This alternative pattern grammar and semantics only changes the syntax and semantics of BMP patterns. The following grammar extensions include productions parameterized with the [U] parameter. However, none of these extensions change the syntax of Unicode patterns recognized when parsing with the [U] parameter present on the goal symbol.</p>
       <h2>Syntax</h2>
-      <emu-grammar definition>
+      <emu-grammar use="definition">
         Term[U] ::
           [+U] Assertion[+U]
           [+U] Atom[+U]
@@ -38643,33 +38643,33 @@ THH:mm:ss.sss
       <emu-annex id="sec-regular-expression-patterns-semantics">
         <h1>Pattern Semantics</h1>
         <p>The semantics of <emu-xref href="#sec-pattern-semantics"></emu-xref> is extended as follows:</p>
-        <p>Within <emu-xref href="#sec-term"></emu-xref> reference to &ldquo;<emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar>ExtendedAtom :: `(` Disjunction `)`</emu-grammar> &rdquo;.</p>
+        <p>Within <emu-xref href="#sec-term"></emu-xref> reference to &ldquo;<emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar use="reference">ExtendedAtom :: `(` Disjunction `)`</emu-grammar> &rdquo;.</p>
 
         <p>Term (<emu-xref href="#sec-term"></emu-xref>) includes the following additional evaluation rules:</p>
-        <p>The production <emu-grammar>Term :: QuantifiableAssertion Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
-        <p>The production <emu-grammar>Term :: ExtendedAtom Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
-        <p>The production <emu-grammar>Term :: ExtendedAtom</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
+        <p>The production <emu-grammar use="reference">Term :: QuantifiableAssertion Quantifier</emu-grammar> evaluates the same as the production <emu-grammar use="reference">Term :: Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
+        <p>The production <emu-grammar use="reference">Term :: ExtendedAtom Quantifier</emu-grammar> evaluates the same as the production <emu-grammar use="reference">Term :: Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
+        <p>The production <emu-grammar use="reference">Term :: ExtendedAtom</emu-grammar> evaluates the same as the production <emu-grammar use="reference">Term :: Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
 
         <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>Assertion :: QuantifiableAssertion</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">Assertion :: QuantifiableAssertion</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |QuantifiableAssertion| to obtain a Matcher _m_.
           1. Return _m_.
         </emu-alg>
 
-        <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) evaluation rules for the <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
+        <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) evaluation rules for the <emu-grammar use="reference">Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar use="reference">Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
 
-        <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules are also added:</p>
-        <p>The production <emu-grammar>ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar use="reference">Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules are also added:</p>
+        <p>The production <emu-grammar use="reference">ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar>ExtendedAtom :: InvalidBracedQuantifier</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ExtendedAtom :: InvalidBracedQuantifier</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Throw a *SyntaxError* exception.
         </emu-alg>
-        <p>The production <emu-grammar>ExtendedAtom :: ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ExtendedAtom :: ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character represented by |ExtendedPatternCharacter|.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
@@ -38677,14 +38677,14 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>CharacterEscape (<emu-xref href="#sec-characterescape"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate the SV of the |LegacyOctalEscapeSequence| (see <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>) to obtain a character _ch_.
           1. Return _ch_.
         </emu-alg>
 
         <p>NonemptyClassRanges (<emu-xref href="#sec-nonemptyclassranges"></emu-xref>) modifies the following evaluation rule:</p>
-        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate the first |ClassAtom| to obtain a CharSet _A_.
           1. Evaluate the second |ClassAtom| to obtain a CharSet _B_.
@@ -38694,7 +38694,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>NonemptyClassRangesNoDash (<emu-xref href="#sec-nonemptyclassrangesnodash"></emu-xref>) modifies the following evaluation rule:</p>
-        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Evaluate |ClassAtom| to obtain a CharSet _B_.
@@ -38704,7 +38704,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>ClassEscape (<emu-xref href="#sec-classescape"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>ClassEscape :: `c` ClassControlLetter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassEscape :: `c` ClassControlLetter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character matched by |ClassControlLetter|.
           1. Let _i_ be _ch_'s character value.
@@ -38714,7 +38714,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>ClassAtomNoDash (<emu-xref href="#sec-classatomnodash"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>ClassAtomNoDash :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar use="reference">ClassAtomNoDash :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
         </emu-alg>
@@ -39198,14 +39198,14 @@ THH:mm:ss.sss
     <emu-annex id="sec-__proto__-property-names-in-object-initializers">
       <h1>__proto__ Property Names in Object Initializers</h1>
       <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the Early Error rule is <b>not</b> applied. In addition, it is not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|.</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         ObjectLiteral : `{` PropertyDefinitionList `}`
 
         ObjectLiteral : `{` PropertyDefinitionList `,` `}`
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for `"__proto__"` and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
+          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for `"__proto__"` and at least two of those entries were obtained from productions of the form <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
         </li>
       </ul>
       <emu-note>
@@ -39213,10 +39213,10 @@ THH:mm:ss.sss
       </emu-note>
       <p>In <emu-xref href="#sec-object-initializer-runtime-semantics-propertydefinitionevaluation"></emu-xref> the PropertyDefinitionEvaluation algorithm for the production
         <br>
-        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+        <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <br>
         is replaced with the following definition:</p>
-      <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+      <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
@@ -39238,7 +39238,7 @@ THH:mm:ss.sss
     <emu-annex id="sec-labelled-function-declarations">
       <h1>Labelled Function Declarations</h1>
       <p>Prior to ECMAScript 2015, the specification of |LabelledStatement| did not allow for the association of a statement label with a |FunctionDeclaration|. However, a labelled |FunctionDeclaration| was an allowable extension for non-strict code and most browser-hosted ECMAScript implementations supported that extension. In ECMAScript 2015, the grammar productions for |LabelledStatement| permits use of |FunctionDeclaration| as a |LabelledItem| but <emu-xref href="#sec-labelled-statements-static-semantics-early-errors"></emu-xref> includes an Early Error rule that produces a Syntax Error if that occurs. For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if any <ins>strict mode</ins> source code matches this rule.
@@ -39411,7 +39411,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-block-duplicates-allowed-static-semantics">
         <h1>Changes to Block Static Semantics: Early Errors</h1>
         <p>For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
-        <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
+        <emu-grammar use="reference">Block : `{` StatementList `}`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries, <ins>unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.</ins>
@@ -39421,7 +39421,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-switch-duplicates-allowed-static-semantics">
         <h1>Changes to `switch` Statement Static Semantics: Early Errors</h1>
         <p>For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
-        <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+        <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries, <ins>unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.</ins>
@@ -39450,7 +39450,7 @@ THH:mm:ss.sss
     <emu-annex id="sec-functiondeclarations-in-ifstatement-statement-clauses">
       <h1>FunctionDeclarations in IfStatement Statement Clauses</h1>
       <p>The following augments the |IfStatement| production in <emu-xref href="#sec-if-statement"></emu-xref>:</p>
-      <emu-grammar>
+      <emu-grammar use="definition">
         IfStatement[Yield, Await, Return] :
           `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` Statement[?Yield, ?Await, ?Return]
           `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
@@ -39464,7 +39464,7 @@ THH:mm:ss.sss
     <emu-annex id="sec-variablestatements-in-catch-blocks">
       <h1>VariableStatements in Catch Blocks</h1>
       <p>The content of subclause <emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref> is replaced with the following:</p>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |CatchParameter| contains any duplicate elements.
@@ -39473,7 +39473,7 @@ THH:mm:ss.sss
           It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the LexicallyDeclaredNames of |Block|.
         </li>
         <li>
-          It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the VarDeclaredNames of |Block| unless |CatchParameter| is <emu-grammar>CatchParameter : BindingIdentifier</emu-grammar> and that element is only bound by a |VariableStatement|, the |VariableDeclarationList| of a for statement, the |ForBinding| of a for-in statement, or the |BindingIdentifier| of a for-in statement.
+          It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the VarDeclaredNames of |Block| unless |CatchParameter| is <emu-grammar use="reference">CatchParameter : BindingIdentifier</emu-grammar> and that element is only bound by a |VariableStatement|, the |VariableDeclarationList| of a for statement, the |ForBinding| of a for-in statement, or the |BindingIdentifier| of a for-in statement.
         </li>
       </ul>
       <emu-note>
@@ -39495,28 +39495,28 @@ THH:mm:ss.sss
     <emu-annex id="sec-initializers-in-forin-statement-heads">
       <h1>Initializers in ForIn Statement Heads</h1>
       <p>The following augments the |IterationStatement| production in <emu-xref href="#sec-iteration-statements"></emu-xref>:</p>
-      <emu-grammar>
+      <emu-grammar use="definition">
         IterationStatement[Yield, Await, Return] :
           `for` `(` `var` BindingIdentifier[?Yield, ?Await] Initializer[~In, ?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
       </emu-grammar>
       <p>This production only applies when parsing non-strict code.</p>
       <p>The static semantics of ContainsDuplicateLabels in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
       <p>The static semantics of ContainsUndefinedBreakTarget in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
       <p>The static semantics of ContainsUndefinedContinueTarget in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
       <p>The static semantics of IsDestructuring in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-isdestructuring"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>
+      <emu-grammar use="reference">
         BindingIdentifier :
           Identifier
           `yield`
@@ -39526,21 +39526,21 @@ THH:mm:ss.sss
         1. Return *false*.
       </emu-alg>
       <p>The static semantics of VarDeclaredNames in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-vardeclarednames"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _names_ be the BoundNames of |BindingIdentifier|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
         1. Return _names_.
       </emu-alg>
       <p>The static semantics of VarScopedDeclarations in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be a List containing |BindingIdentifier|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
         1. Return _declarations_.
       </emu-alg>
       <p>The runtime semantics of LabelledEvaluation in <emu-xref href="#sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _bindingId_ be StringValue of |BindingIdentifier|.
         1. Let _lhs_ be ? ResolveBinding(_bindingId_).

--- a/spec.html
+++ b/spec.html
@@ -3514,61 +3514,61 @@
           <p>The conversion of a String to a Number value is similar overall to the determination of the Number value for a numeric literal (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different, so the process for converting a String numeric literal to a value of Number type is given here. This value is determined in two steps: first, a mathematical value (MV) is derived from the String numeric literal; second, this mathematical value is rounded as described below. The MV on any grammar symbol, not provided below, is the MV for that symbol defined in <emu-xref href="#sec-static-semantics-mv"></emu-xref>.</p>
           <ul>
             <li>
-              The MV of <emu-grammar use="reference">StringNumericLiteral ::: [empty]</emu-grammar> is 0.
+              The MV of <emu-grammar>StringNumericLiteral ::: [empty]</emu-grammar> is 0.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StringNumericLiteral ::: StrWhiteSpace</emu-grammar> is 0.
+              The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace</emu-grammar> is 0.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar> is the MV of |StrNumericLiteral|, no matter whether white space is present or not.
+              The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar> is the MV of |StrNumericLiteral|, no matter whether white space is present or not.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrNumericLiteral ::: StrDecimalLiteral</emu-grammar> is the MV of |StrDecimalLiteral|.
+              The MV of <emu-grammar>StrNumericLiteral ::: StrDecimalLiteral</emu-grammar> is the MV of |StrDecimalLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrNumericLiteral ::: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
+              The MV of <emu-grammar>StrNumericLiteral ::: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrNumericLiteral ::: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
+              The MV of <emu-grammar>StrNumericLiteral ::: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrNumericLiteral ::: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
+              The MV of <emu-grammar>StrNumericLiteral ::: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrDecimalLiteral ::: StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
+              The MV of <emu-grammar>StrDecimalLiteral ::: StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrDecimalLiteral ::: `+` StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
+              The MV of <emu-grammar>StrDecimalLiteral ::: `+` StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar> is the negative of the MV of |StrUnsignedDecimalLiteral|. (Note that if the MV of |StrUnsignedDecimalLiteral| is 0, the negative of this MV is also 0. The rounding rule described below handles the conversion of this signless mathematical zero to a floating-point *+0* or *-0* as appropriate.)
+              The MV of <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar> is the negative of the MV of |StrUnsignedDecimalLiteral|. (Note that if the MV of |StrUnsignedDecimalLiteral| is 0, the negative of this MV is also 0. The rounding rule described below handles the conversion of this signless mathematical zero to a floating-point *+0* or *-0* as appropriate.)
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sup>10000</sup> (a value so large that it will round to *+&infin;*).
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sup>10000</sup> (a value so large that it will round to *+&infin;*).
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits `.`</emu-grammar> is the MV of |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.`</emu-grammar> is the MV of |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>), where _n_ is the number of code points in the second |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>), where _n_ is the number of code points in the second |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>)) times 10<sup>_e_</sup>, where _n_ is the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>)) times 10<sup>_e_</sup>, where _n_ is the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar use="reference">StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
           </ul>
           <p>Once the exact MV for a String numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0* unless the first non white space code point in the String numeric literal is `"-"`, in which case the rounded value is *-0*. Otherwise, the rounded value must be the Number value for the MV (in the sense defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal includes a |StrUnsignedDecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit and then incrementing the literal at the 20th digit position. A digit is significant if it is not part of an |ExponentPart| and</p>
@@ -9697,13 +9697,13 @@
       <!-- es6num="11.6.1.1" -->
       <emu-clause id="sec-identifier-names-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
+        <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
-        <emu-grammar use="reference">IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
+        <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
@@ -9715,7 +9715,7 @@
       <emu-clause id="sec-identifier-names-static-semantics-stringvalue">
         <h1>Static Semantics: StringValue</h1>
         <emu-see-also-para op="StringValue"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IdentifierName ::
             IdentifierStart
             IdentifierName IdentifierPart
@@ -9957,151 +9957,151 @@
         <p>A numeric literal stands for a value of the Number type. This value is determined in two steps: first, a mathematical value (MV) is derived from the literal; second, this mathematical value is rounded as described below.</p>
         <ul>
           <li>
-            The MV of <emu-grammar use="reference">NumericLiteral :: DecimalLiteral</emu-grammar> is the MV of |DecimalLiteral|.
+            The MV of <emu-grammar>NumericLiteral :: DecimalLiteral</emu-grammar> is the MV of |DecimalLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">NumericLiteral :: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
+            The MV of <emu-grammar>NumericLiteral :: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">NumericLiteral :: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
+            The MV of <emu-grammar>NumericLiteral :: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">NumericLiteral :: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
+            The MV of <emu-grammar>NumericLiteral :: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral `.`</emu-grammar> is the MV of |DecimalIntegerLiteral|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.`</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>), where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>), where _n_ is the number of code points in |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>)) &times; 10<sup>_e_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>)) &times; 10<sup>_e_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>_e_-_n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral</emu-grammar> is the MV of |DecimalIntegerLiteral|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalLiteral :: DecimalIntegerLiteral ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalIntegerLiteral :: `0`</emu-grammar> is 0.
+            The MV of <emu-grammar>DecimalIntegerLiteral :: `0`</emu-grammar> is 0.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalIntegerLiteral :: NonZeroDigit</emu-grammar> is the MV of |NonZeroDigit|.
+            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit</emu-grammar> is the MV of |NonZeroDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalIntegerLiteral :: NonZeroDigit DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the number of code points in |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigits :: DecimalDigit</emu-grammar> is the MV of |DecimalDigit|.
+            The MV of <emu-grammar>DecimalDigits :: DecimalDigit</emu-grammar> is the MV of |DecimalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10) plus the MV of |DecimalDigit|.
+            The MV of <emu-grammar>DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10) plus the MV of |DecimalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">ExponentPart :: ExponentIndicator SignedInteger</emu-grammar> is the MV of |SignedInteger|.
+            The MV of <emu-grammar>ExponentPart :: ExponentIndicator SignedInteger</emu-grammar> is the MV of |SignedInteger|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">SignedInteger :: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
+            The MV of <emu-grammar>SignedInteger :: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">SignedInteger :: `+` DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
+            The MV of <emu-grammar>SignedInteger :: `+` DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">SignedInteger :: `-` DecimalDigits</emu-grammar> is the negative of the MV of |DecimalDigits|.
+            The MV of <emu-grammar>SignedInteger :: `-` DecimalDigits</emu-grammar> is the negative of the MV of |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `0`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `0`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `0`</emu-grammar> or of <emu-grammar use="reference">BinaryDigit :: `0`</emu-grammar> is 0.
+            The MV of <emu-grammar>DecimalDigit :: `0`</emu-grammar> or of <emu-grammar>HexDigit :: `0`</emu-grammar> or of <emu-grammar>OctalDigit :: `0`</emu-grammar> or of <emu-grammar>BinaryDigit :: `0`</emu-grammar> is 0.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `1`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `1`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `1`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `1`</emu-grammar> or of <emu-grammar use="reference">BinaryDigit :: `1`</emu-grammar> is 1.
+            The MV of <emu-grammar>DecimalDigit :: `1`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `1`</emu-grammar> or of <emu-grammar>HexDigit :: `1`</emu-grammar> or of <emu-grammar>OctalDigit :: `1`</emu-grammar> or of <emu-grammar>BinaryDigit :: `1`</emu-grammar> is 1.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `2`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `2`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `2`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `2`</emu-grammar> is 2.
+            The MV of <emu-grammar>DecimalDigit :: `2`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `2`</emu-grammar> or of <emu-grammar>HexDigit :: `2`</emu-grammar> or of <emu-grammar>OctalDigit :: `2`</emu-grammar> is 2.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `3`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `3`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `3`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `3`</emu-grammar> is 3.
+            The MV of <emu-grammar>DecimalDigit :: `3`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `3`</emu-grammar> or of <emu-grammar>HexDigit :: `3`</emu-grammar> or of <emu-grammar>OctalDigit :: `3`</emu-grammar> is 3.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `4`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `4`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `4`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `4`</emu-grammar> is 4.
+            The MV of <emu-grammar>DecimalDigit :: `4`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `4`</emu-grammar> or of <emu-grammar>HexDigit :: `4`</emu-grammar> or of <emu-grammar>OctalDigit :: `4`</emu-grammar> is 4.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `5`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `5`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `5`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `5`</emu-grammar> is 5.
+            The MV of <emu-grammar>DecimalDigit :: `5`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `5`</emu-grammar> or of <emu-grammar>HexDigit :: `5`</emu-grammar> or of <emu-grammar>OctalDigit :: `5`</emu-grammar> is 5.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `6`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `6`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `6`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `6`</emu-grammar> is 6.
+            The MV of <emu-grammar>DecimalDigit :: `6`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `6`</emu-grammar> or of <emu-grammar>HexDigit :: `6`</emu-grammar> or of <emu-grammar>OctalDigit :: `6`</emu-grammar> is 6.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `7`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `7`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `7`</emu-grammar> or of <emu-grammar use="reference">OctalDigit :: `7`</emu-grammar> is 7.
+            The MV of <emu-grammar>DecimalDigit :: `7`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `7`</emu-grammar> or of <emu-grammar>HexDigit :: `7`</emu-grammar> or of <emu-grammar>OctalDigit :: `7`</emu-grammar> is 7.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `8`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `8`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `8`</emu-grammar> is 8.
+            The MV of <emu-grammar>DecimalDigit :: `8`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `8`</emu-grammar> or of <emu-grammar>HexDigit :: `8`</emu-grammar> is 8.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">DecimalDigit :: `9`</emu-grammar> or of <emu-grammar use="reference">NonZeroDigit :: `9`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `9`</emu-grammar> is 9.
+            The MV of <emu-grammar>DecimalDigit :: `9`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `9`</emu-grammar> or of <emu-grammar>HexDigit :: `9`</emu-grammar> is 9.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexDigit :: `a`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `A`</emu-grammar> is 10.
+            The MV of <emu-grammar>HexDigit :: `a`</emu-grammar> or of <emu-grammar>HexDigit :: `A`</emu-grammar> is 10.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexDigit :: `b`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `B`</emu-grammar> is 11.
+            The MV of <emu-grammar>HexDigit :: `b`</emu-grammar> or of <emu-grammar>HexDigit :: `B`</emu-grammar> is 11.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexDigit :: `c`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `C`</emu-grammar> is 12.
+            The MV of <emu-grammar>HexDigit :: `c`</emu-grammar> or of <emu-grammar>HexDigit :: `C`</emu-grammar> is 12.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexDigit :: `d`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `D`</emu-grammar> is 13.
+            The MV of <emu-grammar>HexDigit :: `d`</emu-grammar> or of <emu-grammar>HexDigit :: `D`</emu-grammar> is 13.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexDigit :: `e`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `E`</emu-grammar> is 14.
+            The MV of <emu-grammar>HexDigit :: `e`</emu-grammar> or of <emu-grammar>HexDigit :: `E`</emu-grammar> is 14.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexDigit :: `f`</emu-grammar> or of <emu-grammar use="reference">HexDigit :: `F`</emu-grammar> is 15.
+            The MV of <emu-grammar>HexDigit :: `f`</emu-grammar> or of <emu-grammar>HexDigit :: `F`</emu-grammar> is 15.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">BinaryIntegerLiteral :: `0b` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
+            The MV of <emu-grammar>BinaryIntegerLiteral :: `0b` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">BinaryIntegerLiteral :: `0B` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
+            The MV of <emu-grammar>BinaryIntegerLiteral :: `0B` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">BinaryDigits :: BinaryDigit</emu-grammar> is the MV of |BinaryDigit|.
+            The MV of <emu-grammar>BinaryDigits :: BinaryDigit</emu-grammar> is the MV of |BinaryDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2) plus the MV of |BinaryDigit|.
+            The MV of <emu-grammar>BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2) plus the MV of |BinaryDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">OctalIntegerLiteral :: `0o` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
+            The MV of <emu-grammar>OctalIntegerLiteral :: `0o` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">OctalIntegerLiteral :: `0O` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
+            The MV of <emu-grammar>OctalIntegerLiteral :: `0O` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">OctalDigits :: OctalDigit</emu-grammar> is the MV of |OctalDigit|.
+            The MV of <emu-grammar>OctalDigits :: OctalDigit</emu-grammar> is the MV of |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8) plus the MV of |OctalDigit|.
+            The MV of <emu-grammar>OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8) plus the MV of |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexIntegerLiteral :: `0x` HexDigits</emu-grammar> is the MV of |HexDigits|.
+            The MV of <emu-grammar>HexIntegerLiteral :: `0x` HexDigits</emu-grammar> is the MV of |HexDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexIntegerLiteral :: `0X` HexDigits</emu-grammar> is the MV of |HexDigits|.
+            The MV of <emu-grammar>HexIntegerLiteral :: `0X` HexDigits</emu-grammar> is the MV of |HexDigits|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexDigits :: HexDigit</emu-grammar> is the MV of |HexDigit|.
+            The MV of <emu-grammar>HexDigits :: HexDigit</emu-grammar> is the MV of |HexDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16) plus the MV of |HexDigit|.
+            The MV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16) plus the MV of |HexDigit|.
           </li>
         </ul>
         <p>Once the exact MV for a numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0*; otherwise, the rounded value must be the Number value for the MV (as specified in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal is a |DecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit and then incrementing the literal at the 20th significant digit position. A digit is <em>significant</em> if it is not part of an |ExponentPart| and</p>
@@ -10189,7 +10189,7 @@
       <!-- es6num="11.8.4.1" -->
       <emu-clause id="sec-string-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
+        <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the MV of |HexDigits| &gt; 0x10FFFF.
@@ -10201,7 +10201,7 @@
       <emu-clause id="sec-string-literals-static-semantics-stringvalue">
         <h1>Static Semantics: StringValue</h1>
         <emu-see-also-para op="StringValue"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           StringLiteral ::
             `"` DoubleStringCharacters? `"`
             `'` SingleStringCharacters? `'`
@@ -10217,61 +10217,61 @@
         <p>A string literal stands for a value of the String type. The String value (SV) of the literal is described in terms of code unit values contributed by the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value (MV), as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
         <ul>
           <li>
-            The SV of <emu-grammar use="reference">StringLiteral :: `"` `"`</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar>StringLiteral :: `"` `"`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">StringLiteral :: `'` `'`</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar>StringLiteral :: `'` `'`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">StringLiteral :: `"` DoubleStringCharacters `"`</emu-grammar> is the SV of |DoubleStringCharacters|.
+            The SV of <emu-grammar>StringLiteral :: `"` DoubleStringCharacters `"`</emu-grammar> is the SV of |DoubleStringCharacters|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">StringLiteral :: `'` SingleStringCharacters `'`</emu-grammar> is the SV of |SingleStringCharacters|.
+            The SV of <emu-grammar>StringLiteral :: `'` SingleStringCharacters `'`</emu-grammar> is the SV of |SingleStringCharacters|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">DoubleStringCharacters :: DoubleStringCharacter</emu-grammar> is a sequence of one or two code units that is the SV of |DoubleStringCharacter|.
+            The SV of <emu-grammar>DoubleStringCharacters :: DoubleStringCharacter</emu-grammar> is a sequence of one or two code units that is the SV of |DoubleStringCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">DoubleStringCharacters :: DoubleStringCharacter DoubleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |DoubleStringCharacter| followed by all the code units in the SV of |DoubleStringCharacters| in order.
+            The SV of <emu-grammar>DoubleStringCharacters :: DoubleStringCharacter DoubleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |DoubleStringCharacter| followed by all the code units in the SV of |DoubleStringCharacters| in order.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">SingleStringCharacters :: SingleStringCharacter</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter|.
+            The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter| followed by all the code units in the SV of |SingleStringCharacters| in order.
+            The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is a sequence of one or two code units that is the SV of |SingleStringCharacter| followed by all the code units in the SV of |SingleStringCharacters| in order.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">DoubleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
+            The SV of <emu-grammar>DoubleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar>DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">SingleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
+            The SV of <emu-grammar>SingleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">SingleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar>SingleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the SV of the |CharacterEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the SV of the |CharacterEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">EscapeSequence :: `0`</emu-grammar> is the code unit value 0.
+            The SV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit value 0.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">EscapeSequence :: HexEscapeSequence</emu-grammar> is the SV of the |HexEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: HexEscapeSequence</emu-grammar> is the SV of the |HexEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the SV of the |UnicodeEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the SV of the |UnicodeEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-34"></emu-xref>.
+            The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-34"></emu-xref>.
           </li>
         </ul>
         <emu-table id="table-34" caption="String Single Character Escape Sequences">
@@ -10422,22 +10422,22 @@
         </emu-table>
         <ul>
           <li>
-            The SV of <emu-grammar use="reference">CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
+            The SV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit value that is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
+            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit value that is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the SV of |Hex4Digits|.
+            The SV of <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the SV of |Hex4Digits|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit value that is (0x1000 times the MV of the first |HexDigit|) plus (0x100 times the MV of the second |HexDigit|) plus (0x10 times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
+            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit value that is (0x1000 times the MV of the first |HexDigit|) plus (0x100 times the MV of the second |HexDigit|) plus (0x10 times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the UTF16Encoding of the MV of |HexDigits|.
+            The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the UTF16Encoding of the MV of |HexDigits|.
           </li>
         </ul>
       </emu-clause>
@@ -10501,7 +10501,7 @@
       <!-- es6num="11.8.5.1" -->
       <emu-clause id="sec-literals-regular-expression-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">RegularExpressionFlags :: RegularExpressionFlags IdentifierPart</emu-grammar>
+        <emu-grammar>RegularExpressionFlags :: RegularExpressionFlags IdentifierPart</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if |IdentifierPart| contains a Unicode escape sequence.
@@ -10512,7 +10512,7 @@
       <!-- es6num="11.8.5.2" -->
       <emu-clause id="sec-static-semantics-bodytext">
         <h1>Static Semantics: BodyText</h1>
-        <emu-grammar use="reference">RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
+        <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
         <emu-alg>
           1. Return the source text that was recognized as |RegularExpressionBody|.
         </emu-alg>
@@ -10521,7 +10521,7 @@
       <!-- es6num="11.8.5.3" -->
       <emu-clause id="sec-static-semantics-flagtext">
         <h1>Static Semantics: FlagText</h1>
-        <emu-grammar use="reference">RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
+        <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
         <emu-alg>
           1. Return the source text that was recognized as |RegularExpressionFlags|.
         </emu-alg>
@@ -10574,145 +10574,145 @@
         <p>A template literal component is interpreted as a sequence of Unicode code points. The Template Value (TV) of a literal component is described in terms of code unit values (SV, <emu-xref href="#sec-literals-string-literals"></emu-xref>) contributed by the various parts of the template literal component. As part of this process, some Unicode code points within the template component are interpreted as having a mathematical value (MV, <emu-xref href="#sec-literals-numeric-literals"></emu-xref>). In determining a TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence. The Template Raw Value (TRV) is similar to a Template Value with the difference that in TRVs escape sequences are interpreted literally.</p>
         <ul>
           <li>
-            The TV and TRV of <emu-grammar use="reference">NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TV and TRV of <emu-grammar use="reference">TemplateHead :: ``` `${`</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar>TemplateHead :: ``` `${`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TV and TRV of <emu-grammar use="reference">TemplateMiddle :: `}` `${`</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar>TemplateMiddle :: `}` `${`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TV and TRV of <emu-grammar use="reference">TemplateTail :: `}` ```</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar>TemplateTail :: `}` ```</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">NoSubstitutionTemplate :: ``` TemplateCharacters ```</emu-grammar> is the TV of |TemplateCharacters|.
+            The TV of <emu-grammar>NoSubstitutionTemplate :: ``` TemplateCharacters ```</emu-grammar> is the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateHead :: ``` TemplateCharacters `${`</emu-grammar> is the TV of |TemplateCharacters|.
+            The TV of <emu-grammar>TemplateHead :: ``` TemplateCharacters `${`</emu-grammar> is the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateMiddle :: `}` TemplateCharacters `${`</emu-grammar> is the TV of |TemplateCharacters|.
+            The TV of <emu-grammar>TemplateMiddle :: `}` TemplateCharacters `${`</emu-grammar> is the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateTail :: `}` TemplateCharacters ```</emu-grammar> is the TV of |TemplateCharacters|.
+            The TV of <emu-grammar>TemplateTail :: `}` TemplateCharacters ```</emu-grammar> is the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateCharacters :: TemplateCharacter</emu-grammar> is the TV of |TemplateCharacter|.
+            The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter</emu-grammar> is the TV of |TemplateCharacter|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TV of |TemplateCharacter| followed by all the code units in the TV of |TemplateCharacters| in order.
+            The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TV of |TemplateCharacter| followed by all the code units in the TV of |TemplateCharacters| in order.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
+            The TV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the SV of |EscapeSequence|.
+            The TV of <emu-grammar>TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the SV of |EscapeSequence|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateCharacter :: LineContinuation</emu-grammar> is the TV of |LineContinuation|.
+            The TV of <emu-grammar>TemplateCharacter :: LineContinuation</emu-grammar> is the TV of |LineContinuation|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
+            The TV of <emu-grammar>TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TV of <emu-grammar use="reference">LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the empty code unit sequence.
+            The TV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">NoSubstitutionTemplate :: ``` TemplateCharacters ```</emu-grammar> is the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar>NoSubstitutionTemplate :: ``` TemplateCharacters ```</emu-grammar> is the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateHead :: ``` TemplateCharacters `${`</emu-grammar> is the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar>TemplateHead :: ``` TemplateCharacters `${`</emu-grammar> is the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateMiddle :: `}` TemplateCharacters `${`</emu-grammar> is the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar>TemplateMiddle :: `}` TemplateCharacters `${`</emu-grammar> is the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateTail :: `}` TemplateCharacters ```</emu-grammar> is the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar>TemplateTail :: `}` TemplateCharacters ```</emu-grammar> is the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateCharacters :: TemplateCharacter</emu-grammar> is the TRV of |TemplateCharacter|.
+            The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter</emu-grammar> is the TRV of |TemplateCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TRV of |TemplateCharacter| followed by all the code units in the TRV of |TemplateCharacters|, in order.
+            The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units in the TRV of |TemplateCharacter| followed by all the code units in the TRV of |TemplateCharacters|, in order.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+            The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
+            The TRV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the code unit value 0x0024.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the sequence consisting of the code unit value 0x005C followed by the code units of TRV of |EscapeSequence|.
+            The TRV of <emu-grammar>TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the sequence consisting of the code unit value 0x005C followed by the code units of TRV of |EscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateCharacter :: LineContinuation</emu-grammar> is the TRV of |LineContinuation|.
+            The TRV of <emu-grammar>TemplateCharacter :: LineContinuation</emu-grammar> is the TRV of |LineContinuation|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
+            The TRV of <emu-grammar>TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the TRV of the |CharacterEscapeSequence|.
+            The TRV of <emu-grammar>EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the TRV of the |CharacterEscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">EscapeSequence :: `0`</emu-grammar> is the code unit value 0x0030 (DIGIT ZERO).
+            The TRV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit value 0x0030 (DIGIT ZERO).
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">EscapeSequence :: HexEscapeSequence</emu-grammar> is the TRV of the |HexEscapeSequence|.
+            The TRV of <emu-grammar>EscapeSequence :: HexEscapeSequence</emu-grammar> is the TRV of the |HexEscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the TRV of the |UnicodeEscapeSequence|.
+            The TRV of <emu-grammar>EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the TRV of the |UnicodeEscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the TRV of the |SingleEscapeCharacter|.
+            The TRV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the TRV of the |SingleEscapeCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
+            The TRV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">SingleEscapeCharacter :: one of `'` `"` `\` `b` `f` `n` `r` `t` `v`</emu-grammar> is the SV of the |SourceCharacter| that is that single code point.
+            The TRV of <emu-grammar>SingleEscapeCharacter :: one of `'` `"` `\` `b` `f` `n` `r` `t` `v`</emu-grammar> is the SV of the |SourceCharacter| that is that single code point.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the sequence consisting of code unit value 0x0078 followed by TRV of the first |HexDigit| followed by the TRV of the second |HexDigit|.
+            The TRV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the sequence consisting of code unit value 0x0078 followed by TRV of the first |HexDigit| followed by the TRV of the second |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the sequence consisting of code unit value 0x0075 followed by TRV of |Hex4Digits|.
+            The TRV of <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the sequence consisting of code unit value 0x0075 followed by TRV of |Hex4Digits|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the sequence consisting of code unit value 0x0075 followed by code unit value 0x007B followed by TRV of |HexDigits| followed by code unit value 0x007D.
+            The TRV of <emu-grammar>UnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> is the sequence consisting of code unit value 0x0075 followed by code unit value 0x007B followed by TRV of |HexDigits| followed by code unit value 0x007D.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the sequence consisting of the TRV of the first |HexDigit| followed by the TRV of the second |HexDigit| followed by the TRV of the third |HexDigit| followed by the TRV of the fourth |HexDigit|.
+            The TRV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the sequence consisting of the TRV of the first |HexDigit| followed by the TRV of the second |HexDigit| followed by the TRV of the third |HexDigit| followed by the TRV of the fourth |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">HexDigits :: HexDigit</emu-grammar> is the TRV of |HexDigit|.
+            The TRV of <emu-grammar>HexDigits :: HexDigit</emu-grammar> is the TRV of |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">HexDigits :: HexDigits HexDigit</emu-grammar> is the sequence consisting of TRV of |HexDigits| followed by TRV of |HexDigit|.
+            The TRV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is the sequence consisting of TRV of |HexDigits| followed by TRV of |HexDigit|.
           </li>
           <li>
             The TRV of a |HexDigit| is the SV of the |SourceCharacter| that is that |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the sequence consisting of the code unit value 0x005C followed by the code units of TRV of |LineTerminatorSequence|.
+            The TRV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the sequence consisting of the code unit value 0x005C followed by the code units of TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;LF&gt;</emu-grammar> is the code unit value 0x000A.
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;LF&gt;</emu-grammar> is the code unit value 0x000A.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;CR&gt;</emu-grammar> is the code unit value 0x000A.
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt;</emu-grammar> is the code unit value 0x000A.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;LS&gt;</emu-grammar> is the code unit value 0x2028.
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;LS&gt;</emu-grammar> is the code unit value 0x2028.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;PS&gt;</emu-grammar> is the code unit value 0x2029.
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;PS&gt;</emu-grammar> is the code unit value 0x2029.
           </li>
           <li>
-            The TRV of <emu-grammar use="reference">LineTerminatorSequence :: &lt;CR&gt;&lt;LF&gt;</emu-grammar> is the sequence consisting of the code unit value 0x000A.
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt;&lt;LF&gt;</emu-grammar> is the sequence consisting of the code unit value 0x000A.
           </li>
         </ul>
         <emu-note>
@@ -10757,7 +10757,7 @@
       <p>However, there is an additional overriding condition on the preceding rules: a semicolon is never inserted automatically if the semicolon would then be parsed as an empty statement or if that semicolon would become one of the two semicolons in the header of a `for` statement (see <emu-xref href="#sec-for-statement"></emu-xref>).</p>
       <emu-note>
         <p>The following are the only restricted productions in the grammar:</p>
-        <emu-grammar use="reference">
+        <emu-grammar>
           UpdateExpression[Yield, Await] :
             LeftHandSideExpression[?Yield, ?Await] [no LineTerminator here] `++`
             LeftHandSideExpression[?Yield, ?Await] [no LineTerminator here] `--`
@@ -10913,13 +10913,13 @@
     <!-- es6num="12.1.1" -->
     <emu-clause id="sec-identifiers-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">BindingIdentifier : Identifier</emu-grammar>
+      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the code matched by this production is contained in strict mode code and the StringValue of |Identifier| is `"arguments"` or `"eval"`.
         </li>
       </ul>
-      <emu-grammar use="reference">
+      <emu-grammar>
         IdentifierReference : `yield`
 
         BindingIdentifier : `yield`
@@ -10931,7 +10931,7 @@
           It is a Syntax Error if the code matched by this production is contained in strict mode code.
         </li>
       </ul>
-      <emu-grammar use="reference">
+      <emu-grammar>
         IdentifierReference : `await`
 
         BindingIdentifier : `await`
@@ -10943,7 +10943,7 @@
           It is a Syntax Error if the goal symbol of the syntactic grammar is |Module|.
         </li>
       </ul>
-      <emu-grammar use="reference">
+      <emu-grammar>
         BindingIdentifier : `yield`
       </emu-grammar>
       <ul>
@@ -10951,7 +10951,7 @@
           It is a Syntax Error if this production has a <sub>[Yield]</sub> parameter.
         </li>
       </ul>
-      <emu-grammar use="reference">
+      <emu-grammar>
         BindingIdentifier : `await`
       </emu-grammar>
       <ul>
@@ -10959,7 +10959,7 @@
           It is a Syntax Error if this production has an <sub>[Await]</sub> parameter.
         </li>
       </ul>
-      <emu-grammar use="reference">
+      <emu-grammar>
         IdentifierReference[Yield, Await] : Identifier
 
         BindingIdentifier[Yield, Await] : Identifier
@@ -10974,7 +10974,7 @@
           It is a Syntax Error if this production has an <sub>[Await]</sub> parameter and StringValue of |Identifier| is `"await"`.
         </li>
       </ul>
-      <emu-grammar use="reference">Identifier : IdentifierName but not ReservedWord</emu-grammar>
+      <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, `"static"`, or `"yield"`.
@@ -10995,15 +10995,15 @@
     <emu-clause id="sec-identifiers-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar use="reference">BindingIdentifier : Identifier</emu-grammar>
+      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
         1. Return a new List containing the StringValue of |Identifier|.
       </emu-alg>
-      <emu-grammar use="reference">BindingIdentifier : `yield`</emu-grammar>
+      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
       <emu-alg>
         1. Return a new List containing `"yield"`.
       </emu-alg>
-      <emu-grammar use="reference">BindingIdentifier : `await`</emu-grammar>
+      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
       <emu-alg>
         1. Return a new List containing `"await"`.
       </emu-alg>
@@ -11013,16 +11013,16 @@
     <emu-clause id="sec-identifiers-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">IdentifierReference : Identifier</emu-grammar>
+      <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
         1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is `"eval"` or `"arguments"`, return *false*.
         1. Return *true*.
       </emu-alg>
-      <emu-grammar use="reference">IdentifierReference : `yield`</emu-grammar>
+      <emu-grammar>IdentifierReference : `yield`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar use="reference">IdentifierReference : `await`</emu-grammar>
+      <emu-grammar>IdentifierReference : `await`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -11032,7 +11032,7 @@
     <emu-clause id="sec-identifiers-static-semantics-stringvalue">
       <h1>Static Semantics: StringValue</h1>
       <emu-see-also-para op="StringValue"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         IdentifierReference : `yield`
 
         BindingIdentifier : `yield`
@@ -11042,7 +11042,7 @@
       <emu-alg>
         1. Return `"yield"`.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         IdentifierReference : `await`
 
         BindingIdentifier : `await`
@@ -11052,7 +11052,7 @@
       <emu-alg>
         1. Return `"await"`.
       </emu-alg>
-      <emu-grammar use="reference">Identifier : IdentifierName but not ReservedWord</emu-grammar>
+      <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
       <emu-alg>
         1. Return the StringValue of |IdentifierName|.
       </emu-alg>
@@ -11066,16 +11066,16 @@
       <emu-note>
         <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and formal parameter lists of some non-strict functions (See <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
       </emu-note>
-      <emu-grammar use="reference">BindingIdentifier : Identifier</emu-grammar>
+      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |Identifier|.
         1. Return ? InitializeBoundName(_name_, _value_, _environment_).
       </emu-alg>
-      <emu-grammar use="reference">BindingIdentifier : `yield`</emu-grammar>
+      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
       <emu-alg>
         1. Return ? InitializeBoundName(`"yield"`, _value_, _environment_).
       </emu-alg>
-      <emu-grammar use="reference">BindingIdentifier : `await`</emu-grammar>
+      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
       <emu-alg>
         1. Return ? InitializeBoundName(`"await"`, _value_, _environment_).
       </emu-alg>
@@ -11099,15 +11099,15 @@
     <!-- es6num="12.1.6" -->
     <emu-clause id="sec-identifiers-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">IdentifierReference : Identifier</emu-grammar>
+      <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
         1. Return ? ResolveBinding(StringValue of |Identifier|).
       </emu-alg>
-      <emu-grammar use="reference">IdentifierReference : `yield`</emu-grammar>
+      <emu-grammar>IdentifierReference : `yield`</emu-grammar>
       <emu-alg>
         1. Return ? ResolveBinding(`"yield"`).
       </emu-alg>
-      <emu-grammar use="reference">IdentifierReference : `await`</emu-grammar>
+      <emu-grammar>IdentifierReference : `await`</emu-grammar>
       <emu-alg>
         1. Return ? ResolveBinding(`"await"`).
       </emu-alg>
@@ -11151,7 +11151,7 @@
     <h2>Supplemental Syntax</h2>
     <p>When processing an instance of the production
       <br>
-      <emu-grammar use="reference">PrimaryExpression[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
+      <emu-grammar>PrimaryExpression[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
       <br>
       the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
     <emu-grammar use="definition">
@@ -11166,7 +11166,7 @@
       <!-- es6num="12.2.1.1" -->
       <emu-clause id="sec-static-semantics-coveredparenthesizedexpression">
         <h1>Static Semantics: CoveredParenthesizedExpression</h1>
-        <emu-grammar use="reference">CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] : `(` Expression[+In, ?Yield, ?Await] `)`</emu-grammar>
+        <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] : `(` Expression[+In, ?Yield, ?Await] `)`</emu-grammar>
         <emu-alg>
           1. Return the result of parsing the lexical token stream matched by |CoverParenthesizedExpressionAndArrowParameterList| using |ParenthesizedExpression| as the goal symbol with its <sub>[Yield]</sub> and <sub>[Await]</sub> parameters set to the values used when parsing this |CoverParenthesizedExpressionAndArrowParameterList|.
         </emu-alg>
@@ -11176,7 +11176,7 @@
       <emu-clause id="sec-semantics-static-semantics-hasname">
         <h1>Static Semantics: HasName</h1>
         <emu-see-also-para op="HasName"></emu-see-also-para>
-        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
@@ -11188,7 +11188,7 @@
       <emu-clause id="sec-semantics-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           PrimaryExpression :
             `this`
             IdentifierReference
@@ -11201,7 +11201,7 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return IsFunctionDefinition of _expr_.
@@ -11212,11 +11212,11 @@
       <emu-clause id="sec-semantics-static-semantics-isidentifierref">
         <h1>Static Semantics: IsIdentifierRef</h1>
         <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
-        <emu-grammar use="reference">PrimaryExpression : IdentifierReference</emu-grammar>
+        <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           PrimaryExpression :
             `this`
             Literal
@@ -11239,7 +11239,7 @@
       <emu-clause id="sec-semantics-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           PrimaryExpression :
             `this`
             Literal
@@ -11255,7 +11255,7 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return IsValidSimpleAssignmentTarget of _expr_.
@@ -11270,7 +11270,7 @@
       <!-- es6num="12.2.2.1" -->
       <emu-clause id="sec-this-keyword-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">PrimaryExpression : `this`</emu-grammar>
+        <emu-grammar>PrimaryExpression : `this`</emu-grammar>
         <emu-alg>
           1. Return ? ResolveThisBinding( ).
         </emu-alg>
@@ -11298,20 +11298,20 @@
       <!-- es6num="12.2.4.1" -->
       <emu-clause id="sec-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">Literal : NullLiteral</emu-grammar>
+        <emu-grammar>Literal : NullLiteral</emu-grammar>
         <emu-alg>
           1. Return *null*.
         </emu-alg>
-        <emu-grammar use="reference">Literal : BooleanLiteral</emu-grammar>
+        <emu-grammar>Literal : BooleanLiteral</emu-grammar>
         <emu-alg>
           1. If |BooleanLiteral| is the token `false`, return *false*.
           1. If |BooleanLiteral| is the token `true`, return *true*.
         </emu-alg>
-        <emu-grammar use="reference">Literal : NumericLiteral</emu-grammar>
+        <emu-grammar>Literal : NumericLiteral</emu-grammar>
         <emu-alg>
           1. Return the number whose value is MV of |NumericLiteral| as defined in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.
         </emu-alg>
-        <emu-grammar use="reference">Literal : StringLiteral</emu-grammar>
+        <emu-grammar>Literal : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return the StringValue of |StringLiteral| as defined in <emu-xref href="#sec-string-literals-static-semantics-stringvalue"></emu-xref>.
         </emu-alg>
@@ -11349,11 +11349,11 @@
       <!-- es6num="12.2.5.1" -->
       <emu-clause id="sec-static-semantics-elisionwidth">
         <h1>Static Semantics: ElisionWidth</h1>
-        <emu-grammar use="reference">Elision : `,`</emu-grammar>
+        <emu-grammar>Elision : `,`</emu-grammar>
         <emu-alg>
           1. Return the numeric value 1.
         </emu-alg>
-        <emu-grammar use="reference">Elision : Elision `,`</emu-grammar>
+        <emu-grammar>Elision : Elision `,`</emu-grammar>
         <emu-alg>
           1. Let _preceding_ be the ElisionWidth of |Elision|.
           1. Return _preceding_+1.
@@ -11364,7 +11364,7 @@
       <emu-clause id="sec-runtime-semantics-arrayaccumulation">
         <h1>Runtime Semantics: ArrayAccumulation</h1>
         <p>With parameters _array_ and _nextIndex_.</p>
-        <emu-grammar use="reference">ElementList : Elision? AssignmentExpression</emu-grammar>
+        <emu-grammar>ElementList : Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
@@ -11373,12 +11373,12 @@
           1. Assert: _created_ is *true*.
           1. Return _nextIndex_+_padding_+1.
         </emu-alg>
-        <emu-grammar use="reference">ElementList : Elision? SpreadElement</emu-grammar>
+        <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
         <emu-alg>
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _nextIndex_+_padding_.
         </emu-alg>
-        <emu-grammar use="reference">ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
+        <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _postIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
           1. ReturnIfAbrupt(_postIndex_).
@@ -11389,14 +11389,14 @@
           1. Assert: _created_ is *true*.
           1. Return _postIndex_+_padding_+1.
         </emu-alg>
-        <emu-grammar use="reference">ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
+        <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
         <emu-alg>
           1. Let _postIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
           1. ReturnIfAbrupt(_postIndex_).
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _postIndex_+_padding_.
         </emu-alg>
-        <emu-grammar use="reference">SpreadElement : `...` AssignmentExpression</emu-grammar>
+        <emu-grammar>SpreadElement : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
@@ -11417,7 +11417,7 @@
       <!-- es6num="12.2.5.3" -->
       <emu-clause id="sec-array-initializer-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">ArrayLiteral : `[` Elision? `]`</emu-grammar>
+        <emu-grammar>ArrayLiteral : `[` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. Let _pad_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
@@ -11425,7 +11425,7 @@
           1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
           1. Return _array_.
         </emu-alg>
-        <emu-grammar use="reference">ArrayLiteral : `[` ElementList `]`</emu-grammar>
+        <emu-grammar>ArrayLiteral : `[` ElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. Let _len_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
@@ -11434,7 +11434,7 @@
           1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
           1. Return _array_.
         </emu-alg>
-        <emu-grammar use="reference">ArrayLiteral : `[` ElementList `,` Elision? `]`</emu-grammar>
+        <emu-grammar>ArrayLiteral : `[` ElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. Let _len_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
@@ -11498,14 +11498,14 @@
       <!-- es6num="12.2.6.1" -->
       <emu-clause id="sec-object-initializer-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">PropertyDefinition : MethodDefinition</emu-grammar>
+        <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
           </li>
         </ul>
         <p>In addition to describing an actual object initializer the |ObjectLiteral| productions are also used as a cover grammar for |ObjectAssignmentPattern| and may be recognized as part of a |CoverParenthesizedExpressionAndArrowParameterList|. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the following Early Error rules are <b>not</b> applied. In addition, they are not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or |CoverCallExpressionAndAsyncArrowHead|.</p>
-        <emu-grammar use="reference">PropertyDefinition : CoverInitializedName</emu-grammar>
+        <emu-grammar>PropertyDefinition : CoverInitializedName</emu-grammar>
         <ul>
           <li>
             Always throw a Syntax Error if code matches this production.
@@ -11521,11 +11521,11 @@
         <h1>Static Semantics: ComputedPropertyContains</h1>
         <p>With parameter _symbol_.</p>
         <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-        <emu-grammar use="reference">PropertyName : LiteralPropertyName</emu-grammar>
+        <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">PropertyName : ComputedPropertyName</emu-grammar>
+        <emu-grammar>PropertyName : ComputedPropertyName</emu-grammar>
         <emu-alg>
           1. Return the result of |ComputedPropertyName| Contains _symbol_.
         </emu-alg>
@@ -11536,7 +11536,7 @@
         <h1>Static Semantics: Contains</h1>
         <p>With parameter _symbol_.</p>
         <emu-see-also-para op="Contains"></emu-see-also-para>
-        <emu-grammar use="reference">PropertyDefinition : MethodDefinition</emu-grammar>
+        <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
         <emu-alg>
           1. If _symbol_ is |MethodDefinition|, return *true*.
           1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
@@ -11544,7 +11544,7 @@
         <emu-note>
           <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
         </emu-note>
-        <emu-grammar use="reference">LiteralPropertyName : IdentifierName</emu-grammar>
+        <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
           1. If _symbol_ is a |ReservedWord|, return *false*.
           1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
@@ -11555,11 +11555,11 @@
       <!-- es6num="12.2.6.5" -->
       <emu-clause id="sec-static-semantics-iscomputedpropertykey">
         <h1>Static Semantics: IsComputedPropertyKey</h1>
-        <emu-grammar use="reference">PropertyName : LiteralPropertyName</emu-grammar>
+        <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">PropertyName : ComputedPropertyName</emu-grammar>
+        <emu-grammar>PropertyName : ComputedPropertyName</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -11569,28 +11569,28 @@
       <emu-clause id="sec-object-initializer-static-semantics-propname">
         <h1>Static Semantics: PropName</h1>
         <emu-see-also-para op="PropName"></emu-see-also-para>
-        <emu-grammar use="reference">PropertyDefinition : IdentifierReference</emu-grammar>
+        <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
         <emu-alg>
           1. Return StringValue of |IdentifierReference|.
         </emu-alg>
-        <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Return PropName of |PropertyName|.
         </emu-alg>
-        <emu-grammar use="reference">LiteralPropertyName : IdentifierName</emu-grammar>
+        <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return StringValue of |IdentifierName|.
         </emu-alg>
-        <emu-grammar use="reference">LiteralPropertyName : StringLiteral</emu-grammar>
+        <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return a String value whose code units are the SV of the |StringLiteral|.
         </emu-alg>
-        <emu-grammar use="reference">LiteralPropertyName : NumericLiteral</emu-grammar>
+        <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
           1. Let _nbr_ be the result of forming the value of the |NumericLiteral|.
           1. Return ! ToString(_nbr_).
         </emu-alg>
-        <emu-grammar use="reference">ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
+        <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
         <emu-alg>
           1. Return ~empty~.
         </emu-alg>
@@ -11599,12 +11599,12 @@
       <!-- es6num="12.2.6.7" -->
       <emu-clause id="sec-static-semantics-propertynamelist">
         <h1>Static Semantics: PropertyNameList</h1>
-        <emu-grammar use="reference">PropertyDefinitionList : PropertyDefinition</emu-grammar>
+        <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
         <emu-alg>
           1. If PropName of |PropertyDefinition| is ~empty~, return a new empty List.
           1. Return a new List containing PropName of |PropertyDefinition|.
         </emu-alg>
-        <emu-grammar use="reference">PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
+        <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
           1. Let _list_ be PropertyNameList of |PropertyDefinitionList|.
           1. If PropName of |PropertyDefinition| is ~empty~, return _list_.
@@ -11616,11 +11616,11 @@
       <!-- es6num="12.2.6.8" -->
       <emu-clause id="sec-object-initializer-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">ObjectLiteral : `{` `}`</emu-grammar>
+        <emu-grammar>ObjectLiteral : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return ObjectCreate(%ObjectPrototype%).
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ObjectLiteral :
             `{` PropertyDefinitionList `}`
             `{` PropertyDefinitionList `,` `}`
@@ -11630,20 +11630,20 @@
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_ and *true*.
           1. Return _obj_.
         </emu-alg>
-        <emu-grammar use="reference">LiteralPropertyName : IdentifierName</emu-grammar>
+        <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return StringValue of |IdentifierName|.
         </emu-alg>
-        <emu-grammar use="reference">LiteralPropertyName : StringLiteral</emu-grammar>
+        <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return a String value whose code units are the SV of the |StringLiteral|.
         </emu-alg>
-        <emu-grammar use="reference">LiteralPropertyName : NumericLiteral</emu-grammar>
+        <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
           1. Let _nbr_ be the result of forming the value of the |NumericLiteral|.
           1. Return ! ToString(_nbr_).
         </emu-alg>
-        <emu-grammar use="reference">ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
+        <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
         <emu-alg>
           1. Let _exprValue_ be the result of evaluating |AssignmentExpression|.
           1. Let _propName_ be ? GetValue(_exprValue_).
@@ -11656,12 +11656,12 @@
         <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
         <p>With parameters _object_ and _enumerable_.</p>
         <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-        <emu-grammar use="reference">PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
+        <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _object_ and _enumerable_.
           1. Return the result of performing PropertyDefinitionEvaluation of |PropertyDefinition| with arguments _object_ and _enumerable_.
         </emu-alg>
-        <emu-grammar use="reference">PropertyDefinition : IdentifierReference</emu-grammar>
+        <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
         <emu-alg>
           1. Let _propName_ be StringValue of |IdentifierReference|.
           1. Let _exprValue_ be the result of evaluating |IdentifierReference|.
@@ -11669,7 +11669,7 @@
           1. Assert: _enumerable_ is *true*.
           1. Return CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
         </emu-alg>
-        <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _propKey_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_propKey_).
@@ -11690,10 +11690,10 @@
     <!-- es6num="12.2.7" -->
     <emu-clause id="sec-function-defining-expressions">
       <h1>Function Defining Expressions</h1>
-      <p>See <emu-xref href="#sec-function-definitions"></emu-xref> for <emu-grammar use="reference">PrimaryExpression : FunctionExpression</emu-grammar>.</p>
-      <p>See <emu-xref href="#sec-generator-function-definitions"></emu-xref> for <emu-grammar use="reference">PrimaryExpression : GeneratorExpression</emu-grammar>.</p>
-      <p>See <emu-xref href="#sec-class-definitions"></emu-xref> for <emu-grammar use="reference">PrimaryExpression : ClassExpression</emu-grammar>.</p>
-      <p>See <emu-xref href="#sec-async-function-definitions"></emu-xref> for <emu-grammar use="reference">PrimaryExpression : AsyncFunctionExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : FunctionExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-generator-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : GeneratorExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-class-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : ClassExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-async-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : AsyncFunctionExpression</emu-grammar>.</p>
     </emu-clause>
 
     <!-- es6num="12.2.8" -->
@@ -11705,7 +11705,7 @@
       <!-- es6num="12.2.8.1" -->
       <emu-clause id="sec-primary-expression-regular-expression-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">PrimaryExpression : RegularExpressionLiteral</emu-grammar>
+        <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if BodyText of |RegularExpressionLiteral| cannot be recognized using the goal symbol |Pattern| of the ECMAScript RegExp grammar specified in <emu-xref href="#sec-patterns"></emu-xref>.
@@ -11719,7 +11719,7 @@
       <!-- es6num="12.2.8.2" -->
       <emu-clause id="sec-regular-expression-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">PrimaryExpression : RegularExpressionLiteral</emu-grammar>
+        <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
         <emu-alg>
           1. Let _pattern_ be the String value consisting of the UTF16Encoding of each code point of BodyText of |RegularExpressionLiteral|.
           1. Let _flags_ be the String value consisting of the UTF16Encoding of each code point of FlagText of |RegularExpressionLiteral|.
@@ -11748,7 +11748,7 @@
 
       <emu-clause id="sec-primary-expression-template-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">
+        <emu-grammar>
           TemplateLiteral :
             NoSubstitutionTemplate
             TemplateHead Expression TemplateSpans
@@ -11764,7 +11764,7 @@
       <emu-clause id="sec-static-semantics-templatestrings">
         <h1>Static Semantics: TemplateStrings</h1>
         <p>With parameter _raw_.</p>
-        <emu-grammar use="reference">TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
+        <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
             1. Let _string_ be the TV of |NoSubstitutionTemplate|.
@@ -11772,7 +11772,7 @@
             1. Let _string_ be the TRV of |NoSubstitutionTemplate|.
           1. Return a List containing the single element, _string_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-grammar>TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
             1. Let _head_ be the TV of |TemplateHead|.
@@ -11781,7 +11781,7 @@
           1. Let _tail_ be TemplateStrings of |TemplateSpans| with argument _raw_.
           1. Return a List containing _head_ followed by the elements, in order, of _tail_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateSpans : TemplateTail</emu-grammar>
+        <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
             1. Let _tail_ be the TV of |TemplateTail|.
@@ -11789,7 +11789,7 @@
             1. Let _tail_ be the TRV of |TemplateTail|.
           1. Return a List containing the single element, _tail_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
+        <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _middle_ be TemplateStrings of |TemplateMiddleList| with argument _raw_.
           1. If _raw_ is *false*, then
@@ -11798,7 +11798,7 @@
             1. Let _tail_ be the TRV of |TemplateTail|.
           1. Return a List containing the elements, in order, of _middle_ followed by _tail_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
+        <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
             1. Let _string_ be the TV of |TemplateMiddle|.
@@ -11806,7 +11806,7 @@
             1. Let _string_ be the TRV of |TemplateMiddle|.
           1. Return a List containing the single element, _string_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
+        <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _front_ be TemplateStrings of |TemplateMiddleList| with argument _raw_.
           1. If _raw_ is *false*, then
@@ -11822,13 +11822,13 @@
       <emu-clause id="sec-template-literals-runtime-semantics-argumentlistevaluation">
         <h1>Runtime Semantics: ArgumentListEvaluation</h1>
         <emu-see-also-para op="ArgumentListEvaluation"></emu-see-also-para>
-        <emu-grammar use="reference">TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
+        <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
           1. Let _templateLiteral_ be this |TemplateLiteral|.
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
           1. Return a List containing the one element which is _siteObj_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-grammar>TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. Let _templateLiteral_ be this |TemplateLiteral|.
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
@@ -11885,21 +11885,21 @@
       <!-- es6num="12.2.9.4" -->
       <emu-clause id="sec-runtime-semantics-substitutionevaluation">
         <h1>Runtime Semantics: SubstitutionEvaluation</h1>
-        <emu-grammar use="reference">TemplateSpans : TemplateTail</emu-grammar>
+        <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
+        <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
           1. Return the result of SubstitutionEvaluation of |TemplateMiddleList|.
         </emu-alg>
-        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
+        <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _subRef_ be the result of evaluating |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Return a List containing only _sub_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
+        <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _preceding_ be the result of SubstitutionEvaluation of |TemplateMiddleList|.
           1. ReturnIfAbrupt(_preceding_).
@@ -11913,11 +11913,11 @@
       <!-- es6num="12.2.9.5" -->
       <emu-clause id="sec-template-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
+        <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
           1. Return the String value whose code units are the elements of the TV of |NoSubstitutionTemplate| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
         </emu-alg>
-        <emu-grammar use="reference">TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-grammar>TemplateLiteral : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateHead| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Let _sub_ be the result of evaluating |Expression|.
@@ -11930,19 +11930,19 @@
         <emu-note>
           <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
         </emu-note>
-        <emu-grammar use="reference">TemplateSpans : TemplateTail</emu-grammar>
+        <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Return the String consisting of the code units of _tail_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
+        <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _head_ be the result of evaluating |TemplateMiddleList|.
           1. ReturnIfAbrupt(_head_).
           1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Return the String value whose code units are the elements of _head_ followed by the elements of _tail_.
         </emu-alg>
-        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
+        <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Let _sub_ be the result of evaluating |Expression|.
@@ -11953,7 +11953,7 @@
         <emu-note>
           <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
         </emu-note>
-        <emu-grammar use="reference">TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
+        <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _rest_ be the result of evaluating |TemplateMiddleList|.
           1. ReturnIfAbrupt(_rest_).
@@ -11976,7 +11976,7 @@
       <!-- es6num="12.2.10.1" -->
       <emu-clause id="sec-grouping-operator-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the lexical token sequence matched by |CoverParenthesizedExpressionAndArrowParameterList| cannot be parsed with no tokens left over using |ParenthesizedExpression| as the goal symbol.
@@ -11991,7 +11991,7 @@
       <emu-clause id="sec-grouping-operator-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar use="reference">ParenthesizedExpression : `(` Expression `)`</emu-grammar>
+        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
           1. Return IsFunctionDefinition of |Expression|.
         </emu-alg>
@@ -12001,7 +12001,7 @@
       <emu-clause id="sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-        <emu-grammar use="reference">ParenthesizedExpression : `(` Expression `)`</emu-grammar>
+        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
           1. Return IsValidSimpleAssignmentTarget of |Expression|.
         </emu-alg>
@@ -12010,12 +12010,12 @@
       <!-- es6num="12.2.10.4" -->
       <emu-clause id="sec-grouping-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return the result of evaluating _expr_.
         </emu-alg>
-        <emu-grammar use="reference">ParenthesizedExpression : `(` Expression `)`</emu-grammar>
+        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
           1. Return the result of evaluating |Expression|. This may be of type Reference.
         </emu-alg>
@@ -12081,7 +12081,7 @@
         CallExpression[?Yield, ?Await]
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
-    <p>When processing an instance of the production <emu-grammar use="reference">CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
+    <p>When processing an instance of the production <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
     <emu-grammar use="definition">
       CallMemberExpression[Yield, Await] :
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
@@ -12093,7 +12093,7 @@
 
       <emu-clause id="sec-left-hand-side-expressions-static-semantics-coveredcallexpression">
         <h1>Static Semantics: CoveredCallExpression</h1>
-        <emu-grammar use="reference">
+        <emu-grammar>
           CallExpression : CoverCallExpressionAndAsyncArrowHead
         </emu-grammar>
         <emu-alg>
@@ -12106,21 +12106,21 @@
         <h1>Static Semantics: Contains</h1>
         <p>With parameter _symbol_.</p>
         <emu-see-also-para op="Contains"></emu-see-also-para>
-        <emu-grammar use="reference">MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
+        <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If |MemberExpression| Contains _symbol_ is *true*, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
           1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">SuperProperty : `super` `.` IdentifierName</emu-grammar>
+        <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If _symbol_ is the |ReservedWord| `super`, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
           1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">CallExpression : CallExpression `.` IdentifierName</emu-grammar>
+        <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If |CallExpression| Contains _symbol_ is *true*, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
@@ -12133,7 +12133,7 @@
       <emu-clause id="sec-static-semantics-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           MemberExpression :
             MemberExpression `[` Expression `]`
             MemberExpression `.` IdentifierName
@@ -12157,12 +12157,12 @@
       <emu-clause id="sec-static-semantics-static-semantics-isdestructuring">
         <h1>Static Semantics: IsDestructuring</h1>
         <emu-see-also-para op="IsDestructuring"></emu-see-also-para>
-        <emu-grammar use="reference">MemberExpression : PrimaryExpression</emu-grammar>
+        <emu-grammar>MemberExpression : PrimaryExpression</emu-grammar>
         <emu-alg>
           1. If |PrimaryExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           MemberExpression :
             MemberExpression `[` Expression `]`
             MemberExpression `.` IdentifierName
@@ -12186,7 +12186,7 @@
       <emu-clause id="sec-static-semantics-static-semantics-isidentifierref">
         <h1>Static Semantics: IsIdentifierRef</h1>
         <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           MemberExpression :
             MemberExpression `[` Expression `]`
             MemberExpression `.` IdentifierName
@@ -12210,7 +12210,7 @@
       <emu-clause id="sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           CallExpression :
             CallExpression `[` Expression `]`
             CallExpression `.` IdentifierName
@@ -12223,7 +12223,7 @@
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           CallExpression :
             CoverCallExpressionAndAsyncArrowHead
             SuperCall
@@ -12284,7 +12284,7 @@
       <!-- es6num="12.3.2.1" -->
       <emu-clause id="sec-property-accessors-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">MemberExpression : MemberExpression `[` Expression `]`</emu-grammar>
+        <emu-grammar>MemberExpression : MemberExpression `[` Expression `]`</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
@@ -12295,7 +12295,7 @@
           1. If the code matched by this |MemberExpression| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return a value of type Reference whose base value component is _bv_, whose referenced name component is _propertyKey_, and whose strict reference flag is _strict_.
         </emu-alg>
-        <emu-grammar use="reference">MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
+        <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
@@ -12304,10 +12304,10 @@
           1. If the code matched by this |MemberExpression| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return a value of type Reference whose base value component is _bv_, whose referenced name component is _propertyNameString_, and whose strict reference flag is _strict_.
         </emu-alg>
-        <emu-grammar use="reference">CallExpression : CallExpression `[` Expression `]`</emu-grammar>
-        <p>Is evaluated in exactly the same manner as <emu-grammar use="reference">MemberExpression : MemberExpression `[` Expression `]`</emu-grammar> except that the contained |CallExpression| is evaluated in step 1.</p>
-        <emu-grammar use="reference">CallExpression : CallExpression `.` IdentifierName</emu-grammar>
-        <p>Is evaluated in exactly the same manner as <emu-grammar use="reference">MemberExpression : MemberExpression `.` IdentifierName</emu-grammar> except that the contained |CallExpression| is evaluated in step 1.</p>
+        <emu-grammar>CallExpression : CallExpression `[` Expression `]`</emu-grammar>
+        <p>Is evaluated in exactly the same manner as <emu-grammar>MemberExpression : MemberExpression `[` Expression `]`</emu-grammar> except that the contained |CallExpression| is evaluated in step 1.</p>
+        <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
+        <p>Is evaluated in exactly the same manner as <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar> except that the contained |CallExpression| is evaluated in step 1.</p>
       </emu-clause>
     </emu-clause>
 
@@ -12318,11 +12318,11 @@
       <!-- es6num="12.3.3.1" -->
       <emu-clause id="sec-new-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">NewExpression : `new` NewExpression</emu-grammar>
+        <emu-grammar>NewExpression : `new` NewExpression</emu-grammar>
         <emu-alg>
           1. Return ? EvaluateNew(|NewExpression|, ~empty~).
         </emu-alg>
-        <emu-grammar use="reference">MemberExpression : `new` MemberExpression Arguments</emu-grammar>
+        <emu-grammar>MemberExpression : `new` MemberExpression Arguments</emu-grammar>
         <emu-alg>
           1. Return ? EvaluateNew(|MemberExpression|, |Arguments|).
         </emu-alg>
@@ -12354,7 +12354,7 @@
       <!-- es6num="12.3.4.1" -->
       <emu-clause id="sec-function-calls-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
+        <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredCallExpression of |CoverCallExpressionAndAsyncArrowHead|.
           1. Let _memberExpr_ be the |MemberExpression| of _expr_.
@@ -12383,7 +12383,7 @@
           1. Return ? EvaluateDirectCall(_func_, _thisValue_, _arguments_, _tailCall_).
         </emu-alg>
         <p>A |CallExpression| evaluation that executes step 6.a.vii is a <dfn>direct eval</dfn>.</p>
-        <emu-grammar use="reference">CallExpression : CallExpression Arguments</emu-grammar>
+        <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |CallExpression|.
           1. Let _thisCall_ be this |CallExpression|.
@@ -12434,7 +12434,7 @@
       <!-- es6num="12.3.5.1" -->
       <emu-clause id="sec-super-keyword-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">SuperProperty : `super` `[` Expression `]`</emu-grammar>
+        <emu-grammar>SuperProperty : `super` `[` Expression `]`</emu-grammar>
         <emu-alg>
           1. Let _propertyNameReference_ be the result of evaluating |Expression|.
           1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
@@ -12442,13 +12442,13 @@
           1. If the code matched by this |SuperProperty| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? MakeSuperPropertyReference(_propertyKey_, _strict_).
         </emu-alg>
-        <emu-grammar use="reference">SuperProperty : `super` `.` IdentifierName</emu-grammar>
+        <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _propertyKey_ be StringValue of |IdentifierName|.
           1. If the code matched by this |SuperProperty| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? MakeSuperPropertyReference(_propertyKey_, _strict_).
         </emu-alg>
-        <emu-grammar use="reference">SuperCall : `super` Arguments</emu-grammar>
+        <emu-grammar>SuperCall : `super` Arguments</emu-grammar>
         <emu-alg>
           1. Let _newTarget_ be GetNewTarget().
           1. Assert: Type(_newTarget_) is Object.
@@ -12502,17 +12502,17 @@
       <emu-clause id="sec-argument-lists-runtime-semantics-argumentlistevaluation">
         <h1>Runtime Semantics: ArgumentListEvaluation</h1>
         <emu-see-also-para op="ArgumentListEvaluation"></emu-see-also-para>
-        <emu-grammar use="reference">Arguments : `(` `)`</emu-grammar>
+        <emu-grammar>Arguments : `(` `)`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ArgumentList : AssignmentExpression</emu-grammar>
+        <emu-grammar>ArgumentList : AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
           1. Return a List whose sole item is _arg_.
         </emu-alg>
-        <emu-grammar use="reference">ArgumentList : `...` AssignmentExpression</emu-grammar>
+        <emu-grammar>ArgumentList : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _list_ be a new empty List.
           1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
@@ -12524,7 +12524,7 @@
             1. Let _nextArg_ be ? IteratorValue(_next_).
             1. Append _nextArg_ as the last element of _list_.
         </emu-alg>
-        <emu-grammar use="reference">ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
+        <emu-grammar>ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _precedingArgs_ be ArgumentListEvaluation of |ArgumentList|.
           1. ReturnIfAbrupt(_precedingArgs_).
@@ -12533,7 +12533,7 @@
           1. Append _arg_ to the end of _precedingArgs_.
           1. Return _precedingArgs_.
         </emu-alg>
-        <emu-grammar use="reference">ArgumentList : ArgumentList `,` `...` AssignmentExpression</emu-grammar>
+        <emu-grammar>ArgumentList : ArgumentList `,` `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _precedingArgs_ be ArgumentListEvaluation of |ArgumentList|.
           1. ReturnIfAbrupt(_precedingArgs_).
@@ -12558,14 +12558,14 @@
       <!-- es6num="12.3.7.1" -->
       <emu-clause id="sec-tagged-templates-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
+        <emu-grammar>MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
         <emu-alg>
           1. Let _tagRef_ be the result of evaluating |MemberExpression|.
           1. Let _thisCall_ be this |MemberExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_tagRef_, |TemplateLiteral|, _tailCall_).
         </emu-alg>
-        <emu-grammar use="reference">CallExpression : CallExpression TemplateLiteral</emu-grammar>
+        <emu-grammar>CallExpression : CallExpression TemplateLiteral</emu-grammar>
         <emu-alg>
           1. Let _tagRef_ be the result of evaluating |CallExpression|.
           1. Let _thisCall_ be this |CallExpression|.
@@ -12582,7 +12582,7 @@
       <!-- es6num="12.3.8.1" -->
       <emu-clause id="sec-meta-properties-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">NewTarget : `new` `.` `target`</emu-grammar>
+        <emu-grammar>NewTarget : `new` `.` `target`</emu-grammar>
         <emu-alg>
           1. Return GetNewTarget().
         </emu-alg>
@@ -12606,7 +12606,7 @@
     <!-- es6num="12.4.1" -->
     <emu-clause id="sec-update-expressions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         UpdateExpression :
           LeftHandSideExpression `++`
           LeftHandSideExpression `--`
@@ -12617,7 +12617,7 @@
         </li>
       </ul>
 
-      <emu-grammar use="reference">
+      <emu-grammar>
         UpdateExpression :
           `++` UnaryExpression
           `--` UnaryExpression
@@ -12633,7 +12633,7 @@
     <emu-clause id="sec-update-expressions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         UpdateExpression :
           LeftHandSideExpression `++`
           LeftHandSideExpression `--`
@@ -12649,7 +12649,7 @@
     <emu-clause id="sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         UpdateExpression :
           LeftHandSideExpression `++`
           LeftHandSideExpression `--`
@@ -12668,7 +12668,7 @@
       <!-- es6num="12.4.4.1" -->
       <emu-clause id="sec-postfix-increment-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
+        <emu-grammar>UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_lhs_)).
@@ -12686,7 +12686,7 @@
       <!-- es6num="12.4.5.1" -->
       <emu-clause id="sec-postfix-decrement-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
+        <emu-grammar>UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_lhs_)).
@@ -12704,7 +12704,7 @@
       <!-- es6num="12.5.7.1" -->
       <emu-clause id="sec-prefix-increment-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UpdateExpression : `++` UnaryExpression</emu-grammar>
+        <emu-grammar>UpdateExpression : `++` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
@@ -12722,7 +12722,7 @@
       <!-- es6num="12.5.8.1" -->
       <emu-clause id="sec-prefix-decrement-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UpdateExpression : `--` UnaryExpression</emu-grammar>
+        <emu-grammar>UpdateExpression : `--` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
@@ -12755,7 +12755,7 @@
     <emu-clause id="sec-unary-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         UnaryExpression :
           `delete` UnaryExpression
           `void` UnaryExpression
@@ -12775,7 +12775,7 @@
     <emu-clause id="sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         UnaryExpression :
           `delete` UnaryExpression
           `void` UnaryExpression
@@ -12798,15 +12798,15 @@
       <!-- es6num="12.5.4.1" -->
       <emu-clause id="sec-delete-operator-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">UnaryExpression : `delete` UnaryExpression</emu-grammar>
+        <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the |UnaryExpression| is contained in strict mode code and the derived |UnaryExpression| is <emu-grammar use="reference">PrimaryExpression : IdentifierReference</emu-grammar>.
+            It is a Syntax Error if the |UnaryExpression| is contained in strict mode code and the derived |UnaryExpression| is <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>.
           </li>
           <li>
             <p>It is a Syntax Error if the derived |UnaryExpression| is
               <br>
-              <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+              <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
               <br>
               and |CoverParenthesizedExpressionAndArrowParameterList| ultimately derives a phrase that, if used in place of |UnaryExpression|, would produce a Syntax Error according to these rules. This rule is recursively applied.</p>
           </li>
@@ -12819,7 +12819,7 @@
       <!-- es6num="12.5.4.2" -->
       <emu-clause id="sec-delete-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UnaryExpression : `delete` UnaryExpression</emu-grammar>
+        <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |UnaryExpression|.
           1. ReturnIfAbrupt(_ref_).
@@ -12850,7 +12850,7 @@
       <!-- es6num="12.5.5.1" -->
       <emu-clause id="sec-void-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UnaryExpression : `void` UnaryExpression</emu-grammar>
+        <emu-grammar>UnaryExpression : `void` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Perform ? GetValue(_expr_).
@@ -12869,7 +12869,7 @@
       <!-- es6num="12.5.6.1" -->
       <emu-clause id="sec-typeof-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UnaryExpression : `typeof` UnaryExpression</emu-grammar>
+        <emu-grammar>UnaryExpression : `typeof` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _val_ be the result of evaluating |UnaryExpression|.
           1. If Type(_val_) is Reference, then
@@ -12988,7 +12988,7 @@
       <!-- es6num="12.5.9.1" -->
       <emu-clause id="sec-unary-plus-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UnaryExpression : `+` UnaryExpression</emu-grammar>
+        <emu-grammar>UnaryExpression : `+` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Return ? ToNumber(? GetValue(_expr_)).
@@ -13006,7 +13006,7 @@
       <!-- es6num="12.5.10.1" -->
       <emu-clause id="sec-unary-minus-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UnaryExpression : `-` UnaryExpression</emu-grammar>
+        <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
@@ -13023,7 +13023,7 @@
       <!-- es6num="12.5.11.1" -->
       <emu-clause id="sec-bitwise-not-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UnaryExpression : `~` UnaryExpression</emu-grammar>
+        <emu-grammar>UnaryExpression : `~` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToInt32(? GetValue(_expr_)).
@@ -13039,7 +13039,7 @@
       <!-- es6num="12.5.12.1" -->
       <emu-clause id="sec-logical-not-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">UnaryExpression : `!` UnaryExpression</emu-grammar>
+        <emu-grammar>UnaryExpression : `!` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ToBoolean(? GetValue(_expr_)).
@@ -13063,7 +13063,7 @@
     <emu-clause id="sec-exp-operator-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         ExponentiationExpression :
           UpdateExpression `**` ExponentiationExpression
       </emu-grammar>
@@ -13075,7 +13075,7 @@
     <emu-clause id="sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         ExponentiationExpression :
           UpdateExpression `**` ExponentiationExpression
       </emu-grammar>
@@ -13086,7 +13086,7 @@
 
     <emu-clause id="sec-exp-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         ExponentiationExpression : UpdateExpression `**` ExponentiationExpression
       </emu-grammar>
       <emu-alg>
@@ -13153,7 +13153,7 @@
     <emu-clause id="sec-multiplicative-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
+      <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -13163,7 +13163,7 @@
     <emu-clause id="sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
+      <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -13172,7 +13172,7 @@
     <!-- es6num="12.6.3" -->
     <emu-clause id="sec-multiplicative-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
+      <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
         1. Let _left_ be the result of evaluating |MultiplicativeExpression|.
         1. Let _leftValue_ be ? GetValue(_left_).
@@ -13293,7 +13293,7 @@
     <emu-clause id="sec-additive-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AdditiveExpression :
           AdditiveExpression `+` MultiplicativeExpression
           AdditiveExpression `-` MultiplicativeExpression
@@ -13307,7 +13307,7 @@
     <emu-clause id="sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AdditiveExpression :
           AdditiveExpression `+` MultiplicativeExpression
           AdditiveExpression `-` MultiplicativeExpression
@@ -13327,7 +13327,7 @@
       <!-- es6num="12.7.3.1" -->
       <emu-clause id="sec-addition-operator-plus-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">AdditiveExpression : AdditiveExpression `+` MultiplicativeExpression</emu-grammar>
+        <emu-grammar>AdditiveExpression : AdditiveExpression `+` MultiplicativeExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |AdditiveExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13359,7 +13359,7 @@
       <!-- es6num="12.7.4.1" -->
       <emu-clause id="sec-subtraction-operator-minus-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">AdditiveExpression : AdditiveExpression `-` MultiplicativeExpression</emu-grammar>
+        <emu-grammar>AdditiveExpression : AdditiveExpression `-` MultiplicativeExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |AdditiveExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13426,7 +13426,7 @@
     <emu-clause id="sec-bitwise-shift-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         ShiftExpression :
           ShiftExpression `&lt;&lt;` AdditiveExpression
           ShiftExpression `&gt;&gt;` AdditiveExpression
@@ -13441,7 +13441,7 @@
     <emu-clause id="sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         ShiftExpression :
           ShiftExpression `&lt;&lt;` AdditiveExpression
           ShiftExpression `&gt;&gt;` AdditiveExpression
@@ -13462,7 +13462,7 @@
       <!-- es6num="12.8.3.1" -->
       <emu-clause id="sec-left-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">ShiftExpression : ShiftExpression `&lt;&lt;` AdditiveExpression</emu-grammar>
+        <emu-grammar>ShiftExpression : ShiftExpression `&lt;&lt;` AdditiveExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |ShiftExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13486,7 +13486,7 @@
       <!-- es6num="12.8.4.1" -->
       <emu-clause id="sec-signed-right-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">ShiftExpression : ShiftExpression `&gt;&gt;` AdditiveExpression</emu-grammar>
+        <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;` AdditiveExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |ShiftExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13510,7 +13510,7 @@
       <!-- es6num="12.8.5.1" -->
       <emu-clause id="sec-unsigned-right-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">ShiftExpression : ShiftExpression `&gt;&gt;&gt;` AdditiveExpression</emu-grammar>
+        <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;&gt;` AdditiveExpression</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |ShiftExpression|.
           1. Let _lval_ be ? GetValue(_lref_).
@@ -13550,7 +13550,7 @@
     <emu-clause id="sec-relational-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         RelationalExpression :
           RelationalExpression `&lt;` ShiftExpression
           RelationalExpression `&gt;` ShiftExpression
@@ -13568,7 +13568,7 @@
     <emu-clause id="sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         RelationalExpression :
           RelationalExpression `&lt;` ShiftExpression
           RelationalExpression `&gt;` ShiftExpression
@@ -13585,7 +13585,7 @@
     <!-- es6num="12.9.3" -->
     <emu-clause id="sec-relational-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
+      <emu-grammar>RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13595,7 +13595,7 @@
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
-      <emu-grammar use="reference">RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
+      <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13605,7 +13605,7 @@
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
-      <emu-grammar use="reference">RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
+      <emu-grammar>RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13615,7 +13615,7 @@
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
-      <emu-grammar use="reference">RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
+      <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13625,7 +13625,7 @@
         1. ReturnIfAbrupt(_r_).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
-      <emu-grammar use="reference">RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
+      <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13633,7 +13633,7 @@
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return ? InstanceofOperator(_lval_, _rval_).
       </emu-alg>
-      <emu-grammar use="reference">RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
+      <emu-grammar>RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13682,7 +13682,7 @@
     <emu-clause id="sec-equality-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         EqualityExpression :
           EqualityExpression `==` RelationalExpression
           EqualityExpression `!=` RelationalExpression
@@ -13698,7 +13698,7 @@
     <emu-clause id="sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         EqualityExpression :
           EqualityExpression `==` RelationalExpression
           EqualityExpression `!=` RelationalExpression
@@ -13713,7 +13713,7 @@
     <!-- es6num="12.10.3" -->
     <emu-clause id="sec-equality-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
+      <emu-grammar>EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13721,7 +13721,7 @@
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return the result of performing Abstract Equality Comparison _rval_ == _lval_.
       </emu-alg>
-      <emu-grammar use="reference">EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
+      <emu-grammar>EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13730,7 +13730,7 @@
         1. Let _r_ be the result of performing Abstract Equality Comparison _rval_ == _lval_.
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
-      <emu-grammar use="reference">EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
+      <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13738,7 +13738,7 @@
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return the result of performing Strict Equality Comparison _rval_ === _lval_.
       </emu-alg>
-      <emu-grammar use="reference">EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
+      <emu-grammar>EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13811,7 +13811,7 @@
     <emu-clause id="sec-binary-bitwise-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
 
         BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression
@@ -13827,7 +13827,7 @@
     <emu-clause id="sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
 
         BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression
@@ -13876,7 +13876,7 @@
     <emu-clause id="sec-binary-logical-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression
 
         LogicalORExpression : LogicalORExpression `||` LogicalANDExpression
@@ -13890,7 +13890,7 @@
     <emu-clause id="sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression
 
         LogicalORExpression : LogicalORExpression `||` LogicalANDExpression
@@ -13903,7 +13903,7 @@
     <!-- es6num="12.12.3" -->
     <emu-clause id="sec-binary-logical-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
+      <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalANDExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13912,7 +13912,7 @@
         1. Let _rref_ be the result of evaluating |BitwiseORExpression|.
         1. Return ? GetValue(_rref_).
       </emu-alg>
-      <emu-grammar use="reference">LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
+      <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalORExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -13941,7 +13941,7 @@
     <emu-clause id="sec-conditional-operator-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+      <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -13951,7 +13951,7 @@
     <emu-clause id="sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+      <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -13960,7 +13960,7 @@
     <!-- es6num="12.13.3" -->
     <emu-clause id="sec-conditional-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+      <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalORExpression|.
         1. Let _lval_ be ToBoolean(? GetValue(_lref_)).
@@ -13994,7 +13994,7 @@
     <!-- es6num="12.14.1" -->
     <emu-clause id="sec-assignment-operators-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
+      <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and the lexical token sequence matched by |LeftHandSideExpression| cannot be parsed with no tokens left over using |AssignmentPattern| as the goal symbol.
@@ -14003,7 +14003,7 @@
           It is an early Reference Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
         </li>
       </ul>
-      <emu-grammar use="reference">AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
+      <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <ul>
         <li>
           It is an early Reference Error if IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
@@ -14015,7 +14015,7 @@
     <emu-clause id="sec-assignment-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AssignmentExpression :
           ArrowFunction
           AsyncArrowFunction
@@ -14023,7 +14023,7 @@
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AssignmentExpression :
           YieldExpression
           LeftHandSideExpression `=` AssignmentExpression
@@ -14038,7 +14038,7 @@
     <emu-clause id="sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AssignmentExpression :
           YieldExpression
           ArrowFunction
@@ -14054,7 +14054,7 @@
     <!-- es6num="12.14.4" -->
     <emu-clause id="sec-assignment-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">AssignmentExpression[In, Yield, Await] : LeftHandSideExpression[?Yield, ?Await] `=` AssignmentExpression[?In, ?Yield, ?Await]</emu-grammar>
+      <emu-grammar>AssignmentExpression[In, Yield, Await] : LeftHandSideExpression[?Yield, ?Await] `=` AssignmentExpression[?In, ?Yield, ?Await]</emu-grammar>
       <emu-alg>
         1. If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
           1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
@@ -14072,7 +14072,7 @@
         1. Perform ? DestructuringAssignmentEvaluation of _assignmentPattern_ using _rval_ as the argument.
         1. Return _rval_.
       </emu-alg>
-      <emu-grammar use="reference">AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
+      <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
@@ -14092,7 +14092,7 @@
     <emu-clause id="sec-destructuring-assignment">
       <h1>Destructuring Assignment</h1>
       <h2>Supplemental Syntax</h2>
-      <p>In certain circumstances when processing an instance of the production <emu-grammar use="reference">AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar> the following grammar is used to refine the interpretation of |LeftHandSideExpression|.</p>
+      <p>In certain circumstances when processing an instance of the production <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar> the following grammar is used to refine the interpretation of |LeftHandSideExpression|.</p>
       <emu-grammar use="definition">
         AssignmentPattern[Yield, Await] :
           ObjectAssignmentPattern[?Yield, ?Await]
@@ -14136,13 +14136,13 @@
       <!-- es6num="12.14.5.1" -->
       <emu-clause id="sec-destructuring-assignment-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
+        <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if IsValidSimpleAssignmentTarget of |IdentifierReference| is *false*.
           </li>
         </ul>
-        <emu-grammar use="reference">DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
+        <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and if the lexical token sequence matched by |LeftHandSideExpression| cannot be parsed with no tokens left over using |AssignmentPattern| as the goal symbol.
@@ -14157,12 +14157,12 @@
       <emu-clause id="sec-runtime-semantics-destructuringassignmentevaluation">
         <h1>Runtime Semantics: DestructuringAssignmentEvaluation</h1>
         <p>With parameter _value_.</p>
-        <emu-grammar use="reference">ObjectAssignmentPattern : `{` `}`</emu-grammar>
+        <emu-grammar>ObjectAssignmentPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ObjectAssignmentPattern :
             `{` AssignmentPropertyList `}`
             `{` AssignmentPropertyList `,` `}`
@@ -14171,12 +14171,12 @@
           1. Perform ? RequireObjectCoercible(_value_).
           1. Return the result of performing DestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
         </emu-alg>
-        <emu-grammar use="reference">ArrayAssignmentPattern : `[` `]`</emu-grammar>
+        <emu-grammar>ArrayAssignmentPattern : `[` `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Return ? IteratorClose(_iterator_, NormalCompletion(~empty~)).
         </emu-alg>
-        <emu-grammar use="reference">ArrayAssignmentPattern : `[` Elision `]`</emu-grammar>
+        <emu-grammar>ArrayAssignmentPattern : `[` Elision `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -14184,7 +14184,7 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _result_).
           1. Return _result_.
         </emu-alg>
-        <emu-grammar use="reference">ArrayAssignmentPattern : `[` Elision? AssignmentRestElement `]`</emu-grammar>
+        <emu-grammar>ArrayAssignmentPattern : `[` Elision? AssignmentRestElement `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -14196,7 +14196,7 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _result_).
           1. Return _result_.
         </emu-alg>
-        <emu-grammar use="reference">ArrayAssignmentPattern : `[` AssignmentElementList `]`</emu-grammar>
+        <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -14204,7 +14204,7 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _result_).
           1. Return _result_.
         </emu-alg>
-        <emu-grammar use="reference">ArrayAssignmentPattern : `[` AssignmentElementList `,` Elision? AssignmentRestElement? `]`</emu-grammar>
+        <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `,` Elision? AssignmentRestElement? `]`</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -14221,12 +14221,12 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _status_).
           1. Return Completion(_status_).
         </emu-alg>
-        <emu-grammar use="reference">AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
+        <emu-grammar>AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
         <emu-alg>
           1. Perform ? DestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
           1. Return the result of performing DestructuringAssignmentEvaluation for |AssignmentProperty| using _value_ as the argument.
         </emu-alg>
-        <emu-grammar use="reference">AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
+        <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
         <emu-alg>
           1. Let _P_ be StringValue of |IdentifierReference|.
           1. Let _lref_ be ? ResolveBinding(_P_).
@@ -14239,7 +14239,7 @@
               1. If _hasNameProperty_ is *false*, perform SetFunctionName(_v_, _P_).
           1. Return ? PutValue(_lref_, _v_).
         </emu-alg>
-        <emu-grammar use="reference">AssignmentProperty : PropertyName `:` AssignmentElement</emu-grammar>
+        <emu-grammar>AssignmentProperty : PropertyName `:` AssignmentElement</emu-grammar>
         <emu-alg>
           1. Let _name_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_name_).
@@ -14251,25 +14251,25 @@
       <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation">
         <h1>Runtime Semantics: IteratorDestructuringAssignmentEvaluation</h1>
         <p>With parameter _iteratorRecord_.</p>
-        <emu-grammar use="reference">AssignmentElementList : AssignmentElisionElement</emu-grammar>
+        <emu-grammar>AssignmentElementList : AssignmentElisionElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| using _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar use="reference">AssignmentElementList : AssignmentElementList `,` AssignmentElisionElement</emu-grammar>
+        <emu-grammar>AssignmentElementList : AssignmentElementList `,` AssignmentElisionElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| using _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| using _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar use="reference">AssignmentElisionElement : AssignmentElement</emu-grammar>
+        <emu-grammar>AssignmentElisionElement : AssignmentElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar use="reference">AssignmentElisionElement : Elision AssignmentElement</emu-grammar>
+        <emu-grammar>AssignmentElisionElement : Elision AssignmentElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar use="reference">Elision : `,`</emu-grammar>
+        <emu-grammar>Elision : `,`</emu-grammar>
         <emu-alg>
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be IteratorStep(_iteratorRecord_.[[Iterator]]).
@@ -14278,7 +14278,7 @@
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">Elision : Elision `,`</emu-grammar>
+        <emu-grammar>Elision : Elision `,`</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. If _iteratorRecord_.[[Done]] is *false*, then
@@ -14288,7 +14288,7 @@
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">AssignmentElement[Yield, Await] : DestructuringAssignmentTarget Initializer?</emu-grammar>
+        <emu-grammar>AssignmentElement[Yield, Await] : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
@@ -14318,7 +14318,7 @@
         <emu-note>
           <p>Left to right evaluation order is maintained by evaluating a |DestructuringAssignmentTarget| that is not a destructuring pattern prior to accessing the iterator or evaluating the |Initializer|.</p>
         </emu-note>
-        <emu-grammar use="reference">AssignmentRestElement[Yield, Await] : `...` DestructuringAssignmentTarget</emu-grammar>
+        <emu-grammar>AssignmentRestElement[Yield, Await] : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
@@ -14348,7 +14348,7 @@
       <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation">
         <h1>Runtime Semantics: KeyedDestructuringAssignmentEvaluation</h1>
         <p>With parameters _value_ and _propertyName_.</p>
-        <emu-grammar use="reference">AssignmentElement[Yield, Await] : DestructuringAssignmentTarget Initializer?</emu-grammar>
+        <emu-grammar>AssignmentElement[Yield, Await] : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
@@ -14384,7 +14384,7 @@
     <emu-clause id="sec-comma-operator-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">Expression : Expression `,` AssignmentExpression</emu-grammar>
+      <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14394,7 +14394,7 @@
     <emu-clause id="sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
-      <emu-grammar use="reference">Expression : Expression `,` AssignmentExpression</emu-grammar>
+      <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14403,7 +14403,7 @@
     <!-- es6num="12.15.3" -->
     <emu-clause id="sec-comma-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">Expression : Expression `,` AssignmentExpression</emu-grammar>
+      <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |Expression|.
         1. Perform ? GetValue(_lref_).
@@ -14462,7 +14462,7 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         Statement :
           VariableStatement
           EmptyStatement
@@ -14483,7 +14483,7 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         Statement :
           VariableStatement
           EmptyStatement
@@ -14503,7 +14503,7 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         Statement :
           VariableStatement
           EmptyStatement
@@ -14516,7 +14516,7 @@
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">BreakableStatement : IterationStatement</emu-grammar>
+      <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
         1. Let _newIterationSet_ be a copy of _iterationSet_ with all the elements of _labelSet_ appended.
         1. Return ContainsUndefinedContinueTarget of |IterationStatement| with arguments _newIterationSet_ and &laquo; &raquo;.
@@ -14526,23 +14526,23 @@
     <!-- es6num="13.1.4" -->
     <emu-clause id="sec-static-semantics-declarationpart">
       <h1>Static Semantics: DeclarationPart</h1>
-      <emu-grammar use="reference">HoistableDeclaration : FunctionDeclaration</emu-grammar>
+      <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return |FunctionDeclaration|.
       </emu-alg>
-      <emu-grammar use="reference">HoistableDeclaration : GeneratorDeclaration</emu-grammar>
+      <emu-grammar>HoistableDeclaration : GeneratorDeclaration</emu-grammar>
       <emu-alg>
         1. Return |GeneratorDeclaration|.
       </emu-alg>
-      <emu-grammar use="reference">HoistableDeclaration : AsyncFunctionDeclaration</emu-grammar>
+      <emu-grammar>HoistableDeclaration : AsyncFunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return |AsyncFunctionDeclaration|.
       </emu-alg>
-      <emu-grammar use="reference">Declaration : ClassDeclaration</emu-grammar>
+      <emu-grammar>Declaration : ClassDeclaration</emu-grammar>
       <emu-alg>
         1. Return |ClassDeclaration|.
       </emu-alg>
-      <emu-grammar use="reference">Declaration : LexicalDeclaration</emu-grammar>
+      <emu-grammar>Declaration : LexicalDeclaration</emu-grammar>
       <emu-alg>
         1. Return |LexicalDeclaration|.
       </emu-alg>
@@ -14552,7 +14552,7 @@
     <emu-clause id="sec-statement-semantics-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         Statement :
           EmptyStatement
           ExpressionStatement
@@ -14571,7 +14571,7 @@
     <emu-clause id="sec-statement-semantics-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         Statement :
           EmptyStatement
           ExpressionStatement
@@ -14591,7 +14591,7 @@
       <h1>Runtime Semantics: LabelledEvaluation</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-      <emu-grammar use="reference">BreakableStatement : IterationStatement</emu-grammar>
+      <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
         1. Let _stmtResult_ be the result of performing LabelledEvaluation of |IterationStatement| with argument _labelSet_.
         1. If _stmtResult_.[[Type]] is ~break~, then
@@ -14600,7 +14600,7 @@
             1. Else, set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
         1. Return Completion(_stmtResult_).
       </emu-alg>
-      <emu-grammar use="reference">BreakableStatement : SwitchStatement</emu-grammar>
+      <emu-grammar>BreakableStatement : SwitchStatement</emu-grammar>
       <emu-alg>
         1. Let _stmtResult_ be the result of evaluating |SwitchStatement|.
         1. If _stmtResult_.[[Type]] is ~break~, then
@@ -14617,25 +14617,25 @@
     <!-- es6num="13.1.8" -->
     <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         HoistableDeclaration : GeneratorDeclaration
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         HoistableDeclaration : AsyncFunctionDeclaration
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         HoistableDeclaration : FunctionDeclaration
       </emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |FunctionDeclaration|.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         BreakableStatement :
           IterationStatement
           SwitchStatement
@@ -14670,7 +14670,7 @@
     <!-- es6num="13.2.1" -->
     <emu-clause id="sec-block-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">Block : `{` StatementList `}`</emu-grammar>
+      <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries.
@@ -14686,17 +14686,17 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |StatementListItem| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14707,17 +14707,17 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |StatementListItem| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14728,17 +14728,17 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |StatementListItem| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -14748,22 +14748,22 @@
     <emu-clause id="sec-block-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names_ be LexicallyDeclaredNames of |StatementList|.
         1. Append to _names_ the elements of the LexicallyDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return LexicallyDeclaredNames of |LabelledStatement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyDeclaredNames of |LabelledStatement|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |Declaration|.
       </emu-alg>
@@ -14773,18 +14773,18 @@
     <emu-clause id="sec-block-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be LexicallyScopedDeclarations of |StatementList|.
         1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return LexicallyScopedDeclarations of |LabelledStatement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyScopedDeclarations of |LabelledStatement|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return a new List containing DeclarationPart of |Declaration|.
       </emu-alg>
@@ -14794,19 +14794,19 @@
     <emu-clause id="sec-block-static-semantics-toplevellexicallydeclarednames">
       <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
       <emu-see-also-para op="TopLevelLexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names_ be TopLevelLexicallyDeclaredNames of |StatementList|.
         1. Append to _names_ the elements of the TopLevelLexicallyDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. If |Declaration| is <emu-grammar use="reference">Declaration : HoistableDeclaration</emu-grammar> , then
+        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
           1. Return &laquo; &raquo;.
         1. Return the BoundNames of |Declaration|.
       </emu-alg>
@@ -14819,23 +14819,23 @@
     <emu-clause id="sec-block-static-semantics-toplevellexicallyscopeddeclarations">
       <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelLexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be TopLevelLexicallyScopedDeclarations of |StatementList|.
         1. Append to _declarations_ the elements of the TopLevelLexicallyScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. If |Declaration| is <emu-grammar use="reference">Declaration : HoistableDeclaration</emu-grammar> , then
+        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
           1. Return &laquo; &raquo;.
         1. Return a new List containing |Declaration|.
       </emu-alg>
@@ -14845,25 +14845,25 @@
     <emu-clause id="sec-block-static-semantics-toplevelvardeclarednames">
       <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
       <emu-see-also-para op="TopLevelVarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names_ be TopLevelVarDeclaredNames of |StatementList|.
         1. Append to _names_ the elements of the TopLevelVarDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. If |Declaration| is <emu-grammar use="reference">Declaration : HoistableDeclaration</emu-grammar> , then
+        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
           1. Return the BoundNames of |HoistableDeclaration|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
         1. Return VarDeclaredNames of |Statement|.
       </emu-alg>
       <emu-note>
@@ -14875,24 +14875,24 @@
     <emu-clause id="sec-block-static-semantics-toplevelvarscopeddeclarations">
       <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelVarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be TopLevelVarScopedDeclarations of |StatementList|.
         1. Append to _declarations_ the elements of the TopLevelVarScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Statement</emu-grammar>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
         1. Return VarScopedDeclarations of |Statement|.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. If |Declaration| is <emu-grammar use="reference">Declaration : HoistableDeclaration</emu-grammar> , then
+        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
           1. Let _declaration_ be DeclarationPart of |HoistableDeclaration|.
           1. Return &laquo; _declaration_ &raquo;.
         1. Return a new empty List.
@@ -14903,17 +14903,17 @@
     <emu-clause id="sec-block-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |StatementList|.
         1. Append to _names_ the elements of the VarDeclaredNames of |StatementListItem|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -14923,17 +14923,17 @@
     <emu-clause id="sec-block-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |StatementList|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |StatementListItem|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">StatementListItem : Declaration</emu-grammar>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -14942,11 +14942,11 @@
     <!-- es6num="13.2.13" -->
     <emu-clause id="sec-block-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">Block : `{` `}`</emu-grammar>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar use="reference">Block : `{` StatementList `}`</emu-grammar>
+      <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
       <emu-alg>
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -14959,7 +14959,7 @@
       <emu-note>
         <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
       </emu-note>
-      <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _sl_ be the result of evaluating |StatementList|.
         1. ReturnIfAbrupt(_sl_).
@@ -15037,7 +15037,7 @@
       <!-- es6num="13.3.1.1" -->
       <emu-clause id="sec-let-and-const-declarations-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the BoundNames of |BindingList| contains `"let"`.
@@ -15046,7 +15046,7 @@
             It is a Syntax Error if the BoundNames of |BindingList| contains any duplicate entries.
           </li>
         </ul>
-        <emu-grammar use="reference">LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar>LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if |Initializer| is not present and IsConstantDeclaration of the |LexicalDeclaration| containing this |LexicalBinding| is *true*.
@@ -15058,21 +15058,21 @@
       <emu-clause id="sec-let-and-const-declarations-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar use="reference">LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingList|.
         </emu-alg>
-        <emu-grammar use="reference">BindingList : BindingList `,` LexicalBinding</emu-grammar>
+        <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |BindingList|.
           1. Append to _names_ the elements of the BoundNames of |LexicalBinding|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar>LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingIdentifier|.
         </emu-alg>
-        <emu-grammar use="reference">LexicalBinding : BindingPattern Initializer</emu-grammar>
+        <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingPattern|.
         </emu-alg>
@@ -15082,15 +15082,15 @@
       <emu-clause id="sec-let-and-const-declarations-static-semantics-isconstantdeclaration">
         <h1>Static Semantics: IsConstantDeclaration</h1>
         <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-        <emu-grammar use="reference">LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
           1. Return IsConstantDeclaration of |LetOrConst|.
         </emu-alg>
-        <emu-grammar use="reference">LetOrConst : `let`</emu-grammar>
+        <emu-grammar>LetOrConst : `let`</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">LetOrConst : `const`</emu-grammar>
+        <emu-grammar>LetOrConst : `const`</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -15099,19 +15099,19 @@
       <!-- es6num="13.3.1.4" -->
       <emu-clause id="sec-let-and-const-declarations-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
           1. Let _next_ be the result of evaluating |BindingList|.
           1. ReturnIfAbrupt(_next_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">BindingList : BindingList `,` LexicalBinding</emu-grammar>
+        <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
         <emu-alg>
           1. Let _next_ be the result of evaluating |BindingList|.
           1. ReturnIfAbrupt(_next_).
           1. Return the result of evaluating |LexicalBinding|.
         </emu-alg>
-        <emu-grammar use="reference">LexicalBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar>LexicalBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ResolveBinding(StringValue of |BindingIdentifier|).
           1. Return InitializeReferencedBinding(_lhs_, *undefined*).
@@ -15119,7 +15119,7 @@
         <emu-note>
           <p>A static semantics rule ensures that this form of |LexicalBinding| never occurs in a `const` declaration.</p>
         </emu-note>
-        <emu-grammar use="reference">LexicalBinding : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar>LexicalBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ResolveBinding(_bindingId_).
@@ -15130,7 +15130,7 @@
             1. If _hasNameProperty_ is *false*, perform SetFunctionName(_value_, _bindingId_).
           1. Return InitializeReferencedBinding(_lhs_, _value_).
         </emu-alg>
-        <emu-grammar use="reference">LexicalBinding : BindingPattern Initializer</emu-grammar>
+        <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
@@ -15164,17 +15164,17 @@
       <emu-clause id="sec-variable-statement-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar use="reference">VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
+        <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |VariableDeclarationList|.
           1. Append to _names_ the elements of BoundNames of |VariableDeclaration|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">VariableDeclaration : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar>VariableDeclaration : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingIdentifier|.
         </emu-alg>
-        <emu-grammar use="reference">VariableDeclaration : BindingPattern Initializer</emu-grammar>
+        <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingPattern|.
         </emu-alg>
@@ -15184,7 +15184,7 @@
       <emu-clause id="sec-variable-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar use="reference">VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
+        <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
         <emu-alg>
           1. Return BoundNames of |VariableDeclarationList|.
         </emu-alg>
@@ -15194,11 +15194,11 @@
       <emu-clause id="sec-variable-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar use="reference">VariableDeclarationList : VariableDeclaration</emu-grammar>
+        <emu-grammar>VariableDeclarationList : VariableDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new List containing |VariableDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
+        <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
           1. Append |VariableDeclaration| to _declarations_.
@@ -15209,23 +15209,23 @@
       <!-- es6num="13.3.2.4" -->
       <emu-clause id="sec-variable-statement-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
+        <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
         <emu-alg>
           1. Let _next_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_next_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
+        <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _next_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_next_).
           1. Return the result of evaluating |VariableDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">VariableDeclaration : BindingIdentifier</emu-grammar>
+        <emu-grammar>VariableDeclaration : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">VariableDeclaration : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar>VariableDeclaration : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_).
@@ -15239,7 +15239,7 @@
         <emu-note>
           <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's object Environment Record, then step 6 will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
         </emu-note>
-        <emu-grammar use="reference">VariableDeclaration : BindingPattern Initializer</emu-grammar>
+        <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _rval_ be ? GetValue(_rhs_).
@@ -15298,53 +15298,53 @@
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar use="reference">ObjectBindingPattern : `{` `}`</emu-grammar>
+        <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingRestElement|.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingElementList|.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |BindingElementList|.
           1. Append to _names_ the elements of BoundNames of |BindingRestElement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
+        <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |BindingPropertyList|.
           1. Append to _names_ the elements of BoundNames of |BindingProperty|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |BindingElementList|.
           1. Append to _names_ the elements of BoundNames of |BindingElisionElement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">BindingElisionElement : Elision? BindingElement</emu-grammar>
+        <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
         <emu-alg>
           1. Return BoundNames of |BindingElement|.
         </emu-alg>
-        <emu-grammar use="reference">BindingProperty : PropertyName `:` BindingElement</emu-grammar>
+        <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingElement|.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingIdentifier|.
         </emu-alg>
-        <emu-grammar use="reference">BindingElement : BindingPattern Initializer?</emu-grammar>
+        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |BindingPattern|.
         </emu-alg>
@@ -15354,67 +15354,67 @@
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-containsexpression">
         <h1>Static Semantics: ContainsExpression</h1>
         <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-        <emu-grammar use="reference">ObjectBindingPattern : `{` `}`</emu-grammar>
+        <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Return ContainsExpression of |BindingRestElement|.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Return ContainsExpression of |BindingElementList|.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Let _has_ be ContainsExpression of |BindingElementList|.
           1. If _has_ is *true*, return *true*.
           1. Return ContainsExpression of |BindingRestElement|.
         </emu-alg>
-        <emu-grammar use="reference">BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
+        <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
           1. Let _has_ be ContainsExpression of |BindingPropertyList|.
           1. If _has_ is *true*, return *true*.
           1. Return ContainsExpression of |BindingProperty|.
         </emu-alg>
-        <emu-grammar use="reference">BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
         <emu-alg>
           1. Let _has_ be ContainsExpression of |BindingElementList|.
           1. If _has_ is *true*, return *true*.
           1. Return ContainsExpression of |BindingElisionElement|.
         </emu-alg>
-        <emu-grammar use="reference">BindingElisionElement : Elision? BindingElement</emu-grammar>
+        <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
         <emu-alg>
           1. Return ContainsExpression of |BindingElement|.
         </emu-alg>
-        <emu-grammar use="reference">BindingProperty : PropertyName `:` BindingElement</emu-grammar>
+        <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
         <emu-alg>
           1. Let _has_ be IsComputedPropertyKey of |PropertyName|.
           1. If _has_ is *true*, return *true*.
           1. Return ContainsExpression of |BindingElement|.
         </emu-alg>
-        <emu-grammar use="reference">BindingElement : BindingPattern Initializer</emu-grammar>
+        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar use="reference">BindingRestElement : `...` BindingIdentifier</emu-grammar>
+        <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">BindingRestElement : `...` BindingPattern</emu-grammar>
+        <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
         <emu-alg>
           1. Return ContainsExpression of |BindingPattern|.
         </emu-alg>
@@ -15424,19 +15424,19 @@
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-hasinitializer">
         <h1>Static Semantics: HasInitializer</h1>
         <emu-see-also-para op="HasInitializer"></emu-see-also-para>
-        <emu-grammar use="reference">BindingElement : BindingPattern</emu-grammar>
+        <emu-grammar>BindingElement : BindingPattern</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">BindingElement : BindingPattern Initializer</emu-grammar>
+        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -15446,19 +15446,19 @@
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-issimpleparameterlist">
         <h1>Static Semantics: IsSimpleParameterList</h1>
         <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-        <emu-grammar use="reference">BindingElement : BindingPattern</emu-grammar>
+        <emu-grammar>BindingElement : BindingPattern</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">BindingElement : BindingPattern Initializer</emu-grammar>
+        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
@@ -15472,12 +15472,12 @@
         <emu-note>
           <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
         </emu-note>
-        <emu-grammar use="reference">BindingPattern : ObjectBindingPattern</emu-grammar>
+        <emu-grammar>BindingPattern : ObjectBindingPattern</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
           1. Return the result of performing BindingInitialization for |ObjectBindingPattern| using _value_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingPattern : ArrayBindingPattern</emu-grammar>
+        <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
         <emu-alg>
           1. Let _iterator_ be ? GetIterator(_value_).
           1. Let _iteratorRecord_ be Record {[[Iterator]]: _iterator_, [[Done]]: *false*}.
@@ -15485,21 +15485,21 @@
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iterator_, _result_).
           1. Return _result_.
         </emu-alg>
-        <emu-grammar use="reference">ObjectBindingPattern : `{` `}`</emu-grammar>
+        <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
+        <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
           1. Perform ? BindingInitialization for |BindingPropertyList| using _value_ and _environment_ as arguments.
           1. Return the result of performing BindingInitialization for |BindingProperty| using _value_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingProperty : SingleNameBinding</emu-grammar>
+        <emu-grammar>BindingProperty : SingleNameBinding</emu-grammar>
         <emu-alg>
           1. Let _name_ be the string that is the only element of BoundNames of |SingleNameBinding|.
           1. Return the result of performing KeyedBindingInitialization for |SingleNameBinding| using _value_, _environment_, and _name_ as the arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingProperty : PropertyName `:` BindingElement</emu-grammar>
+        <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
         <emu-alg>
           1. Let _P_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_P_).
@@ -15515,63 +15515,63 @@
         <emu-note>
           <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
         </emu-note>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` `]`</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` Elision `]`</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. If |Elision| is present, then
             1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `]`</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` `]`</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
         </emu-alg>
-        <emu-grammar use="reference">ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
           1. If |Elision| is present, then
             1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingElementList : BindingElisionElement</emu-grammar>
+        <emu-grammar>BindingElementList : BindingElisionElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization for |BindingElisionElement| with _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
           1. Return the result of performing IteratorBindingInitialization for |BindingElisionElement| using _iteratorRecord_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingElisionElement : BindingElement</emu-grammar>
+        <emu-grammar>BindingElisionElement : BindingElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization of |BindingElement| with _iteratorRecord_ and _environment_ as the arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingElisionElement : Elision BindingElement</emu-grammar>
+        <emu-grammar>BindingElisionElement : Elision BindingElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
           1. Return the result of performing IteratorBindingInitialization of |BindingElement| with _iteratorRecord_ and _environment_ as the arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingElement : SingleNameBinding</emu-grammar>
+        <emu-grammar>BindingElement : SingleNameBinding</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorBindingInitialization for |SingleNameBinding| with _iteratorRecord_ and _environment_ as the arguments.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
@@ -15594,7 +15594,7 @@
           1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
           1. Return InitializeReferencedBinding(_lhs_, _v_).
         </emu-alg>
-        <emu-grammar use="reference">BindingElement : BindingPattern Initializer?</emu-grammar>
+        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
         <emu-alg>
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be IteratorStep(_iteratorRecord_.[[Iterator]]).
@@ -15611,7 +15611,7 @@
             1. Set _v_ to ? GetValue(_defaultValue_).
           1. Return the result of performing BindingInitialization of |BindingPattern| with _v_ and _environment_ as the arguments.
         </emu-alg>
-        <emu-grammar use="reference">BindingRestElement : `...` BindingIdentifier</emu-grammar>
+        <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
           1. Let _A_ be ! ArrayCreate(0).
@@ -15632,7 +15632,7 @@
             1. Assert: _status_ is *true*.
             1. Increment _n_ by 1.
         </emu-alg>
-        <emu-grammar use="reference">BindingRestElement : `...` BindingPattern</emu-grammar>
+        <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
         <emu-alg>
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
@@ -15660,7 +15660,7 @@
         <emu-note>
           <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
         </emu-note>
-        <emu-grammar use="reference">BindingElement : BindingPattern Initializer?</emu-grammar>
+        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
         <emu-alg>
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
@@ -15668,7 +15668,7 @@
             1. Set _v_ to ? GetValue(_defaultValue_).
           1. Return the result of performing BindingInitialization for |BindingPattern| passing _v_ and _environment_ as arguments.
         </emu-alg>
-        <emu-grammar use="reference">SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
@@ -15698,7 +15698,7 @@
     <!-- es6num="13.4.1" -->
     <emu-clause id="sec-empty-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">EmptyStatement : `;`</emu-grammar>
+      <emu-grammar>EmptyStatement : `;`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
@@ -15720,7 +15720,7 @@
     <!-- es6num="13.5.1" -->
     <emu-clause id="sec-expression-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">ExpressionStatement : Expression `;`</emu-grammar>
+      <emu-grammar>ExpressionStatement : Expression `;`</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Return ? GetValue(_exprRef_).
@@ -15742,7 +15742,7 @@
     <!-- es6num="13.6.1" -->
     <emu-clause id="sec-if-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         IfStatement :
           `if` `(` Expression `)` Statement `else` Statement
           `if` `(` Expression `)` Statement
@@ -15762,13 +15762,13 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicate_ be ContainsDuplicateLabels of the first |Statement| with argument _labelSet_.
         1. If _hasDuplicate_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of the second |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -15779,13 +15779,13 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |Statement| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of the second |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -15796,13 +15796,13 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of the second |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -15812,13 +15812,13 @@
     <emu-clause id="sec-if-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of the first |Statement|.
         1. Append to _names_ the elements of the VarDeclaredNames of the second |Statement|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
@@ -15828,13 +15828,13 @@
     <emu-clause id="sec-if-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of the first |Statement|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of the second |Statement|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
@@ -15843,7 +15843,7 @@
     <!-- es6num="13.6.7" -->
     <emu-clause id="sec-if-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
@@ -15853,7 +15853,7 @@
           1. Let _stmtCompletion_ be the result of evaluating the second |Statement|.
         1. Return Completion(UpdateEmpty(_stmtCompletion_, *undefined*)).
       </emu-alg>
-      <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
@@ -15902,7 +15902,7 @@
       <!-- es6num="13.7.1.1" -->
       <emu-clause id="sec-semantics-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `do` Statement `while` `(` Expression `)` `;`
             `while` `(` Expression `)` Statement
@@ -15952,7 +15952,7 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
         </emu-alg>
@@ -15963,7 +15963,7 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
         </emu-alg>
@@ -15974,7 +15974,7 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
@@ -15984,7 +15984,7 @@
       <emu-clause id="sec-do-while-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -15994,7 +15994,7 @@
       <emu-clause id="sec-do-while-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16005,7 +16005,7 @@
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
@@ -16028,7 +16028,7 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
         </emu-alg>
@@ -16039,7 +16039,7 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
         </emu-alg>
@@ -16050,7 +16050,7 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
@@ -16060,7 +16060,7 @@
       <emu-clause id="sec-while-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -16070,7 +16070,7 @@
       <emu-clause id="sec-while-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16081,7 +16081,7 @@
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
@@ -16102,7 +16102,7 @@
       <!-- es6num="13.7.4.1" -->
       <emu-clause id="sec-for-statement-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if any element of the BoundNames of |LexicalDeclaration| also occurs in the VarDeclaredNames of |Statement|.
@@ -16115,7 +16115,7 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
             `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
@@ -16131,7 +16131,7 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
             `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
@@ -16147,7 +16147,7 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
             `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
@@ -16162,17 +16162,17 @@
       <emu-clause id="sec-for-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |VariableDeclarationList|.
           1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -16182,17 +16182,17 @@
       <emu-clause id="sec-for-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16203,20 +16203,20 @@
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. If the first |Expression| is present, then
             1. Let _exprRef_ be the result of evaluating the first |Expression|.
             1. Perform ? GetValue(_exprRef_).
           1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _varDcl_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_varDcl_).
           1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -16291,7 +16291,7 @@
       <!-- es6num="13.7.5.1" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
@@ -16307,13 +16307,13 @@
             It is a Syntax Error if IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
           </li>
           <li>
-            It is a Syntax Error if the |LeftHandSideExpression| is <emu-grammar use="reference">CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar> and |Expression| derives a phrase that would produce a Syntax Error according to these rules if that phrase were substituted for |LeftHandSideExpression|. This rule is recursively applied.
+            It is a Syntax Error if the |LeftHandSideExpression| is <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar> and |Expression| derives a phrase that would produce a Syntax Error according to these rules if that phrase were substituted for |LeftHandSideExpression|. This rule is recursively applied.
           </li>
         </ul>
         <emu-note>
           <p>The last rule means that the other rules are applied even if parentheses surround |Expression|.</p>
         </emu-note>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `for` `(` ForDeclaration `in` Expression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
@@ -16335,7 +16335,7 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar use="reference">ForDeclaration : LetOrConst ForBinding</emu-grammar>
+        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |ForBinding|.
         </emu-alg>
@@ -16346,7 +16346,7 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` `var` ForBinding `in` Expression `)` Statement
@@ -16368,7 +16368,7 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` `var` ForBinding `in` Expression `)` Statement
@@ -16390,7 +16390,7 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` `var` ForBinding `in` Expression `)` Statement
@@ -16411,15 +16411,15 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-isdestructuring">
         <h1>Static Semantics: IsDestructuring</h1>
         <emu-see-also-para op="IsDestructuring"></emu-see-also-para>
-        <emu-grammar use="reference">ForDeclaration : LetOrConst ForBinding</emu-grammar>
+        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Return IsDestructuring of |ForBinding|.
         </emu-alg>
-        <emu-grammar use="reference">ForBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar>ForBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">ForBinding : BindingPattern</emu-grammar>
+        <emu-grammar>ForBinding : BindingPattern</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -16432,31 +16432,31 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ForBinding|.
           1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ForBinding|.
           1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -16469,31 +16469,31 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be a List containing |ForBinding|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be a List containing |ForBinding|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16510,7 +16510,7 @@
         <emu-note>
           <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and the formal parameter lists of some non-strict functions (see <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
         </emu-note>
-        <emu-grammar use="reference">ForDeclaration : LetOrConst ForBinding</emu-grammar>
+        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Return the result of performing BindingInitialization for |ForBinding| passing _value_ and _environment_ as the arguments.
         </emu-alg>
@@ -16520,7 +16520,7 @@
       <emu-clause id="sec-runtime-semantics-bindinginstantiation">
         <h1>Runtime Semantics: BindingInstantiation</h1>
         <p>With parameter _environment_.</p>
-        <emu-grammar use="reference">ForDeclaration : LetOrConst ForBinding</emu-grammar>
+        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Let _envRec_ be _environment_'s EnvironmentRecord.
           1. Assert: _envRec_ is a declarative Environment Record.
@@ -16537,32 +16537,32 @@
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
           1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~enumerate~, ~assignment~, _labelSet_).
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~enumerate~, ~varBinding~, _labelSet_).
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |Expression|, ~enumerate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~enumerate~, ~lexicalBinding~, _labelSet_).
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_).
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_).
         </emu-alg>
-        <emu-grammar use="reference">IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
@@ -16666,7 +16666,7 @@
       <!-- es6num="13.7.5.14" -->
       <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">ForBinding : BindingIdentifier</emu-grammar>
+        <emu-grammar>ForBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Return ? ResolveBinding(_bindingId_).
@@ -16721,7 +16721,7 @@
     <!-- es6num="13.8.1" -->
     <emu-clause id="sec-continue-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         ContinueStatement : `continue` `;`
 
         ContinueStatement : `continue` LabelIdentifier `;`
@@ -16738,11 +16738,11 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar use="reference">ContinueStatement : `continue` `;`</emu-grammar>
+      <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
+      <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. If the StringValue of |LabelIdentifier| is not an element of _iterationSet_, return *true*.
         1. Return *false*.
@@ -16752,11 +16752,11 @@
     <!-- es6num="13.8.3" -->
     <emu-clause id="sec-continue-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">ContinueStatement : `continue` `;`</emu-grammar>
+      <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
       <emu-alg>
         1. Return Completion{[[Type]]: ~continue~, [[Value]]: ~empty~, [[Target]]: ~empty~}.
       </emu-alg>
-      <emu-grammar use="reference">ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
+      <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Return Completion{[[Type]]: ~continue~, [[Value]]: ~empty~, [[Target]]: _label_ }.
@@ -16777,7 +16777,7 @@
     <!-- es6num="13.9.1" -->
     <emu-clause id="sec-break-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">BreakStatement : `break` `;`</emu-grammar>
+      <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if this |BreakStatement| is not nested, directly or indirectly (but not crossing function boundaries), within an |IterationStatement| or a |SwitchStatement|.
@@ -16790,11 +16790,11 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar use="reference">BreakStatement : `break` `;`</emu-grammar>
+      <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
+      <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. If the StringValue of |LabelIdentifier| is not an element of _labelSet_, return *true*.
         1. Return *false*.
@@ -16804,11 +16804,11 @@
     <!-- es6num="13.9.3" -->
     <emu-clause id="sec-break-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">BreakStatement : `break` `;`</emu-grammar>
+      <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
       <emu-alg>
         1. Return Completion{[[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~}.
       </emu-alg>
-      <emu-grammar use="reference">BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
+      <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Return Completion{[[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: _label_ }.
@@ -16832,11 +16832,11 @@
     <!-- es6num="13.10.1" -->
     <emu-clause id="sec-return-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">ReturnStatement : `return` `;`</emu-grammar>
+      <emu-grammar>ReturnStatement : `return` `;`</emu-grammar>
       <emu-alg>
         1. Return Completion{[[Type]]: ~return~, [[Value]]: *undefined*, [[Target]]: ~empty~}.
       </emu-alg>
-      <emu-grammar use="reference">ReturnStatement : `return` Expression `;`</emu-grammar>
+      <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
@@ -16860,7 +16860,7 @@
     <!-- es6num="13.11.1" -->
     <emu-clause id="sec-with-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the code that matches this production is contained in strict mode code.
@@ -16879,7 +16879,7 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -16890,7 +16890,7 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -16901,7 +16901,7 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -16911,7 +16911,7 @@
     <emu-clause id="sec-with-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
@@ -16921,7 +16921,7 @@
     <emu-clause id="sec-with-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
@@ -16930,7 +16930,7 @@
     <!-- es6num="13.11.7" -->
     <emu-clause id="sec-with-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _val_ be the result of evaluating |Expression|.
         1. Let _obj_ be ? ToObject(? GetValue(_val_)).
@@ -16974,7 +16974,7 @@
     <!-- es6num="13.12.1" -->
     <emu-clause id="sec-switch-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries.
@@ -16990,15 +16990,15 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |CaseBlock| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
           1. Let _hasDuplicates_ be ContainsDuplicateLabels of the first |CaseClauses| with argument _labelSet_.
@@ -17008,18 +17008,18 @@
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsDuplicateLabels of the second |CaseClauses| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |CaseClauses| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |CaseClause| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
         1. Return *false*.
@@ -17031,15 +17031,15 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |CaseBlock| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
           1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |CaseClauses| with argument _labelSet_.
@@ -17049,18 +17049,18 @@
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsUndefinedBreakTarget of the second |CaseClauses| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |CaseClauses| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |CaseClause| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
         1. Return *false*.
@@ -17072,15 +17072,15 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |CaseBlock| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
           1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
@@ -17090,18 +17090,18 @@
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsUndefinedContinueTarget of the second |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |CaseClause| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
         1. Return *false*.
@@ -17112,11 +17112,11 @@
     <emu-clause id="sec-switch-statement-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, let _names_ be the LexicallyDeclaredNames of the first |CaseClauses|.
         1. Else, let _names_ be a new empty List.
@@ -17124,18 +17124,18 @@
         1. If the second |CaseClauses| is not present, return _names_.
         1. Return the result of appending to _names_ the elements of the LexicallyDeclaredNames of the second |CaseClauses|.
       </emu-alg>
-      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _names_ be LexicallyDeclaredNames of |CaseClauses|.
         1. Append to _names_ the elements of the LexicallyDeclaredNames of |CaseClause|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
         1. Return a new empty List.
@@ -17146,11 +17146,11 @@
     <emu-clause id="sec-switch-statement-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, let _declarations_ be the LexicallyScopedDeclarations of the first |CaseClauses|.
         1. Else, let _declarations_ be a new empty List.
@@ -17158,18 +17158,18 @@
         1. If the second |CaseClauses| is not present, return _declarations_.
         1. Return the result of appending to _declarations_ the elements of the LexicallyScopedDeclarations of the second |CaseClauses|.
       </emu-alg>
-      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be LexicallyScopedDeclarations of |CaseClauses|.
         1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |CaseClause|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
         1. Return a new empty List.
@@ -17180,15 +17180,15 @@
     <emu-clause id="sec-switch-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |CaseBlock|.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, let _names_ be the VarDeclaredNames of the first |CaseClauses|.
         1. Else, let _names_ be a new empty List.
@@ -17196,18 +17196,18 @@
         1. If the second |CaseClauses| is not present, return _names_.
         1. Return the result of appending to _names_ the elements of the VarDeclaredNames of the second |CaseClauses|.
       </emu-alg>
-      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |CaseClauses|.
         1. Append to _names_ the elements of the VarDeclaredNames of |CaseClause|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
         1. Return a new empty List.
@@ -17218,15 +17218,15 @@
     <emu-clause id="sec-switch-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |CaseBlock|.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, let _declarations_ be the VarScopedDeclarations of the first |CaseClauses|.
         1. Else, let _declarations_ be a new empty List.
@@ -17234,18 +17234,18 @@
         1. If the second |CaseClauses| is not present, return _declarations_.
         1. Return the result of appending to _declarations_ the elements of the VarScopedDeclarations of the second |CaseClauses|.
       </emu-alg>
-      <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |CaseClauses|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |CaseClause|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
       <emu-alg>
         1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
         1. Return a new empty List.
@@ -17256,11 +17256,11 @@
     <emu-clause id="sec-runtime-semantics-caseblockevaluation">
       <h1>Runtime Semantics: CaseBlockEvaluation</h1>
       <p>With parameter _input_.</p>
-      <emu-grammar use="reference">CaseBlock : `{` `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses `}`</emu-grammar>
       <emu-alg>
         1. Let _V_ be *undefined*.
         1. Let _A_ be the List of |CaseClause| items in |CaseClauses|, in source text order.
@@ -17276,7 +17276,7 @@
             1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
         1. Return NormalCompletion(_V_).
       </emu-alg>
-      <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. Let _V_ be *undefined*.
         1. If the first |CaseClauses| is present, then
@@ -17323,7 +17323,7 @@
     <!-- es6num="13.12.10" -->
     <emu-clause id="sec-runtime-semantics-caseselectorevaluation">
       <h1>Runtime Semantics: CaseSelectorEvaluation</h1>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Return ? GetValue(_exprRef_).
@@ -17336,7 +17336,7 @@
     <!-- es6num="13.12.11" -->
     <emu-clause id="sec-switch-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _switchValue_ be ? GetValue(_exprRef_).
@@ -17351,19 +17351,19 @@
       <emu-note>
         <p>No matter how control leaves the |SwitchStatement| the LexicalEnvironment is always restored to its former state.</p>
       </emu-note>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:`</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar use="reference">CaseClause : `case` Expression `:` StatementList</emu-grammar>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:`</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar use="reference">DefaultClause : `default` `:` StatementList</emu-grammar>
+      <emu-grammar>DefaultClause : `default` `:` StatementList</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
@@ -17389,7 +17389,7 @@
     <!-- es6num="13.13.1" -->
     <emu-clause id="sec-labelled-statements-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if any source text matches this rule.
@@ -17405,14 +17405,14 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. If _label_ is an element of _labelSet_, return *true*.
         1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
         1. Return ContainsDuplicateLabels of |LabelledItem| with argument _newLabelSet_.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -17423,13 +17423,13 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
         1. Return ContainsUndefinedBreakTarget of |LabelledItem| with argument _newLabelSet_.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -17440,13 +17440,13 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
         1. Return ContainsUndefinedContinueTarget of |LabelledItem| with arguments _iterationSet_ and _newLabelSet_.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -17459,7 +17459,7 @@
       <emu-alg>
         1. If _stmt_ is not a |LabelledStatement|, return *false*.
         1. Let _item_ be the |LabelledItem| of _stmt_.
-        1. If _item_ is <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar> , return *true*.
+        1. If _item_ is <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar> , return *true*.
         1. Let _subStmt_ be the |Statement| of _item_.
         1. Return IsLabelledFunction(_subStmt_).
       </emu-alg>
@@ -17469,15 +17469,15 @@
     <emu-clause id="sec-labelled-statements-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the LexicallyDeclaredNames of |LabelledItem|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return BoundNames of |FunctionDeclaration|.
       </emu-alg>
@@ -17487,15 +17487,15 @@
     <emu-clause id="sec-labelled-statements-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the LexicallyScopedDeclarations of |LabelledItem|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return a new List containing |FunctionDeclaration|.
       </emu-alg>
@@ -17505,7 +17505,7 @@
     <emu-clause id="sec-labelled-statements-static-semantics-toplevellexicallydeclarednames">
       <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
       <emu-see-also-para op="TopLevelLexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -17515,7 +17515,7 @@
     <emu-clause id="sec-labelled-statements-static-semantics-toplevellexicallyscopeddeclarations">
       <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelLexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -17525,16 +17525,16 @@
     <emu-clause id="sec-labelled-statements-static-semantics-toplevelvardeclarednames">
       <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
       <emu-see-also-para op="TopLevelVarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the TopLevelVarDeclaredNames of |LabelledItem|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
         1. Return VarDeclaredNames of |Statement|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return BoundNames of |FunctionDeclaration|.
       </emu-alg>
@@ -17544,16 +17544,16 @@
     <emu-clause id="sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations">
       <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelVarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the TopLevelVarScopedDeclarations of |LabelledItem|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar use="reference">Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
         1. Return VarScopedDeclarations of |Statement|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return a new List containing |FunctionDeclaration|.
       </emu-alg>
@@ -17563,11 +17563,11 @@
     <emu-clause id="sec-labelled-statements-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |LabelledItem|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -17577,11 +17577,11 @@
     <emu-clause id="sec-labelled-statements-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |LabelledItem|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -17592,7 +17592,7 @@
       <h1>Runtime Semantics: LabelledEvaluation</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Append _label_ as an element of _labelSet_.
@@ -17601,14 +17601,14 @@
           1. Set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
         1. Return Completion(_stmtResult_).
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : Statement</emu-grammar>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
       <emu-alg>
         1. If |Statement| is either a |LabelledStatement| or a |BreakableStatement|, then
           1. Return LabelledEvaluation of |Statement| with argument _labelSet_.
         1. Else,
           1. Return the result of evaluating |Statement|.
       </emu-alg>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |FunctionDeclaration|.
       </emu-alg>
@@ -17617,7 +17617,7 @@
     <!-- es6num="13.13.15" -->
     <emu-clause id="sec-labelled-statements-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _newLabelSet_ be a new empty List.
         1. Return LabelledEvaluation of this |LabelledStatement| with argument _newLabelSet_.
@@ -17637,7 +17637,7 @@
     <!-- es6num="13.14.1" -->
     <emu-clause id="sec-throw-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">ThrowStatement : `throw` Expression `;`</emu-grammar>
+      <emu-grammar>ThrowStatement : `throw` Expression `;`</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
@@ -17673,7 +17673,7 @@
     <!-- es6num="13.15.1" -->
     <emu-clause id="sec-try-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |CatchParameter| contains any duplicate elements.
@@ -17695,19 +17695,19 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |Catch| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
         1. If _hasDuplicates_ is *true*, return *true*.
@@ -17715,7 +17715,7 @@
         1. If _hasDuplicates_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Block| with argument _labelSet_.
       </emu-alg>
@@ -17726,19 +17726,19 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |Catch| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
@@ -17746,7 +17746,7 @@
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
       </emu-alg>
@@ -17757,19 +17757,19 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |Catch| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
@@ -17777,7 +17777,7 @@
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -17787,26 +17787,26 @@
     <emu-clause id="sec-try-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |Block|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Catch|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |Block|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Finally|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of |Block|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Catch|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Finally|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Block|.
       </emu-alg>
@@ -17816,26 +17816,26 @@
     <emu-clause id="sec-try-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |Block|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Catch|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |Block|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Finally|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |Block|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Catch|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Finally|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Block|.
       </emu-alg>
@@ -17845,7 +17845,7 @@
     <emu-clause id="sec-runtime-semantics-catchclauseevaluation">
       <h1>Runtime Semantics: CatchClauseEvaluation</h1>
       <p>With parameter _thrownValue_.</p>
-      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
         1. Let _catchEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -17869,21 +17869,21 @@
     <!-- es6num="13.15.8" -->
     <emu-clause id="sec-try-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
         1. If _B_.[[Type]] is ~throw~, let _C_ be CatchClauseEvaluation of |Catch| with argument _B_.[[Value]].
         1. Else, let _C_ be _B_.
         1. Return Completion(UpdateEmpty(_C_, *undefined*)).
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
         1. Let _F_ be the result of evaluating |Finally|.
         1. If _F_.[[Type]] is ~normal~, set _F_ to _B_.
         1. Return Completion(UpdateEmpty(_F_, *undefined*)).
       </emu-alg>
-      <emu-grammar use="reference">TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
         1. If _B_.[[Type]] is ~throw~, let _C_ be CatchClauseEvaluation of |Catch| with argument _B_.[[Value]].
@@ -17910,7 +17910,7 @@
       <emu-note>
         <p>Evaluating a |DebuggerStatement| may allow an implementation to cause a breakpoint when run under a debugger. If a debugger is not present or active this statement has no observable effect.</p>
       </emu-note>
-      <emu-grammar use="reference">DebuggerStatement : `debugger` `;`</emu-grammar>
+      <emu-grammar>DebuggerStatement : `debugger` `;`</emu-grammar>
       <emu-alg>
         1. If an implementation-defined debugging facility is available and enabled, then
           1. Perform an implementation-defined debugging action.
@@ -17983,7 +17983,7 @@
     <!-- es6num="14.1.2" -->
     <emu-clause id="sec-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
 
         FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
@@ -17992,7 +17992,7 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
           If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
@@ -18019,13 +18019,13 @@
       <emu-note>
         <p>The LexicallyDeclaredNames of a |FunctionBody| does not include identifiers bound using var or function declarations.</p>
       </emu-note>
-      <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar>
+      <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |FormalParameters| contains any duplicate elements.
         </li>
       </ul>
-      <emu-grammar use="reference">FormalParameters : FormalParameterList</emu-grammar>
+      <emu-grammar>FormalParameters : FormalParameterList</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if IsSimpleParameterList of |FormalParameterList| is *false* and BoundNames of |FormalParameterList| contains any duplicate elements.
@@ -18034,7 +18034,7 @@
       <emu-note>
         <p>Multiple occurrences of the same |BindingIdentifier| in a |FormalParameterList| is only allowed for functions which have simple parameter lists and which are not defined in strict mode code.</p>
       </emu-note>
-      <emu-grammar use="reference">FunctionBody : FunctionStatementList</emu-grammar>
+      <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the LexicallyDeclaredNames of |FunctionStatementList| contains any duplicate entries.
@@ -18058,28 +18058,28 @@
     <emu-clause id="sec-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar use="reference">FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return &laquo; `"*default*"` &raquo;.
       </emu-alg>
       <emu-note>
         <p>`"*default*"` is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
       </emu-note>
-      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Let _names_ be BoundNames of |FormalParameterList|.
         1. Append to _names_ the BoundNames of |FunctionRestParameter|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. Let _names_ be BoundNames of |FormalParameterList|.
         1. Append to _names_ the BoundNames of |FormalParameter|.
@@ -18092,7 +18092,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
 
         FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
@@ -18111,16 +18111,16 @@
     <emu-clause id="sec-function-definitions-static-semantics-containsexpression">
       <h1>Static Semantics: ContainsExpression</h1>
       <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. If ContainsExpression of |FormalParameterList| is *true*, return *true*.
         1. Return ContainsExpression of |FunctionRestParameter|.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. If ContainsExpression of |FormalParameterList| is *true*, return *true*.
         1. Return ContainsExpression of |FormalParameter|.
@@ -18130,7 +18130,7 @@
     <emu-clause id="sec-function-definitions-static-semantics-containsusestrict">
       <h1>Static Semantics: ContainsUseStrict</h1>
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionBody : FunctionStatementList</emu-grammar>
+      <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. If the Directive Prologue of |FunctionStatementList| contains a Use Strict Directive, return *true*; otherwise, return *false*.
       </emu-alg>
@@ -18140,18 +18140,18 @@
     <emu-clause id="sec-function-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return 0.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Return ExpectedArgumentCount of |FormalParameterList|.
       </emu-alg>
       <emu-note>
         <p>The ExpectedArgumentCount of a |FormalParameterList| is the number of |FormalParameters| to the left of either the rest parameter or the first |FormalParameter| with an Initializer. A |FormalParameter| without an initializer is allowed after the first parameter with an initializer but such parameters are considered to be optional with *undefined* as their default value.</p>
       </emu-note>
-      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. Let _count_ be ExpectedArgumentCount of |FormalParameterList|.
         1. If HasInitializer of |FormalParameterList| is *true* or HasInitializer of |FormalParameter| is *true*, return _count_.
@@ -18163,7 +18163,7 @@
     <emu-clause id="sec-function-definitions-static-semantics-hasinitializer">
       <h1>Static Semantics: HasInitializer</h1>
       <emu-see-also-para op="HasInitializer"></emu-see-also-para>
-      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. If HasInitializer of |FormalParameterList| is *true*, return *true*.
         1. Return HasInitializer of |FormalParameter|.
@@ -18174,11 +18174,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -18200,7 +18200,7 @@
     <emu-clause id="sec-function-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
 
         FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
@@ -18214,7 +18214,7 @@
     <emu-clause id="sec-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -18224,20 +18224,20 @@
     <emu-clause id="sec-function-definitions-static-semantics-issimpleparameterlist">
       <h1>Static Semantics: IsSimpleParameterList</h1>
       <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. If IsSimpleParameterList of |FormalParameterList| is *false*, return *false*.
         1. Return IsSimpleParameterList of |FormalParameter|.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameter : BindingElement</emu-grammar>
+      <emu-grammar>FormalParameter : BindingElement</emu-grammar>
       <emu-alg>
         1. Return IsSimpleParameterList of |BindingElement|.
       </emu-alg>
@@ -18247,11 +18247,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">FunctionStatementList : StatementList</emu-grammar>
+      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
       </emu-alg>
@@ -18261,11 +18261,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">FunctionStatementList : StatementList</emu-grammar>
+      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Return the TopLevelLexicallyScopedDeclarations of |StatementList|.
       </emu-alg>
@@ -18275,11 +18275,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">FunctionStatementList : StatementList</emu-grammar>
+      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelVarDeclaredNames of |StatementList|.
       </emu-alg>
@@ -18289,11 +18289,11 @@
     <emu-clause id="sec-function-definitions-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar use="reference">FunctionStatementList : StatementList</emu-grammar>
+      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Return the TopLevelVarScopedDeclarations of |StatementList|.
       </emu-alg>
@@ -18304,7 +18304,7 @@
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
       <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionBody : FunctionStatementList</emu-grammar>
+      <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Return the result of evaluating |FunctionStatementList|.
@@ -18319,21 +18319,21 @@
         <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
       </emu-note>
       <emu-see-also-para op="IteratorBindingInitialization"></emu-see-also-para>
-      <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar use="reference">FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
         1. Return the result of performing IteratorBindingInitialization for |FunctionRestParameter| using _iteratorRecord_ and _environment_ as the arguments.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
         1. Return the result of performing IteratorBindingInitialization for |FormalParameter| using _iteratorRecord_ and _environment_ as the arguments.
       </emu-alg>
-      <emu-grammar use="reference">FormalParameter : BindingElement</emu-grammar>
+      <emu-grammar>FormalParameter : BindingElement</emu-grammar>
       <emu-alg>
         1. If ContainsExpression of |BindingElement| is *false*, return the result of performing IteratorBindingInitialization for |BindingElement| using _iteratorRecord_ and _environment_ as the arguments.
         1. Let _currentContext_ be the running execution context.
@@ -18351,7 +18351,7 @@
       <emu-note>
         <p>The new Environment Record created in step 6 is only used if the |BindingElement| contains a direct eval.</p>
       </emu-note>
-      <emu-grammar use="reference">FunctionRestParameter : BindingRestElement</emu-grammar>
+      <emu-grammar>FunctionRestParameter : BindingRestElement</emu-grammar>
       <emu-alg>
         1. If ContainsExpression of |BindingRestElement| is *false*, return the result of performing IteratorBindingInitialization for |BindingRestElement| using _iteratorRecord_ and _environment_ as the arguments.
         1. Let _currentContext_ be the running execution context.
@@ -18376,7 +18376,7 @@
       <h1>Runtime Semantics: InstantiateFunctionObject</h1>
       <p>With parameter _scope_.</p>
       <emu-see-also-para op="InstantiateFunctionObject"></emu-see-also-para>
-      <emu-grammar use="reference">FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for |FunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _name_ be StringValue of |BindingIdentifier|.
@@ -18385,7 +18385,7 @@
         1. Perform SetFunctionName(_F_, _name_).
         1. Return _F_.
       </emu-alg>
-      <emu-grammar use="reference">FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _F_ be FunctionCreate(~Normal~, |FormalParameters|, |FunctionBody|, _scope_, *true*).
         1. Perform MakeConstructor(_F_).
@@ -18400,18 +18400,18 @@
     <!-- es6num="14.1.20" -->
     <emu-clause id="sec-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
       <emu-note>
         <p>An alternative semantics is provided in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
       </emu-note>
-      <emu-grammar use="reference">FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar use="reference">FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for |FunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
@@ -18419,7 +18419,7 @@
         1. Perform MakeConstructor(_closure_).
         1. Return _closure_.
       </emu-alg>
-      <emu-grammar use="reference">FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for |FunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
@@ -18439,7 +18439,7 @@
       <emu-note>
         <p>A `prototype` property is automatically created for every function defined using a |FunctionDeclaration| or |FunctionExpression|, to allow for the possibility that the function will be used as a constructor.</p>
       </emu-note>
-      <emu-grammar use="reference">FunctionStatementList : [empty]</emu-grammar>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
@@ -18465,7 +18465,7 @@
     <h2>Supplemental Syntax</h2>
     <p>When the production
       <br>
-      <emu-grammar use="reference">ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
+      <emu-grammar>ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
       <br>
       is recognized the following grammar is used to refine the interpretation of |CoverParenthesizedExpressionAndArrowParameterList|:</p>
     <emu-grammar use="definition">
@@ -18476,7 +18476,7 @@
     <!-- es6num="14.2.1" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if |ArrowParameters| Contains |YieldExpression| is *true*.
@@ -18491,7 +18491,7 @@
           It is a Syntax Error if any element of the BoundNames of |ArrowParameters| also occurs in the LexicallyDeclaredNames of |ConciseBody|.
         </li>
       </ul>
-      <emu-grammar use="reference">ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
+      <emu-grammar>ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the lexical token sequence matched by |CoverParenthesizedExpressionAndArrowParameterList| cannot be parsed with no tokens left over using |ArrowFormalParameters| as the goal symbol with its <sub>[Yield]</sub> and <sub>[Await]</sub> parameters set to the values used when parsing this |CoverParenthesizedExpressionAndArrowParameterList|.
@@ -18506,7 +18506,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar use="reference">ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return the BoundNames of _formals_.
@@ -18518,7 +18518,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar use="reference">ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
         1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super` or `this`, return *false*.
         1. If |ArrowParameters| Contains _symbol_ is *true*, return *true*.
@@ -18527,7 +18527,7 @@
       <emu-note>
         <p>Normally, Contains does not look inside most function forms. However, Contains is used to detect `new.target`, `this`, and `super` usage within an |ArrowFunction|.</p>
       </emu-note>
-      <emu-grammar use="reference">ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return _formals_ Contains _symbol_.
@@ -18538,7 +18538,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-containsexpression">
       <h1>Static Semantics: ContainsExpression</h1>
       <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -18547,7 +18547,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-containsusestrict">
       <h1>Static Semantics: ContainsUseStrict</h1>
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
-      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -18557,7 +18557,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return 1.
       </emu-alg>
@@ -18567,7 +18567,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar use="reference">ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -18577,11 +18577,11 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-issimpleparameterlist">
       <h1>Static Semantics: IsSimpleParameterList</h1>
       <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar use="reference">ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return IsSimpleParameterList of _formals_.
@@ -18591,11 +18591,11 @@
     <!-- es6num="14.2.9" -->
     <emu-clause id="sec-static-semantics-coveredformalslist">
       <h1>Static Semantics: CoveredFormalsList</h1>
-      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Return this |ArrowParameters|.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] :
           `(` Expression `)`
           `(` `)`
@@ -18613,7 +18613,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -18623,7 +18623,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -18633,7 +18633,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -18643,7 +18643,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -18657,7 +18657,7 @@
       <emu-note>
         <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
       </emu-note>
-      <emu-grammar use="reference">ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Assert: _iteratorRecord_.[[Done]] is *false*.
         1. Let _next_ be IteratorStep(_iteratorRecord_.[[Iterator]]).
@@ -18678,7 +18678,7 @@
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
       <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
-      <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
@@ -18690,7 +18690,7 @@
     <!-- es6num="14.2.16" -->
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
         1. If the function code for this |ArrowFunction| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
@@ -18723,7 +18723,7 @@
     <!-- es6num="14.3.1" -->
     <emu-clause id="sec-method-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.
@@ -18732,7 +18732,7 @@
           It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
         </li>
       </ul>
-      <emu-grammar use="reference">MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |PropertySetParameterList| contains any duplicate elements.
@@ -18751,7 +18751,7 @@
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         MethodDefinition :
           PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
           `get` PropertyName `(` `)` `{` FunctionBody `}`
@@ -18766,7 +18766,7 @@
     <emu-clause id="sec-method-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar use="reference">PropertySetParameterList : FormalParameter</emu-grammar>
+      <emu-grammar>PropertySetParameterList : FormalParameter</emu-grammar>
       <emu-alg>
         1. If HasInitializer of |FormalParameter| is *true*, return 0.
         1. Return 1.
@@ -18777,16 +18777,16 @@
     <emu-clause id="sec-method-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |FunctionBody| Contains |SuperCall|.
       </emu-alg>
-      <emu-grammar use="reference">MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return |FunctionBody| Contains |SuperCall|.
       </emu-alg>
-      <emu-grammar use="reference">MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If |PropertySetParameterList| Contains |SuperCall| is *true*, return *true*.
         1. Return |FunctionBody| Contains |SuperCall|.
@@ -18797,7 +18797,7 @@
     <emu-clause id="sec-method-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         MethodDefinition :
           PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
           `get` PropertyName `(` `)` `{` FunctionBody `}`
@@ -18811,11 +18811,11 @@
     <!-- es6num="14.3.7" -->
     <emu-clause id="sec-static-semantics-specialmethod">
       <h1>Static Semantics: SpecialMethod</h1>
-      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         MethodDefinition :
           GeneratorMethod
           AsyncMethod
@@ -18831,7 +18831,7 @@
     <emu-clause id="sec-runtime-semantics-definemethod">
       <h1>Runtime Semantics: DefineMethod</h1>
       <p>With parameters _object_ and optional parameter _functionPrototype_.</p>
-      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
@@ -18854,7 +18854,7 @@
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
       <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-      <emu-grammar use="reference">MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _methodDef_ be DefineMethod of |MethodDefinition| with argument _object_.
         1. ReturnIfAbrupt(_methodDef_).
@@ -18862,20 +18862,20 @@
         1. Let _desc_ be the PropertyDescriptor{[[Value]]: _methodDef_.[[Closure]], [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
         1. Return ? DefinePropertyOrThrow(_object_, _methodDef_.[[Key]], _desc_).
       </emu-alg>
-      <emu-grammar use="reference">MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _formalParameterList_ be an instance of the production <emu-grammar use="reference">FormalParameters : [empty]</emu-grammar>.
+        1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. Let _closure_ be FunctionCreate(~Method~, _formalParameterList_, |FunctionBody|, _scope_, _strict_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_, `"get"`).
         1. Let _desc_ be the PropertyDescriptor{[[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
-      <emu-grammar use="reference">MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
@@ -18926,7 +18926,7 @@
     <!-- es6num="14.4.1" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if HasDirectSuper of |GeneratorMethod| is *true*.
@@ -18941,7 +18941,7 @@
           It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
         </li>
       </ul>
-      <emu-grammar use="reference">
+      <emu-grammar>
         GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
 
         GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
@@ -18950,7 +18950,7 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
           If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
@@ -18983,11 +18983,11 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar use="reference">GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return &laquo; `"*default*"` &raquo;.
       </emu-alg>
@@ -19001,7 +19001,7 @@
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
       </emu-alg>
@@ -19012,7 +19012,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
 
         GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
@@ -19031,7 +19031,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |GeneratorBody| Contains |SuperCall|.
@@ -19042,11 +19042,11 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19056,7 +19056,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
 
         GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
@@ -19070,7 +19070,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19080,7 +19080,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return PropName of |PropertyName|.
       </emu-alg>
@@ -19091,7 +19091,7 @@
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
       <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorBody : FunctionBody</emu-grammar>
+      <emu-grammar>GeneratorBody : FunctionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, `"%GeneratorPrototype%"`, &laquo; [[GeneratorState]], [[GeneratorContext]] &raquo;).
@@ -19105,7 +19105,7 @@
       <h1>Runtime Semantics: InstantiateFunctionObject</h1>
       <p>With parameter _scope_.</p>
       <emu-see-also-para op="InstantiateFunctionObject"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for |GeneratorDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _name_ be StringValue of |BindingIdentifier|.
@@ -19115,7 +19115,7 @@
         1. Perform SetFunctionName(_F_, _name_).
         1. Return _F_.
       </emu-alg>
-      <emu-grammar use="reference">GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _F_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_, *true*).
         1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
@@ -19133,7 +19133,7 @@
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
       <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-      <emu-grammar use="reference">GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
@@ -19152,7 +19152,7 @@
     <!-- es6num="14.4.14" -->
     <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for this |GeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
@@ -19161,7 +19161,7 @@
         1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
         1. Return _closure_.
       </emu-alg>
-      <emu-grammar use="reference">GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If the function code for this |GeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
@@ -19179,17 +19179,17 @@
       <emu-note>
         <p>The |BindingIdentifier| in a |GeneratorExpression| can be referenced from inside the |GeneratorExpression|'s |FunctionBody| to allow the generator code to call itself recursively. However, unlike in a |GeneratorDeclaration|, the |BindingIdentifier| in a |GeneratorExpression| cannot be referenced from and does not affect the scope enclosing the |GeneratorExpression|.</p>
       </emu-note>
-      <emu-grammar use="reference">YieldExpression : `yield`</emu-grammar>
+      <emu-grammar>YieldExpression : `yield`</emu-grammar>
       <emu-alg>
         1. Return ? GeneratorYield(CreateIterResultObject(*undefined*, *false*)).
       </emu-alg>
-      <emu-grammar use="reference">YieldExpression : `yield` AssignmentExpression</emu-grammar>
+      <emu-grammar>YieldExpression : `yield` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
       </emu-alg>
-      <emu-grammar use="reference">YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
+      <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
@@ -19269,7 +19269,7 @@
     <!-- es6num="14.5.1" -->
     <emu-clause id="sec-class-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
+      <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
       <ul>
         <li>
           <p>It is a Syntax Error if |ClassHeritage| is not present and the following algorithm evaluates to *true*:</p>
@@ -19280,13 +19280,13 @@
           </emu-alg>
         </li>
       </ul>
-      <emu-grammar use="reference">ClassBody : ClassElementList</emu-grammar>
+      <emu-grammar>ClassBody : ClassElementList</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if PrototypePropertyNameList of |ClassElementList| contains more than one occurrence of `"constructor"`.
         </li>
       </ul>
-      <emu-grammar use="reference">ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if PropName of |MethodDefinition| is not `"constructor"` and HasDirectSuper of |MethodDefinition| is *true*.
@@ -19295,7 +19295,7 @@
           It is a Syntax Error if PropName of |MethodDefinition| is `"constructor"` and SpecialMethod of |MethodDefinition| is *true*.
         </li>
       </ul>
-      <emu-grammar use="reference">ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
@@ -19310,11 +19310,11 @@
     <emu-clause id="sec-class-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar use="reference">ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar use="reference">ClassDeclaration : `class` ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
       <emu-alg>
         1. Return &laquo; `"*default*"` &raquo;.
       </emu-alg>
@@ -19323,18 +19323,18 @@
     <!-- es6num="14.5.3" -->
     <emu-clause id="sec-static-semantics-constructormethod">
       <h1>Static Semantics: ConstructorMethod</h1>
-      <emu-grammar use="reference">ClassElementList : ClassElement</emu-grammar>
+      <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. If |ClassElement| is <emu-grammar use="reference">ClassElement : `;`</emu-grammar> , return ~empty~.
+        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return ~empty~.
         1. If IsStatic of |ClassElement| is *true*, return ~empty~.
         1. If PropName of |ClassElement| is not `"constructor"`, return ~empty~.
         1. Return |ClassElement|.
       </emu-alg>
-      <emu-grammar use="reference">ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _head_ be ConstructorMethod of |ClassElementList|.
         1. If _head_ is not ~empty~, return _head_.
-        1. If |ClassElement| is <emu-grammar use="reference">ClassElement : `;`</emu-grammar> , return ~empty~.
+        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return ~empty~.
         1. If IsStatic of |ClassElement| is *true*, return ~empty~.
         1. If PropName of |ClassElement| is not `"constructor"`, return ~empty~.
         1. Return |ClassElement|.
@@ -19349,7 +19349,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar use="reference">ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
+      <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
       <emu-alg>
         1. If _symbol_ is |ClassBody|, return *true*.
         1. If _symbol_ is |ClassHeritage|, then
@@ -19368,21 +19368,21 @@
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar use="reference">ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _inList_ be the result of ComputedPropertyContains for |ClassElementList| with argument _symbol_.
         1. If _inList_ is *true*, return *true*.
         1. Return the result of ComputedPropertyContains for |ClassElement| with argument _symbol_.
       </emu-alg>
-      <emu-grammar use="reference">ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
       </emu-alg>
-      <emu-grammar use="reference">ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
       </emu-alg>
-      <emu-grammar use="reference">ClassElement : `;`</emu-grammar>
+      <emu-grammar>ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -19392,11 +19392,11 @@
     <emu-clause id="sec-class-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar use="reference">ClassExpression : `class` ClassTail</emu-grammar>
+      <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar>ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19406,7 +19406,7 @@
     <emu-clause id="sec-class-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar use="reference">
+      <emu-grammar>
         ClassDeclaration : `class` BindingIdentifier ClassTail
 
         ClassDeclaration : `class` ClassTail
@@ -19420,7 +19420,7 @@
     <emu-clause id="sec-class-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar use="reference">ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
+      <emu-grammar>ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19429,15 +19429,15 @@
     <!-- es6num="14.5.9" -->
     <emu-clause id="sec-static-semantics-isstatic">
       <h1>Static Semantics: IsStatic</h1>
-      <emu-grammar use="reference">ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar use="reference">ClassElement : `;`</emu-grammar>
+      <emu-grammar>ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -19446,16 +19446,16 @@
     <!-- es6num="14.5.10" -->
     <emu-clause id="sec-static-semantics-nonconstructormethoddefinitions">
       <h1>Static Semantics: NonConstructorMethodDefinitions</h1>
-      <emu-grammar use="reference">ClassElementList : ClassElement</emu-grammar>
+      <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. If |ClassElement| is <emu-grammar use="reference">ClassElement : `;`</emu-grammar> , return a new empty List.
+        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return a new empty List.
         1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is `"constructor"`, return a new empty List.
         1. Return a List containing |ClassElement|.
       </emu-alg>
-      <emu-grammar use="reference">ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _list_ be NonConstructorMethodDefinitions of |ClassElementList|.
-        1. If |ClassElement| is <emu-grammar use="reference">ClassElement : `;`</emu-grammar> , return _list_.
+        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return _list_.
         1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is `"constructor"`, return _list_.
         1. Append |ClassElement| to the end of _list_.
         1. Return _list_.
@@ -19465,13 +19465,13 @@
     <!-- es6num="14.5.11" -->
     <emu-clause id="sec-static-semantics-prototypepropertynamelist">
       <h1>Static Semantics: PrototypePropertyNameList</h1>
-      <emu-grammar use="reference">ClassElementList : ClassElement</emu-grammar>
+      <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
         1. If PropName of |ClassElement| is ~empty~, return a new empty List.
         1. If IsStatic of |ClassElement| is *true*, return a new empty List.
         1. Return a List containing PropName of |ClassElement|.
       </emu-alg>
-      <emu-grammar use="reference">ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _list_ be PrototypePropertyNameList of |ClassElementList|.
         1. If PropName of |ClassElement| is ~empty~, return _list_.
@@ -19485,7 +19485,7 @@
     <emu-clause id="sec-class-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar use="reference">ClassElement : `;`</emu-grammar>
+      <emu-grammar>ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return ~empty~.
       </emu-alg>
@@ -19495,7 +19495,7 @@
     <emu-clause id="sec-runtime-semantics-classdefinitionevaluation">
       <h1>Runtime Semantics: ClassDefinitionEvaluation</h1>
       <p>With parameter _className_.</p>
-      <emu-grammar use="reference">ClassTail : ClassHeritage? `{` ClassBody? `}`</emu-grammar>
+      <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody? `}`</emu-grammar>
       <emu-alg>
         1. Let _lex_ be the LexicalEnvironment of the running execution context.
         1. Let _classScope_ be NewDeclarativeEnvironment(_lex_).
@@ -19558,7 +19558,7 @@
     <!-- es6num="14.5.15" -->
     <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation">
       <h1>Runtime Semantics: BindingClassDeclarationEvaluation</h1>
-      <emu-grammar use="reference">ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Let _className_ be StringValue of |BindingIdentifier|.
         1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with argument _className_.
@@ -19569,27 +19569,27 @@
         1. Perform ? InitializeBoundName(_className_, _value_, _env_).
         1. Return _value_.
       </emu-alg>
-      <emu-grammar use="reference">ClassDeclaration : `class` ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
       <emu-alg>
         1. Return the result of ClassDefinitionEvaluation of |ClassTail| with argument *undefined*.
       </emu-alg>
       <emu-note>
-        <p><emu-grammar use="reference">ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and the setting of a name property and establishing its binding are handled as part of the evaluation action for that production. See <emu-xref href="#sec-exports-runtime-semantics-evaluation"></emu-xref>.</p>
+        <p><emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and the setting of a name property and establishing its binding are handled as part of the evaluation action for that production. See <emu-xref href="#sec-exports-runtime-semantics-evaluation"></emu-xref>.</p>
       </emu-note>
     </emu-clause>
 
     <!-- es6num="14.5.16" -->
     <emu-clause id="sec-class-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Perform ? BindingClassDeclarationEvaluation of this |ClassDeclaration|.
         1. Return NormalCompletion(~empty~).
       </emu-alg>
       <emu-note>
-        <p><emu-grammar use="reference">ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and is never directly evaluated.</p>
+        <p><emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and is never directly evaluated.</p>
       </emu-note>
-      <emu-grammar use="reference">ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
+      <emu-grammar>ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
       <emu-alg>
         1. If |BindingIdentifier_opt| is not present, let _className_ be *undefined*.
         1. Else, let _className_ be StringValue of |BindingIdentifier|.
@@ -19648,7 +19648,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <ul>
@@ -19657,7 +19657,7 @@
         <li>It is a Syntax Error if |UniqueFormalParameters| Contains |AwaitExpression| is *true*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
       </ul>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -19669,7 +19669,7 @@
       <ul>
         <li>It is a Syntax Error if ContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
-        <li>If the source code matching this production is strict code, the Early Error rules for <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If the source code matching this production is strict code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
         <li>If the source code matching this production is strict code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
@@ -19681,13 +19681,13 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-BoundNames">
       <h1>Static Semantics: BoundNames</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19699,7 +19699,7 @@
     <emu-clause id="sec-async-function-definitions-static-semantics-ComputedPropertyContains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19710,7 +19710,7 @@
     <emu-clause id="sec-async-function-definitions-static-semantics-Contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -19726,7 +19726,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-HasDirectSuper">
       <h1>Static Semantics: HasDirectSuper</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19737,13 +19737,13 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-HasName">
       <h1>Static Semantics: HasName</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19753,7 +19753,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-IsConstantDeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -19765,7 +19765,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-IsFunctionDefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -19777,7 +19777,7 @@
 
     <emu-clause id="sec-async-function-definitions-static-semantics-PropName">
       <h1>Static Semantics: PropName</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19788,7 +19788,7 @@
     <emu-clause id="sec-async-function-definitions-InstantiateFunctionObject">
       <h1>Runtime Semantics: InstantiateFunctionObject</h1>
       <p>With parameter _scope_.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19798,7 +19798,7 @@
         1. Perform ! SetFunctionName(_F_, _name_).
         1. Return _F_.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19812,7 +19812,7 @@
     <emu-clause id="sec-async-function-definitions-EvaluateBody">
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionBody : FunctionBody
       </emu-grammar>
       <emu-alg>
@@ -19829,7 +19829,7 @@
     <emu-clause id="sec-async-function-definitions-PropertyDefinitionEvaluation">
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19846,21 +19846,21 @@
     </emu-clause>
     <emu-clause id="sec-async-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
 
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
 
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19870,7 +19870,7 @@
         1. Return _closure_.
       </emu-alg>
 
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -19886,7 +19886,7 @@
         1. Return _closure_.
       </emu-alg>
 
-      <emu-grammar use="reference">
+      <emu-grammar>
         AwaitExpression : `await` UnaryExpression
       </emu-grammar>
       <emu-alg>
@@ -19916,7 +19916,7 @@
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
-    <p>When processing an instance of the production <emu-grammar use="reference">AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
+    <p>When processing an instance of the production <emu-grammar>AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody</emu-grammar> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
 
     <emu-grammar use="definition">
       AsyncArrowHead :
@@ -19925,13 +19925,13 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <ul>
         <li>It is a Syntax Error if any element of the BoundNames of |AsyncArrowBindingIdentifier| also occurs in the LexicallyDeclaredNames of |AsyncConciseBody|.</li>
       </ul>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <ul>
@@ -19946,7 +19946,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-CoveredAsyncArrowHead">
       <h1>Static Semantics: CoveredAsyncArrowHead</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>
       <emu-alg>
@@ -19956,7 +19956,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-BoundNames">
       <h1>Static Semantics: BoundNames</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>
       <emu-alg>
@@ -19968,14 +19968,14 @@
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-Contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
         1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
         1. Return |AsyncConciseBody| Contains _symbol_.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
@@ -19989,7 +19989,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-ContainsExpression">
       <h1>Static Semantics: ContainsExpression</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
@@ -19999,7 +19999,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
@@ -20009,7 +20009,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-HasName">
       <h1>Static Semantics: HasName</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
 
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
@@ -20021,13 +20021,13 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-IsSimpleParameterList">
       <h1>Static Semantics: IsSimpleParameterList</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowBindingIdentifier[Yield] : BindingIdentifier[?Yield, +Await]
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>
       <emu-alg>
@@ -20038,7 +20038,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-LexicallyDeclaredNames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20048,7 +20048,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-LexicallyScopedDeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20058,7 +20058,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-VarDeclaredNames">
       <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20068,7 +20068,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-VarScopedDeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20079,7 +20079,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-IteratorBindingInitialization">
       <h1>Runtime Semantics: IteratorBindingInitialization</h1>
       <p>With parameters _iteratorRecord_ and _environment_.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
@@ -20100,7 +20100,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-EvaluateBody">
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncConciseBody : [lookahead != `{`] AssignmentExpression
       </emu-grammar>
       <emu-alg>
@@ -20112,7 +20112,7 @@
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_declResult_.[[Value]]&raquo;).
         1. Return Completion{[[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~}.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncConciseBody : `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
@@ -20122,7 +20122,7 @@
 
     <emu-clause id="sec-async-arrow-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
@@ -20132,7 +20132,7 @@
         1. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
         1. Return _closure_.
       </emu-alg>
-      <emu-grammar use="reference">
+      <emu-grammar>
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
@@ -20180,17 +20180,17 @@
       <!-- es6num="14.6.2.1" -->
       <emu-clause id="sec-statement-rules">
         <h1>Statement Rules</h1>
-        <emu-grammar use="reference">ConciseBody : AssignmentExpression</emu-grammar>
+        <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |AssignmentExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">StatementList : StatementList StatementListItem</emu-grammar>
+        <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of |StatementList| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of |StatementListItem| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           FunctionStatementList : [empty]
 
           StatementListItem : Declaration
@@ -20220,13 +20220,13 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+        <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of the first |Statement| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of the second |Statement| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           IfStatement : `if` `(` Expression `)` Statement
 
           IterationStatement :
@@ -20244,22 +20244,22 @@
         <emu-alg>
           1. Return HasCallInTailPosition of |Statement| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           LabelledStatement :
             LabelIdentifier `:` LabelledItem
         </emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |LabelledItem| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">ReturnStatement : `return` Expression `;`</emu-grammar>
+        <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Expression| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+        <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |CaseBlock| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+        <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
         <emu-alg>
           1. Let _has_ be *false*.
           1. If the first |CaseClauses| is present, let _has_ be HasCallInTailPosition of the first |CaseClauses| with argument _call_.
@@ -20269,13 +20269,13 @@
           1. If the second |CaseClauses| is present, let _has_ be HasCallInTailPosition of the second |CaseClauses| with argument _call_.
           1. Return _has_.
         </emu-alg>
-        <emu-grammar use="reference">CaseClauses : CaseClauses CaseClause</emu-grammar>
+        <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of |CaseClauses| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of |CaseClause| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           CaseClause : `case` Expression `:` StatementList?
 
           DefaultClause : `default` `:` StatementList?
@@ -20284,11 +20284,11 @@
           1. If |StatementList| is present, return HasCallInTailPosition of |StatementList| with argument _call_.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">TryStatement : `try` Block Catch</emu-grammar>
+        <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Catch| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           TryStatement : `try` Block Finally
 
           TryStatement : `try` Block Catch Finally
@@ -20296,7 +20296,7 @@
         <emu-alg>
           1. Return HasCallInTailPosition of |Finally| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+        <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Block| with argument _call_.
         </emu-alg>
@@ -20308,7 +20308,7 @@
         <emu-note>
           <p>A potential tail position call that is immediately followed by return GetValue of the call result is also a possible tail position call. Function calls cannot return reference values, so such a GetValue operation will always return the same value as the actual function call result.</p>
         </emu-note>
-        <emu-grammar use="reference">
+        <emu-grammar>
           AssignmentExpression :
             YieldExpression
             ArrowFunction
@@ -20397,7 +20397,7 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           Expression :
             AssignmentExpression
             Expression `,` AssignmentExpression
@@ -20405,21 +20405,21 @@
         <emu-alg>
           1. Return HasCallInTailPosition of |AssignmentExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+        <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of the first |AssignmentExpression| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of the second |AssignmentExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
+        <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |BitwiseORExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
+        <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |LogicalANDExpression| with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           CallExpression :
             CoverCallExpressionAndAsyncArrowHead
             CallExpression Arguments
@@ -20429,7 +20429,7 @@
           1. If this |CallExpression| is _call_, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           MemberExpression :
             MemberExpression TemplateLiteral
         </emu-grammar>
@@ -20437,12 +20437,12 @@
           1. If this |MemberExpression| is _call_, return *true*.
           1. Return *false*.
         </emu-alg>
-        <emu-grammar use="reference">PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return HasCallInTailPosition of _expr_ with argument _call_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ParenthesizedExpression :
             `(` Expression `)`
         </emu-grammar>
@@ -20489,7 +20489,7 @@
     <!-- es6num="15.1.1" -->
     <emu-clause id="sec-scripts-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar use="reference">Script : ScriptBody</emu-grammar>
+      <emu-grammar>Script : ScriptBody</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if the LexicallyDeclaredNames of |ScriptBody| contains any duplicate entries.
@@ -20498,7 +20498,7 @@
           It is a Syntax Error if any element of the LexicallyDeclaredNames of |ScriptBody| also occurs in the VarDeclaredNames of |ScriptBody|.
         </li>
       </ul>
-      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if |StatementList| Contains `super` unless the source code containing `super` is eval code that is being processed by a direct eval. Additional early error rules for `super` within direct eval are defined in <emu-xref href="#sec-performeval"></emu-xref>.
@@ -20521,7 +20521,7 @@
     <!-- es6num="15.1.2" -->
     <emu-clause id="sec-static-semantics-isstrict">
       <h1>Static Semantics: IsStrict</h1>
-      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. If the Directive Prologue of |StatementList| contains a Use Strict Directive, return *true*; otherwise, return *false*.
       </emu-alg>
@@ -20531,7 +20531,7 @@
     <emu-clause id="sec-scripts-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
       </emu-alg>
@@ -20544,7 +20544,7 @@
     <emu-clause id="sec-scripts-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelLexicallyScopedDeclarations of |StatementList|.
       </emu-alg>
@@ -20554,7 +20554,7 @@
     <emu-clause id="sec-scripts-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelVarDeclaredNames of |StatementList|.
       </emu-alg>
@@ -20564,7 +20564,7 @@
     <emu-clause id="sec-scripts-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
         1. Return TopLevelVarScopedDeclarations of |StatementList|.
       </emu-alg>
@@ -20572,7 +20572,7 @@
 
     <emu-clause id="sec-script-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar use="reference">Script : [empty]</emu-grammar>
+      <emu-grammar>Script : [empty]</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
@@ -20805,7 +20805,7 @@
       <!-- es6num="15.2.1.1" -->
       <emu-clause id="sec-module-semantics-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">ModuleBody : ModuleItemList</emu-grammar>
+        <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the LexicallyDeclaredNames of |ModuleItemList| contains any duplicate entries.
@@ -20845,13 +20845,13 @@
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _hasDuplicates_ be ContainsDuplicateLabels of |ModuleItemList| with argument _labelSet_.
           1. If _hasDuplicates_ is *true*, return *true*.
           1. Return ContainsDuplicateLabels of |ModuleItem| with argument _labelSet_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ModuleItem :
             ImportDeclaration
             ExportDeclaration
@@ -20866,13 +20866,13 @@
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |ModuleItemList| with argument _labelSet_.
           1. If _hasUndefinedLabels_ is *true*, return *true*.
           1. Return ContainsUndefinedBreakTarget of |ModuleItem| with argument _labelSet_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ModuleItem :
             ImportDeclaration
             ExportDeclaration
@@ -20887,13 +20887,13 @@
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
         <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |ModuleItemList| with arguments _iterationSet_ and &laquo; &raquo;.
           1. If _hasUndefinedLabels_ is *true*, return *true*.
           1. Return ContainsUndefinedContinueTarget of |ModuleItem| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ModuleItem :
             ImportDeclaration
             ExportDeclaration
@@ -20910,13 +20910,13 @@
         <emu-note>
           <p>ExportedBindings are the locally bound names that are explicitly associated with a |Module|'s ExportedNames.</p>
         </emu-note>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _names_ be ExportedBindings of |ModuleItemList|.
           1. Append to _names_ the elements of the ExportedBindings of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ModuleItem :
             ImportDeclaration
             StatementListItem
@@ -20933,17 +20933,17 @@
         <emu-note>
           <p>ExportedNames are the externally visible names that a |Module| explicitly maps to one of its local name bindings.</p>
         </emu-note>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _names_ be ExportedNames of |ModuleItemList|.
           1. Append to _names_ the elements of the ExportedNames of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. Return the ExportedNames of |ExportDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ModuleItem :
             ImportDeclaration
             StatementListItem
@@ -20957,17 +20957,17 @@
       <emu-clause id="sec-module-semantics-static-semantics-exportentries">
         <h1>Static Semantics: ExportEntries</h1>
         <emu-see-also-para op="ExportEntries"></emu-see-also-para>
-        <emu-grammar use="reference">Module : [empty]</emu-grammar>
+        <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _entries_ be ExportEntries of |ModuleItemList|.
           1. Append to _entries_ the elements of the ExportEntries of |ModuleItem|.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ModuleItem :
             ImportDeclaration
             StatementListItem
@@ -20981,17 +20981,17 @@
       <emu-clause id="sec-module-semantics-static-semantics-importentries">
         <h1>Static Semantics: ImportEntries</h1>
         <emu-see-also-para op="ImportEntries"></emu-see-also-para>
-        <emu-grammar use="reference">Module : [empty]</emu-grammar>
+        <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _entries_ be ImportEntries of |ModuleItemList|.
           1. Append to _entries_ the elements of the ImportEntries of |ModuleItem|.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ModuleItem :
             ExportDeclaration
             StatementListItem
@@ -21017,22 +21017,22 @@
       <emu-clause id="sec-module-semantics-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
-        <emu-grammar use="reference">Module : [empty]</emu-grammar>
+        <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItemList : ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItem</emu-grammar>
         <emu-alg>
           1. Return ModuleRequests of |ModuleItem|.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _moduleNames_ be ModuleRequests of |ModuleItemList|.
           1. Let _additionalNames_ be ModuleRequests of |ModuleItem|.
           1. Append to _moduleNames_ each element of _additionalNames_ that is not already an element of _moduleNames_.
           1. Return _moduleNames_.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : StatementListItem</emu-grammar>
+        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -21045,22 +21045,22 @@
         <emu-note>
           <p>The LexicallyDeclaredNames of a |Module| includes the names of all of its imported bindings.</p>
         </emu-note>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _names_ be LexicallyDeclaredNames of |ModuleItemList|.
           1. Append to _names_ the elements of the LexicallyDeclaredNames of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |ImportDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. If |ExportDeclaration| is `export` |VariableStatement|, return a new empty List.
           1. Return the BoundNames of |ExportDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : StatementListItem</emu-grammar>
+        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return LexicallyDeclaredNames of |StatementListItem|.
         </emu-alg>
@@ -21073,17 +21073,17 @@
       <emu-clause id="sec-module-semantics-static-semantics-lexicallyscopeddeclarations">
         <h1>Static Semantics: LexicallyScopedDeclarations</h1>
         <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-        <emu-grammar use="reference">Module : [empty]</emu-grammar>
+        <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be LexicallyScopedDeclarations of |ModuleItemList|.
           1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |ModuleItem|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -21093,21 +21093,21 @@
       <emu-clause id="sec-module-semantics-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar use="reference">Module : [empty]</emu-grammar>
+        <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _names_ be VarDeclaredNames of |ModuleItemList|.
           1. Append to _names_ the elements of the VarDeclaredNames of |ModuleItem|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. If |ExportDeclaration| is `export` |VariableStatement|, return BoundNames of |ExportDeclaration|.
           1. Return a new empty List.
@@ -21118,21 +21118,21 @@
       <emu-clause id="sec-module-semantics-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar use="reference">Module : [empty]</emu-grammar>
+        <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _declarations_ be VarScopedDeclarations of |ModuleItemList|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |ModuleItem|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
         <emu-alg>
           1. If |ExportDeclaration| is `export` |VariableStatement|, return VarScopedDeclarations of |VariableStatement|.
           1. Return a new empty List.
@@ -21993,18 +21993,18 @@
       <!-- es6num="15.2.1.20" -->
       <emu-clause id="sec-module-semantics-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">Module : [empty]</emu-grammar>
+        <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(*undefined*).
         </emu-alg>
-        <emu-grammar use="reference">ModuleBody : ModuleItemList</emu-grammar>
+        <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
         <emu-alg>
           1. Let _result_ be the result of evaluating |ModuleItemList|.
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
             1. Return NormalCompletion(*undefined*).
           1. Return Completion(_result_).
         </emu-alg>
-        <emu-grammar use="reference">ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _sl_ be the result of evaluating |ModuleItemList|.
           1. ReturnIfAbrupt(_sl_).
@@ -22014,7 +22014,7 @@
         <emu-note>
           <p>The value of a |ModuleItemList| is the value of the last value-producing item in the |ModuleItemList|.</p>
         </emu-note>
-        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
@@ -22069,7 +22069,7 @@
       <!-- es6num="15.2.2.1" -->
       <emu-clause id="sec-imports-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">ModuleItem : ImportDeclaration</emu-grammar>
+        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the BoundNames of |ImportDeclaration| contains any duplicate entries.
@@ -22081,37 +22081,37 @@
       <emu-clause id="sec-imports-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar use="reference">ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |ImportClause|.
         </emu-alg>
-        <emu-grammar use="reference">ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
+        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ImportedDefaultBinding|.
           1. Append to _names_ the elements of the BoundNames of |NameSpaceImport|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
+        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ImportedDefaultBinding|.
           1. Append to _names_ the elements of the BoundNames of |NamedImports|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">NamedImports : `{` `}`</emu-grammar>
+        <emu-grammar>NamedImports : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
+        <emu-grammar>ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ImportsList|.
           1. Append to _names_ the elements of the BoundNames of |ImportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
+        <emu-grammar>ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |ImportedBinding|.
         </emu-alg>
@@ -22121,12 +22121,12 @@
       <emu-clause id="sec-imports-static-semantics-importentries">
         <h1>Static Semantics: ImportEntries</h1>
         <emu-see-also-para op="ImportEntries"></emu-see-also-para>
-        <emu-grammar use="reference">ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
           1. Return ImportEntriesForModule of |ImportClause| with argument _module_.
         </emu-alg>
-        <emu-grammar use="reference">ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -22136,47 +22136,47 @@
       <emu-clause id="sec-static-semantics-importentriesformodule">
         <h1>Static Semantics: ImportEntriesForModule</h1>
         <p>With parameter _module_.</p>
-        <emu-grammar use="reference">ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
+        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
         <emu-alg>
           1. Let _entries_ be ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
           1. Append to _entries_ the elements of the ImportEntriesForModule of |NameSpaceImport| with argument _module_.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar use="reference">ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
+        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
         <emu-alg>
           1. Let _entries_ be ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
           1. Append to _entries_ the elements of the ImportEntriesForModule of |NamedImports| with argument _module_.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar use="reference">ImportedDefaultBinding : ImportedBinding</emu-grammar>
+        <emu-grammar>ImportedDefaultBinding : ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
           1. Let _defaultEntry_ be the ImportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: `"default"`, [[LocalName]]: _localName_ }.
           1. Return a new List containing _defaultEntry_.
         </emu-alg>
-        <emu-grammar use="reference">NameSpaceImport : `*` `as` ImportedBinding</emu-grammar>
+        <emu-grammar>NameSpaceImport : `*` `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the StringValue of |ImportedBinding|.
           1. Let _entry_ be the ImportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: `"*"`, [[LocalName]]: _localName_ }.
           1. Return a new List containing _entry_.
         </emu-alg>
-        <emu-grammar use="reference">NamedImports : `{` `}`</emu-grammar>
+        <emu-grammar>NamedImports : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
+        <emu-grammar>ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _specs_ be the ImportEntriesForModule of |ImportsList| with argument _module_.
           1. Append to _specs_ the elements of the ImportEntriesForModule of |ImportSpecifier| with argument _module_.
           1. Return _specs_.
         </emu-alg>
-        <emu-grammar use="reference">ImportSpecifier : ImportedBinding</emu-grammar>
+        <emu-grammar>ImportSpecifier : ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
           1. Let _entry_ be the ImportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: _localName_, [[LocalName]]: _localName_ }.
           1. Return a new List containing _entry_.
         </emu-alg>
-        <emu-grammar use="reference">ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
+        <emu-grammar>ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _importName_ be the StringValue of |IdentifierName|.
           1. Let _localName_ be the StringValue of |ImportedBinding|.
@@ -22189,11 +22189,11 @@
       <emu-clause id="sec-imports-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
-        <emu-grammar use="reference">ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Return ModuleRequests of |FromClause|.
         </emu-alg>
-        <emu-grammar use="reference">ModuleSpecifier : StringLiteral</emu-grammar>
+        <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |StringLiteral|.
         </emu-alg>
@@ -22232,7 +22232,7 @@
       <!-- es6num="15.2.3.1" -->
       <emu-clause id="sec-exports-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">ExportDeclaration : `export` ExportClause `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
         <ul>
           <li>
             For each |IdentifierName| _n_ in ReferencedBindings of |ExportClause|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or if the StringValue of _n_ is one of: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, or `"static"`.
@@ -22247,7 +22247,7 @@
       <emu-clause id="sec-exports-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration :
             `export` `*` FromClause `;`
             `export` ExportClause FromClause `;`
@@ -22256,27 +22256,27 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |VariableStatement|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |Declaration|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _declarationNames_ be the BoundNames of |HoistableDeclaration|.
           1. If _declarationNames_ does not include the element `"*default*"`, append `"*default*"` to _declarationNames_.
           1. Return _declarationNames_.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _declarationNames_ be the BoundNames of |ClassDeclaration|.
           1. If _declarationNames_ does not include the element `"*default*"`, append `"*default*"` to _declarationNames_.
           1. Return _declarationNames_.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Return &laquo; `"*default*"` &raquo;.
         </emu-alg>
@@ -22286,7 +22286,7 @@
       <emu-clause id="sec-exports-static-semantics-exportedbindings">
         <h1>Static Semantics: ExportedBindings</h1>
         <emu-see-also-para op="ExportedBindings"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration :
             `export` ExportClause FromClause `;`
             `export` `*` FromClause `;`
@@ -22294,19 +22294,19 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` ExportClause `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
         <emu-alg>
           1. Return the ExportedBindings of |ExportClause|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |VariableStatement|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |Declaration|.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration : `export` `default` HoistableDeclaration
 
           ExportDeclaration : `export` `default` ClassDeclaration
@@ -22316,21 +22316,21 @@
         <emu-alg>
           1. Return the BoundNames of this |ExportDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">ExportClause : `{` `}`</emu-grammar>
+        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
+        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _names_ be the ExportedBindings of |ExportsList|.
           1. Append to _names_ the elements of the ExportedBindings of |ExportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |IdentifierName|.
         </emu-alg>
-        <emu-grammar use="reference">ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of the first |IdentifierName|.
         </emu-alg>
@@ -22340,11 +22340,11 @@
       <emu-clause id="sec-exports-static-semantics-exportednames">
         <h1>Static Semantics: ExportedNames</h1>
         <emu-see-also-para op="ExportedNames"></emu-see-also-para>
-        <emu-grammar use="reference">ExportDeclaration : `export` `*` FromClause `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `*` FromClause `;`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration : `export` ExportClause FromClause `;`
 
           ExportDeclaration : `export` ExportClause `;`
@@ -22352,15 +22352,15 @@
         <emu-alg>
           1. Return the ExportedNames of |ExportClause|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |VariableStatement|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return the BoundNames of |Declaration|.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration : `export` `default` HoistableDeclaration
 
           ExportDeclaration : `export` `default` ClassDeclaration
@@ -22370,21 +22370,21 @@
         <emu-alg>
           1. Return &laquo; `"default"` &raquo;.
         </emu-alg>
-        <emu-grammar use="reference">ExportClause : `{` `}`</emu-grammar>
+        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
+        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _names_ be the ExportedNames of |ExportsList|.
           1. Append to _names_ the elements of the ExportedNames of |ExportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |IdentifierName|.
         </emu-alg>
-        <emu-grammar use="reference">ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of the second |IdentifierName|.
         </emu-alg>
@@ -22394,22 +22394,22 @@
       <emu-clause id="sec-exports-static-semantics-exportentries">
         <h1>Static Semantics: ExportEntries</h1>
         <emu-see-also-para op="ExportEntries"></emu-see-also-para>
-        <emu-grammar use="reference">ExportDeclaration : `export` `*` FromClause `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `*` FromClause `;`</emu-grammar>
         <emu-alg>
           1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
           1. Let _entry_ be the ExportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: `"*"`, [[LocalName]]: *null*, [[ExportName]]: *null* }.
           1. Return a new List containing _entry_.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` ExportClause FromClause `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` ExportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
           1. Return ExportEntriesForModule of |ExportClause| with argument _module_.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` ExportClause `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
         <emu-alg>
           1. Return ExportEntriesForModule of |ExportClause| with argument *null*.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Let _entries_ be a new empty List.
           1. Let _names_ be the BoundNames of |VariableStatement|.
@@ -22417,7 +22417,7 @@
             1. Append the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _name_, [[ExportName]]: _name_ } to _entries_.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Let _entries_ be a new empty List.
           1. Let _names_ be the BoundNames of |Declaration|.
@@ -22425,19 +22425,19 @@
             1. Append the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _name_, [[ExportName]]: _name_ } to _entries_.
           1. Return _entries_.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |HoistableDeclaration|.
           1. Let _localName_ be the sole element of _names_.
           1. Return a new List containing the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: `"default"`}.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |ClassDeclaration|.
           1. Let _localName_ be the sole element of _names_.
           1. Return a new List containing the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: `"default"`}.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Let _entry_ be the ExportEntry Record {[[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: `"*default*"`, [[ExportName]]: `"default"`}.
           1. Return a new List containing _entry_.
@@ -22451,17 +22451,17 @@
       <emu-clause id="sec-static-semantics-exportentriesformodule">
         <h1>Static Semantics: ExportEntriesForModule</h1>
         <p>With parameter _module_.</p>
-        <emu-grammar use="reference">ExportClause : `{` `}`</emu-grammar>
+        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
+        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _specs_ be the ExportEntriesForModule of |ExportsList| with argument _module_.
           1. Append to _specs_ the elements of the ExportEntriesForModule of |ExportSpecifier| with argument _module_.
           1. Return _specs_.
         </emu-alg>
-        <emu-grammar use="reference">ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _sourceName_ be the StringValue of |IdentifierName|.
           1. If _module_ is *null*, then
@@ -22472,7 +22472,7 @@
             1. Let _importName_ be _sourceName_.
           1. Return a new List containing the ExportEntry Record {[[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _sourceName_ }.
         </emu-alg>
-        <emu-grammar use="reference">ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _sourceName_ be the StringValue of the first |IdentifierName|.
           1. Let _exportName_ be the StringValue of the second |IdentifierName|.
@@ -22490,7 +22490,7 @@
       <emu-clause id="sec-exports-static-semantics-isconstantdeclaration">
         <h1>Static Semantics: IsConstantDeclaration</h1>
         <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration :
             `export` `*` FromClause `;`
             `export` ExportClause FromClause `;`
@@ -22509,7 +22509,7 @@
       <emu-clause id="sec-exports-static-semantics-lexicallyscopeddeclarations">
         <h1>Static Semantics: LexicallyScopedDeclarations</h1>
         <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration :
             `export` `*` FromClause `;`
             `export` ExportClause FromClause `;`
@@ -22519,19 +22519,19 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return a new List containing DeclarationPart of |Declaration|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new List containing DeclarationPart of |HoistableDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Return a new List containing |ClassDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Return a new List containing this |ExportDeclaration|.
         </emu-alg>
@@ -22541,7 +22541,7 @@
       <emu-clause id="sec-exports-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration : `export` `*` FromClause `;`
 
           ExportDeclaration : `export` ExportClause FromClause `;`
@@ -22549,7 +22549,7 @@
         <emu-alg>
           1. Return the ModuleRequests of |FromClause|.
         </emu-alg>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration :
             `export` ExportClause `;`
             `export` VariableStatement
@@ -22566,21 +22566,21 @@
       <!-- es6num="15.2.3.10" -->
       <emu-clause id="sec-static-semantics-referencedbindings">
         <h1>Static Semantics: ReferencedBindings</h1>
-        <emu-grammar use="reference">ExportClause : `{` `}`</emu-grammar>
+        <emu-grammar>ExportClause : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar use="reference">ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
+        <emu-grammar>ExportsList : ExportsList `,` ExportSpecifier</emu-grammar>
         <emu-alg>
           1. Let _names_ be the ReferencedBindings of |ExportsList|.
           1. Append to _names_ the elements of the ReferencedBindings of |ExportSpecifier|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar use="reference">ExportSpecifier : IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the |IdentifierName|.
         </emu-alg>
-        <emu-grammar use="reference">ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
+        <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the first |IdentifierName|.
         </emu-alg>
@@ -22589,7 +22589,7 @@
       <!-- es6num="15.2.3.11" -->
       <emu-clause id="sec-exports-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar use="reference">
+        <emu-grammar>
           ExportDeclaration :
             `export` `*` FromClause `;`
             `export` ExportClause FromClause `;`
@@ -22598,19 +22598,19 @@
         <emu-alg>
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` VariableStatement</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
           1. Return the result of evaluating |VariableStatement|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
           1. Return the result of evaluating |Declaration|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Return the result of evaluating |HoistableDeclaration|.
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _value_ be the result of BindingClassDeclarationEvaluation of |ClassDeclaration|.
           1. ReturnIfAbrupt(_value_).
@@ -22622,7 +22622,7 @@
             1. Perform ? InitializeBoundName(`"*default*"`, _value_, _env_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
-        <emu-grammar use="reference">ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
           1. Let _value_ be ? GetValue(_rhs_).
@@ -22835,7 +22835,7 @@
         <emu-clause id="sec-performeval-rules-outside-functions">
           <h1>Additional Early Error Rules for Eval Outside Functions</h1>
           <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of any function.</p>
-          <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+          <emu-grammar>ScriptBody : StatementList</emu-grammar>
           <ul>
             <li>It is a Syntax Error if |StatementList| Contains |NewTarget|.</li>
           </ul>
@@ -22844,7 +22844,7 @@
         <emu-clause id="sec-performeval-rules-outside-methods">
           <h1>Additional Early Error Rules for Eval Outside Methods</h1>
           <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of a |MethodDefinition|.</p>
-          <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+          <emu-grammar>ScriptBody : StatementList</emu-grammar>
           <ul>
             <li>It is a Syntax Error if |StatementList| Contains |SuperProperty|.</li>
           </ul>
@@ -22853,7 +22853,7 @@
         <emu-clause id="sec-performeval-rules-outside-constructors">
           <h1>Additional Early Error Rules for Eval Outside Constructor Methods</h1>
           <p>These static semantics are applied by PerformEval when a direct eval call occurs outside of the <emu-xref href="#sec-static-semantics-constructormethod">constructor method</emu-xref> of a |ClassDeclaration| or |ClassExpression|.</p>
-          <emu-grammar use="reference">ScriptBody : StatementList</emu-grammar>
+          <emu-grammar>ScriptBody : StatementList</emu-grammar>
           <ul>
             <li>It is a Syntax Error if |StatementList| Contains |SuperCall|.</li>
           </ul>
@@ -24166,7 +24166,7 @@
             1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
             1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
             1. Let _strict_ be ContainsUseStrict of _body_.
-            1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar use="reference">UniqueFormalParameters : FormalParameters</emu-grammar> are applied. Parsing and early error detection may be interweaved in an implementation-dependent manner.
+            1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied. Parsing and early error detection may be interweaved in an implementation-dependent manner.
             1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
             1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.
             1. If _body_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
@@ -28777,13 +28777,13 @@ THH:mm:ss.sss
       <!-- es6num="21.2.1.1" -->
       <emu-clause id="sec-patterns-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar use="reference">Pattern :: Disjunction</emu-grammar>
+        <emu-grammar>Pattern :: Disjunction</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if _NcapturingParens_ &ge; 2<sup>32</sup>-1.
           </li>
         </ul>
-        <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
+        <emu-grammar>RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the MV of |HexDigits| &gt; 0x10FFFF.
@@ -28816,7 +28816,7 @@ THH:mm:ss.sss
             _InputLength_ is the number of characters in _Input_.
           </li>
           <li>
-            _NcapturingParens_ is the total number of left-capturing parentheses (i.e. the total number of <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes) in the pattern. A left-capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> production.
+            _NcapturingParens_ is the total number of left-capturing parentheses (i.e. the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes) in the pattern. A left-capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> production.
           </li>
           <li>
             _IgnoreCase_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains `"i"` and otherwise is *false*.
@@ -28854,7 +28854,7 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.2" -->
       <emu-clause id="sec-pattern">
         <h1>Pattern</h1>
-        <p>The production <emu-grammar use="reference">Pattern :: Disjunction</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Pattern :: Disjunction</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
           1. Return an internal closure that takes two arguments, a String _str_ and an integer _index_, and performs the following steps:
@@ -28875,12 +28875,12 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.3" -->
       <emu-clause id="sec-disjunction">
         <h1>Disjunction</h1>
-        <p>The production <emu-grammar use="reference">Disjunction :: Alternative</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Disjunction :: Alternative</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Alternative| to obtain a Matcher _m_.
           1. Return _m_.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Disjunction :: Alternative `|` Disjunction</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Disjunction :: Alternative `|` Disjunction</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Alternative| to obtain a Matcher _m1_.
           1. Evaluate |Disjunction| to obtain a Matcher _m2_.
@@ -28904,11 +28904,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.4" -->
       <emu-clause id="sec-alternative">
         <h1>Alternative</h1>
-        <p>The production <emu-grammar use="reference">Alternative :: [empty]</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Alternative :: [empty]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return a Matcher that takes two arguments, a State _x_ and a Continuation _c_, and returns the result of calling _c_(_x_).
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Alternative :: Alternative Term</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Alternative :: Alternative Term</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Alternative| to obtain a Matcher _m1_.
           1. Evaluate |Term| to obtain a Matcher _m2_.
@@ -28924,7 +28924,7 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.5" -->
       <emu-clause id="sec-term">
         <h1>Term</h1>
-        <p>The production <emu-grammar use="reference">Term :: Assertion</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Term :: Assertion</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps when evaluated:
             1. Evaluate |Assertion| to obtain an AssertionTester _t_.
@@ -28932,17 +28932,17 @@ THH:mm:ss.sss
             1. If _r_ is *false*, return ~failure~.
             1. Call _c_(_x_) and return its result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Term :: Atom</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Term :: Atom</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Atom|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Term :: Atom Quantifier</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Term :: Atom Quantifier</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Atom| to obtain a Matcher _m_.
           1. Evaluate |Quantifier| to obtain the three results: an integer _min_, an integer (or &infin;) _max_, and Boolean _greedy_.
           1. If _max_ is finite and less than _min_, throw a *SyntaxError* exception.
-          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Term|. This is the total number of <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Term|.
-          1. Let _parenCount_ be the number of left-capturing parentheses in |Atom|. This is the total number of <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes enclosed by |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Term|. This is the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Term|.
+          1. Let _parenCount_ be the number of left-capturing parentheses in |Atom|. This is the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes enclosed by |Atom|.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps when evaluated:
             1. Call RepeatMatcher(_m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_) and return its result.
         </emu-alg>
@@ -29017,7 +29017,7 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.6" -->
       <emu-clause id="sec-assertion">
         <h1>Assertion</h1>
-        <p>The production <emu-grammar use="reference">Assertion :: `^`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Assertion :: `^`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal AssertionTester closure that takes a State argument _x_ and performs the following steps when evaluated:
             1. Let _e_ be _x_'s _endIndex_.
@@ -29029,7 +29029,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>Even when the `y` flag is used with a pattern, `^` always matches only at the beginning of _Input_, or (if _Multiline_ is *true*) at the beginning of a line.</p>
         </emu-note>
-        <p>The production <emu-grammar use="reference">Assertion :: `$`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Assertion :: `$`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal AssertionTester closure that takes a State argument _x_ and performs the following steps when evaluated:
             1. Let _e_ be _x_'s _endIndex_.
@@ -29038,7 +29038,7 @@ THH:mm:ss.sss
             1. If the character _Input_[_e_] is one of |LineTerminator|, return *true*.
             1. Return *false*.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Assertion :: `\` `b`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Assertion :: `\` `b`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal AssertionTester closure that takes a State argument _x_ and performs the following steps when evaluated:
             1. Let _e_ be _x_'s _endIndex_.
@@ -29048,7 +29048,7 @@ THH:mm:ss.sss
             1. If _a_ is *false* and _b_ is *true*, return *true*.
             1. Return *false*.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Assertion :: `\` `B`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Assertion :: `\` `B`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return an internal AssertionTester closure that takes a State argument _x_ and performs the following steps when evaluated:
             1. Let _e_ be _x_'s _endIndex_.
@@ -29058,7 +29058,7 @@ THH:mm:ss.sss
             1. If _a_ is *false* and _b_ is *true*, return *false*.
             1. Return *true*.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps:
@@ -29071,7 +29071,7 @@ THH:mm:ss.sss
             1. Let _z_ be the State (_xe_, _cap_).
             1. Call _c_(_z_) and return its result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps:
@@ -29341,39 +29341,39 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.7" -->
       <emu-clause id="sec-quantifier">
         <h1>Quantifier</h1>
-        <p>The production <emu-grammar use="reference">Quantifier :: QuantifierPrefix</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Quantifier :: QuantifierPrefix</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |QuantifierPrefix| to obtain the two results: an integer _min_ and an integer (or &infin;) _max_.
           1. Return the three results _min_, _max_, and *true*.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Quantifier :: QuantifierPrefix `?`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Quantifier :: QuantifierPrefix `?`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |QuantifierPrefix| to obtain the two results: an integer _min_ and an integer (or &infin;) _max_.
           1. Return the three results _min_, _max_, and *false*.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `*`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>QuantifierPrefix :: `*`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the two results 0 and &infin;.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `+`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>QuantifierPrefix :: `+`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the two results 1 and &infin;.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `?`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>QuantifierPrefix :: `?`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the two results 0 and 1.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `{` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _i_ be the MV of |DecimalDigits| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>).
           1. Return the two results _i_ and _i_.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `{` DecimalDigits `,` `}`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _i_ be the MV of |DecimalDigits|.
           1. Return the two results _i_ and &infin;.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _i_ be the MV of the first |DecimalDigits|.
           1. Let _j_ be the MV of the second |DecimalDigits|.
@@ -29384,30 +29384,30 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.8" -->
       <emu-clause id="sec-atom">
         <h1>Atom</h1>
-        <p>The production <emu-grammar use="reference">Atom :: PatternCharacter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom :: PatternCharacter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character matched by |PatternCharacter|.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Atom :: `.`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom :: `.`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _A_ be the set of all characters except |LineTerminator|.
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Atom :: `\` AtomEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom :: `\` AtomEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |AtomEscape|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Atom :: CharacterClass</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom :: CharacterClass</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterClass| to obtain a CharSet _A_ and a Boolean _invert_.
           1. Call CharacterSetMatcher(_A_, _invert_) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| to obtain a Matcher _m_.
-          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Atom|. This is the total number of <emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Atom|. This is the total number of <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Atom|.
           1. Return an internal Matcher closure that takes two arguments, a State _x_ and a Continuation _c_, and performs the following steps:
             1. Let _d_ be an internal Continuation closure that takes one State argument _y_ and performs the following steps:
               1. Let _cap_ be a fresh copy of _y_'s _captures_ List.
@@ -29419,7 +29419,7 @@ THH:mm:ss.sss
               1. Call _c_(_z_) and return its result.
             1. Call _m_(_x_, _d_) and return its result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">Atom :: `(` `?` `:` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom :: `(` `?` `:` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Disjunction|.
         </emu-alg>
@@ -29494,7 +29494,7 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.9" -->
       <emu-clause id="sec-atomescape">
         <h1>AtomEscape</h1>
-        <p>The production <emu-grammar use="reference">AtomEscape :: DecimalEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |DecimalEscape| to obtain an integer _n_.
           1. If _n_&gt;_NcapturingParens_, throw a *SyntaxError* exception.
@@ -29510,13 +29510,13 @@ THH:mm:ss.sss
             1. Let _y_ be the State (_f_, _cap_).
             1. Call _c_(_y_) and return its result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">AtomEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>AtomEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterEscape| to obtain a character _ch_.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">AtomEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>AtomEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterClassEscape| to obtain a CharSet _A_.
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
@@ -29529,14 +29529,14 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.10" -->
       <emu-clause id="sec-characterescape">
         <h1>CharacterEscape</h1>
-        <p>The production <emu-grammar use="reference">CharacterEscape :: `0`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterEscape :: `0`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character U+0000 (NULL).
         </emu-alg>
         <emu-note>
           <p>`\\0` represents the &lt;NUL&gt; character and cannot be followed by a decimal digit.</p>
         </emu-note>
-        <p>The production <emu-grammar use="reference">CharacterEscape :: ControlEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterEscape :: ControlEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character according to <emu-xref href="#table-47"></emu-xref>.
         </emu-alg>
@@ -29648,61 +29648,61 @@ THH:mm:ss.sss
             </tbody>
           </table>
         </emu-table>
-        <p>The production <emu-grammar use="reference">CharacterEscape :: `c` ControlLetter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterEscape :: `c` ControlLetter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character matched by |ControlLetter|.
           1. Let _i_ be _ch_'s character value.
           1. Let _j_ be the remainder of dividing _i_ by 32.
           1. Return the character whose character value is _j_.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterEscape :: HexEscapeSequence</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterEscape :: HexEscapeSequence</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |HexEscapeSequence|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterEscape :: RegExpUnicodeEscapeSequence</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterEscape :: RegExpUnicodeEscapeSequence</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the result of evaluating |RegExpUnicodeEscapeSequence|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterEscape :: IdentityEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterEscape :: IdentityEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character matched by |IdentityEscape|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` LeadSurrogate `\u` TrailSurrogate</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` LeadSurrogate `\u` TrailSurrogate</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _lead_ be the result of evaluating |LeadSurrogate|.
           1. Let _trail_ be the result of evaluating |TrailSurrogate|.
           1. Let _cp_ be UTF16Decode(_lead_, _trail_).
           1. Return the character whose character value is _cp_.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` LeadSurrogate</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` LeadSurrogate</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the result of evaluating |LeadSurrogate|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` TrailSurrogate</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` TrailSurrogate</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the result of evaluating |TrailSurrogate|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` NonSurrogate</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` NonSurrogate</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the result of evaluating |NonSurrogate|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |Hex4Digits|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>RegExpUnicodeEscapeSequence :: `u{` HexDigits `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the MV of |HexDigits|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">LeadSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>LeadSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |Hex4Digits|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">TrailSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>TrailSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |Hex4Digits|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">NonSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonSurrogate :: Hex4Digits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the character whose code is the SV of |Hex4Digits|.
         </emu-alg>
@@ -29711,11 +29711,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.11" -->
       <emu-clause id="sec-decimalescape">
         <h1>DecimalEscape</h1>
-        <p>The production <emu-grammar use="reference">DecimalEscape :: NonZeroDigit</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>DecimalEscape :: NonZeroDigit</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the MV of |NonZeroDigit|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">DecimalEscape :: NonZeroDigit DecimalDigits</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>DecimalEscape :: NonZeroDigit DecimalDigits</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _n_ be the number of code points in |DecimalDigits|.
           1. Return (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|.
@@ -29729,41 +29729,41 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.12" -->
       <emu-clause id="sec-characterclassescape">
         <h1>CharacterClassEscape</h1>
-        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `d`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the ten-element set of characters containing the characters `0` through `9` inclusive.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `D`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the set of all characters not included in the set returned by <emu-grammar use="reference">CharacterClassEscape :: `d`</emu-grammar>.
+          1. Return the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar>.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `s`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the set of characters containing the characters that are on the right-hand side of the |WhiteSpace| or |LineTerminator| productions.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `S`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the set of all characters not included in the set returned by <emu-grammar use="reference">CharacterClassEscape :: `s`</emu-grammar> .
+          1. Return the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> .
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `w`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the set of all characters returned by WordCharacters().
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterClassEscape :: `W`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the set of all characters not included in the set returned by <emu-grammar use="reference">CharacterClassEscape :: `w`</emu-grammar> .
+          1. Return the set of all characters not included in the set returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> .
         </emu-alg>
       </emu-clause>
 
       <!-- es6num="21.2.2.13" -->
       <emu-clause id="sec-characterclass">
         <h1>CharacterClass</h1>
-        <p>The production <emu-grammar use="reference">CharacterClass :: `[` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterClass :: `[` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassRanges| to obtain a CharSet _A_.
           1. Return the two results _A_ and *false*.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">CharacterClass :: `[` `^` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterClass :: `[` `^` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassRanges| to obtain a CharSet _A_.
           1. Return the two results _A_ and *true*.
@@ -29773,11 +29773,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.14" -->
       <emu-clause id="sec-classranges">
         <h1>ClassRanges</h1>
-        <p>The production <emu-grammar use="reference">ClassRanges :: [empty]</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassRanges :: [empty]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the empty CharSet.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">ClassRanges :: NonemptyClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassRanges :: NonemptyClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |NonemptyClassRanges| to obtain a CharSet _A_.
           1. Return _A_.
@@ -29787,17 +29787,17 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.15" -->
       <emu-clause id="sec-nonemptyclassranges">
         <h1>NonemptyClassRanges</h1>
-        <p>The production <emu-grammar use="reference">NonemptyClassRanges :: ClassAtom</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |ClassAtom|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">NonemptyClassRanges :: ClassAtom NonemptyClassRangesNoDash</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom NonemptyClassRangesNoDash</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtom| to obtain a CharSet _A_.
           1. Evaluate |NonemptyClassRangesNoDash| to obtain a CharSet _B_.
           1. Return the union of CharSets _A_ and _B_.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate the first |ClassAtom| to obtain a CharSet _A_.
           1. Evaluate the second |ClassAtom| to obtain a CharSet _B_.
@@ -29825,17 +29825,17 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.16" -->
       <emu-clause id="sec-nonemptyclassrangesnodash">
         <h1>NonemptyClassRangesNoDash</h1>
-        <p>The production <emu-grammar use="reference">NonemptyClassRangesNoDash :: ClassAtom</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtom</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |ClassAtom|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">NonemptyClassRangesNoDash :: ClassAtomNoDash NonemptyClassRangesNoDash</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash NonemptyClassRangesNoDash</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Evaluate |NonemptyClassRangesNoDash| to obtain a CharSet _B_.
           1. Return the union of CharSets _A_ and _B_.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Evaluate |ClassAtom| to obtain a CharSet _B_.
@@ -29857,11 +29857,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.17" -->
       <emu-clause id="sec-classatom">
         <h1>ClassAtom</h1>
-        <p>The production <emu-grammar use="reference">ClassAtom :: `-`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassAtom :: `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
         </emu-alg>
-        <p>The production <emu-grammar use="reference">ClassAtom :: ClassAtomNoDash</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassAtom :: ClassAtomNoDash</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Return _A_.
@@ -29871,11 +29871,11 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.18" -->
       <emu-clause id="sec-classatomnodash">
         <h1>ClassAtomNoDash</h1>
-        <p>The production <emu-grammar use="reference">ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the character matched by |SourceCharacter|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">ClassAtomNoDash :: `\` ClassEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassAtomNoDash :: `\` ClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |ClassEscape|.
         </emu-alg>
@@ -29884,19 +29884,19 @@ THH:mm:ss.sss
       <!-- es6num="21.2.2.19" -->
       <emu-clause id="sec-classescape">
         <h1>ClassEscape</h1>
-        <p>The production <emu-grammar use="reference">ClassEscape :: `b`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassEscape :: `b`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character &lt;BS&gt; U+0008 (BACKSPACE).
         </emu-alg>
-        <p>The production <emu-grammar use="reference">ClassEscape :: `-`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassEscape :: `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
         </emu-alg>
-        <p>The production <emu-grammar use="reference">ClassEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character that is the result of evaluating |CharacterEscape|.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">ClassEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |CharacterClassEscape|.
         </emu-alg>
@@ -35370,7 +35370,7 @@ THH:mm:ss.sss
       </emu-grammar>
       <ul>
         <li>
-          The SV of <emu-grammar use="reference">DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or U+0000 through U+001F</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
+          The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or U+0000 through U+001F</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
         </li>
       </ul>
       <emu-note>
@@ -38392,34 +38392,34 @@ THH:mm:ss.sss
       <h1>Static Semantics</h1>
       <ul>
         <li>
-          The MV of <emu-grammar use="reference">LegacyOctalIntegerLiteral :: `0` OctalDigit</emu-grammar> is the MV of |OctalDigit|.
+          The MV of <emu-grammar>LegacyOctalIntegerLiteral :: `0` OctalDigit</emu-grammar> is the MV of |OctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">LegacyOctalIntegerLiteral :: LegacyOctalIntegerLiteral OctalDigit</emu-grammar> is (the MV of |LegacyOctalIntegerLiteral| times 8) plus the MV of |OctalDigit|.
+          The MV of <emu-grammar>LegacyOctalIntegerLiteral :: LegacyOctalIntegerLiteral OctalDigit</emu-grammar> is (the MV of |LegacyOctalIntegerLiteral| times 8) plus the MV of |OctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral</emu-grammar> is the MV of |NonOctalDecimalIntegerLiteral|.
+          The MV of <emu-grammar>DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral</emu-grammar> is the MV of |NonOctalDecimalIntegerLiteral|.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">NonOctalDecimalIntegerLiteral :: `0` NonOctalDigit</emu-grammar> is the MV of |NonOctalDigit|.
+          The MV of <emu-grammar>NonOctalDecimalIntegerLiteral :: `0` NonOctalDigit</emu-grammar> is the MV of |NonOctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">NonOctalDecimalIntegerLiteral :: LegacyOctalLikeDecimalIntegerLiteral NonOctalDigit</emu-grammar> is (the MV of |LegacyOctalLikeDecimalIntegerLiteral| times 10) plus the MV of |NonOctalDigit|.
+          The MV of <emu-grammar>NonOctalDecimalIntegerLiteral :: LegacyOctalLikeDecimalIntegerLiteral NonOctalDigit</emu-grammar> is (the MV of |LegacyOctalLikeDecimalIntegerLiteral| times 10) plus the MV of |NonOctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">NonOctalDecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral DecimalDigit</emu-grammar> is (the MV of |NonOctalDecimalIntegerLiteral| times 10) plus the MV of |DecimalDigit|.
+          The MV of <emu-grammar>NonOctalDecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral DecimalDigit</emu-grammar> is (the MV of |NonOctalDecimalIntegerLiteral| times 10) plus the MV of |DecimalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">LegacyOctalLikeDecimalIntegerLiteral :: `0` OctalDigit</emu-grammar> is the MV of |OctalDigit|.
+          The MV of <emu-grammar>LegacyOctalLikeDecimalIntegerLiteral :: `0` OctalDigit</emu-grammar> is the MV of |OctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">LegacyOctalLikeDecimalIntegerLiteral :: LegacyOctalLikeDecimalIntegerLiteral OctalDigit</emu-grammar> is (the MV of |LegacyOctalLikeDecimalIntegerLiteral| times 10) plus the MV of |OctalDigit|.
+          The MV of <emu-grammar>LegacyOctalLikeDecimalIntegerLiteral :: LegacyOctalLikeDecimalIntegerLiteral OctalDigit</emu-grammar> is (the MV of |LegacyOctalLikeDecimalIntegerLiteral| times 10) plus the MV of |OctalDigit|.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">NonOctalDigit :: `8`</emu-grammar> is 8.
+          The MV of <emu-grammar>NonOctalDigit :: `8`</emu-grammar> is 8.
         </li>
         <li>
-          The MV of <emu-grammar use="reference">NonOctalDigit :: `9`</emu-grammar> is 9.
+          The MV of <emu-grammar>NonOctalDigit :: `9`</emu-grammar> is 9.
         </li>
       </ul>
       </emu-annex>
@@ -38456,43 +38456,43 @@ THH:mm:ss.sss
         <h1>Static Semantics</h1>
         <ul>
           <li>
-            The SV of <emu-grammar use="reference">EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the SV of the |LegacyOctalEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the SV of the |LegacyOctalEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">LegacyOctalEscapeSequence :: OctalDigit</emu-grammar> is the code unit whose value is the MV of the |OctalDigit|.
+            The SV of <emu-grammar>LegacyOctalEscapeSequence :: OctalDigit</emu-grammar> is the code unit whose value is the MV of the |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |ZeroToThree|) plus the MV of the |OctalDigit|.
+            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |ZeroToThree|) plus the MV of the |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">LegacyOctalEscapeSequence :: FourToSeven OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |FourToSeven|) plus the MV of the |OctalDigit|.
+            The SV of <emu-grammar>LegacyOctalEscapeSequence :: FourToSeven OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |FourToSeven|) plus the MV of the |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar use="reference">LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is the code unit whose value is (64 (that is, 8<sup>2</sup>) times the MV of the |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
+            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is the code unit whose value is (64 (that is, 8<sup>2</sup>) times the MV of the |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">ZeroToThree :: `0`</emu-grammar> is 0.
+            The MV of <emu-grammar>ZeroToThree :: `0`</emu-grammar> is 0.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">ZeroToThree :: `1`</emu-grammar> is 1.
+            The MV of <emu-grammar>ZeroToThree :: `1`</emu-grammar> is 1.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">ZeroToThree :: `2`</emu-grammar> is 2.
+            The MV of <emu-grammar>ZeroToThree :: `2`</emu-grammar> is 2.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">ZeroToThree :: `3`</emu-grammar> is 3.
+            The MV of <emu-grammar>ZeroToThree :: `3`</emu-grammar> is 3.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">FourToSeven :: `4`</emu-grammar> is 4.
+            The MV of <emu-grammar>FourToSeven :: `4`</emu-grammar> is 4.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">FourToSeven :: `5`</emu-grammar> is 5.
+            The MV of <emu-grammar>FourToSeven :: `5`</emu-grammar> is 5.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">FourToSeven :: `6`</emu-grammar> is 6.
+            The MV of <emu-grammar>FourToSeven :: `6`</emu-grammar> is 6.
           </li>
           <li>
-            The MV of <emu-grammar use="reference">FourToSeven :: `7`</emu-grammar> is 7.
+            The MV of <emu-grammar>FourToSeven :: `7`</emu-grammar> is 7.
           </li>
         </ul>
       </emu-annex>
@@ -38643,33 +38643,33 @@ THH:mm:ss.sss
       <emu-annex id="sec-regular-expression-patterns-semantics">
         <h1>Pattern Semantics</h1>
         <p>The semantics of <emu-xref href="#sec-pattern-semantics"></emu-xref> is extended as follows:</p>
-        <p>Within <emu-xref href="#sec-term"></emu-xref> reference to &ldquo;<emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar use="reference">Atom :: `(` Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar use="reference">ExtendedAtom :: `(` Disjunction `)`</emu-grammar> &rdquo;.</p>
+        <p>Within <emu-xref href="#sec-term"></emu-xref> reference to &ldquo;<emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar>ExtendedAtom :: `(` Disjunction `)`</emu-grammar> &rdquo;.</p>
 
         <p>Term (<emu-xref href="#sec-term"></emu-xref>) includes the following additional evaluation rules:</p>
-        <p>The production <emu-grammar use="reference">Term :: QuantifiableAssertion Quantifier</emu-grammar> evaluates the same as the production <emu-grammar use="reference">Term :: Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
-        <p>The production <emu-grammar use="reference">Term :: ExtendedAtom Quantifier</emu-grammar> evaluates the same as the production <emu-grammar use="reference">Term :: Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
-        <p>The production <emu-grammar use="reference">Term :: ExtendedAtom</emu-grammar> evaluates the same as the production <emu-grammar use="reference">Term :: Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
+        <p>The production <emu-grammar>Term :: QuantifiableAssertion Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
+        <p>The production <emu-grammar>Term :: ExtendedAtom Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
+        <p>The production <emu-grammar>Term :: ExtendedAtom</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
 
         <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar use="reference">Assertion :: QuantifiableAssertion</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Assertion :: QuantifiableAssertion</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |QuantifiableAssertion| to obtain a Matcher _m_.
           1. Return _m_.
         </emu-alg>
 
-        <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) evaluation rules for the <emu-grammar use="reference">Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar use="reference">Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
+        <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) evaluation rules for the <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
 
-        <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar use="reference">Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules are also added:</p>
-        <p>The production <emu-grammar use="reference">ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules are also added:</p>
+        <p>The production <emu-grammar>ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
           1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">ExtendedAtom :: InvalidBracedQuantifier</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ExtendedAtom :: InvalidBracedQuantifier</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Throw a *SyntaxError* exception.
         </emu-alg>
-        <p>The production <emu-grammar use="reference">ExtendedAtom :: ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ExtendedAtom :: ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character represented by |ExtendedPatternCharacter|.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
@@ -38677,14 +38677,14 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>CharacterEscape (<emu-xref href="#sec-characterescape"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar use="reference">CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate the SV of the |LegacyOctalEscapeSequence| (see <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>) to obtain a character _ch_.
           1. Return _ch_.
         </emu-alg>
 
         <p>NonemptyClassRanges (<emu-xref href="#sec-nonemptyclassranges"></emu-xref>) modifies the following evaluation rule:</p>
-        <p>The production <emu-grammar use="reference">NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate the first |ClassAtom| to obtain a CharSet _A_.
           1. Evaluate the second |ClassAtom| to obtain a CharSet _B_.
@@ -38694,7 +38694,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>NonemptyClassRangesNoDash (<emu-xref href="#sec-nonemptyclassrangesnodash"></emu-xref>) modifies the following evaluation rule:</p>
-        <p>The production <emu-grammar use="reference">NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Evaluate |ClassAtom| to obtain a CharSet _B_.
@@ -38704,7 +38704,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>ClassEscape (<emu-xref href="#sec-classescape"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar use="reference">ClassEscape :: `c` ClassControlLetter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassEscape :: `c` ClassControlLetter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character matched by |ClassControlLetter|.
           1. Let _i_ be _ch_'s character value.
@@ -38714,7 +38714,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <p>ClassAtomNoDash (<emu-xref href="#sec-classatomnodash"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar use="reference">ClassAtomNoDash :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassAtomNoDash :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
         </emu-alg>
@@ -39198,14 +39198,14 @@ THH:mm:ss.sss
     <emu-annex id="sec-__proto__-property-names-in-object-initializers">
       <h1>__proto__ Property Names in Object Initializers</h1>
       <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the Early Error rule is <b>not</b> applied. In addition, it is not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|.</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         ObjectLiteral : `{` PropertyDefinitionList `}`
 
         ObjectLiteral : `{` PropertyDefinitionList `,` `}`
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for `"__proto__"` and at least two of those entries were obtained from productions of the form <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
+          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for `"__proto__"` and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
         </li>
       </ul>
       <emu-note>
@@ -39213,10 +39213,10 @@ THH:mm:ss.sss
       </emu-note>
       <p>In <emu-xref href="#sec-object-initializer-runtime-semantics-propertydefinitionevaluation"></emu-xref> the PropertyDefinitionEvaluation algorithm for the production
         <br>
-        <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <br>
         is replaced with the following definition:</p>
-      <emu-grammar use="reference">PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+      <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
@@ -39238,7 +39238,7 @@ THH:mm:ss.sss
     <emu-annex id="sec-labelled-function-declarations">
       <h1>Labelled Function Declarations</h1>
       <p>Prior to ECMAScript 2015, the specification of |LabelledStatement| did not allow for the association of a statement label with a |FunctionDeclaration|. However, a labelled |FunctionDeclaration| was an allowable extension for non-strict code and most browser-hosted ECMAScript implementations supported that extension. In ECMAScript 2015, the grammar productions for |LabelledStatement| permits use of |FunctionDeclaration| as a |LabelledItem| but <emu-xref href="#sec-labelled-statements-static-semantics-early-errors"></emu-xref> includes an Early Error rule that produces a Syntax Error if that occurs. For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
-      <emu-grammar use="reference">LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if any <ins>strict mode</ins> source code matches this rule.
@@ -39411,7 +39411,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-block-duplicates-allowed-static-semantics">
         <h1>Changes to Block Static Semantics: Early Errors</h1>
         <p>For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
-        <emu-grammar use="reference">Block : `{` StatementList `}`</emu-grammar>
+        <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries, <ins>unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.</ins>
@@ -39421,7 +39421,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-switch-duplicates-allowed-static-semantics">
         <h1>Changes to `switch` Statement Static Semantics: Early Errors</h1>
         <p>For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
-        <emu-grammar use="reference">SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+        <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries, <ins>unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.</ins>
@@ -39464,7 +39464,7 @@ THH:mm:ss.sss
     <emu-annex id="sec-variablestatements-in-catch-blocks">
       <h1>VariableStatements in Catch Blocks</h1>
       <p>The content of subclause <emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref> is replaced with the following:</p>
-      <emu-grammar use="reference">Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if BoundNames of |CatchParameter| contains any duplicate elements.
@@ -39473,7 +39473,7 @@ THH:mm:ss.sss
           It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the LexicallyDeclaredNames of |Block|.
         </li>
         <li>
-          It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the VarDeclaredNames of |Block| unless |CatchParameter| is <emu-grammar use="reference">CatchParameter : BindingIdentifier</emu-grammar> and that element is only bound by a |VariableStatement|, the |VariableDeclarationList| of a for statement, the |ForBinding| of a for-in statement, or the |BindingIdentifier| of a for-in statement.
+          It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the VarDeclaredNames of |Block| unless |CatchParameter| is <emu-grammar>CatchParameter : BindingIdentifier</emu-grammar> and that element is only bound by a |VariableStatement|, the |VariableDeclarationList| of a for statement, the |ForBinding| of a for-in statement, or the |BindingIdentifier| of a for-in statement.
         </li>
       </ul>
       <emu-note>
@@ -39501,22 +39501,22 @@ THH:mm:ss.sss
       </emu-grammar>
       <p>This production only applies when parsing non-strict code.</p>
       <p>The static semantics of ContainsDuplicateLabels in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels"></emu-xref> are augmented with the following:</p>
-      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
       <p>The static semantics of ContainsUndefinedBreakTarget in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget"></emu-xref> are augmented with the following:</p>
-      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
       <p>The static semantics of ContainsUndefinedContinueTarget in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget"></emu-xref> are augmented with the following:</p>
-      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
       <p>The static semantics of IsDestructuring in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-isdestructuring"></emu-xref> are augmented with the following:</p>
-      <emu-grammar use="reference">
+      <emu-grammar>
         BindingIdentifier :
           Identifier
           `yield`
@@ -39526,21 +39526,21 @@ THH:mm:ss.sss
         1. Return *false*.
       </emu-alg>
       <p>The static semantics of VarDeclaredNames in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-vardeclarednames"></emu-xref> are augmented with the following:</p>
-      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _names_ be the BoundNames of |BindingIdentifier|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
         1. Return _names_.
       </emu-alg>
       <p>The static semantics of VarScopedDeclarations in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations"></emu-xref> are augmented with the following:</p>
-      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be a List containing |BindingIdentifier|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
         1. Return _declarations_.
       </emu-alg>
       <p>The runtime semantics of LabelledEvaluation in <emu-xref href="#sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation"></emu-xref> are augmented with the following:</p>
-      <emu-grammar use="reference">IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _bindingId_ be StringValue of |BindingIdentifier|.
         1. Let _lhs_ be ? ResolveBinding(_bindingId_).

--- a/spec.html
+++ b/spec.html
@@ -3457,7 +3457,7 @@
           <p>The terminal symbols of this grammar are all composed of Unicode BMP code points so the result will be *NaN* if the string contains the UTF-16 encoding of any supplementary code points or any unpaired surrogate code points.</p>
         </emu-note>
         <h2>Syntax</h2>
-        <emu-grammar>
+        <emu-grammar strict>
           StringNumericLiteral :::
             StrWhiteSpace?
             StrWhiteSpace? StrNumericLiteral StrWhiteSpace?
@@ -9175,7 +9175,7 @@
   <emu-clause id="sec-source-text">
     <h1>Source Text</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       SourceCharacter ::
         &gt; any Unicode code point
     </emu-grammar>
@@ -9285,7 +9285,7 @@
     </code></pre>
   </emu-note>
   <h2>Syntax</h2>
-  <emu-grammar>
+  <emu-grammar strict>
     InputElementDiv ::
       WhiteSpace
       LineTerminator
@@ -9495,7 +9495,7 @@
       <p>Other than for the code points listed in <emu-xref href="#table-32"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       WhiteSpace ::
         &lt;TAB&gt;
         &lt;VT&gt;
@@ -9577,7 +9577,7 @@
     </emu-table>
     <p>Only the Unicode code points in <emu-xref href="#table-33"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-32"></emu-xref>. The sequence &lt;CR&gt;&lt;LF&gt; is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       LineTerminator ::
         &lt;LF&gt;
         &lt;CR&gt;
@@ -9600,7 +9600,7 @@
     <p>Because a single-line comment can contain any Unicode code point except a |LineTerminator| code point, and because of the general rule that a token is always as long as possible, a single-line comment always consists of all code points from the `//` marker to the end of the line. However, the |LineTerminator| at the end of the line is not considered to be part of the single-line comment; it is recognized separately by the lexical grammar and becomes part of the stream of input elements for the syntactic grammar. This point is very important, because it implies that the presence or absence of single-line comments does not affect the process of automatic semicolon insertion (see <emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>).</p>
     <p>Comments behave like white space and are discarded except that, if a |MultiLineComment| contains a line terminator code point, then the entire comment is considered to be a |LineTerminator| for purposes of parsing by the syntactic grammar.</p>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       Comment ::
         MultiLineComment
         SingleLineComment
@@ -9637,7 +9637,7 @@
   <emu-clause id="sec-tokens">
     <h1>Tokens</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       CommonToken ::
         IdentifierName
         Punctuator
@@ -9660,7 +9660,7 @@
     <p>Unicode escape sequences are permitted in an |IdentifierName|, where they contribute a single Unicode code point to the |IdentifierName|. The code point is expressed by the |HexDigits| of the |UnicodeEscapeSequence| (see <emu-xref href="#sec-literals-string-literals"></emu-xref>). The `\\` preceding the |UnicodeEscapeSequence| and the `u` and `{ }` code units, if they appear, do not contribute code points to the |IdentifierName|. A |UnicodeEscapeSequence| cannot be used to put a code point into an |IdentifierName| that would otherwise be illegal. In other words, if a `\\` |UnicodeEscapeSequence| sequence were replaced by the |SourceCharacter| it contributes, the result must still be a valid |IdentifierName| that has the exact same sequence of |SourceCharacter| elements as the original |IdentifierName|. All interpretations of |IdentifierName| within this specification are based upon their actual code points regardless of whether or not an escape sequence was used to contribute any particular code point.</p>
     <p>Two |IdentifierName|s that are canonically equivalent according to the Unicode standard are <em>not</em> equal unless, after replacement of each |UnicodeEscapeSequence|, they are represented by the exact same sequence of code points.</p>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       IdentifierName ::
         IdentifierStart
         IdentifierName IdentifierPart
@@ -9731,7 +9731,7 @@
       <h1>Reserved Words</h1>
       <p>A reserved word is an |IdentifierName| that cannot be used as an |Identifier|.</p>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         ReservedWord ::
           Keyword
           FutureReservedWord
@@ -9747,7 +9747,7 @@
         <h1>Keywords</h1>
         <p>The following tokens are ECMAScript keywords and may not be used as |Identifier|s in ECMAScript programs.</p>
         <h2>Syntax</h2>
-        <emu-grammar>
+        <emu-grammar strict>
           Keyword :: one of
             `await`
             `break`
@@ -9774,7 +9774,7 @@
         <h1>Future Reserved Words</h1>
         <p>The following tokens are reserved for use as keywords in future language extensions.</p>
         <h2>Syntax</h2>
-        <emu-grammar>
+        <emu-grammar strict>
           FutureReservedWord ::
             `enum`
         </emu-grammar>
@@ -9821,7 +9821,7 @@
   <emu-clause id="sec-punctuators">
     <h1>Punctuators</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       Punctuator :: one of
         `{` `(` `)` `[` `]`
         `.` `...` `;` `,`
@@ -9854,7 +9854,7 @@
     <emu-clause id="sec-null-literals">
       <h1>Null Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         NullLiteral ::
           `null`
       </emu-grammar>
@@ -9864,7 +9864,7 @@
     <emu-clause id="sec-boolean-literals">
       <h1>Boolean Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         BooleanLiteral ::
           `true`
           `false`
@@ -9875,7 +9875,7 @@
     <emu-clause id="sec-literals-numeric-literals">
       <h1>Numeric Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         NumericLiteral ::
           DecimalLiteral
           BinaryIntegerLiteral
@@ -10123,7 +10123,7 @@
         <p>A string literal is zero or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encoding"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         StringLiteral ::
           `"` DoubleStringCharacters? `"`
           `'` SingleStringCharacters? `'`
@@ -10149,12 +10149,12 @@
 
         EscapeSequence ::
           CharacterEscapeSequence
-          `0` [lookahead &lt;! DecimalDigit]
+          `0` [lookahead != DecimalDigit]
           HexEscapeSequence
           UnicodeEscapeSequence
       </emu-grammar>
       <p>A conforming implementation, when processing strict mode code, must not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.</p>
-      <emu-grammar>
+      <emu-grammar strict>
         CharacterEscapeSequence ::
           SingleEscapeCharacter
           NonEscapeCharacter
@@ -10452,7 +10452,7 @@
       <p>The productions below describe the syntax for a regular expression literal and are used by the input element scanner to find the end of the regular expression literal. The source text comprising the |RegularExpressionBody| and the |RegularExpressionFlags| are subsequently parsed again using the more stringent ECMAScript Regular Expression grammar (<emu-xref href="#sec-patterns"></emu-xref>).</p>
       <p>An implementation may extend the ECMAScript Regular Expression grammar defined in <emu-xref href="#sec-patterns"></emu-xref>, but it must not extend the |RegularExpressionBody| and |RegularExpressionFlags| productions defined below or the productions used by these productions.</p>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         RegularExpressionLiteral ::
           `/` RegularExpressionBody `/` RegularExpressionFlags
 
@@ -10532,7 +10532,7 @@
     <emu-clause id="sec-template-literal-lexical-components">
       <h1>Template Literal Lexical Components</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         Template ::
           NoSubstitutionTemplate
           TemplateHead
@@ -10882,7 +10882,7 @@
   <emu-clause id="sec-identifiers">
     <h1>Identifiers</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       IdentifierReference[Yield, Await] :
         Identifier
         [~Yield] `yield`
@@ -11124,7 +11124,7 @@
   <emu-clause id="sec-primary-expression">
     <h1>Primary Expression</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       PrimaryExpression[Yield, Await] :
         `this`
         IdentifierReference[?Yield, ?Await]
@@ -11287,7 +11287,7 @@
     <emu-clause id="sec-primary-expression-literals">
       <h1>Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         Literal :
           NullLiteral
           BooleanLiteral
@@ -11326,7 +11326,7 @@
       </emu-note>
       <p>Array elements may be elided at the beginning, middle or end of the element list. Whenever a comma in the element list is not preceded by an |AssignmentExpression| (i.e., a comma at the beginning or after another comma), the missing array element contributes to the length of the Array and increases the index of subsequent elements. Elided array elements are not defined. If an element is elided at the end of an array, that element does not contribute to the length of the Array.</p>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         ArrayLiteral[Yield, Await] :
           `[` Elision? `]`
           `[` ElementList[?Yield, ?Await] `]`
@@ -11454,7 +11454,7 @@
         <p>An object initializer is an expression describing the initialization of an Object, written in a form resembling a literal. It is a list of zero or more pairs of property keys and associated values, enclosed in curly brackets. The values need not be literals; they are evaluated each time the object initializer is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         ObjectLiteral[Yield, Await] :
           `{` `}`
           `{` PropertyDefinitionList[?Yield, ?Await] `}`
@@ -11732,7 +11732,7 @@
     <emu-clause id="sec-template-literals">
       <h1>Template Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         TemplateLiteral[Yield, Await] :
           NoSubstitutionTemplate
           TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await]
@@ -12030,7 +12030,7 @@
   <emu-clause id="sec-left-hand-side-expressions">
     <h1>Left-Hand-Side Expressions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       MemberExpression[Yield, Await] :
         PrimaryExpression[?Yield, ?Await]
         MemberExpression[?Yield, ?Await] `[` Expression[+In, ?Yield, ?Await] `]`
@@ -12594,7 +12594,7 @@
   <emu-clause id="sec-update-expressions">
     <h1>Update Expressions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       UpdateExpression[Yield, Await] :
         LeftHandSideExpression[?Yield, ?Await]
         LeftHandSideExpression[?Yield, ?Await] [no LineTerminator here] `++`
@@ -12738,7 +12738,7 @@
   <emu-clause id="sec-unary-operators">
     <h1>Unary Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       UnaryExpression[Yield, Await] :
         UpdateExpression[?Yield, ?Await]
         `delete` UnaryExpression[?Yield, ?Await]
@@ -13054,7 +13054,7 @@
     <h1>Exponentiation Operator</h1>
     <h2>Syntax</h2>
 
-    <emu-grammar>
+    <emu-grammar strict>
       ExponentiationExpression[Yield, Await] :
         UnaryExpression[?Yield, ?Await]
         UpdateExpression[?Yield, ?Await] `**` ExponentiationExpression[?Yield, ?Await]
@@ -13140,7 +13140,7 @@
   <emu-clause id="sec-multiplicative-operators">
     <h1>Multiplicative Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       MultiplicativeExpression[Yield, Await] :
         ExponentiationExpression[?Yield, ?Await]
         MultiplicativeExpression[?Yield, ?Await] MultiplicativeOperator ExponentiationExpression[?Yield, ?Await]
@@ -13282,7 +13282,7 @@
   <emu-clause id="sec-additive-operators">
     <h1>Additive Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       AdditiveExpression[Yield, Await] :
         MultiplicativeExpression[?Yield, ?Await]
         AdditiveExpression[?Yield, ?Await] `+` MultiplicativeExpression[?Yield, ?Await]
@@ -13414,7 +13414,7 @@
   <emu-clause id="sec-bitwise-shift-operators">
     <h1>Bitwise Shift Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       ShiftExpression[Yield, Await] :
         AdditiveExpression[?Yield, ?Await]
         ShiftExpression[?Yield, ?Await] `&lt;&lt;` AdditiveExpression[?Yield, ?Await]
@@ -13532,7 +13532,7 @@
       <p>The result of evaluating a relational operator is always of type Boolean, reflecting whether the relationship named by the operator holds between its two operands.</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       RelationalExpression[In, Yield, Await] :
         ShiftExpression[?Yield, ?Await]
         RelationalExpression[?In, ?Yield, ?Await] `&lt;` ShiftExpression[?Yield, ?Await]
@@ -13669,7 +13669,7 @@
       <p>The result of evaluating an equality operator is always of type Boolean, reflecting whether the relationship named by the operator holds between its two operands.</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       EqualityExpression[In, Yield, Await] :
         RelationalExpression[?In, ?Yield, ?Await]
         EqualityExpression[?In, ?Yield, ?Await] `==` RelationalExpression[?In, ?Yield, ?Await]
@@ -13793,7 +13793,7 @@
   <emu-clause id="sec-binary-bitwise-operators">
     <h1>Binary Bitwise Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       BitwiseANDExpression[In, Yield, Await] :
         EqualityExpression[?In, ?Yield, ?Await]
         BitwiseANDExpression[?In, ?Yield, ?Await] `&amp;` EqualityExpression[?In, ?Yield, ?Await]
@@ -13859,7 +13859,7 @@
   <emu-clause id="sec-binary-logical-operators">
     <h1>Binary Logical Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       LogicalANDExpression[In, Yield, Await] :
         BitwiseORExpression[?In, ?Yield, ?Await]
         LogicalANDExpression[?In, ?Yield, ?Await] `&amp;&amp;` BitwiseORExpression[?In, ?Yield, ?Await]
@@ -13928,7 +13928,7 @@
   <emu-clause id="sec-conditional-operator">
     <h1>Conditional Operator ( `? :` )</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       ConditionalExpression[In, Yield, Await] :
         LogicalORExpression[?In, ?Yield, ?Await]
         LogicalORExpression[?In, ?Yield, ?Await] `?` AssignmentExpression[+In, ?Yield, ?Await] `:` AssignmentExpression[?In, ?Yield, ?Await]
@@ -13978,7 +13978,7 @@
   <emu-clause id="sec-assignment-operators">
     <h1>Assignment Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       AssignmentExpression[In, Yield, Await] :
         ConditionalExpression[?In, ?Yield, ?Await]
         [+Yield] YieldExpression[?In, ?Await]
@@ -14374,7 +14374,7 @@
   <emu-clause id="sec-comma-operator">
     <h1>Comma Operator ( `,` )</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       Expression[In, Yield, Await] :
         AssignmentExpression[?In, ?Yield, ?Await]
         Expression[?In, ?Yield, ?Await] `,` AssignmentExpression[?In, ?Yield, ?Await]
@@ -14421,7 +14421,7 @@
 <emu-clause id="sec-ecmascript-language-statements-and-declarations">
   <h1>ECMAScript Language: Statements and Declarations</h1>
   <h2>Syntax</h2>
-  <emu-grammar>
+  <emu-grammar strict>
     Statement[Yield, Await, Return] :
       BlockStatement[?Yield, ?Await, ?Return]
       VariableStatement[?Yield, ?Await]
@@ -14651,7 +14651,7 @@
   <emu-clause id="sec-block">
     <h1>Block</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       BlockStatement[Yield, Await, Return] :
         Block[?Yield, ?Await, ?Return]
 
@@ -15017,7 +15017,7 @@
         <p>`let` and `const` declarations define variables that are scoped to the running execution context's LexicalEnvironment. The variables are created when their containing Lexical Environment is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         LexicalDeclaration[In, Yield, Await] :
           LetOrConst BindingList[?In, ?Yield, ?Await] `;`
 
@@ -15147,7 +15147,7 @@
         <p>A `var` statement declares variables that are scoped to the running execution context's VariableEnvironment. Var variables are created when their containing Lexical Environment is instantiated and are initialized to *undefined* when created. Within the scope of any VariableEnvironment a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         VariableStatement[Yield, Await] :
           `var` VariableDeclarationList[+In, ?Yield, ?Await] `;`
 
@@ -15252,7 +15252,7 @@
     <emu-clause id="sec-destructuring-binding-patterns">
       <h1>Destructuring Binding Patterns</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         BindingPattern[Yield, Await] :
           ObjectBindingPattern[?Yield, ?Await]
           ArrayBindingPattern[?Yield, ?Await]
@@ -15690,7 +15690,7 @@
   <emu-clause id="sec-empty-statement">
     <h1>Empty Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       EmptyStatement :
         `;`
     </emu-grammar>
@@ -15709,7 +15709,7 @@
   <emu-clause id="sec-expression-statement">
     <h1>Expression Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       ExpressionStatement[Yield, Await] :
         [lookahead &lt;! {`{`, `function`, `async` [no |LineTerminator| here] `function`, `class`, `let [`}] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
@@ -15732,7 +15732,7 @@
   <emu-clause id="sec-if-statement">
     <h1>The `if` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       IfStatement[Yield, Await, Return] :
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` Statement[?Yield, ?Await, ?Return]
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -15870,7 +15870,7 @@
   <emu-clause id="sec-iteration-statements">
     <h1>Iteration Statements</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       IterationStatement[Yield, Await, Return] :
         `do` Statement[?Yield, ?Await, ?Return] `while` `(` Expression[+In, ?Yield, ?Await] `)` `;`
         `while` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -16712,7 +16712,7 @@
   <emu-clause id="sec-continue-statement">
     <h1>The `continue` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       ContinueStatement[Yield, Await] :
         `continue` `;`
         `continue` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
@@ -16768,7 +16768,7 @@
   <emu-clause id="sec-break-statement">
     <h1>The `break` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       BreakStatement[Yield, Await] :
         `break` `;`
         `break` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
@@ -16820,7 +16820,7 @@
   <emu-clause id="sec-return-statement">
     <h1>The `return` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       ReturnStatement[Yield, Await] :
         `return` `;`
         `return` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
@@ -16849,7 +16849,7 @@
   <emu-clause id="sec-with-statement">
     <h1>The `with` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       WithStatement[Yield, Await, Return] :
         `with` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     </emu-grammar>
@@ -16952,7 +16952,7 @@
   <emu-clause id="sec-switch-statement">
     <h1>The `switch` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       SwitchStatement[Yield, Await, Return] :
         `switch` `(` Expression[+In, ?Yield, ?Await] `)` CaseBlock[?Yield, ?Await, ?Return]
 
@@ -17374,7 +17374,7 @@
   <emu-clause id="sec-labelled-statements">
     <h1>Labelled Statements</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       LabelledStatement[Yield, Await, Return] :
         LabelIdentifier[?Yield, ?Await] `:` LabelledItem[?Yield, ?Await, ?Return]
 
@@ -17629,7 +17629,7 @@
   <emu-clause id="sec-throw-statement">
     <h1>The `throw` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       ThrowStatement[Yield, Await] :
         `throw` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
@@ -17650,7 +17650,7 @@
   <emu-clause id="sec-try-statement">
     <h1>The `try` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       TryStatement[Yield, Await, Return] :
         `try` Block[?Yield, ?Await, ?Return] Catch[?Yield, ?Await, ?Return]
         `try` Block[?Yield, ?Await, ?Return] Finally[?Yield, ?Await, ?Return]
@@ -17899,7 +17899,7 @@
   <emu-clause id="sec-debugger-statement">
     <h1>The `debugger` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       DebuggerStatement :
         `debugger` `;`
     </emu-grammar>
@@ -17934,7 +17934,7 @@
   <emu-clause id="sec-function-definitions">
     <h1>Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       FunctionDeclaration[Yield, Await, Default] :
         `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         [+Default] `function` `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
@@ -18450,7 +18450,7 @@
   <emu-clause id="sec-arrow-function-definitions">
     <h1>Arrow Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       ArrowFunction[In, Yield, Await] :
         ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=&gt;` ConciseBody[?In]
 
@@ -18708,7 +18708,7 @@
   <emu-clause id="sec-method-definitions">
     <h1>Method Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       MethodDefinition[Yield, Await] :
         PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         GeneratorMethod[?Yield, ?Await]
@@ -18894,7 +18894,7 @@
   <emu-clause id="sec-generator-function-definitions">
     <h1>Generator Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       GeneratorMethod[Yield, Await] :
         `*` PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, ~Await] `)` `{` GeneratorBody `}`
 
@@ -19236,7 +19236,7 @@
   <emu-clause id="sec-class-definitions">
     <h1>Class Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       ClassDeclaration[Yield, Await, Default] :
         `class` BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
         [+Default] `class` ClassTail[?Yield, ?Await]
@@ -19610,7 +19610,7 @@
   <emu-clause id="sec-async-function-definitions">
     <h1>Async Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       AsyncFunctionDeclaration[Yield, Await, Default] :
         `async` [no LineTerminator here] `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
         [+Default] `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
@@ -19900,7 +19900,7 @@
   <emu-clause id="sec-async-arrow-function-definitions">
     <h1>Async Arrow Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       AsyncArrowFunction[In, Yield, Await] :
         `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
         CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
@@ -20478,7 +20478,7 @@
   <emu-clause id="sec-scripts">
     <h1>Scripts</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       Script :
         ScriptBody?
 
@@ -20781,7 +20781,7 @@
   <emu-clause id="sec-modules">
     <h1>Modules</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar strict>
       Module :
         ModuleBody?
 
@@ -22025,7 +22025,7 @@
     <emu-clause id="sec-imports">
       <h1>Imports</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         ImportDeclaration :
           `import` ImportClause FromClause `;`
           `import` ModuleSpecifier `;`
@@ -22204,7 +22204,7 @@
     <emu-clause id="sec-exports">
       <h1>Exports</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         ExportDeclaration :
           `export` `*` FromClause `;`
           `export` ExportClause FromClause `;`
@@ -23061,7 +23061,7 @@
         <p>where the italicized names represent components and &ldquo;`:`&rdquo;, &ldquo;`/`&rdquo;, &ldquo;`;`&rdquo; and &ldquo;`?`&rdquo; are reserved for use as separators. The `encodeURI` and `decodeURI` functions are intended to work with complete URIs; they assume that any reserved code units in the URI are intended to have special meaning and so are not encoded. The `encodeURIComponent` and `decodeURIComponent` functions are intended to work with the individual component parts of a URI; they assume that any reserved code units represent text and so must be encoded so that they are not interpreted as reserved code units when the component is part of a complete URI.</p>
         <p>The following lexical grammar specifies the form of encoded URIs.</p>
         <h2>Syntax</h2>
-        <emu-grammar>
+        <emu-grammar strict>
           uri :::
             uriCharacters?
 
@@ -28640,7 +28640,7 @@ THH:mm:ss.sss
       <h1>Patterns</h1>
       <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         Pattern[U] ::
           Disjunction[?U]
 
@@ -28699,7 +28699,7 @@ THH:mm:ss.sss
         CharacterEscape[U] ::
           ControlEscape
           `c` ControlLetter
-          `0` [lookahead &lt;! DecimalDigit]
+          `0` [lookahead != DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?U]
           IdentityEscape[?U]
@@ -28720,7 +28720,7 @@ THH:mm:ss.sss
           [+U] `u{` HexDigits `}`
       </emu-grammar>
       <p>Each `\\u` |TrailSurrogate| for which the choice of associated `u` |LeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |LeadSurrogate| that would otherwise have no corresponding `\\u` |TrailSurrogate|.</p>
-      <emu-grammar>
+      <emu-grammar strict>
         LeadSurrogate ::
           Hex4Digits [> but only if the SV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
 
@@ -28736,7 +28736,7 @@ THH:mm:ss.sss
           [~U] SourceCharacter but not UnicodeIDContinue
 
         DecimalEscape ::
-          NonZeroDigit DecimalDigits? [lookahead &lt;! DecimalDigit]
+          NonZeroDigit DecimalDigits? [lookahead != DecimalDigit]
 
         CharacterClassEscape :: one of
           `d` `D` `s` `S` `w` `W`
@@ -38357,7 +38357,7 @@ THH:mm:ss.sss
       <h1>Numeric Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-numeric-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         NumericLiteral ::
           DecimalLiteral
           BinaryIntegerLiteral
@@ -38430,7 +38430,7 @@ THH:mm:ss.sss
       <h1>String Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-string-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         EscapeSequence ::
           CharacterEscapeSequence
           LegacyOctalEscapeSequence
@@ -38438,8 +38438,8 @@ THH:mm:ss.sss
           UnicodeEscapeSequence
 
         LegacyOctalEscapeSequence ::
-          OctalDigit [lookahead &lt;! OctalDigit]
-          ZeroToThree OctalDigit [lookahead &lt;! OctalDigit]
+          OctalDigit [lookahead != OctalDigit]
+          ZeroToThree OctalDigit [lookahead != OctalDigit]
           FourToSeven OctalDigit
           ZeroToThree OctalDigit OctalDigit
 
@@ -38503,7 +38503,7 @@ THH:mm:ss.sss
       <h1>HTML-like Comments</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source code using the goal symbol |Module|:</p>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         Comment ::
           MultiLineComment
           SingleLineComment
@@ -38558,7 +38558,7 @@ THH:mm:ss.sss
       <p>The syntax of <emu-xref href="#sec-patterns"></emu-xref> is modified and extended as follows. These changes introduce ambiguities that are broken by the ordering of grammar productions and by contextual information. When parsing using the following grammar, each alternative is considered only if previous production alternatives do not match.</p>
       <p>This alternative pattern grammar and semantics only changes the syntax and semantics of BMP patterns. The following grammar extensions include productions parameterized with the [U] parameter. However, none of these extensions change the syntax of Unicode patterns recognized when parsing with the [U] parameter present on the goal symbol.</p>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar strict>
         Term[U] ::
           [+U] Assertion[+U]
           [+U] Atom[+U]
@@ -38608,7 +38608,7 @@ THH:mm:ss.sss
         CharacterEscape[U] ::
           ControlEscape
           `c` ControlLetter
-          `0` [lookahead &lt;! DecimalDigit]
+          `0` [lookahead != DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?U]
           [~U] LegacyOctalEscapeSequence

--- a/spec.html
+++ b/spec.html
@@ -3457,7 +3457,7 @@
           <p>The terminal symbols of this grammar are all composed of Unicode BMP code points so the result will be *NaN* if the string contains the UTF-16 encoding of any supplementary code points or any unpaired surrogate code points.</p>
         </emu-note>
         <h2>Syntax</h2>
-        <emu-grammar strict>
+        <emu-grammar definition>
           StringNumericLiteral :::
             StrWhiteSpace?
             StrWhiteSpace? StrNumericLiteral StrWhiteSpace?
@@ -9175,7 +9175,7 @@
   <emu-clause id="sec-source-text">
     <h1>Source Text</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       SourceCharacter ::
         &gt; any Unicode code point
     </emu-grammar>
@@ -9285,7 +9285,7 @@
     </code></pre>
   </emu-note>
   <h2>Syntax</h2>
-  <emu-grammar strict>
+  <emu-grammar definition>
     InputElementDiv ::
       WhiteSpace
       LineTerminator
@@ -9495,7 +9495,7 @@
       <p>Other than for the code points listed in <emu-xref href="#table-32"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       WhiteSpace ::
         &lt;TAB&gt;
         &lt;VT&gt;
@@ -9577,7 +9577,7 @@
     </emu-table>
     <p>Only the Unicode code points in <emu-xref href="#table-33"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-32"></emu-xref>. The sequence &lt;CR&gt;&lt;LF&gt; is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       LineTerminator ::
         &lt;LF&gt;
         &lt;CR&gt;
@@ -9600,7 +9600,7 @@
     <p>Because a single-line comment can contain any Unicode code point except a |LineTerminator| code point, and because of the general rule that a token is always as long as possible, a single-line comment always consists of all code points from the `//` marker to the end of the line. However, the |LineTerminator| at the end of the line is not considered to be part of the single-line comment; it is recognized separately by the lexical grammar and becomes part of the stream of input elements for the syntactic grammar. This point is very important, because it implies that the presence or absence of single-line comments does not affect the process of automatic semicolon insertion (see <emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>).</p>
     <p>Comments behave like white space and are discarded except that, if a |MultiLineComment| contains a line terminator code point, then the entire comment is considered to be a |LineTerminator| for purposes of parsing by the syntactic grammar.</p>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       Comment ::
         MultiLineComment
         SingleLineComment
@@ -9637,7 +9637,7 @@
   <emu-clause id="sec-tokens">
     <h1>Tokens</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       CommonToken ::
         IdentifierName
         Punctuator
@@ -9660,7 +9660,7 @@
     <p>Unicode escape sequences are permitted in an |IdentifierName|, where they contribute a single Unicode code point to the |IdentifierName|. The code point is expressed by the |HexDigits| of the |UnicodeEscapeSequence| (see <emu-xref href="#sec-literals-string-literals"></emu-xref>). The `\\` preceding the |UnicodeEscapeSequence| and the `u` and `{ }` code units, if they appear, do not contribute code points to the |IdentifierName|. A |UnicodeEscapeSequence| cannot be used to put a code point into an |IdentifierName| that would otherwise be illegal. In other words, if a `\\` |UnicodeEscapeSequence| sequence were replaced by the |SourceCharacter| it contributes, the result must still be a valid |IdentifierName| that has the exact same sequence of |SourceCharacter| elements as the original |IdentifierName|. All interpretations of |IdentifierName| within this specification are based upon their actual code points regardless of whether or not an escape sequence was used to contribute any particular code point.</p>
     <p>Two |IdentifierName|s that are canonically equivalent according to the Unicode standard are <em>not</em> equal unless, after replacement of each |UnicodeEscapeSequence|, they are represented by the exact same sequence of code points.</p>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       IdentifierName ::
         IdentifierStart
         IdentifierName IdentifierPart
@@ -9731,7 +9731,7 @@
       <h1>Reserved Words</h1>
       <p>A reserved word is an |IdentifierName| that cannot be used as an |Identifier|.</p>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         ReservedWord ::
           Keyword
           FutureReservedWord
@@ -9747,7 +9747,7 @@
         <h1>Keywords</h1>
         <p>The following tokens are ECMAScript keywords and may not be used as |Identifier|s in ECMAScript programs.</p>
         <h2>Syntax</h2>
-        <emu-grammar strict>
+        <emu-grammar definition>
           Keyword :: one of
             `await`
             `break`
@@ -9774,7 +9774,7 @@
         <h1>Future Reserved Words</h1>
         <p>The following tokens are reserved for use as keywords in future language extensions.</p>
         <h2>Syntax</h2>
-        <emu-grammar strict>
+        <emu-grammar definition>
           FutureReservedWord ::
             `enum`
         </emu-grammar>
@@ -9821,7 +9821,7 @@
   <emu-clause id="sec-punctuators">
     <h1>Punctuators</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       Punctuator :: one of
         `{` `(` `)` `[` `]`
         `.` `...` `;` `,`
@@ -9854,7 +9854,7 @@
     <emu-clause id="sec-null-literals">
       <h1>Null Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         NullLiteral ::
           `null`
       </emu-grammar>
@@ -9864,7 +9864,7 @@
     <emu-clause id="sec-boolean-literals">
       <h1>Boolean Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         BooleanLiteral ::
           `true`
           `false`
@@ -9875,7 +9875,7 @@
     <emu-clause id="sec-literals-numeric-literals">
       <h1>Numeric Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         NumericLiteral ::
           DecimalLiteral
           BinaryIntegerLiteral
@@ -10123,7 +10123,7 @@
         <p>A string literal is zero or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encoding"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         StringLiteral ::
           `"` DoubleStringCharacters? `"`
           `'` SingleStringCharacters? `'`
@@ -10154,7 +10154,7 @@
           UnicodeEscapeSequence
       </emu-grammar>
       <p>A conforming implementation, when processing strict mode code, must not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.</p>
-      <emu-grammar strict>
+      <emu-grammar definition>
         CharacterEscapeSequence ::
           SingleEscapeCharacter
           NonEscapeCharacter
@@ -10452,7 +10452,7 @@
       <p>The productions below describe the syntax for a regular expression literal and are used by the input element scanner to find the end of the regular expression literal. The source text comprising the |RegularExpressionBody| and the |RegularExpressionFlags| are subsequently parsed again using the more stringent ECMAScript Regular Expression grammar (<emu-xref href="#sec-patterns"></emu-xref>).</p>
       <p>An implementation may extend the ECMAScript Regular Expression grammar defined in <emu-xref href="#sec-patterns"></emu-xref>, but it must not extend the |RegularExpressionBody| and |RegularExpressionFlags| productions defined below or the productions used by these productions.</p>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         RegularExpressionLiteral ::
           `/` RegularExpressionBody `/` RegularExpressionFlags
 
@@ -10532,7 +10532,7 @@
     <emu-clause id="sec-template-literal-lexical-components">
       <h1>Template Literal Lexical Components</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         Template ::
           NoSubstitutionTemplate
           TemplateHead
@@ -10882,7 +10882,7 @@
   <emu-clause id="sec-identifiers">
     <h1>Identifiers</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       IdentifierReference[Yield, Await] :
         Identifier
         [~Yield] `yield`
@@ -11124,7 +11124,7 @@
   <emu-clause id="sec-primary-expression">
     <h1>Primary Expression</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       PrimaryExpression[Yield, Await] :
         `this`
         IdentifierReference[?Yield, ?Await]
@@ -11287,7 +11287,7 @@
     <emu-clause id="sec-primary-expression-literals">
       <h1>Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         Literal :
           NullLiteral
           BooleanLiteral
@@ -11326,7 +11326,7 @@
       </emu-note>
       <p>Array elements may be elided at the beginning, middle or end of the element list. Whenever a comma in the element list is not preceded by an |AssignmentExpression| (i.e., a comma at the beginning or after another comma), the missing array element contributes to the length of the Array and increases the index of subsequent elements. Elided array elements are not defined. If an element is elided at the end of an array, that element does not contribute to the length of the Array.</p>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         ArrayLiteral[Yield, Await] :
           `[` Elision? `]`
           `[` ElementList[?Yield, ?Await] `]`
@@ -11454,7 +11454,7 @@
         <p>An object initializer is an expression describing the initialization of an Object, written in a form resembling a literal. It is a list of zero or more pairs of property keys and associated values, enclosed in curly brackets. The values need not be literals; they are evaluated each time the object initializer is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         ObjectLiteral[Yield, Await] :
           `{` `}`
           `{` PropertyDefinitionList[?Yield, ?Await] `}`
@@ -11732,7 +11732,7 @@
     <emu-clause id="sec-template-literals">
       <h1>Template Literals</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         TemplateLiteral[Yield, Await] :
           NoSubstitutionTemplate
           TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await]
@@ -12030,7 +12030,7 @@
   <emu-clause id="sec-left-hand-side-expressions">
     <h1>Left-Hand-Side Expressions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       MemberExpression[Yield, Await] :
         PrimaryExpression[?Yield, ?Await]
         MemberExpression[?Yield, ?Await] `[` Expression[+In, ?Yield, ?Await] `]`
@@ -12594,7 +12594,7 @@
   <emu-clause id="sec-update-expressions">
     <h1>Update Expressions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       UpdateExpression[Yield, Await] :
         LeftHandSideExpression[?Yield, ?Await]
         LeftHandSideExpression[?Yield, ?Await] [no LineTerminator here] `++`
@@ -12738,7 +12738,7 @@
   <emu-clause id="sec-unary-operators">
     <h1>Unary Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       UnaryExpression[Yield, Await] :
         UpdateExpression[?Yield, ?Await]
         `delete` UnaryExpression[?Yield, ?Await]
@@ -13054,7 +13054,7 @@
     <h1>Exponentiation Operator</h1>
     <h2>Syntax</h2>
 
-    <emu-grammar strict>
+    <emu-grammar definition>
       ExponentiationExpression[Yield, Await] :
         UnaryExpression[?Yield, ?Await]
         UpdateExpression[?Yield, ?Await] `**` ExponentiationExpression[?Yield, ?Await]
@@ -13140,7 +13140,7 @@
   <emu-clause id="sec-multiplicative-operators">
     <h1>Multiplicative Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       MultiplicativeExpression[Yield, Await] :
         ExponentiationExpression[?Yield, ?Await]
         MultiplicativeExpression[?Yield, ?Await] MultiplicativeOperator ExponentiationExpression[?Yield, ?Await]
@@ -13282,7 +13282,7 @@
   <emu-clause id="sec-additive-operators">
     <h1>Additive Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       AdditiveExpression[Yield, Await] :
         MultiplicativeExpression[?Yield, ?Await]
         AdditiveExpression[?Yield, ?Await] `+` MultiplicativeExpression[?Yield, ?Await]
@@ -13414,7 +13414,7 @@
   <emu-clause id="sec-bitwise-shift-operators">
     <h1>Bitwise Shift Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       ShiftExpression[Yield, Await] :
         AdditiveExpression[?Yield, ?Await]
         ShiftExpression[?Yield, ?Await] `&lt;&lt;` AdditiveExpression[?Yield, ?Await]
@@ -13532,7 +13532,7 @@
       <p>The result of evaluating a relational operator is always of type Boolean, reflecting whether the relationship named by the operator holds between its two operands.</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       RelationalExpression[In, Yield, Await] :
         ShiftExpression[?Yield, ?Await]
         RelationalExpression[?In, ?Yield, ?Await] `&lt;` ShiftExpression[?Yield, ?Await]
@@ -13669,7 +13669,7 @@
       <p>The result of evaluating an equality operator is always of type Boolean, reflecting whether the relationship named by the operator holds between its two operands.</p>
     </emu-note>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       EqualityExpression[In, Yield, Await] :
         RelationalExpression[?In, ?Yield, ?Await]
         EqualityExpression[?In, ?Yield, ?Await] `==` RelationalExpression[?In, ?Yield, ?Await]
@@ -13793,7 +13793,7 @@
   <emu-clause id="sec-binary-bitwise-operators">
     <h1>Binary Bitwise Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       BitwiseANDExpression[In, Yield, Await] :
         EqualityExpression[?In, ?Yield, ?Await]
         BitwiseANDExpression[?In, ?Yield, ?Await] `&amp;` EqualityExpression[?In, ?Yield, ?Await]
@@ -13859,7 +13859,7 @@
   <emu-clause id="sec-binary-logical-operators">
     <h1>Binary Logical Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       LogicalANDExpression[In, Yield, Await] :
         BitwiseORExpression[?In, ?Yield, ?Await]
         LogicalANDExpression[?In, ?Yield, ?Await] `&amp;&amp;` BitwiseORExpression[?In, ?Yield, ?Await]
@@ -13928,7 +13928,7 @@
   <emu-clause id="sec-conditional-operator">
     <h1>Conditional Operator ( `? :` )</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       ConditionalExpression[In, Yield, Await] :
         LogicalORExpression[?In, ?Yield, ?Await]
         LogicalORExpression[?In, ?Yield, ?Await] `?` AssignmentExpression[+In, ?Yield, ?Await] `:` AssignmentExpression[?In, ?Yield, ?Await]
@@ -13978,7 +13978,7 @@
   <emu-clause id="sec-assignment-operators">
     <h1>Assignment Operators</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       AssignmentExpression[In, Yield, Await] :
         ConditionalExpression[?In, ?Yield, ?Await]
         [+Yield] YieldExpression[?In, ?Await]
@@ -14374,7 +14374,7 @@
   <emu-clause id="sec-comma-operator">
     <h1>Comma Operator ( `,` )</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       Expression[In, Yield, Await] :
         AssignmentExpression[?In, ?Yield, ?Await]
         Expression[?In, ?Yield, ?Await] `,` AssignmentExpression[?In, ?Yield, ?Await]
@@ -14421,7 +14421,7 @@
 <emu-clause id="sec-ecmascript-language-statements-and-declarations">
   <h1>ECMAScript Language: Statements and Declarations</h1>
   <h2>Syntax</h2>
-  <emu-grammar strict>
+  <emu-grammar definition>
     Statement[Yield, Await, Return] :
       BlockStatement[?Yield, ?Await, ?Return]
       VariableStatement[?Yield, ?Await]
@@ -14651,7 +14651,7 @@
   <emu-clause id="sec-block">
     <h1>Block</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       BlockStatement[Yield, Await, Return] :
         Block[?Yield, ?Await, ?Return]
 
@@ -15017,7 +15017,7 @@
         <p>`let` and `const` declarations define variables that are scoped to the running execution context's LexicalEnvironment. The variables are created when their containing Lexical Environment is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         LexicalDeclaration[In, Yield, Await] :
           LetOrConst BindingList[?In, ?Yield, ?Await] `;`
 
@@ -15147,7 +15147,7 @@
         <p>A `var` statement declares variables that are scoped to the running execution context's VariableEnvironment. Var variables are created when their containing Lexical Environment is instantiated and are initialized to *undefined* when created. Within the scope of any VariableEnvironment a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
       </emu-note>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         VariableStatement[Yield, Await] :
           `var` VariableDeclarationList[+In, ?Yield, ?Await] `;`
 
@@ -15252,7 +15252,7 @@
     <emu-clause id="sec-destructuring-binding-patterns">
       <h1>Destructuring Binding Patterns</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         BindingPattern[Yield, Await] :
           ObjectBindingPattern[?Yield, ?Await]
           ArrayBindingPattern[?Yield, ?Await]
@@ -15690,7 +15690,7 @@
   <emu-clause id="sec-empty-statement">
     <h1>Empty Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       EmptyStatement :
         `;`
     </emu-grammar>
@@ -15709,7 +15709,7 @@
   <emu-clause id="sec-expression-statement">
     <h1>Expression Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       ExpressionStatement[Yield, Await] :
         [lookahead &lt;! {`{`, `function`, `async` [no |LineTerminator| here] `function`, `class`, `let [`}] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
@@ -15732,7 +15732,7 @@
   <emu-clause id="sec-if-statement">
     <h1>The `if` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       IfStatement[Yield, Await, Return] :
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` Statement[?Yield, ?Await, ?Return]
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -15870,7 +15870,7 @@
   <emu-clause id="sec-iteration-statements">
     <h1>Iteration Statements</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       IterationStatement[Yield, Await, Return] :
         `do` Statement[?Yield, ?Await, ?Return] `while` `(` Expression[+In, ?Yield, ?Await] `)` `;`
         `while` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -16712,7 +16712,7 @@
   <emu-clause id="sec-continue-statement">
     <h1>The `continue` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       ContinueStatement[Yield, Await] :
         `continue` `;`
         `continue` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
@@ -16768,7 +16768,7 @@
   <emu-clause id="sec-break-statement">
     <h1>The `break` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       BreakStatement[Yield, Await] :
         `break` `;`
         `break` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
@@ -16820,7 +16820,7 @@
   <emu-clause id="sec-return-statement">
     <h1>The `return` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       ReturnStatement[Yield, Await] :
         `return` `;`
         `return` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
@@ -16849,7 +16849,7 @@
   <emu-clause id="sec-with-statement">
     <h1>The `with` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       WithStatement[Yield, Await, Return] :
         `with` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     </emu-grammar>
@@ -16952,7 +16952,7 @@
   <emu-clause id="sec-switch-statement">
     <h1>The `switch` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       SwitchStatement[Yield, Await, Return] :
         `switch` `(` Expression[+In, ?Yield, ?Await] `)` CaseBlock[?Yield, ?Await, ?Return]
 
@@ -17374,7 +17374,7 @@
   <emu-clause id="sec-labelled-statements">
     <h1>Labelled Statements</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       LabelledStatement[Yield, Await, Return] :
         LabelIdentifier[?Yield, ?Await] `:` LabelledItem[?Yield, ?Await, ?Return]
 
@@ -17629,7 +17629,7 @@
   <emu-clause id="sec-throw-statement">
     <h1>The `throw` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       ThrowStatement[Yield, Await] :
         `throw` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
@@ -17650,7 +17650,7 @@
   <emu-clause id="sec-try-statement">
     <h1>The `try` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       TryStatement[Yield, Await, Return] :
         `try` Block[?Yield, ?Await, ?Return] Catch[?Yield, ?Await, ?Return]
         `try` Block[?Yield, ?Await, ?Return] Finally[?Yield, ?Await, ?Return]
@@ -17899,7 +17899,7 @@
   <emu-clause id="sec-debugger-statement">
     <h1>The `debugger` Statement</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       DebuggerStatement :
         `debugger` `;`
     </emu-grammar>
@@ -17934,7 +17934,7 @@
   <emu-clause id="sec-function-definitions">
     <h1>Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       FunctionDeclaration[Yield, Await, Default] :
         `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         [+Default] `function` `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
@@ -18450,7 +18450,7 @@
   <emu-clause id="sec-arrow-function-definitions">
     <h1>Arrow Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       ArrowFunction[In, Yield, Await] :
         ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=&gt;` ConciseBody[?In]
 
@@ -18708,7 +18708,7 @@
   <emu-clause id="sec-method-definitions">
     <h1>Method Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       MethodDefinition[Yield, Await] :
         PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         GeneratorMethod[?Yield, ?Await]
@@ -18894,7 +18894,7 @@
   <emu-clause id="sec-generator-function-definitions">
     <h1>Generator Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       GeneratorMethod[Yield, Await] :
         `*` PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, ~Await] `)` `{` GeneratorBody `}`
 
@@ -19236,7 +19236,7 @@
   <emu-clause id="sec-class-definitions">
     <h1>Class Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       ClassDeclaration[Yield, Await, Default] :
         `class` BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
         [+Default] `class` ClassTail[?Yield, ?Await]
@@ -19610,7 +19610,7 @@
   <emu-clause id="sec-async-function-definitions">
     <h1>Async Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       AsyncFunctionDeclaration[Yield, Await, Default] :
         `async` [no LineTerminator here] `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
         [+Default] `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
@@ -19900,7 +19900,7 @@
   <emu-clause id="sec-async-arrow-function-definitions">
     <h1>Async Arrow Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       AsyncArrowFunction[In, Yield, Await] :
         `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
         CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
@@ -20478,7 +20478,7 @@
   <emu-clause id="sec-scripts">
     <h1>Scripts</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       Script :
         ScriptBody?
 
@@ -20781,7 +20781,7 @@
   <emu-clause id="sec-modules">
     <h1>Modules</h1>
     <h2>Syntax</h2>
-    <emu-grammar strict>
+    <emu-grammar definition>
       Module :
         ModuleBody?
 
@@ -22025,7 +22025,7 @@
     <emu-clause id="sec-imports">
       <h1>Imports</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         ImportDeclaration :
           `import` ImportClause FromClause `;`
           `import` ModuleSpecifier `;`
@@ -22204,7 +22204,7 @@
     <emu-clause id="sec-exports">
       <h1>Exports</h1>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         ExportDeclaration :
           `export` `*` FromClause `;`
           `export` ExportClause FromClause `;`
@@ -23061,7 +23061,7 @@
         <p>where the italicized names represent components and &ldquo;`:`&rdquo;, &ldquo;`/`&rdquo;, &ldquo;`;`&rdquo; and &ldquo;`?`&rdquo; are reserved for use as separators. The `encodeURI` and `decodeURI` functions are intended to work with complete URIs; they assume that any reserved code units in the URI are intended to have special meaning and so are not encoded. The `encodeURIComponent` and `decodeURIComponent` functions are intended to work with the individual component parts of a URI; they assume that any reserved code units represent text and so must be encoded so that they are not interpreted as reserved code units when the component is part of a complete URI.</p>
         <p>The following lexical grammar specifies the form of encoded URIs.</p>
         <h2>Syntax</h2>
-        <emu-grammar strict>
+        <emu-grammar definition>
           uri :::
             uriCharacters?
 
@@ -28640,7 +28640,7 @@ THH:mm:ss.sss
       <h1>Patterns</h1>
       <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         Pattern[U] ::
           Disjunction[?U]
 
@@ -28720,7 +28720,7 @@ THH:mm:ss.sss
           [+U] `u{` HexDigits `}`
       </emu-grammar>
       <p>Each `\\u` |TrailSurrogate| for which the choice of associated `u` |LeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |LeadSurrogate| that would otherwise have no corresponding `\\u` |TrailSurrogate|.</p>
-      <emu-grammar strict>
+      <emu-grammar definition>
         LeadSurrogate ::
           Hex4Digits [> but only if the SV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
 
@@ -38357,7 +38357,7 @@ THH:mm:ss.sss
       <h1>Numeric Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-numeric-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         NumericLiteral ::
           DecimalLiteral
           BinaryIntegerLiteral
@@ -38430,7 +38430,7 @@ THH:mm:ss.sss
       <h1>String Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-string-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         EscapeSequence ::
           CharacterEscapeSequence
           LegacyOctalEscapeSequence
@@ -38503,7 +38503,7 @@ THH:mm:ss.sss
       <h1>HTML-like Comments</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source code using the goal symbol |Module|:</p>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         Comment ::
           MultiLineComment
           SingleLineComment
@@ -38558,7 +38558,7 @@ THH:mm:ss.sss
       <p>The syntax of <emu-xref href="#sec-patterns"></emu-xref> is modified and extended as follows. These changes introduce ambiguities that are broken by the ordering of grammar productions and by contextual information. When parsing using the following grammar, each alternative is considered only if previous production alternatives do not match.</p>
       <p>This alternative pattern grammar and semantics only changes the syntax and semantics of BMP patterns. The following grammar extensions include productions parameterized with the [U] parameter. However, none of these extensions change the syntax of Unicode patterns recognized when parsing with the [U] parameter present on the goal symbol.</p>
       <h2>Syntax</h2>
-      <emu-grammar strict>
+      <emu-grammar definition>
         Term[U] ::
           [+U] Assertion[+U]
           [+U] Atom[+U]

--- a/spec.html
+++ b/spec.html
@@ -10149,7 +10149,7 @@
 
         EscapeSequence ::
           CharacterEscapeSequence
-          `0` [lookahead != DecimalDigit]
+          `0` [lookahead &lt;! DecimalDigit]
           HexEscapeSequence
           UnicodeEscapeSequence
       </emu-grammar>
@@ -28699,7 +28699,7 @@ THH:mm:ss.sss
         CharacterEscape[U] ::
           ControlEscape
           `c` ControlLetter
-          `0` [lookahead != DecimalDigit]
+          `0` [lookahead &lt;! DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?U]
           IdentityEscape[?U]
@@ -28736,7 +28736,7 @@ THH:mm:ss.sss
           [~U] SourceCharacter but not UnicodeIDContinue
 
         DecimalEscape ::
-          NonZeroDigit DecimalDigits? [lookahead != DecimalDigit]
+          NonZeroDigit DecimalDigits? [lookahead &lt;! DecimalDigit]
 
         CharacterClassEscape :: one of
           `d` `D` `s` `S` `w` `W`
@@ -38438,8 +38438,8 @@ THH:mm:ss.sss
           UnicodeEscapeSequence
 
         LegacyOctalEscapeSequence ::
-          OctalDigit [lookahead != OctalDigit]
-          ZeroToThree OctalDigit [lookahead != OctalDigit]
+          OctalDigit [lookahead &lt;! OctalDigit]
+          ZeroToThree OctalDigit [lookahead &lt;! OctalDigit]
           FourToSeven OctalDigit
           ZeroToThree OctalDigit OctalDigit
 
@@ -38608,7 +38608,7 @@ THH:mm:ss.sss
         CharacterEscape[U] ::
           ControlEscape
           `c` ControlLetter
-          `0` [lookahead != DecimalDigit]
+          `0` [lookahead &lt;! DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?U]
           [~U] LegacyOctalEscapeSequence


### PR DESCRIPTION
The ecmarkup-vscode plugin can perform some static verification of grammar during editing, but it needs to be able to distinguish between `emu-grammar` elements that add definitive grammar to the document vs. elements that are used for examples or static semantics. To support this, ecmarkup-vscode can recognize a `strict` or `relaxed` parameter in any `emu-grammar` element, as well as a `grammar: 'strict'` or `grammar: 'relaxed'` property of the document metadata. `strict` elements are checked while `relaxed` elements are not. The `grammar` metadata property sets the default for the document for any `emu-grammar` elements without either of these attributes, and the default for any spec document is `relaxed`.

This PR adds a `strict` attribute to each `emu-grammar` element that contributes syntax directly to the language. The `strict` attribute does not effect emit in any way.

~This PR also fixes several places in the grammar that were written as `[lookahead <! DecimalDigit]` (using the `<!` grammarkdown sigil indicating "not in set") that should have been written as `[lookahead != DecimalDigit]`. This inconsistency was discovered once `strict` checking was enabled for the grammar. This change _does_ affect output and should be considered carefully. If it is intended that `[lookahead <! DecimialDigit]` should be valid in grammarkdown please let me know and I can make the change there.~

*edit: support for* `[lookahead <! NonTerminal]` *at check time has been fixed in grammarkdown 1.0.8*
