### PR TITLE
Normative: built-in functions are not allowed to have caller/arguments properties

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23102,7 +23102,7 @@
         ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"`. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
       </li>
       <li>
-        If an implementation extends non-strict or built-in function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
+        If an implementation extends non-strict function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
       </li>
       <li>
         Neither mapped nor unmapped arguments objects may be created with an own property named `"caller"`.

--- a/spec.html
+++ b/spec.html
@@ -23102,7 +23102,7 @@
         ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"`. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
       </li>
       <li>
-        If an implementation extends non-strict function objects with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
+        If an implementation extends any function object with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
       </li>
       <li>
         Neither mapped nor unmapped arguments objects may be created with an own property named `"caller"`.


### PR DESCRIPTION
Thus I think this statement is contradictory with the previous bullet. @allenwb, @jmdyck noticed [old bug 1075](https://bugs.ecmascript.org/show_bug.cgi?id=1075) seems relevant, but presumably this is not needed anymore.