### PR TITLE
Normative: Fix [?Await] in async function FormalParameters (#978)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19721,8 +19721,8 @@
     <h2>Syntax</h2>
     <emu-grammar>
       AsyncFunctionDeclaration[Yield, Await, Default] :
-        `async` [no LineTerminator here] `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
-        [+Default] `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, ?Await] `)` `{` AsyncFunctionBody `}`
+        `async` [no LineTerminator here] `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
+        [+Default] `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
 
       AsyncFunctionExpression :
         `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`


### PR DESCRIPTION
In the AsyncFunctionDeclaration production, FormalParameters were parameterized
with [?Await] instead of [+Await]. According to the note below, the intention
was [+Await].

This also makes AsyncFunctionDeclaration consistent with AsyncFunctionExpression
in this regard.