### PR TITLE
Editorial: fix grammar of synchronizes-with conditions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38273,7 +38273,7 @@ THH:mm:ss.sss
           <ul>
             <li>_R_.[[Order]] is `"SeqCst"`.</li>
             <li>_W_.[[Order]] is `"SeqCst"` or `"Init"`.</li>
-            <li>If _W_.[[Order]] is `"SeqCst"` then _R_ and _W_ have equal ranges.</li>
+            <li>If _W_.[[Order]] is `"SeqCst"`, then _R_ and _W_ have equal ranges.</li>
             <li>If _W_.[[Order]] is `"Init"`, then for each event _V_ such that (_R_, _V_) is in _execution_.[[ReadsFrom]], _V_.[[Order]] is `"Init"`.</li>
           </ul>
         </li>

--- a/spec.html
+++ b/spec.html
@@ -38272,6 +38272,7 @@ THH:mm:ss.sss
           <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if all the following are true.</p>
           <ul>
             <li>_R_.[[Order]] is `"SeqCst"`.</li>
+            <li>_W_.[[Order]] is `"SeqCst"` or `"Init"`.</li>
             <li>If _W_.[[Order]] is `"SeqCst"` then _R_ and _W_ have equal ranges.</li>
             <li>If _W_.[[Order]] is `"Init"`, then for each event _V_ such that (_R_, _V_) is in _execution_.[[ReadsFrom]], _V_.[[Order]] is `"Init"`.</li>
           </ul>

--- a/spec.html
+++ b/spec.html
@@ -38272,8 +38272,8 @@ THH:mm:ss.sss
           <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if all the following are true.</p>
           <ul>
             <li>_R_.[[Order]] is `"SeqCst"`.</li>
-            <li>If _W_.[[Order]] is `"SeqCst"` and _R_ and _W_ have equal ranges.</li>
-            <li>If _W_.[[Order]] is `"Init"`, and for each event _V_ such that (_R_, _V_) is in _execution_.[[ReadsFrom]], _V_.[[Order]] is `"Init"`.</li>
+            <li>If _W_.[[Order]] is `"SeqCst"` then _R_ and _W_ have equal ranges.</li>
+            <li>If _W_.[[Order]] is `"Init"`, then for each event _V_ such that (_R_, _V_) is in _execution_.[[ReadsFrom]], _V_.[[Order]] is `"Init"`.</li>
           </ul>
         </li>
         <li>For each pair (_E_, _D_) in _execution_.[[HostSynchronizesWith]], (_E_, _D_) is in _execution_.[[SynchronizesWith]].</li>


### PR DESCRIPTION
Read painfully literally, the conditions of synchronizes-with are mutually incompatible, or at least ungrammatical.

https://tc39.github.io/ecma262/#sec-synchronizes-with

The phrasing of these conditions seems to come, at least partially, from an earlier draft, where synchronizes-with was computed in a more algorithmic way.
https://tc39.github.io/ecmascript_sharedmem/shmem.html#MemoryModel.SynchronizesWith

The switch to the non-algorithmic definition with the phrasing "if all the following are true"  in the preamble means that the conditions must be rephrased.