### PR TITLE
Editorial: Extract thisSymbolValue abstract op

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25090,6 +25090,15 @@
       <p>The Symbol prototype object is the intrinsic object <dfn>%SymbolPrototype%</dfn>. The Symbol prototype object is an ordinary object. It is not a Symbol instance and does not have a [[SymbolData]] internal slot.</p>
       <p>The value of the [[Prototype]] internal slot of the Symbol prototype object is the intrinsic object %ObjectPrototype%.</p>
 
+      <p>The abstract operation <dfn id="sec-thissymbolvalue" aoid="thisSymbolValue">thisSymbolValue</dfn>(_value_) performs the following steps:</p>
+      <emu-alg>
+        1. If Type(_value_) is Symbol, return _value_.
+        1. If Type(_value_) is Object and _value_ has a [[SymbolData]] internal slot, then
+          1. Assert: _value_.[[SymbolData]] is a Symbol value.
+          1. Return _value_.[[SymbolData]].
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+
       <!-- es6num="19.4.3.1" -->
       <emu-clause id="sec-symbol.prototype.constructor">
         <h1>Symbol.prototype.constructor</h1>
@@ -25101,12 +25110,7 @@
         <h1>Symbol.prototype.toString ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _s_ be the *this* value.
-          1. If Type(_s_) is Symbol, let _sym_ be _s_.
-          1. Else,
-            1. If Type(_s_) is not Object, throw a *TypeError* exception.
-            1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-            1. Let _sym_ be _s_.[[SymbolData]].
+          1. Let _sym_ be ? thisSymbolValue(*this* value).
           1. Return SymbolDescriptiveString(_sym_).
         </emu-alg>
 
@@ -25129,11 +25133,7 @@
         <h1>Symbol.prototype.valueOf ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _s_ be the *this* value.
-          1. If Type(_s_) is Symbol, return _s_.
-          1. If Type(_s_) is not Object, throw a *TypeError* exception.
-          1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-          1. Return _s_.[[SymbolData]].
+          1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
       </emu-clause>
 
@@ -25143,11 +25143,7 @@
         <p>This function is called by ECMAScript language operators to convert a Symbol object to a primitive value. The allowed values for _hint_ are `"default"`, `"number"`, and `"string"`.</p>
         <p>When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _s_ be the *this* value.
-          1. If Type(_s_) is Symbol, return _s_.
-          1. If Type(_s_) is not Object, throw a *TypeError* exception.
-          1. If _s_ does not have a [[SymbolData]] internal slot, throw a *TypeError* exception.
-          1. Return _s_.[[SymbolData]].
+          1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.toPrimitive]"`.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>


### PR DESCRIPTION
When reading through [`Symbol.prototype`](https://tc39.github.io/ecma262/#sec-properties-of-the-symbol-prototype-object) methods, it takes a bit of concentration to see common steps. This PR relieves that and aligns `thisSymbolValue` with [`thisStringValue`](https://tc39.github.io/ecma262/#sec-thisstringvalue), [`thisNumberValue`](https://tc39.github.io/ecma262/#sec-thisnumbervalue), and [`thisBooleanValue`](https://tc39.github.io/ecma262/#sec-thisbooleanvalue).