### PR TITLE
Editorial: Use HTTPS for unicode.org URLs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28433,7 +28433,7 @@ THH:mm:ss.sss
           <p>The `localeCompare` method itself is not directly suitable as an argument to `Array.prototype.sort` because the latter requires a function of two arguments.</p>
         </emu-note>
         <emu-note>
-          <p>This function is intended to rely on whatever language-sensitive comparison functionality is available to the ECMAScript environment from the host environment, and to compare according to the rules of the host environment's current locale. However, regardless of the host provided comparison capabilities, this function must treat Strings that are canonically equivalent according to the Unicode standard as identical. It is recommended that this function should not honour Unicode compatibility equivalences or decompositions. For a definition and discussion of canonical equivalence see the Unicode Standard, chapters 2 and 3, as well as Unicode Standard Annex #15, Unicode Normalization Forms (<a href="http://www.unicode.org/reports/tr15/">http://www.unicode.org/reports/tr15/</a>) and Unicode Technical Note #5, Canonical Equivalence in Applications (<a href="http://www.unicode.org/notes/tn5/">http://www.unicode.org/notes/tn5/</a>). Also see Unicode Technical Standard #10, Unicode Collation Algorithm (<a href="http://www.unicode.org/reports/tr10/">http://www.unicode.org/reports/tr10/</a>).</p>
+          <p>This function is intended to rely on whatever language-sensitive comparison functionality is available to the ECMAScript environment from the host environment, and to compare according to the rules of the host environment's current locale. However, regardless of the host provided comparison capabilities, this function must treat Strings that are canonically equivalent according to the Unicode standard as identical. It is recommended that this function should not honour Unicode compatibility equivalences or decompositions. For a definition and discussion of canonical equivalence see the Unicode Standard, chapters 2 and 3, as well as Unicode Standard Annex #15, Unicode Normalization Forms (<a href="https://unicode.org/reports/tr15/">https://unicode.org/reports/tr15/</a>) and Unicode Technical Note #5, Canonical Equivalence in Applications (<a href="https://unicode.org/notes/tn5/">https://www.unicode.org/notes/tn5/</a>). Also see Unicode Technical Standard #10, Unicode Collation Algorithm (<a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>).</p>
         </emu-note>
         <emu-note>
           <p>The `localeCompare` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -28469,7 +28469,7 @@ THH:mm:ss.sss
           1. If _form_ is not present or _form_ is *undefined*, let _form_ be `"NFC"`.
           1. Let _f_ be ? ToString(_form_).
           1. If _f_ is not one of `"NFC"`, `"NFD"`, `"NFKC"`, or `"NFKD"`, throw a *RangeError* exception.
-          1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="http://www.unicode.org/reports/tr15/">http://www.unicode.org/reports/tr15/</a>.
+          1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="https://unicode.org/reports/tr15/">https://unicode.org/reports/tr15/</a>.
           1. Return _ns_.
         </emu-alg>
         <emu-note>
@@ -40188,19 +40188,19 @@ THH:mm:ss.sss
       IEEE Std 754-2008: <i>IEEE Standard for Floating-Point Arithmetic</i>. Institute of Electrical and Electronic Engineers, New York (2008)
     </li>
     <li>
-      <i>The Unicode Standard</i>, available at &lt;<a href="http://www.unicode.org/versions/latest">http://www.unicode.org/versions/latest</a>&gt;
+      <i>The Unicode Standard</i>, available at &lt;<a href="https://unicode.org/versions/latest">https://unicode.org/versions/latest</a>&gt;
     </li>
     <li>
-      <i>Unicode Standard Annex #15, Unicode Normalization Forms</i>, available at &lt;<a href="http://www.unicode.org/reports/tr15/">http://www.unicode.org/reports/tr15/</a>&gt;
+      <i>Unicode Standard Annex #15, Unicode Normalization Forms</i>, available at &lt;<a href="https://unicode.org/reports/tr15/">https://unicode.org/reports/tr15/</a>&gt;
     </li>
     <li>
-      <i>Unicode Standard Annex #31, Unicode Identifiers and Pattern Syntax</i>, available at &lt;<a href="http://www.unicode.org/reports/tr31/">http://www.unicode.org/reports/tr31/</a>&gt;
+      <i>Unicode Standard Annex #31, Unicode Identifiers and Pattern Syntax</i>, available at &lt;<a href="https://unicode.org/reports/tr31/">https://unicode.org/reports/tr31/</a>&gt;
     </li>
     <li>
-      <i>Unicode Technical Note #5: Canonical Equivalence in Applications</i>, available at &lt;<a href="http://www.unicode.org/notes/tn5/">http://www.unicode.org/notes/tn5/</a>&gt;
+      <i>Unicode Technical Note #5: Canonical Equivalence in Applications</i>, available at &lt;<a href="https://unicode.org/notes/tn5/">https://unicode.org/notes/tn5/</a>&gt;
     </li>
     <li>
-      <i>Unicode Technical Standard #10: Unicode Collation Algorithm</i>, available at &lt;<a href="http://www.unicode.org/reports/tr10/">http://www.unicode.org/reports/tr10/</a>&gt;
+      <i>Unicode Technical Standard #10: Unicode Collation Algorithm</i>, available at &lt;<a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>&gt;
     </li>
     <li>
       <i>IANA Time Zone Database</i>, available at &lt;<a href="https://www.iana.org/time-zones">https://www.iana.org/time-zones</a>&gt;


### PR DESCRIPTION
unicode.org is now available over HTTPS. Let’s make use of it.