### PR TITLE
refactor EvaluateCall/EvaluateDirectCall

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12363,41 +12363,34 @@
           1. Let _func_ be ? GetValue(_ref_).
           1. If Type(_ref_) is Reference and IsPropertyReference(_ref_) is *false* and GetReferencedName(_ref_) is `"eval"`, then
             1. If SameValue(_func_, %eval%) is *true*, then
-              1. Let _argList_ be ? ArgumentListEvaluation(_arguments_).
+              1. Let _argList_ be ArgumentListEvaluation of _arguments_.
+              1. ReturnIfAbrupt(_argList_).
               1. If _argList_ has no elements, return *undefined*.
               1. Let _evalText_ be the first element of _argList_.
               1. If the source code matching this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
               1. Let _evalRealm_ be the current Realm Record.
               1. Perform ? HostEnsureCanCompileStrings(_evalRealm_, _evalRealm_).
               1. Return ? PerformEval(_evalText_, _evalRealm_, _strictCaller_, *true*).
-          1. If Type(_ref_) is Reference, then
-            1. If IsPropertyReference(_ref_) is *true*, then
-              1. Let _thisValue_ be GetThisValue(_ref_).
-            1. Else the base of _ref_ is an Environment Record,
-              1. Let _refEnv_ be GetBase(_ref_).
-              1. Let _thisValue_ be _refEnv_.WithBaseObject().
-          1. Else Type(_ref_) is not Reference,
-            1. Let _thisValue_ be *undefined*.
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
-          1. Return ? EvaluateDirectCall(_func_, _thisValue_, _arguments_, _tailCall_).
+          1. Return ? EvaluateCall(_func_, _ref_, _arguments_, _tailCall_).
         </emu-alg>
         <p>A |CallExpression| evaluation that executes step 6.a.vii is a <dfn>direct eval</dfn>.</p>
         <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |CallExpression|.
+          1. Let _func_ be ? GetValue(_ref_).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
-          1. Return ? EvaluateCall(_ref_, |Arguments|, _tailCall_).
+          1. Return ? EvaluateCall(_func_, _ref_, |Arguments|, _tailCall_).
         </emu-alg>
       </emu-clause>
 
       <!-- es6num="12.3.4.2" -->
       <emu-clause id="sec-evaluatecall" aoid="EvaluateCall">
-        <h1>Runtime Semantics: EvaluateCall( _ref_, _arguments_, _tailPosition_ )</h1>
-        <p>The abstract operation EvaluateCall takes as arguments a value _ref_, a Parse Node _arguments_, and a Boolean argument _tailPosition_. It performs the following steps:</p>
+        <h1>Runtime Semantics: EvaluateCall(_func_, _ref_, _arguments_, _tailPosition_ )</h1>
+        <p>The abstract operation EvaluateCall takes as arguments a value _func_, a value _ref_, a Parse Node _arguments_, and a Boolean argument _tailPosition_. It performs the following steps:</p>
         <emu-alg>
-          1. Let _func_ be ? GetValue(_ref_).
           1. If Type(_ref_) is Reference, then
             1. If IsPropertyReference(_ref_) is *true*, then
               1. Let _thisValue_ be GetThisValue(_ref_).
@@ -12406,16 +12399,8 @@
               1. Let _thisValue_ be _refEnv_.WithBaseObject().
           1. Else Type(_ref_) is not Reference,
             1. Let _thisValue_ be *undefined*.
-          1. Return ? EvaluateDirectCall(_func_, _thisValue_, _arguments_, _tailPosition_).
-        </emu-alg>
-      </emu-clause>
-
-      <!-- es6num="12.3.4.3" -->
-      <emu-clause id="sec-evaluatedirectcall" aoid="EvaluateDirectCall">
-        <h1>Runtime Semantics: EvaluateDirectCall( _func_, _thisValue_, _arguments_, _tailPosition_ )</h1>
-        <p>The abstract operation EvaluateDirectCall takes as arguments a value _func_, a value _thisValue_, a Parse Node _arguments_, and a Boolean argument _tailPosition_. It performs the following steps:</p>
-        <emu-alg>
-          1. Let _argList_ be ? ArgumentListEvaluation(_arguments_).
+          1. Let _argList_ be ArgumentListEvaluation of _arguments_.
+          1. ReturnIfAbrupt(_argList_).
           1. If Type(_func_) is not Object, throw a *TypeError* exception.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
           1. If _tailPosition_ is *true*, perform PrepareForTailCall().
@@ -12561,16 +12546,18 @@
         <emu-grammar>MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
         <emu-alg>
           1. Let _tagRef_ be the result of evaluating |MemberExpression|.
+          1. Let _tagFunc_ be ? GetValue(_tagRef_).
           1. Let _thisCall_ be this |MemberExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
-          1. Return ? EvaluateCall(_tagRef_, |TemplateLiteral|, _tailCall_).
+          1. Return ? EvaluateCall(_tagFunc_, _tagRef_, |TemplateLiteral|, _tailCall_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression TemplateLiteral</emu-grammar>
         <emu-alg>
           1. Let _tagRef_ be the result of evaluating |CallExpression|.
+          1. Let _tagFunc_ be ? GetValue(_tagRef_).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
-          1. Return ? EvaluateCall(_tagRef_, |TemplateLiteral|, _tailCall_).
+          1. Return ? EvaluateCall(_tagFunc_, _tagRef_, |TemplateLiteral|, _tailCall_).
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
EvaluateDirectCall is used instead of EvaluateCall in only one place,
and this is because additional steps must be added after the first
GetValue(ref) step of EvaluateCall. So:
* factor GetValue(ref) out of EvaluateCall;
* now the call site of EvaluateDirectCall may use directly EvaluateCall;
* merge EvaluateDirectCall into EvaluateCall.
Incidently, correct two convention infringements in the invocation of
ArgumentListEvaluation.