### PR TITLE
Adding explicit number conversion to %TypedArray%.prototype.sort

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33221,7 +33221,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: Both Type(_x_) and Type(_y_) is Number.
           1. If _comparefn_ is not *undefined*, then
-            1. Let _v_ be ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
+            1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. If _v_ is *NaN*, return *+0*.
             1. Return _v_.

--- a/spec.html
+++ b/spec.html
@@ -33221,7 +33221,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: Both Type(_x_) and Type(_y_) is Number.
           1. If _comparefn_ is not *undefined*, then
-            1. Let _v_ be ? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;).
+            1. Let _u_ be ? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;).
+            1. Let _v_ be ? ToNumber(_u_).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. If _v_ is *NaN*, return *+0*.
             1. Return _v_.

--- a/spec.html
+++ b/spec.html
@@ -33221,8 +33221,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: Both Type(_x_) and Type(_y_) is Number.
           1. If _comparefn_ is not *undefined*, then
-            1. Let _u_ be ? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;).
-            1. Let _v_ be ? ToNumber(_u_).
+            1. Let _v_ be ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. If _v_ is *NaN*, return *+0*.
             1. Return _v_.


### PR DESCRIPTION
Clarifying that conversion to a number from comparefn should occur before the detachment check. This ambiguity led to this security problem: https://bugs.chromium.org/p/project-zero/issues/detail?id=983