### PR TITLE
Decode doesn't need to check the reserved-set for non-ASCII characters

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23575,13 +23575,10 @@
                   1. Let _kChar_ be the numeric value of the code unit at index _k_ within _string_.
                   1. If _kChar_ is less than 0xDC00 or greater than 0xDFFF, throw a *URIError* exception.
                   1. Let _V_ be UTF16Decode(_C_, _kChar_).
-                1. Let _Octets_ be the array of octets resulting by applying the UTF-8 transformation to _V_, and let _L_ be the array size.
-                1. Let _j_ be 0.
-                1. Repeat, while _j_ &lt; _L_
-                  1. Let _jOctet_ be the value at index _j_ within _Octets_.
-                  1. Let _S_ be the string-concatenation of `"%"` and the two uppercase hexadecimal digits encoding _jOctet_.
+                1. Let _Octets_ be the List of octets resulting by applying the UTF-8 transformation to _V_.
+                1. For each element _octet_ of _Octets_ in List order, do
+                  1. Let _S_ be the string-concatenation of `"%"` and the two uppercase hexadecimal digits encoding _octet_.
                   1. Set _R_ to the string-concatenation of the previous value of _R_ and _S_.
-                  1. Increase _j_ by 1.
               1. Increase _k_ by 1.
           </emu-alg>
         </emu-clause>
@@ -23614,8 +23611,8 @@
                 1. Else the most significant bit in _B_ is 1,
                   1. Let _n_ be the smallest nonnegative integer such that (_B_ &lt;&lt; _n_) &amp; 0x80 is equal to 0.
                   1. If _n_ equals 1 or _n_ is greater than 4, throw a *URIError* exception.
-                  1. Let _Octets_ be an array of 8-bit integers of size _n_.
-                  1. Put _B_ into _Octets_ at index 0.
+                  1. Let _Octets_ be a List of 8-bit integers of size _n_.
+                  1. Set _Octets_[0] to _B_.
                   1. If _k_ + (3 &times; (_n_ - 1)) is greater than or equal to _strLen_, throw a *URIError* exception.
                   1. Let _j_ be 1.
                   1. Repeat, while _j_ &lt; _n_
@@ -23625,10 +23622,10 @@
                     1. Let _B_ be the 8-bit value represented by the two hexadecimal digits at index (_k_ + 1) and (_k_ + 2).
                     1. If the two most significant bits in _B_ are not 10, throw a *URIError* exception.
                     1. Increment _k_ by 2.
-                    1. Put _B_ into _Octets_ at index _j_.
+                    1. Set _Octets_[_j_] to _B_.
                     1. Increment _j_ by 1.
                   1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
-                  1. Let _V_ be the value obtained by applying the UTF-8 transformation to _Octets_, that is, from an array of octets into a 21-bit value.
+                  1. Let _V_ be the value obtained by applying the UTF-8 transformation to _Octets_, that is, from a List of octets into a 21-bit value.
                   1. Let _S_ be the String value whose elements are, in order, the elements in UTF16Encoding(_V_).
               1. Set _R_ to the string-concatenation of the previous value of _R_ and _S_.
               1. Increase _k_ by 1.

--- a/spec.html
+++ b/spec.html
@@ -23629,14 +23629,7 @@
                     1. Increment _j_ by 1.
                   1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
                   1. Let _V_ be the value obtained by applying the UTF-8 transformation to _Octets_, that is, from an array of octets into a 21-bit value.
-                  1. If _V_ &lt; 0x10000, then
-                    1. Let _C_ be the code unit _V_.
-                    1. If _C_ is not in _reservedSet_, then
-                      1. Let _S_ be the String value containing only the code unit _C_.
-                    1. Else _C_ is in _reservedSet_,
-                      1. Let _S_ be the substring of _string_ from index _start_ to index _k_ inclusive.
-                  1. Else _V_ &ge; 0x10000,
-                    1. Let _S_ be the String value whose elements are, in order, the elements in UTF16Encoding(_V_).
+                  1. Let _S_ be the String value whose elements are, in order, the elements in UTF16Encoding(_V_).
               1. Set _R_ to the string-concatenation of the previous value of _R_ and _S_.
               1. Increase _k_ by 1.
           </emu-alg>


### PR DESCRIPTION
dc370115a779e34ec2998f46de6c87581152c215:
`reservedSet` contains only ASCII characters, so we don't need to check for `reservedSet` when decoding an escaped character. Passing a decoded ASCII character throws a URIError because of the checks in 4.d.vii.2 and 4.d.vii.8. Also see the note below Decode:
> RFC 3629 prohibits the decoding of invalid UTF-8 octet sequences. For example, the invalid sequence C0 80 must not decode into the code unit 0x0000. Implementations of the Decode algorithm are required to throw a URIError when encountering such invalid sequences.

c2b368efe45bbc51cc7ba4a81210299e8443beb3:
Replaces the non-defined term `array` with `List` and simplifies a loop to use list iteration.