### PR TITLE
Editorial: Remove out-of-date sentence about execution contexts

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6184,7 +6184,7 @@
         </tbody>
       </table>
     </emu-table>
-    <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Lexical Environments. When an execution context is created its LexicalEnvironment and VariableEnvironment components initially have the same value.</p>
+    <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Lexical Environments.</p>
     <p>Execution contexts representing the evaluation of generator objects have the additional state components listed in <emu-xref href="#table-24"></emu-xref>.</p>
     <emu-table id="table-24" caption="Additional State Components for Generator Execution Contexts">
       <table>


### PR DESCRIPTION
This sentence has been around for some time and is no longer accurate.
PerformEval can create an execution context with initially different
LexicalEnvironment and VariableEnvironment components.

Closes #980.