### PR TITLE
Meta: Add DFNs for function object and constructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1488,7 +1488,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <em>function object</em> is an object that supports the [[Call]] internal method. A <em>constructor</em> (also referred to as a <em>constructor function</em>) is a function object that supports the [[Construct]] internal method.</p>
+        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> (also referred to as a <em>constructor function</em>) is a function object that supports the [[Construct]] internal method.</p>
         <emu-table id="table-6" caption="Additional Essential Internal Methods of Function Objects">
           <table>
             <tbody>


### PR DESCRIPTION
A link to *function object* is needed by WebIDL (in particular by https://github.com/heycam/webidl/pull/405).

Additionally, it would be useful to link to *constructor* from various parts of the spec, notably from the introductory paragraphs to [interface objects](https://heycam.github.io/webidl/#interface-object): 

> If the interface is declared with a [Constructor] extended attribute, then the interface object can be called as a _constructor_ […]

This PR adds both.