### PR TITLE
Editorial: Use IsConstructor instead of checking [[Constructor]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7444,7 +7444,7 @@
       <p>The abstract operation MakeConstructor requires a Function argument _F_ and optionally, a Boolean _writablePrototype_ and an object _prototype_. If _prototype_ is provided it is assumed to already contain, if needed, a `"constructor"` property whose value is _F_. This operation converts _F_ into a constructor by performing the following steps:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. Assert: _F_ has a [[Construct]] internal method.
+        1. Assert: IsConstructor(_F_) is *true*.
         1. Assert: _F_ is an extensible object that does not have a `prototype` own property.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then
@@ -7765,7 +7765,7 @@
         <p>When the [[Construct]] internal method of a bound function exotic object, _F_ that was created using the bind function is called with a list of arguments _argumentsList_ and _newTarget_, the following steps are taken:</p>
         <emu-alg>
           1. Let _target_ be _F_.[[BoundTargetFunction]].
-          1. Assert: _target_ has a [[Construct]] internal method.
+          1. Assert: IsConstructor(_target_) is *true*.
           1. Let _boundArgs_ be _F_.[[BoundArguments]].
           1. Let _args_ be a new list containing the same values as the list _boundArgs_ in the same order followed by the same values as the list _argumentsList_ in the same order.
           1. If SameValue(_F_, _newTarget_) is *true*, set _newTarget_ to _target_.
@@ -7783,7 +7783,7 @@
           1. Let _obj_ be a newly created object.
           1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-bound-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
-          1. If _targetFunction_ has a [[Construct]] internal method, then
+          1. If IsConstructor(_targetFunction_) is *true*, then
             1. Set _obj_.[[Construct]] as described in <emu-xref href="#sec-bound-function-exotic-objects-construct-argumentslist-newtarget"></emu-xref>.
           1. Set _obj_.[[Prototype]] to _proto_.
           1. Set _obj_.[[Extensible]] to *true*.
@@ -9238,7 +9238,7 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, `"construct"`).
         1. If _trap_ is *undefined*, then
-          1. Assert: _target_ has a [[Construct]] internal method.
+          1. Assert: IsConstructor(_target_) is *true*.
           1. Return ? Construct(_target_, _argumentsList_, _newTarget_).
         1. Let _argArray_ be CreateArrayFromList(_argumentsList_).
         1. Let _newObj_ be ? Call(_trap_, _handler_, &laquo; _target_, _argArray_, _newTarget_ &raquo;).
@@ -9271,7 +9271,7 @@
         1. Set _P_'s essential internal methods (except for [[Call]] and [[Construct]]) to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
         1. If IsCallable(_target_) is *true*, then
           1. Set _P_.[[Call]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
-          1. If _target_ has a [[Construct]] internal method, then
+          1. If IsConstructor(_target_) is *true*, then
             1. Set _P_.[[Construct]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget"></emu-xref>.
         1. Set _P_.[[ProxyTarget]] to _target_.
         1. Set _P_.[[ProxyHandler]] to _handler_.


### PR DESCRIPTION
Benefits: brevity, expressiveness, and consistency with other *constructor* checks.

With this change I was able to see all `IsConstructor` calls in references and make a [JS implementation](https://github.com/shvaikalesh/is-constructor/blob/master/index.js).