### PR TITLE
Normative: add async iteration

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25268,7 +25268,7 @@
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, +Await]|.
               1. Let _fallbackProto_ be `"%AsyncFunctionPrototype%"`.
             1. Else,
-              1. Assert: _kind_ is `"async generator"`
+              1. Assert: _kind_ is `"async generator"`.
               1. Let _goal_ be the grammar symbol |AsyncGeneratorBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, +Await]|.
               1. Let _fallbackProto_ be `"%AsyncGenerator%"`.

--- a/spec.html
+++ b/spec.html
@@ -4962,7 +4962,7 @@
     <p>See Common Iteration Interfaces (<emu-xref href="#sec-iteration"></emu-xref>).</p>
 
     <emu-clause id="sec-asynciteratorclose" aoid="AsyncIteratorClose">
-      <h1><ins>AsyncIteratorClose ( _iteratorRecord_, _completion_ )</ins></h1>
+      <h1>AsyncIteratorClose ( _iteratorRecord_, _completion_ )</h1>
       <p>The abstract operation AsyncIteratorClose with arguments _iteratorRecord_ and _completion_ is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state:</p>
       <emu-alg>
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
@@ -7589,7 +7589,7 @@
     </emu-clause>
 
     <emu-clause id="sec-asyncgeneratorfunctioncreate" aoid="AsyncGeneratorFunctionCreate">
-      <h1><ins>AsyncGeneratorFunctionCreate (_kind_, _ParameterList_, _Body_, _Scope_, _Strict_)</ins></h1>
+      <h1>AsyncGeneratorFunctionCreate (_kind_, _ParameterList_, _Body_, _Scope_, _Strict_)</h1>
       <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list production specified by _ParameterList_, a body production specified by _Body_, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. AsyncGeneratorFunctionCreate performs the following steps:</p>
       <emu-alg>
         1. Let _functionPrototype_ be the intrinsic object %AsyncGenerator%.
@@ -25712,8 +25712,8 @@
       </emu-clause>
 
       <emu-clause id="sec-symbol.asynciterator">
-        <h1><ins>Symbol.asyncIterator</ins></h1>
-        <p>The initial value of `Symbol.asyncIterator` is the well known symbol @@asyncIterator (<emu-xref href="#table-1-patch"></emu-xref>).</p>
+        <h1>Symbol.asyncIterator</h1>
+        <p>The initial value of `Symbol.asyncIterator` is the well known symbol @@asyncIterator (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -37338,7 +37338,7 @@ THH:mm:ss.sss
         <h1>Common Iteration Interfaces</h1>
 
         <emu-clause id="sec-asynciterable-interface">
-          <h1><ins>The <i>AsyncIterable</i> Interface</ins></h1>
+          <h1>The <i>AsyncIterable</i> Interface</h1>
           <p>The <i>AsyncIterable</i> interface includes the properties described in <emu-xref href="#table-async-iterable"></emu-xref>:</p>
           <emu-table id="table-async-iterable" caption="<i>AsyncIterable</i> Interface Required Properties">
             <table>
@@ -37359,7 +37359,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-asynciterator-interface">
-          <h1><ins>The <i>AsyncIterator</i> Interface</ins></h1>
+          <h1>The <i>AsyncIterator</i> Interface</h1>
           <p>An object that implements the <i>AsyncIterator</i> interface must include the properties in <emu-xref href="#table-async-iterator-required"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-async-iterator-optional"></emu-xref>.</p>
           <emu-table id="table-async-iterator-required" caption="<i>AsyncIterator</i> Interface Required Properties">
             <table>
@@ -37488,7 +37488,7 @@ THH:mm:ss.sss
   </emu-clause>
 
   <emu-clause id="sec-asynciteratorprototype">
-    <h1><ins>The %AsyncIteratorPrototype% Object</ins></h1>
+    <h1>The %AsyncIteratorPrototype% Object</h1>
     <p>The value of the [[Prototype]] internal slot of the <dfn>%AsyncIteratorPrototype%</dfn> object is the intrinsic object %ObjectPrototype%. The %AsyncIteratorPrototype% object is an ordinary object. The initial value of the [[Extensible]] internal slot of the %AsyncIteratorPrototype% object is *true*.</p>
     <emu-note>
       <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%.The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
@@ -37505,7 +37505,7 @@ THH:mm:ss.sss
   </emu-clause>
 
   <emu-clause id="sec-async-from-sync-iterator-objects">
-    <h1><ins>Async-from-Sync Iterator Objects</ins></h1>
+    <h1>Async-from-Sync Iterator Objects</h1>
     <p>An Async-from-Sync Iterator object is an async iterator that adapts a specific synchronous iterator. There is not a named constructor for Async-from-Sync Iterator objects. Instead, Async-from-Sync iterator objects are created by the CreateAsyncFromSyncIterator abstract operation as needed.</p>
 
     <emu-clause id="sec-createasyncfromsynciterator" aoid="CreateAsyncFromSyncIterator">
@@ -38056,7 +38056,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-getgeneratorkind" aoid="GetGeneratorKind">
-        <h1><ins>GetGeneratorKind ( )</ins></h1>
+        <h1>GetGeneratorKind ( )</h1>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. If _genContext_ does not have a Generator component, return ~non-generator~.
@@ -38348,7 +38348,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-asyncgeneratoryield" aoid="AsyncGeneratorYield">
-        <h1><ins>AsyncGeneratorYield ( _value_ )</ins></h1>
+        <h1>AsyncGeneratorYield ( _value_ )</h1>
         <p>The abstract operation AsyncGeneratorYield with argument _value_ performs the following steps:</p>
         <emu-alg>
           1. Let _genContext_ be the running execution context.

--- a/spec.html
+++ b/spec.html
@@ -3053,7 +3053,7 @@
         <emu-alg>
           1. Let _asyncContext_ be the running execution context.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _promise_ »).
+          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _promise_ &raquo;).
           1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#await-fulfilled" title></emu-xref>.
           1. Let _onRejected_ be a new built-in function object as defined in <emu-xref href="#await-rejected" title></emu-xref>.
           1. Set _onFulfilled_ and _onRejected_'s [[AsyncContext]] internal slots to _asyncContext_.
@@ -17168,14 +17168,14 @@
           IterationStatement : `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
-          1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(« », |AssignmentExpression|, ~async-iterate~).
+          1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~assignment~, _labelSet_, ~async~).
         </emu-alg>
         <emu-grammar>
           IterationStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
-          1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(« », |AssignmentExpression|, ~async-iterate~).
+          1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~varBinding~, _labelSet_, ~async~).
         </emu-alg>
         <emu-grammar>
@@ -20034,7 +20034,7 @@
       </emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, `"%AsyncGeneratorPrototype%"`, « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]] »).
+        1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, `"%AsyncGeneratorPrototype%"`, &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]] &raquo;).
         1. Perform ! AsyncGeneratorStart(_generator_, _FunctionBody_).
         1. Return Completion{[[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~}.
       </emu-alg>
@@ -38242,7 +38242,7 @@ THH:mm:ss.sss
           1. Assert: _queue_ is not an empty List.
           1. Remove the first element from _queue_ and let _next_ be the value of that element.
           1. Let _promiseCapability_ be _next_.[[Capability]].
-          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _exception_ »).
+          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _exception_ &raquo;).
           1. Perform ! AsyncGeneratorResumeNext(_generator_).
           1. Return *undefined*.
         </emu-alg>
@@ -38268,7 +38268,7 @@ THH:mm:ss.sss
               1. If _completion_.[[Type]] is ~return~:
                 1. Set _generator_.[[AsyncGeneratorState]] to `"awaiting-return"`.
                 1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _completion_.[[Value]] »).
+                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
                 1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
                 1. Let _onRejected_ be a new built-in function object as defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
                 1. Set _onFulfilled_ and _onRejected_'s [[Generator]] internal slots to _generator_.

--- a/spec.html
+++ b/spec.html
@@ -37771,7 +37771,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-asyncgeneratorfunction-objects">
     <h1>AsyncGeneratorFunction Objects</h1>
-    <p>AsyncGenerator Function objects are functions that are usually created by evaluating |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, and |AsyncGeneratorMethod| syntactic productions. They may also be created by calling the %AsyncGeneratorFunction% intrinsic.</p>
+    <p>AsyncGeneratorFunction objects are functions that are usually created by evaluating |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, and |AsyncGeneratorMethod| syntactic productions. They may also be created by calling the %AsyncGeneratorFunction% intrinsic.</p>
 
     <emu-clause id="sec-asyncgeneratorfunction-constructor">
       <h1>The AsyncGeneratorFunction Constructor</h1>

--- a/spec.html
+++ b/spec.html
@@ -4957,24 +4957,6 @@
     <h1>Operations on Iterator Objects</h1>
     <p>See Common Iteration Interfaces (<emu-xref href="#sec-iteration"></emu-xref>).</p>
 
-    <emu-clause id="sec-asynciteratorclose" aoid="AsyncIteratorClose">
-      <h1>AsyncIteratorClose ( _iteratorRecord_, _completion_ )</h1>
-      <p>The abstract operation AsyncIteratorClose with arguments _iteratorRecord_ and _completion_ is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state:</p>
-      <emu-alg>
-        1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
-        1. Assert: _completion_ is a Completion Record.
-        1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
-        1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
-        1. If _return_ is *undefined*, return Completion(_completion_).
-        1. Let _innerResult_ be Call(_return_, _iterator_, &laquo; &raquo;).
-        1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
-        1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
-        1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
-        1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.
-        1. Return Completion(_completion_).
-      </emu-alg>
-    </emu-clause>
-
     <!-- es6num="7.4.1" -->
     <emu-clause id="sec-getiterator" aoid="GetIterator">
       <h1>GetIterator ( _obj_ [ , _hint_ ] [ , _method_ ] )</h1>
@@ -5054,6 +5036,24 @@
         1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
         1. If _return_ is *undefined*, return Completion(_completion_).
         1. Let _innerResult_ be Call(_return_, _iterator_, &laquo; &raquo;).
+        1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
+        1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
+        1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.
+        1. Return Completion(_completion_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asynciteratorclose" aoid="AsyncIteratorClose">
+      <h1>AsyncIteratorClose ( _iteratorRecord_, _completion_ )</h1>
+      <p>The abstract operation AsyncIteratorClose with arguments _iteratorRecord_ and _completion_ is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state:</p>
+      <emu-alg>
+        1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
+        1. Assert: _completion_ is a Completion Record.
+        1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
+        1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
+        1. If _return_ is *undefined*, return Completion(_completion_).
+        1. Let _innerResult_ be Call(_return_, _iterator_, &laquo; &raquo;).
+        1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
         1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
         1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
         1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.

--- a/spec.html
+++ b/spec.html
@@ -37523,8 +37523,8 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-              1. Let _invalidIteratorError_ be a new *TypeError* exception.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
+              1. Let _invalidIteratorError_ be a newly created *TypeError* object.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
             1. Let _nextResult_ be IteratorNext(_syncIteratorRecord_, _value_).
@@ -37549,8 +37549,8 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-              1. Let _invalidIteratorError_ be a new *TypeError* exception.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
+              1. Let _invalidIteratorError_ be a newly created *TypeError* object.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
             1. Let _return_ be GetMethod(_syncIterator_, `"return"`).
@@ -37561,8 +37561,8 @@ THH:mm:ss.sss
               1. Return _promiseCapability_.[[Promise]].
             1. Let _returnResult_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
             1. IfAbruptRejectPromise(_returnResult_, _promiseCapability_).
-            1. If Type(_returnResult_) is not *Object*, then
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
+            1. If Type(_returnResult_) is not Object, then
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _returnDone_ be IteratorComplete(_returnResult_).
             1. IfAbruptRejectPromise(_returnDone_, _promiseCapability_).
@@ -37584,8 +37584,8 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-              1. Let _invalidIteratorError_ be a new *TypeError* exception.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
+              1. Let _invalidIteratorError_ be a newly created *TypeError* object.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
             1. Let _throw_ be GetMethod(_syncIterator_, `"throw"`).
@@ -37595,8 +37595,8 @@ THH:mm:ss.sss
               1. Return _promiseCapability_.[[Promise]].
             1. Let _throwResult_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
             1. IfAbruptRejectPromise(_throwResult_, _promiseCapability_).
-            1. If Type(_throwResult_) is not *Object*, then
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
+            1. If Type(_throwResult_) is not Object, then
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _throwDone_ be IteratorComplete(_throwResult_).
             1. IfAbruptRejectPromise(_throwDone_, _promiseCapability_).
@@ -38330,7 +38330,7 @@ THH:mm:ss.sss
           1. Assert: _completion_ is a Completion Record.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. If Type(_generator_) is not Object, or if _generator_ does not have an [[AsyncGeneratorState]] internal slot, then
-            1. Let _badGeneratorError_ be a new *TypeError* exception.
+            1. Let _badGeneratorError_ be a newly created *TypeError* object.
             1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badGeneratorError_ &raquo;).
             1. Return _promiseCapability_.[[Promise]].
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].

--- a/spec.html
+++ b/spec.html
@@ -3042,10 +3042,6 @@
       <emu-clause id="await" aoid="Await">
         <h1>Await</h1>
 
-        <emu-note type=editor>
-          <p>The AsyncFunctionAwait abstract operation could probably be refactored in terms of this primitive.</p>
-        </emu-note>
-
         <p>Algorithm steps that say</p>
 
         <emu-alg>
@@ -20793,7 +20789,7 @@
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |UnaryExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
-        1. Return ? AsyncFunctionAwait(_value_).
+        1. Return ? Await(_value_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -39301,63 +39297,8 @@ THH:mm:ss.sss
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
-          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are AsyncFunctionAwait or, if the async function doesn't await anything, the step 3.g above.
+          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, the step 3.g above.
           1. Return.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-async-functions-abstract-operations-async-function-await" aoid="AsyncFunctionAwait">
-        <h1>AsyncFunctionAwait ( _value_ )</h1>
-        <emu-alg>
-          1. Let _asyncContext_ be the running execution context.
-          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _value_ &raquo;).
-          1. Let _realm_ be the current Realm Record.
-          1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-functions-abstract-operations-awaited-fulfilled" title></emu-xref>.
-          1. Let _onFulfilled_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[AsyncContext]] &raquo;).
-          1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-functions-abstract-operations-awaited-rejected" title></emu-xref>.
-          1. Let _onRejected_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[AsyncContext]] &raquo;).
-          1. Set _onFulfilled_.[[AsyncContext]] to _asyncContext_.
-          1. Set _onRejected_.[[AsyncContext]] to _asyncContext_.
-          1. Let _throwawayCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
-          1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
-          1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
-            1. Return _resumptionValue_.
-          1. Return.
-        </emu-alg>
-
-        <emu-note>The return value of this abstract operation is unused. The interesting return is that of _resumptionValue_ being returned to the |AwaitExpression| that originally called this abstract operation.</emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-async-functions-abstract-operations-awaited-fulfilled">
-        <h1>AsyncFunction Awaited Fulfilled</h1>
-        <p>An AsyncFunction Awaited Fulfilled function is an anonymous built-in function that has an [[AsyncContext]] internal slot. The value of the [[AsyncContext]] internal slot is the execution context that will be restored when the function is called.</p>
-        <p>When an AsyncFunction Awaited Fulfilled function _F_ is called with argument _value_, the following steps are taken:</p>
-        <emu-alg>
-          1. Let _asyncContext_ be _F_.[[AsyncContext]].
-          1. Let _prevContext_ be the running execution context.
-          1. Suspend _prevContext_.
-          1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _asyncContext_ using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
-          1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
-          1. Return Completion(_result_).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-async-functions-abstract-operations-awaited-rejected">
-        <h1>AsyncFunction Awaited Rejected</h1>
-        <p>An AsyncFunction Awaited Rejected function is an anonymous built-in function that has an [[AsyncContext]] internal slot. The value of the [[AsyncContext]] internal slot is the execution context that will be restored when the function is called.</p>
-        <p>When an AsyncFunction Awaited Rejected function _F_ is called with argument _reason_, the following steps are taken:</p>
-        <emu-alg>
-          1. Let _asyncContext_ be _F_.[[AsyncContext]].
-          1. Let _prevContext_ be the running execution context.
-          1. Suspend _prevContext_.
-          1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _asyncContext_ using Completion{[[Type]]: ~throw~, [[Value]]: _reason_, [[Target]]: ~empty~} as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
-          1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
-          1. Return Completion(_result_).
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -17194,7 +17194,7 @@
       <!-- es6num="13.7.5.12" -->
       <emu-clause id="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
         <h1>Runtime Semantics: ForIn/OfHeadEvaluation ( _TDZnames_, _expr_, _iterationKind_ )</h1>
-        <p>The abstract operation ForIn/OfHeadEvaluation is called with arguments _TDZnames_, _expr_, and _iterationKind_. The value of _iterationKind_ is either ~enumerate~ or ~iterate~.</p>
+        <p>The abstract operation ForIn/OfHeadEvaluation is called with arguments _TDZnames_, _expr_, and _iterationKind_. The value of _iterationKind_ is either ~enumerate~, ~iterate~, or ~async-iterate~.</p>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. If _TDZnames_ is not an empty List, then

--- a/spec.html
+++ b/spec.html
@@ -17173,21 +17173,21 @@
         </emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~assignment~, _labelSet_, ~async~).
+          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_, ~async~).
         </emu-alg>
         <emu-grammar>
           IterationStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~varBinding~, _labelSet_, ~async~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_, ~async~).
         </emu-alg>
         <emu-grammar>
           IterationStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~lexicalBinding~, _labelSet_, ~async~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_, ~async~).
         </emu-alg>
         <emu-note>
           <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>

--- a/spec.html
+++ b/spec.html
@@ -7590,7 +7590,7 @@
       <p>The abstract operation FunctionAllocate requires the three arguments _functionPrototype_, _strict_ and _functionKind_. FunctionAllocate performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_functionPrototype_) is Object.
-        1. Assert: _functionKind_ is either `"normal"`, `"non-constructor"`, `"generator"`, or `"async"`.
+        1. Assert: _functionKind_ is either `"normal"`, `"non-constructor"`, `"generator"`, `"async"`, or `"async generator"`.
         1. If _functionKind_ is `"normal"`, let _needsConstruct_ be *true*.
         1. Else, let _needsConstruct_ be *false*.
         1. If _functionKind_ is `"non-constructor"`, set _functionKind_ to `"normal"`.

--- a/spec.html
+++ b/spec.html
@@ -14944,6 +14944,7 @@
       FunctionDeclaration[?Yield, ?Await, ?Default]
       GeneratorDeclaration[?Yield, ?Await, ?Default]
       AsyncFunctionDeclaration[?Yield, ?Await, ?Default]
+      AsyncGeneratorDeclaration[?Yield, ?Await, ?Default]
 
     BreakableStatement[Yield, Await, Return] :
       IterationStatement[?Yield, ?Await, ?Return]

--- a/spec.html
+++ b/spec.html
@@ -5663,8 +5663,8 @@
       <emu-clause id="sec-global-environment-records">
         <h1>Global Environment Records</h1>
         <p>A global Environment Record is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm. A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-block-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-block-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
-        <p>A global Environment Record is logically a single record but it is specified as a composite encapsulating an object Environment Record and a declarative Environment Record. The object Environment Record has as its base object the global object of the associated Realm Record. This global object is the value returned by the global Environment Record's GetThisBinding concrete method. The object Environment Record component of a global Environment Record contains the bindings for all built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>) and all bindings introduced by a |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration| or |VariableStatement| contained in global code. The bindings for all other ECMAScript declarations in global code are contained in the declarative Environment Record component of the global Environment Record.</p>
-        <p>Properties may be created directly on a global object. Hence, the object Environment Record component of a global Environment Record may contain both bindings created explicitly by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, or |VariableDeclaration| declarations and bindings created implicitly as properties of the global object. In order to identify which bindings were explicitly created using declarations, a global Environment Record maintains a list of the names bound using its CreateGlobalVarBinding and CreateGlobalFunctionBinding concrete methods.</p>
+        <p>A global Environment Record is logically a single record but it is specified as a composite encapsulating an object Environment Record and a declarative Environment Record. The object Environment Record has as its base object the global object of the associated Realm Record. This global object is the value returned by the global Environment Record's GetThisBinding concrete method. The object Environment Record component of a global Environment Record contains the bindings for all built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>) and all bindings introduced by a |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, or |VariableStatement| contained in global code. The bindings for all other ECMAScript declarations in global code are contained in the declarative Environment Record component of the global Environment Record.</p>
+        <p>Properties may be created directly on a global object. Hence, the object Environment Record component of a global Environment Record may contain both bindings created explicitly by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, or |VariableDeclaration| declarations and bindings created implicitly as properties of the global object. In order to identify which bindings were explicitly created using declarations, a global Environment Record maintains a list of the names bound using its CreateGlobalVarBinding and CreateGlobalFunctionBinding concrete methods.</p>
         <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-18"></emu-xref> and the additional methods listed in <emu-xref href="#table-19"></emu-xref>.</p>
         <emu-table id="table-18" caption="Additional Fields of Global Environment Records">
           <table>
@@ -5688,7 +5688,7 @@
                 Object Environment Record
               </td>
               <td>
-                Binding object is the global object. It contains global built-in bindings as well as |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, and |VariableDeclaration| bindings in global code for the associated realm.
+                Binding object is the global object. It contains global built-in bindings as well as |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| bindings in global code for the associated realm.
               </td>
             </tr>
             <tr>
@@ -5710,7 +5710,7 @@
                 Declarative Environment Record
               </td>
               <td>
-                Contains bindings for all declarations in global code for the associated realm code except for |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, and |VariableDeclaration| _bindings_.
+                Contains bindings for all declarations in global code for the associated realm code except for |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| _bindings_.
               </td>
             </tr>
             <tr>
@@ -5721,7 +5721,7 @@
                 List of String
               </td>
               <td>
-                The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, and |VariableDeclaration| declarations in global code for the associated realm.
+                The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| declarations in global code for the associated realm.
               </td>
             </tr>
             </tbody>
@@ -5751,7 +5751,7 @@
                 HasVarDeclaration (N)
               </td>
               <td>
-                Determines if the argument identifier has a binding in this Environment Record that was created using a |VariableDeclaration|, |FunctionDeclaration|, |GeneratorDeclaration|, or |AsyncFunctionDeclaration|.
+                Determines if the argument identifier has a binding in this Environment Record that was created using a |VariableDeclaration|, |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, or |AsyncGeneratorDeclaration|.
               </td>
             </tr>
             <tr>
@@ -7776,7 +7776,7 @@
         1. Let _functionsToInitialize_ be a new empty List.
         1. For each _d_ in _varDeclarations_, in reverse list order, do
           1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
-            1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|.
+            1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
             1. Let _fn_ be the sole element of the BoundNames of _d_.
             1. If _fn_ is not an element of _functionNames_, then
               1. Insert _fn_ as the first element of _functionNames_.
@@ -9580,20 +9580,20 @@
     <p>There are four types of ECMAScript code:</p>
     <ul>
       <li>
-        <em>Global code</em> is source text that is treated as an ECMAScript |Script|. The global code of a particular |Script| does not include any source text that is parsed as part of a |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
+        <em>Global code</em> is source text that is treated as an ECMAScript |Script|. The global code of a particular |Script| does not include any source text that is parsed as part of a |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
       </li>
       <li>
         <em>Eval code</em> is the source text supplied to the built-in `eval` function. More precisely, if the parameter to the built-in `eval` function is a String, it is treated as an ECMAScript |Script|. The eval code for a particular invocation of `eval` is the global code portion of that |Script|.
       </li>
       <li>
-        <em>Function code</em> is source text that is parsed to supply the value of the [[ECMAScriptCode]] and [[FormalParameters]] internal slots (see <emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) of an ECMAScript function object. The function code of a particular ECMAScript function does not include any source text that is parsed as the function code of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
+        <em>Function code</em> is source text that is parsed to supply the value of the [[ECMAScriptCode]] and [[FormalParameters]] internal slots (see <emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) of an ECMAScript function object. The function code of a particular ECMAScript function does not include any source text that is parsed as the function code of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
       </li>
       <li>
-        <em>Module code</em> is source text that is code that is provided as a |ModuleBody|. It is the code that is directly evaluated when a module is initialized. The module code of a particular module does not include any source text that is parsed as part of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
+        <em>Module code</em> is source text that is code that is provided as a |ModuleBody|. It is the code that is directly evaluated when a module is initialized. The module code of a particular module does not include any source text that is parsed as part of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
       </li>
     </ul>
     <emu-note>
-      <p>Function code is generally provided as the bodies of Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>), Arrow Function Definitions (<emu-xref href="#sec-arrow-function-definitions"></emu-xref>), Method Definitions (<emu-xref href="#sec-method-definitions"></emu-xref>), Generator Definitions (<emu-xref href="#sec-generator-function-definitions"></emu-xref>), Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>), and Async Arrow Functions (<emu-xref href="#sec-async-arrow-function-definitions"></emu-xref>). Function code is also derived from the arguments to the `Function` constructor (<emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>), the `GeneratorFunction` constructor (<emu-xref href="#sec-generatorfunction"></emu-xref>), and the `AsyncFunction` constructor (<emu-xref href="#sec-async-function-constructor-arguments"></emu-xref>).</p>
+      <p>Function code is generally provided as the bodies of Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>), Arrow Function Definitions (<emu-xref href="#sec-arrow-function-definitions"></emu-xref>), Method Definitions (<emu-xref href="#sec-method-definitions"></emu-xref>), Generator Function Definitions (<emu-xref href="#sec-generator-function-definitions"></emu-xref>), Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>), Async Generator Function Definitions (<emu-xref href="#sec-async-generator-function-definitions"></emu-xref>), and Async Arrow Functions (<emu-xref href="#sec-async-arrow-function-definitions"></emu-xref>). Function code is also derived from the arguments to the `Function` constructor (<emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>), the `GeneratorFunction` constructor (<emu-xref href="#sec-generatorfunction"></emu-xref>), and the `AsyncFunction` constructor (<emu-xref href="#sec-async-function-constructor-arguments"></emu-xref>).</p>
     </emu-note>
 
     <!-- es6num="10.2.1" -->
@@ -9614,10 +9614,10 @@
           Eval code is strict mode code if it begins with a Directive Prologue that contains a Use Strict Directive or if the call to `eval` is a direct eval that is contained in strict mode code.
         </li>
         <li>
-          Function code is strict mode code if the associated |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |MethodDefinition|, |ArrowFunction|, or |AsyncArrowFunction| is contained in strict mode code or if the code that produces the value of the function's [[ECMAScriptCode]] internal slot begins with a Directive Prologue that contains a Use Strict Directive.
+          Function code is strict mode code if the associated |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |MethodDefinition|, |ArrowFunction|, or |AsyncArrowFunction| is contained in strict mode code or if the code that produces the value of the function's [[ECMAScriptCode]] internal slot begins with a Directive Prologue that contains a Use Strict Directive.
         </li>
         <li>
-          Function code that is supplied as the arguments to the built-in `Function`, `Generator`, and `AsyncFunction` constructors is strict mode code if the last argument is a String that when processed is a |FunctionBody| that begins with a Directive Prologue that contains a Use Strict Directive.
+          Function code that is supplied as the arguments to the built-in `Function`, `Generator`, `AsyncFunction`, and `AsyncGenerator` constructors is strict mode code if the last argument is a String that when processed is a |FunctionBody| that begins with a Directive Prologue that contains a Use Strict Directive.
         </li>
       </ul>
       <p>ECMAScript code that is not strict mode code is called <dfn id="non-strict-code">non-strict code</dfn>.</p>
@@ -11548,6 +11548,7 @@
         ClassExpression[?Yield, ?Await]
         GeneratorExpression
         AsyncFunctionExpression
+        AsyncGeneratorExpression
         RegularExpressionLiteral
         TemplateLiteral[?Yield, ?Await, ~Tagged]
         CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parencover
@@ -11639,6 +11640,7 @@
             ClassExpression
             GeneratorExpression
             AsyncFunctionExpression
+            AsyncGeneratorExpression
             RegularExpressionLiteral
             TemplateLiteral
             CoverParenthesizedExpressionAndArrowParameterList
@@ -11662,6 +11664,7 @@
             ClassExpression
             GeneratorExpression
             AsyncFunctionExpression
+            AsyncGeneratorExpression
             RegularExpressionLiteral
             TemplateLiteral
         </emu-grammar>
@@ -12119,6 +12122,7 @@
       <p>See <emu-xref href="#sec-generator-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : GeneratorExpression</emu-grammar>.</p>
       <p>See <emu-xref href="#sec-class-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : ClassExpression</emu-grammar>.</p>
       <p>See <emu-xref href="#sec-async-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : AsyncFunctionExpression</emu-grammar>.</p>
+      <p>See <emu-xref href="#sec-async-generator-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : AsyncGeneratorExpression</emu-grammar>.</p>
     </emu-clause>
 
     <!-- es6num="12.2.8" -->
@@ -15038,6 +15042,10 @@
       <emu-alg>
         1. Return |AsyncFunctionDeclaration|.
       </emu-alg>
+      <emu-grammar>HoistableDeclaration : AsyncGeneratorDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return |AsyncGeneratorDeclaration|.
+      </emu-alg>
       <emu-grammar>Declaration : ClassDeclaration</emu-grammar>
       <emu-alg>
         1. Return |ClassDeclaration|.
@@ -15118,13 +15126,10 @@
     <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
-        HoistableDeclaration : GeneratorDeclaration
-      </emu-grammar>
-      <emu-alg>
-        1. Return NormalCompletion(~empty~).
-      </emu-alg>
-      <emu-grammar>
-        HoistableDeclaration : AsyncFunctionDeclaration
+        HoistableDeclaration :
+          GeneratorDeclaration
+          AsyncFunctionDeclaration
+          AsyncGeneratorDeclaration
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
@@ -15498,7 +15503,7 @@
               1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
             1. Else,
               1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
-          1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|, then
+          1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
             1. Let _fn_ be the sole element of the BoundNames of _d_.
             1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
             1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
@@ -16266,7 +16271,7 @@
         [lookahead &lt;! {`{`, `function`, `async` [no |LineTerminator| here] `function`, `class`, `let [`}] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
     <emu-note>
-      <p>An |ExpressionStatement| cannot start with a U+007B (LEFT CURLY BRACKET) because that might make it ambiguous with a |Block|. An |ExpressionStatement| cannot start with the `function` or `class` keywords because that would make it ambiguous with a |FunctionDeclaration|, a |GeneratorDeclaration|, or a |ClassDeclaration|. An |ExpressionStatement| cannot start with `async function` because that would make it ambiguous with an |AsyncFunctionDeclaration|.  An |ExpressionStatement| cannot start with the two token sequence `let [` because that would make it ambiguous with a `let` |LexicalDeclaration| whose first |LexicalBinding| was an |ArrayBindingPattern|.</p>
+      <p>An |ExpressionStatement| cannot start with a U+007B (LEFT CURLY BRACKET) because that might make it ambiguous with a |Block|. An |ExpressionStatement| cannot start with the `function` or `class` keywords because that would make it ambiguous with a |FunctionDeclaration|, a |GeneratorDeclaration|, or a |ClassDeclaration|. An |ExpressionStatement| cannot start with `async function` because that would make it ambiguous with an |AsyncFunctionDeclaration| or a |AsyncGeneratorDeclaration|.  An |ExpressionStatement| cannot start with the two token sequence `let [` because that would make it ambiguous with a `let` |LexicalDeclaration| whose first |LexicalBinding| was an |ArrayBindingPattern|.</p>
     </emu-note>
 
     <!-- es6num="13.5.1" -->
@@ -19335,6 +19340,7 @@
         PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
         GeneratorMethod[?Yield, ?Await]
         AsyncMethod[?Yield, ?Await]
+        AsyncGeneratorMethod[?Yield, ?Await]
         `get` PropertyName[?Yield, ?Await] `(` `)` `{` FunctionBody[~Yield, ~Await] `}`
         `set` PropertyName[?Yield, ?Await] `(` PropertySetParameterList `)` `{` FunctionBody[~Yield, ~Await] `}`
 
@@ -19440,8 +19446,8 @@
       <emu-grammar>
         MethodDefinition :
           GeneratorMethod
-          AsyncGeneratorMethod
           AsyncMethod
+          AsyncGeneratorMethod
           `get` PropertyName `(` `)` `{` FunctionBody `}`
           `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
       </emu-grammar>
@@ -20532,12 +20538,12 @@
       <p>`await` is parsed as an |AwaitExpression| when the <sub>[Await]</sub> parameter is present. The <sub>[Await]</sub> parameter is present in the following contexts:</p>
       <ul>
         <li>In an |AsyncFunctionBody|.</li>
-        <li>In the |FormalParameters| of an |AsyncFunctionDeclaration| and |AsyncFunctionExpression|. |AwaitExpression| in this position is a Syntax error via static semantics.</li>
+        <li>In the |FormalParameters| of an |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, or |AsyncGeneratorExpression|. |AwaitExpression| in this position is a Syntax error via static semantics.</li>
       </ul>
       <p>When |Module| is the syntactic goal symbol and the <sub>[Await]</sub> parameter is absent, `await` is parsed as a keyword and will be a Syntax error. When |Script| is the syntactic goal symbol, `await` may be parsed as an identifier when the <sub>[Await]</sub> parameter is absent. This includes the following contexts:</p>
       <ul>
-        <li>Anywhere outside of an |AsyncFunctionBody| or |FormalParameters| of an |AsyncFunctionDeclaration| or |AsyncFunctionExpression|.</li>
-        <li>In the |BindingIdentifier| of a |FunctionExpression| or |GeneratorExpression|.</li>
+        <li>Anywhere outside of an |AsyncFunctionBody| or |FormalParameters| of an |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, or |AsyncGeneratorExpression|.</li>
+        <li>In the |BindingIdentifier| of a |FunctionExpression|, |GeneratorExpression|, or |AsyncGeneratorExpression|.</li>
       </ul>
     </emu-note>
 
@@ -21060,6 +21066,7 @@
         1. Let _body_ be the |FunctionBody|, |ConciseBody|, or |AsyncConciseBody| that most closely contains _call_.
         1. If _body_ is the |FunctionBody| of a |GeneratorBody|, return *false*.
         1. If _body_ is the |FunctionBody| of an |AsyncFunctionBody|, return *false*.
+        1. If _body_ is the |FunctionBody| of an |AsyncGeneratorBody|, return *false*.
         1. If _body_ is an |AsyncConciseBody|, return *false*.
         1. Return the result of HasCallInTailPosition of _body_ with argument _call_.
       </emu-alg>
@@ -21290,6 +21297,7 @@
             ClassExpression
             GeneratorExpression
             AsyncFunctionExpression
+            AsyncGeneratorExpression
             RegularExpressionLiteral
             TemplateLiteral
         </emu-grammar>
@@ -21619,7 +21627,7 @@
         1. Let _declaredFunctionNames_ be a new empty List.
         1. For each _d_ in _varDeclarations_, in reverse list order, do
           1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
-            1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|.
+            1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
             1. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
             1. Let _fn_ be the sole element of the BoundNames of _d_.
             1. If _fn_ is not an element of _declaredFunctionNames_, then
@@ -22904,7 +22912,7 @@
                     1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
                   1. Else,
                     1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
-                  1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|, then
+                  1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
                     1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
                     1. Call _envRec_.InitializeBinding(_dn_, _fo_).
             </emu-alg>
@@ -23799,7 +23807,7 @@
     <p>An implementation must not extend this specification in the following ways:</p>
     <ul>
       <li>
-        ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"`. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
+        ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"`. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
       </li>
       <li>
         If an implementation extends any function object with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
@@ -24031,7 +24039,7 @@
           1. Let _declaredFunctionNames_ be a new empty List.
           1. For each _d_ in _varDeclarations_, in reverse list order, do
             1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
-              1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, or an |AsyncFunctionDeclaration|.
+              1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
               1. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
               1. Let _fn_ be the sole element of the BoundNames of _d_.
               1. If _fn_ is not an element of _declaredFunctionNames_, then
@@ -25220,7 +25228,7 @@
     <emu-clause id="sec-function-constructor">
       <h1>The Function Constructor</h1>
       <p>The Function constructor is the <dfn>%Function%</dfn> intrinsic object and the initial value of the `Function` property of the global object. When `Function` is called as a function rather than as a constructor, it creates and initializes a new function object. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</p>
-      <p>The `Function` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction` and `AsyncFunction` subclasses.</p>
+      <p>The `Function` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction`, `AsyncFunction`, and `AsyncGeneratorFunction` subclasses.</p>
 
       <!-- es6num="19.2.1.1" -->
       <emu-clause id="sec-function-p1-p2-pn-body">
@@ -25448,7 +25456,7 @@
         <p>`toString` Representation Requirements:</p>
         <ul>
           <li>
-            The string representation must have the syntax of a |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |ClassDeclaration|, |ClassExpression|, |ArrowFunction|, |AsyncArrowFunction|, or |MethodDefinition| depending upon the actual characteristics of the object.
+            The string representation must have the syntax of a |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |ArrowFunction|, |AsyncArrowFunction|, or |MethodDefinition| depending upon the actual characteristics of the object.
           </li>
           <li>
             The use and placement of white space, line terminators, and semicolons within the representation String is implementation-dependent.
@@ -25512,7 +25520,7 @@
         <p>Function instances that can be used as a constructor have a `prototype` property. Whenever such a Function instance is created another ordinary object is also created and is the initial value of the function's `prototype` property. Unless otherwise specified, the value of the `prototype` property is used to initialize the [[Prototype]] internal slot of the object created when that function is invoked as a constructor.</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Function objects created using `Function.prototype.bind`, or by evaluating a |MethodDefinition| (that is not a |GeneratorMethod|) or an |ArrowFunction| do not have a `prototype` property.</p>
+          <p>Function objects created using `Function.prototype.bind`, or by evaluating a |MethodDefinition| (that is not a |GeneratorMethod| or |AsyncGeneratorMethod|) or an |ArrowFunction| do not have a `prototype` property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -38231,8 +38231,8 @@ THH:mm:ss.sss
           1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iteratorResult_ &raquo;).
           1. Perform ! AsyncGeneratorResumeNext(_generator_).
           1. Return *undefined*.
-        </emu-clause>
-      </emu-alg>
+        </emu-alg>
+      </emu-clause>
 
       <emu-clause id="sec-asyncgeneratorreject" aoid="AsyncGeneratorReject">
         <h1>AsyncGeneratorReject ( _generator_, _exception_ )</h1>

--- a/spec.html
+++ b/spec.html
@@ -37529,8 +37529,8 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-              1. Let _badIteratorError_ be a new *TypeError* exception.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Let _invalidIteratorError_ be a new *TypeError* exception.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
             1. Let _nextResult_ be IteratorNext(_syncIteratorRecord_, _value_).
@@ -37555,8 +37555,8 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-              1. Let _badIteratorError_ be a new *TypeError* exception.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Let _invalidIteratorError_ be a new *TypeError* exception.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
             1. Let _return_ be GetMethod(_syncIterator_, `"return"`).
@@ -37590,8 +37590,8 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-              1. Let _badIteratorError_ be a new *TypeError* exception.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Let _invalidIteratorError_ be a new *TypeError* exception.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
             1. Let _throw_ be GetMethod(_syncIterator_, `"throw"`).

--- a/spec.html
+++ b/spec.html
@@ -37479,183 +37479,183 @@ THH:mm:ss.sss
         <p>The value of the `name` property of this function is `"[Symbol.iterator]"`.</p>
       </emu-clause>
     </emu-clause>
-  </emu-clause>
 
-  <emu-clause id="sec-asynciteratorprototype">
-    <h1>The %AsyncIteratorPrototype% Object</h1>
-    <p>The value of the [[Prototype]] internal slot of the <dfn>%AsyncIteratorPrototype%</dfn> object is the intrinsic object %ObjectPrototype%. The %AsyncIteratorPrototype% object is an ordinary object. The initial value of the [[Extensible]] internal slot of the %AsyncIteratorPrototype% object is *true*.</p>
-    <emu-note>
-      <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%.The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
-    </emu-note>
+    <emu-clause id="sec-asynciteratorprototype">
+      <h1>The %AsyncIteratorPrototype% Object</h1>
+      <p>The value of the [[Prototype]] internal slot of the <dfn>%AsyncIteratorPrototype%</dfn> object is the intrinsic object %ObjectPrototype%. The %AsyncIteratorPrototype% object is an ordinary object. The initial value of the [[Extensible]] internal slot of the %AsyncIteratorPrototype% object is *true*.</p>
+      <emu-note>
+        <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%.The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
+      </emu-note>
 
-    <emu-clause id="sec-asynciteratorprototype-asynciterator">
-      <h1>%AsyncIteratorPrototype% [ @@asyncIterator ] ( )</h1>
-      <p>The following steps are taken:</p>
-      <emu-alg>
-        1. Return the *this* value.
-      </emu-alg>
-      <p>The value of the `name` property of this function is `"[Symbol.asyncIterator]"`.</p>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-async-from-sync-iterator-objects">
-    <h1>Async-from-Sync Iterator Objects</h1>
-    <p>An Async-from-Sync Iterator object is an async iterator that adapts a specific synchronous iterator. There is not a named constructor for Async-from-Sync Iterator objects. Instead, Async-from-Sync iterator objects are created by the CreateAsyncFromSyncIterator abstract operation as needed.</p>
-
-    <emu-clause id="sec-createasyncfromsynciterator" aoid="CreateAsyncFromSyncIterator">
-      <h1>CreateAsyncFromSyncIterator(_syncIteratorRecord_) Abstract Operation</h1>
-      <p>The abstract operation CreateAsyncFromSyncIterator is used to create an async iterator Record from a synchronous iterator Record. It performs the following steps:</p>
-      <emu-alg>
-        1. Let _asyncIterator_ be ! ObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
-        1. Set _asyncIterator_.[[SyncIteratorRecord]] to _syncIteratorRecord_.
-        1. Return ? GetIterator(_asyncIterator_, ~async~).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-%asyncfromsynciteratorprototype%-object">
-      <h1>The %AsyncFromSyncIteratorPrototype% Object</h1>
-      <p>All Async-from-Sync Iterator Objects inherit properties from the <dfn>%AsyncFromSyncIteratorPrototype%</dfn> intrinsic object. The %AsyncFromSyncIteratorPrototype% object is an ordinary object and its [[Prototype]] internal slot is the %AsyncIteratorPrototype% intrinsic object. In addition, %AsyncFromSyncIteratorPrototype% has the following properties:</p>
-
-      <emu-clause id="sec-%asyncfromsynciteratorprototype%.next">
-        <h1>%AsyncFromSyncIteratorPrototype%.next ( _value_ )</h1>
+      <emu-clause id="sec-asynciteratorprototype-asynciterator">
+        <h1>%AsyncIteratorPrototype% [ @@asyncIterator ] ( )</h1>
+        <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-            1. Let _badIteratorError_ be a new *TypeError* exception.
-            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
-            1. Return _promiseCapability_.[[Promise]].
-          1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
-          1. Let _nextResult_ be IteratorNext(_syncIteratorRecord_, _value_).
-          1. IfAbruptRejectPromise(_nextResult_, _promiseCapability_).
-          1. Let _nextDone_ be IteratorComplete(_nextResult_).
-          1. IfAbruptRejectPromise(_nextDone_, _promiseCapability_).
-          1. Let _nextValue_ be IteratorValue(_nextResult_).
-          1. IfAbruptRejectPromise(_nextValue_, _promiseCapability_).
-          1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _nextValue_ &raquo;).
-          1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
-          1. Set _onFulfilled_.[[Done]] to _nextDone_.
-          1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
-          1. Return _promiseCapability_.[[Promise]].
+          1. Return the *this* value.
         </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-%asyncfromsynciteratorprototype%.return">
-        <h1>%AsyncFromSyncIteratorPrototype%.return ( _value_ )</h1>
-
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-            1. Let _badIteratorError_ be a new *TypeError* exception.
-            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
-            1. Return _promiseCapability_.[[Promise]].
-          1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
-          1. Let _return_ be GetMethod(_syncIterator_, `"return"`).
-          1. IfAbruptRejectPromise(_return_, _promiseCapability_).
-          1. If _return_ is *undefined*, then
-            1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
-            1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
-            1. Return _promiseCapability_.[[Promise]].
-          1. Let _returnResult_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
-          1. IfAbruptRejectPromise(_returnResult_, _promiseCapability_).
-          1. If Type(_returnResult_) is not *Object*,
-            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
-            1. Return _promiseCapability_.[[Promise]].
-          1. Let _returnDone_ be IteratorComplete(_returnResult_).
-          1. IfAbruptRejectPromise(_returnDone_, _promiseCapability_).
-          1. Let _returnValue_ be IteratorValue(_returnResult_).
-          1. IfAbruptRejectPromise(_returnValue_, _promiseCapability_).
-          1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _returnValue_ &raquo;).
-          1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
-          1. Set _onFulfilled_.[[Done]] to _returnDone_.
-          1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
-          1. Return _promiseCapability_.[[Promise]].
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-%asyncfromsynciteratorprototype%.throw">
-        <h1>%AsyncFromSyncIteratorPrototype%.throw ( _value_ )</h1>
-
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
-            1. Let _badIteratorError_ be a new *TypeError* exception.
-            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
-            1. Return _promiseCapability_.[[Promise]].
-          1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
-          1. Let _throw_ be GetMethod(_syncIterator_, `"throw"`).
-          1. IfAbruptRejectPromise(_throw_, _promiseCapability_).
-          1. If _throw_ is *undefined*, then
-            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
-            1. Return _promiseCapability_.[[Promise]].
-          1. Let _throwResult_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
-          1. IfAbruptRejectPromise(_throwResult_, _promiseCapability_).
-          1. If Type(_throwResult_) is not *Object*,
-            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
-            1. Return _promiseCapability_.[[Promise]].
-          1. Let _throwDone_ be IteratorComplete(_throwResult_).
-          1. IfAbruptRejectPromise(_throwDone_, _promiseCapability_).
-          1. Let _throwValue_ be IteratorValue(_throwResult_).
-          1. IfAbruptRejectPromise(_throwValue_, _promiseCapability_).
-          1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _throwValue_ &raquo;).
-          1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
-          1. Set _onFulfilled_.[[Done]] to _throwDone_.
-          1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
-          1. Return _promiseCapability_.[[Promise]].
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-%asyncfromsynciteratorprototype%-@@tostringtag">
-        <h1>%AsyncFromSyncIteratorPrototype% [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"Async-from-Sync Iterator"`.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-async-from-sync-iterator-value-unwrap-functions">
-        <h1>Async-from-Sync Iterator Value Unwrap Functions</h1>
-
-        <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by methods of %AsyncFromSyncIteratorPrototype% when processing the `value` field of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async iterator value unwrap function has a [[Done]] internal slot.</p>
-
-        <p>When an async-from-sync iterator value unwrap function _F_ is called with argument _value_, the following steps are taken:</p>
-
-        <emu-alg>
-          1. Return ! CreateIterResultObject(_value_, _F_.[[Done]]).
-        </emu-alg>
+        <p>The value of the `name` property of this function is `"[Symbol.asyncIterator]"`.</p>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-properties-of-async-from-sync-iterator-instances">
-      <h1>Properties of Async-from-Sync Iterator Instances</h1>
-      <p>Async-from-Sync Iterator instances are ordinary objects that inherit properties from the %AsyncFromSyncIteratorPrototype% intrinsic object. Async-from-Sync Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-async-from-sync-iterator-internal-slots"></emu-xref>.</p>
-      <emu-table id="table-async-from-sync-iterator-internal-slots" caption="Internal Slots of Async-from-Sync Iterator Instances">
-        <table>
-          <thead>
-          <tr>
-            <th>
-              Internal Slot
-            </th>
-            <th>
-              Description
-            </th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr>
-            <td>
-              [[SyncIteratorRecord]]
-            </td>
-            <td>
-              A Record, of the type returned by GetIterator, representing the original synchronous iterator which is being adapted.
-            </td>
-          </tr>
-          </tbody>
-        </table>
-      </emu-table>
+    <emu-clause id="sec-async-from-sync-iterator-objects">
+      <h1>Async-from-Sync Iterator Objects</h1>
+      <p>An Async-from-Sync Iterator object is an async iterator that adapts a specific synchronous iterator. There is not a named constructor for Async-from-Sync Iterator objects. Instead, Async-from-Sync iterator objects are created by the CreateAsyncFromSyncIterator abstract operation as needed.</p>
+
+      <emu-clause id="sec-createasyncfromsynciterator" aoid="CreateAsyncFromSyncIterator">
+        <h1>CreateAsyncFromSyncIterator(_syncIteratorRecord_) Abstract Operation</h1>
+        <p>The abstract operation CreateAsyncFromSyncIterator is used to create an async iterator Record from a synchronous iterator Record. It performs the following steps:</p>
+        <emu-alg>
+          1. Let _asyncIterator_ be ! ObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
+          1. Set _asyncIterator_.[[SyncIteratorRecord]] to _syncIteratorRecord_.
+          1. Return ? GetIterator(_asyncIterator_, ~async~).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-%asyncfromsynciteratorprototype%-object">
+        <h1>The %AsyncFromSyncIteratorPrototype% Object</h1>
+        <p>All Async-from-Sync Iterator Objects inherit properties from the <dfn>%AsyncFromSyncIteratorPrototype%</dfn> intrinsic object. The %AsyncFromSyncIteratorPrototype% object is an ordinary object and its [[Prototype]] internal slot is the %AsyncIteratorPrototype% intrinsic object. In addition, %AsyncFromSyncIteratorPrototype% has the following properties:</p>
+
+        <emu-clause id="sec-%asyncfromsynciteratorprototype%.next">
+          <h1>%AsyncFromSyncIteratorPrototype%.next ( _value_ )</h1>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+            1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
+              1. Let _badIteratorError_ be a new *TypeError* exception.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
+            1. Let _nextResult_ be IteratorNext(_syncIteratorRecord_, _value_).
+            1. IfAbruptRejectPromise(_nextResult_, _promiseCapability_).
+            1. Let _nextDone_ be IteratorComplete(_nextResult_).
+            1. IfAbruptRejectPromise(_nextDone_, _promiseCapability_).
+            1. Let _nextValue_ be IteratorValue(_nextResult_).
+            1. IfAbruptRejectPromise(_nextValue_, _promiseCapability_).
+            1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
+            1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _nextValue_ &raquo;).
+            1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Set _onFulfilled_.[[Done]] to _nextDone_.
+            1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
+            1. Return _promiseCapability_.[[Promise]].
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-%asyncfromsynciteratorprototype%.return">
+          <h1>%AsyncFromSyncIteratorPrototype%.return ( _value_ )</h1>
+
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+            1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
+              1. Let _badIteratorError_ be a new *TypeError* exception.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
+            1. Let _return_ be GetMethod(_syncIterator_, `"return"`).
+            1. IfAbruptRejectPromise(_return_, _promiseCapability_).
+            1. If _return_ is *undefined*, then
+              1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
+              1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Let _returnResult_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
+            1. IfAbruptRejectPromise(_returnResult_, _promiseCapability_).
+            1. If Type(_returnResult_) is not *Object*,
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Let _returnDone_ be IteratorComplete(_returnResult_).
+            1. IfAbruptRejectPromise(_returnDone_, _promiseCapability_).
+            1. Let _returnValue_ be IteratorValue(_returnResult_).
+            1. IfAbruptRejectPromise(_returnValue_, _promiseCapability_).
+            1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
+            1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _returnValue_ &raquo;).
+            1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Set _onFulfilled_.[[Done]] to _returnDone_.
+            1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
+            1. Return _promiseCapability_.[[Promise]].
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-%asyncfromsynciteratorprototype%.throw">
+          <h1>%AsyncFromSyncIteratorPrototype%.throw ( _value_ )</h1>
+
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+            1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
+              1. Let _badIteratorError_ be a new *TypeError* exception.
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
+            1. Let _throw_ be GetMethod(_syncIterator_, `"throw"`).
+            1. IfAbruptRejectPromise(_throw_, _promiseCapability_).
+            1. If _throw_ is *undefined*, then
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Let _throwResult_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
+            1. IfAbruptRejectPromise(_throwResult_, _promiseCapability_).
+            1. If Type(_throwResult_) is not *Object*,
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Let _throwDone_ be IteratorComplete(_throwResult_).
+            1. IfAbruptRejectPromise(_throwDone_, _promiseCapability_).
+            1. Let _throwValue_ be IteratorValue(_throwResult_).
+            1. IfAbruptRejectPromise(_throwValue_, _promiseCapability_).
+            1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
+            1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _throwValue_ &raquo;).
+            1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Set _onFulfilled_.[[Done]] to _throwDone_.
+            1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
+            1. Return _promiseCapability_.[[Promise]].
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-%asyncfromsynciteratorprototype%-@@tostringtag">
+          <h1>%AsyncFromSyncIteratorPrototype% [ @@toStringTag ]</h1>
+          <p>The initial value of the @@toStringTag property is the String value `"Async-from-Sync Iterator"`.</p>
+          <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-async-from-sync-iterator-value-unwrap-functions">
+          <h1>Async-from-Sync Iterator Value Unwrap Functions</h1>
+
+          <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by methods of %AsyncFromSyncIteratorPrototype% when processing the `value` field of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async iterator value unwrap function has a [[Done]] internal slot.</p>
+
+          <p>When an async-from-sync iterator value unwrap function _F_ is called with argument _value_, the following steps are taken:</p>
+
+          <emu-alg>
+            1. Return ! CreateIterResultObject(_value_, _F_.[[Done]]).
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-properties-of-async-from-sync-iterator-instances">
+        <h1>Properties of Async-from-Sync Iterator Instances</h1>
+        <p>Async-from-Sync Iterator instances are ordinary objects that inherit properties from the %AsyncFromSyncIteratorPrototype% intrinsic object. Async-from-Sync Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-async-from-sync-iterator-internal-slots"></emu-xref>.</p>
+        <emu-table id="table-async-from-sync-iterator-internal-slots" caption="Internal Slots of Async-from-Sync Iterator Instances">
+          <table>
+            <thead>
+            <tr>
+              <th>
+                Internal Slot
+              </th>
+              <th>
+                Description
+              </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td>
+                [[SyncIteratorRecord]]
+              </td>
+              <td>
+                A Record, of the type returned by GetIterator, representing the original synchronous iterator which is being adapted.
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -38106,7 +38106,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-asyncgenerator-prototype-next">
         <h1>AsyncGenerator.prototype.next ( _value_ )</h1>
         <emu-alg>
-          1. Let _generator_ be the `this` value.
+          1. Let _generator_ be the *this* value.
           1. Let _completion_ be NormalCompletion(_value_).
           1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_).
         </emu-alg>
@@ -38115,7 +38115,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-asyncgenerator-prototype-return">
         <h1>AsyncGenerator.prototype.return ( _value_ )</h1>
         <emu-alg>
-          1. Let _generator_ be the `this` value.
+          1. Let _generator_ be the *this* value.
           1. Let _completion_ be Completion{[[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~}.
           1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_).
         </emu-alg>
@@ -38124,7 +38124,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-asyncgenerator-prototype-throw">
         <h1>AsyncGenerator.prototype.throw ( _exception_ )</h1>
         <emu-alg>
-          1. Let _generator_ be the `this` value.
+          1. Let _generator_ be the *this* value.
           1. Let _completion_ be Completion{[[Type]]: ~throw~, [[Value]]: _exception_, [[Target]]: ~empty~}.
           1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_).
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -983,6 +983,17 @@
           <table>
             <tbody>
             <tr>
+              <td>
+                @@asyncIterator
+              </td>
+              <td>
+                `"Symbol.asyncIterator"`
+              </td>
+              <td>
+                A method that returns the default AsyncIterator for an object. Called by the semantics of the `for`-`await`-`of` statement.
+              </td>
+            </tr>
+            <tr>
               <th>
                 Specification Name
               </th>
@@ -1834,6 +1845,16 @@
             </tr>
             <tr>
               <td>
+                %AsyncFromSyncIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of async-from-sync iterator objects (<emu-xref href="#sec-async-from-sync-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 %AsyncFunction%
               </td>
               <td>
@@ -1850,6 +1871,46 @@
               </td>
               <td>
                 The initial value of the `prototype` data property of %AsyncFunction%
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncGenerator%
+              </td>
+              <td>
+              </td>
+              <td>
+                The initial value of the `prototype` property of %AsyncGeneratorFunction%
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncGeneratorFunction%
+              </td>
+              <td>
+              </td>
+              <td>
+                The constructor of async iterator objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncGeneratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The initial value of the `prototype` property of %AsyncGenerator%
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                An object that all standard built-in async iterator objects indirectly inherit from
               </td>
             </tr>
             <tr>
@@ -2977,6 +3038,93 @@
         </table>
       </emu-table>
       <p>The term &ldquo;<dfn>abrupt completion</dfn>&rdquo; refers to any completion with a [[Type]] value other than ~normal~.</p>
+
+      <emu-clause id="await" aoid="Await">
+        <h1>Await</h1>
+
+        <emu-note type=editor>
+          <p>The AsyncFunctionAwait abstract operation could probably be refactored in terms of this primitive.</p>
+        </emu-note>
+
+        <p>Algorithm steps that say</p>
+
+        <emu-alg>
+          1. Let _completion_ be Await(_promise_).
+        </emu-alg>
+
+        <p>mean the same thing as:</p>
+
+        <emu-alg>
+          1. Let _asyncContext_ be the running execution context.
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _promise_ »).
+          1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#await-fulfilled" title></emu-xref>.
+          1. Let _onRejected_ be a new built-in function object as defined in <emu-xref href="#await-rejected" title></emu-xref>.
+          1. Set _onFulfilled_ and _onRejected_'s [[AsyncContext]] internal slots to _asyncContext_.
+          1. Let _throwawayCapability_ be NewPromiseCapability(%Promise%).
+          1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
+          1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
+          1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _completion_, the following steps of the algorithm that invoked Await will be performed, with _completion_ available.
+        </emu-alg>
+
+        <p>where all variables in the above steps, with the exception of _completion_, are ephemeral and visible only in the steps pertaining to Await.</p>
+
+        <emu-note>
+          <p>Await can be combined with the `?` and `!` prefixes, so that for example</p>
+
+          <emu-alg>
+            1. Let _value_ be ? Await(_promise_).
+          </emu-alg>
+
+          <p>means the same thing as:</p>
+
+          <emu-alg>
+            1. Let _value_ be Await(_promise_).
+            1. ReturnIfAbrupt(_value_).
+          </emu-alg>
+        </emu-note>
+
+        <emu-clause id="await-fulfilled">
+          <h1>Await Fulfilled Functions</h1>
+
+          <p>An Await fulfilled function is an anonymous built-in function that is used as part of the Await specification device to deliver the promise fulfillment value to the caller as a normal completion. Each Await fulfilled function has an [[AsyncContext]] internal slot.</p>
+
+          <p>When an Await fulfilled function _F_ is called with argument _value_, the following steps are taken:</p>
+
+          <emu-alg>
+            1. Let _asyncContext_ be _F_.[[AsyncContext]].
+            1. Let _prevContext_ be the running execution context.
+            1. Suspend _prevContext_.
+            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
+            1. Resume the suspended evaluation of _asyncContext_ using NormalCompletion(_value_) as the result of the operation that suspended it.
+            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+            1. Return *undefined*.
+          </emu-alg>
+
+          <p>The `length` property of an Await fulfilled function is 1.</p>
+        </emu-clause>
+
+        <emu-clause id="await-rejected">
+          <h1>Await Rejected Functions</h1>
+
+          <p>An Await rejected function is an anonymous built-in function that is used as part of the Await specification device to deliver the promise rejection reason to the caller as an abrupt throw completion. Each Await rejected function has an [[AsyncContext]] internal slot.</p>
+
+          <p>When an Await rejected function _F_ is called with argument _reason_, the following steps are taken:</p>
+
+          <emu-alg>
+            1. Let _asyncContext_ be _F_.[[AsyncContext]].
+            1. Let _prevContext_ be the running execution context.
+            1. Suspend _prevContext_.
+            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
+            1. Resume the suspended evaluation of _asyncContext_ using Completion{[[Type]]: ~throw~, [[Value]]: _reason_, [[Target]]: ~empty~} as the result of the operation that suspended it.
+            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+            1. Return *undefined*.
+          </emu-alg>
+
+          <p>The `length` property of an Await rejected function is 1.</p>
+        </emu-clause>
+      </emu-clause>
 
       <!-- es6num="6.2.2.1" -->
       <emu-clause id="sec-normalcompletion" aoid="NormalCompletion">
@@ -4813,13 +4961,38 @@
     <h1>Operations on Iterator Objects</h1>
     <p>See Common Iteration Interfaces (<emu-xref href="#sec-iteration"></emu-xref>).</p>
 
+    <emu-clause id="sec-asynciteratorclose" aoid="AsyncIteratorClose">
+      <h1><ins>AsyncIteratorClose ( _iteratorRecord_, _completion_ )</ins></h1>
+      <p>The abstract operation AsyncIteratorClose with arguments _iteratorRecord_ and _completion_ is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state:</p>
+      <emu-alg>
+        1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
+        1. Assert: _completion_ is a Completion Record.
+        1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
+        1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
+        1. If _return_ is *undefined*, return Completion(_completion_).
+        1. Let _innerResult_ be Call(_return_, _iterator_, &laquo; &raquo;).
+        1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
+        1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
+        1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
+        1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.
+        1. Return Completion(_completion_).
+      </emu-alg>
+    </emu-clause>
+
     <!-- es6num="7.4.1" -->
     <emu-clause id="sec-getiterator" aoid="GetIterator">
-      <h1>GetIterator ( _obj_ [ , _method_ ] )</h1>
+      <h1>GetIterator ( _obj_ [ , _hint_ ] [ , _method_ ] )</h1>
       <p>The abstract operation GetIterator with argument _obj_ and optional argument _method_ performs the following steps:</p>
       <emu-alg>
+        1. If _hint_ was not passed, let _hint_ be ~normal~.
         1. If _method_ is not present, then
-          1. Set _method_ to ? GetMethod(_obj_, @@iterator).
+          1. If _hint_ is ~async~,
+            1. Set _method_ to ? GetMethod(_obj_, @@asyncIterator).
+            1. If _method_ is *undefined*,
+              1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
+              1. Let _syncIteratorRecord_ be ? GetIterator(_obj_, ~normal~, _syncMethod_).
+              1. Return ? CreateAsyncFromSyncIterator(_syncIteratorRecord_).
+          1. Otherwise, set _method_ to ? GetMethod(_obj_, @@iterator).
         1. Let _iterator_ be ? Call(_method_, _obj_).
         1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
         1. Let _nextMethod_ be ? GetV(_iterator_, `"next"`).
@@ -7412,6 +7585,16 @@
           1. If _result_.[[Value]] is not *undefined*, throw a *TypeError* exception.
         1. Else, ReturnIfAbrupt(_result_).
         1. Return ? _envRec_.GetThisBinding().
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgeneratorfunctioncreate" aoid="AsyncGeneratorFunctionCreate">
+      <h1><ins>AsyncGeneratorFunctionCreate (_kind_, _ParameterList_, _Body_, _Scope_, _Strict_)</ins></h1>
+      <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list production specified by _ParameterList_, a body production specified by _Body_, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. AsyncGeneratorFunctionCreate performs the following steps:</p>
+      <emu-alg>
+        1. Let _functionPrototype_ be the intrinsic object %AsyncGenerator%.
+        1. Let _F_ be ! FunctionAllocate(_functionPrototype_, _Strict_, `"generator"`).
+        1. Return ! FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
     </emu-clause>
 
@@ -14765,7 +14948,14 @@
     BreakableStatement[Yield, Await, Return] :
       IterationStatement[?Yield, ?Await, ?Return]
       SwitchStatement[?Yield, ?Await, ?Return]
+
+    ReturnStatement[Yield, Await] :
+      `return` `;`
+      `return` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
   </emu-grammar>
+  <emu-note>
+    <p>A `return` statement causes a function to cease execution and return a value to the caller. If |Expression| is omitted, the return value is *undefined*. Otherwise, the return value is the value of |Expression|.</p>
+  </emu-note>
 
   <!-- es6num="13.1" -->
   <emu-clause id="sec-statement-semantics">
@@ -16249,6 +16439,9 @@
         `for` `(` [lookahead != `let` ] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+        [+Await] `for` `await` `(` [lookahead != `let` ] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+        [+Await] `for` `await` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+        [+Await] `for` `await` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
 
       ForDeclaration[Yield, Await] :
         LetOrConst ForBinding[?Yield, ?Await]
@@ -16281,6 +16474,9 @@
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <ul>
           <li>
@@ -16652,7 +16848,7 @@
 
     <!-- es6num="13.7.5" -->
     <emu-clause id="sec-for-in-and-for-of-statements">
-      <h1>The `for`-`in` and `for`-`of` Statements</h1>
+      <h1>The `for`-`in`, `for`-`of`, and `for`-`await`-`of` Statements</h1>
 
       <!-- es6num="13.7.5.1" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-early-errors">
@@ -16661,6 +16857,7 @@
           IterationStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <ul>
           <li>
@@ -16683,6 +16880,7 @@
           IterationStatement :
             `for` `(` ForDeclaration `in` Expression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <ul>
           <li>
@@ -16720,6 +16918,10 @@
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+
         </emu-grammar>
         <emu-alg>
           1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
@@ -16742,6 +16944,9 @@
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
@@ -16764,6 +16969,9 @@
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
@@ -16812,17 +17020,29 @@
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>
+          IterationStatement :
+            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+        </emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>
+          IterationStatement :
+            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+        </emu-grammar>
         <emu-alg>
           1. Let _names_ be the BoundNames of |ForBinding|.
           1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
           1. Return _names_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>
+          IterationStatement :
+            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+        </emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
@@ -16845,21 +17065,37 @@
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-grammar>
+          IterationStatement :
+            `for` `(` ForDeclaration `in` Expression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+        </emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>
+          IterationStatement :
+            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+        </emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>
+          IterationStatement :
+            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+        </emu-grammar>
         <emu-alg>
           1. Let _declarations_ be a List containing |ForBinding|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-grammar>
+          IterationStatement :
+            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+        </emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
@@ -16933,6 +17169,27 @@
           1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
           1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
         </emu-alg>
+        <emu-grammar>
+          IterationStatement : `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(« », |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~assignment~, _labelSet_, ~async~).
+        </emu-alg>
+        <emu-grammar>
+          IterationStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(« », |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~varBinding~, _labelSet_, ~async~).
+        </emu-alg>
+        <emu-grammar>
+          IterationStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be the result of performing ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~lexicalBinding~, _labelSet_, ~async~).
+        </emu-alg>
         <emu-note>
           <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
         </emu-note>
@@ -16961,15 +17218,18 @@
             1. Return ? EnumerateObjectProperties(_obj_).
           1. Else,
             1. Assert: _iterationKind_ is ~iterate~.
-            1. Return ? GetIterator(_exprValue_).
+            1. If _iterationKind_ is ~async-iterate~, let _iteratorHint_ be ~async~.
+            1. Else, let _iteratorHint_ be ~normal~.
+            1. Return ? GetIterator(_exprValue_, _iteratorHint_).
         </emu-alg>
       </emu-clause>
 
       <!-- es6num="13.7.5.13" -->
       <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" aoid="ForIn/OfBodyEvaluation">
-        <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ )</h1>
-        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, and _labelSet_. The value of _iterationKind_ is either ~enumerate~ or ~iterate~. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~.</p>
+        <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ])</h1>
+        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _lhsKind_, labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~normal~ or ~async~.</p>
         <emu-alg>
+          1. If _iteratorKind_ was not passed, let _iteratorKind_ be ~normal~.
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _V_ be *undefined*.
           1. Let _destructuring_ be IsDestructuring of _lhs_.
@@ -16977,8 +17237,9 @@
             1. Assert: _lhs_ is a |LeftHandSideExpression|.
             1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by _lhs_.
           1. Repeat,
-            1. Let _nextResult_ be ? IteratorStep(_iteratorRecord_).
-            1. If _nextResult_ is *false*, return NormalCompletion(_V_).
+            1. Let _nextResult_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]], &laquo; &raquo;).
+            1. If _iteratorKind_ is ~async~, then set _nextResult_ to ? Await(_nextResult_).
+            1. If Type(_nextResult_) is not Object, throw a *TypeError* exception.
             1. Let _nextValue_ be ? IteratorValue(_nextResult_).
             1. If _lhsKind_ is either ~assignment~ or ~varBinding~, then
               1. If _destructuring_ is *false*, then
@@ -17012,6 +17273,7 @@
                 1. Let _status_ be the result of performing BindingInitialization for _lhs_ passing _nextValue_ and _iterationEnv_ as arguments.
             1. If _status_ is an abrupt completion, then
               1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+              1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
               1. If _iterationKind_ is ~enumerate~, then
                 1. Return _status_.
               1. Else,
@@ -17206,6 +17468,7 @@
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
+        1. If ! GetGeneratorKind() is ~async~, set _exprValue_ to ? Await(_exprValue_).
         1. Return Completion{[[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~}.
       </emu-alg>
     </emu-clause>
@@ -19179,6 +19442,7 @@
       <emu-grammar>
         MethodDefinition :
           GeneratorMethod
+          AsyncGeneratorMethod
           AsyncMethod
           `get` PropertyName `(` `)` `{` FunctionBody `}`
           `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
@@ -19542,55 +19806,330 @@
       </emu-note>
       <emu-grammar>YieldExpression : `yield`</emu-grammar>
       <emu-alg>
-        1. Return ? GeneratorYield(CreateIterResultObject(*undefined*, *false*)).
+        1. Let _generatorKind_ be ! GetGeneratorKind().
+        1. If _generatorKind_ is ~async~, then return ? AsyncGeneratorYield(*undefined*).
+        1. Otherwise, return ? GeneratorYield(CreateIterResultObject(*undefined*, *false*)).
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` AssignmentExpression</emu-grammar>
       <emu-alg>
+        1. Let _generatorKind_ be ! GetGeneratorKind().
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
-        1. Return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
+        1. If _generatorKind_ is ~async~, then return ? AsyncGeneratorYield(_value_).
+        1. Otherwise, return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
       <emu-alg>
+        1. Let _generatorKind_ be ! GetGeneratorKind().
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
-        1. Let _iteratorRecord_ be ? GetIterator(_value_).
+        1. Let _iteratorRecord_ be ? GetIterator(_value_, _generatorKind_).
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
         1. Let _received_ be NormalCompletion(*undefined*).
         1. Repeat,
           1. If _received_.[[Type]] is ~normal~, then
-            1. Let _innerResult_ be ? IteratorNext(_iteratorRecord_, _received_.[[Value]]).
+            1. Let _innerResult_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]], &laquo; _received_.[[Value]] &raquo;).
+            1. If _generatorKind_ is ~async~, then set _innerResult_ to ? Await(_innerResult_).
+            1. If Type(_innerResult_) is not Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_innerResult_).
             1. If _done_ is *true*, then
               1. Return ? IteratorValue(_innerResult_).
-            1. Set _received_ to GeneratorYield(_innerResult_).
+            1. If _generatorKind_ is ~async~, then let _received_ be AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+            1. Else, let _received_ be GeneratorYield(_innerResult_).
           1. Else if _received_.[[Type]] is ~throw~, then
             1. Let _throw_ be ? GetMethod(_iterator_, `"throw"`).
             1. If _throw_ is not *undefined*, then
               1. Let _innerResult_ be ? Call(_throw_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
+              1. If _generatorKind_ is ~async~, then set _innerResult_ to ? Await(_innerResult_).
               1. NOTE: Exceptions from the inner iterator `throw` method are propagated. Normal completions from an inner `throw` method are processed similarly to an inner `next`.
               1. If Type(_innerResult_) is not Object, throw a *TypeError* exception.
               1. Let _done_ be ? IteratorComplete(_innerResult_).
               1. If _done_ is *true*, then
                 1. Return ? IteratorValue(_innerResult_).
-              1. Set _received_ to GeneratorYield(_innerResult_).
+              1. If _generatorKind_ is ~async~, then let _received_ be AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+              1. Else, let _received_ be GeneratorYield(_innerResult_).
             1. Else,
               1. NOTE: If _iterator_ does not have a `throw` method, this throw is going to terminate the `yield*` loop. But first we need to give _iterator_ a chance to clean up.
-              1. Perform ? IteratorClose(_iteratorRecord_, Completion{[[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~}).
+              1. Let _closeCompletion_ be Completion{[[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~}.
+              1. If _generatorKind_ is ~async~, perform ? AsyncIteratorClose(_iteratorRecord_, _closeCompletion_).
+              1. Else, perform ? IteratorClose(_iteratorRecord_, _closeCompletion_).
               1. NOTE: The next step throws a *TypeError* to indicate that there was a `yield*` protocol violation: _iterator_ does not have a `throw` method.
               1. Throw a *TypeError* exception.
           1. Else,
             1. Assert: _received_.[[Type]] is ~return~.
             1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
-            1. If _return_ is *undefined*, return Completion(_received_).
+            1. If _return_ is *undefined*, then:
+              1. If _generatorKind_ is ~async~, then set _received_.[[Value]] to ? Await(_received_.[[Value]]).
+              1. Return Completion(_received_).
             1. Let _innerReturnResult_ be ? Call(_return_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
+            1. If _generatorKind_ is ~async~, then set _innerReturnResult_ to ? Await(_innerReturnResult_).
             1. If Type(_innerReturnResult_) is not Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_innerReturnResult_).
             1. If _done_ is *true*, then
               1. Let _value_ be ? IteratorValue(_innerReturnResult_).
               1. Return Completion{[[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~}.
-            1. Set _received_ to GeneratorYield(_innerReturnResult_).
+            1. If _generatorKind_ is ~async~, then let _received_ be AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+            1. Else, let _received_ be GeneratorYield(_innerResult_).
       </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-async-generator-function-definitions">
+    <h1>Async Generator Function Definitions</h1>
+    <h2>Syntax</h2>
+    <emu-grammar>
+      AsyncGeneratorMethod[Yield, Await] :
+        `async` [no LineTerminator here] `*` PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+
+      AsyncGeneratorDeclaration[Yield, Await, Default] :
+        `async` [no LineTerminator here] `function` `*` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+        [+Default] `async` [no LineTerminator here] `function` `*` `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+
+      AsyncGeneratorExpression :
+        `async` [no LineTerminator here] `function` `*` BindingIdentifier[+Yield, +Await]? `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+
+      AsyncGeneratorBody :
+        FunctionBody[+Yield, +Await]
+    </emu-grammar>
+    <emu-note>
+      <p>|YieldExpression| and |AwaitExpression| cannot be used within the |FormalParameters| of an async generator function because any expressions that are part of |FormalParameters| are evaluated before the resulting async generator object is in a resumable state.</p>
+    </emu-note>
+    <emu-note>
+      <p>Abstract operations relating to async generator objects are defined in <emu-xref href="#sec-asyncgenerator-abstract-operations"></emu-xref>.</p>
+    </emu-note>
+
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>AsyncGeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <ul>
+        <li>It is a Syntax Error if HasDirectSuper of |AsyncGeneratorMethod| is *true*.</li>
+        <li>It is a Syntax Error if |UniqueFormalParameters| Contains |YieldExpression| is *true*.</li>
+        <li>It is a Syntax Error if |UniqueFormalParameters| Contains |AwaitExpression| is *true*.</li>
+        <li>It is a Syntax Error if ContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.</li>
+        <li>It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
+      </ul>
+      <emu-grammar>
+        AsyncGeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncGeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncGeneratorDeclaration : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <ul>
+        <li>If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.</li>
+        <li>It is a Syntax Error if ContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
+        <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
+        <li>It is a Syntax Error if |FormalParameters| Contains |YieldExpression| is *true*.</li>
+        <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
+        <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
+        <li>It is a Syntax Error if |AsyncGeneratorBody| Contains |SuperProperty| is *true*.</li>
+        <li>It is a Syntax Error if |FormalParameters| Contains |SuperCall| is *true*.</li>
+        <li>It is a Syntax Error if |AsyncGeneratorBody| Contains |SuperCall| is *true*.</li>
+      </ul>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-static-semantics-boundnames">
+      <h1>Static Semantics: BoundNames</h1>
+      <emu-see-also-para op="BoundNames"></emu-see-also-para>
+      <emu-grammar>AsyncGeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>AsyncGeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return &laquo; `"*default*"` &raquo;.
+      </emu-alg>
+      <emu-note>
+        <p>`"*default*"` is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-static-semantics-computedpropertycontains">
+      <h1>Static Semantics: ComputedPropertyContains</h1>
+      <p>With parameter _symbol_.</p>
+      <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
+      <emu-grammar>AsyncGeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-static-semantics-contains">
+      <h1>Static Semantics: Contains</h1>
+      <p>With parameter _symbol_.</p>
+      <emu-see-also-para op="Contains"></emu-see-also-para>
+      <emu-grammar>
+        AsyncGeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncGeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncGeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-note>
+        <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-static-semantics-hasdirectsuper">
+      <h1>Static Semantics: HasDirectSuper</h1>
+      <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
+      <emu-grammar>AsyncGeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
+        1. Return |AsyncGeneratorBody| Contains |SuperCall|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-static-semantics-hasname">
+      <h1>Static Semantics: HasName</h1>
+      <emu-see-also-para op="HasName"></emu-see-also-para>
+      <emu-grammar>AsyncGeneratorExpression : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>AsyncGeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-static-semantics-isconstantdeclaration">
+      <h1>Static Semantics: IsConstantDeclaration</h1>
+      <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
+      <emu-grammar>
+        AsyncGeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncGeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-static-semantics-isfunctiondefinition">
+      <h1>Static Semantics: IsFunctionDefinition</h1>
+      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
+      <emu-grammar>AsyncGeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-static-semantics-propname">
+      <h1>Static Semantics: PropName</h1>
+      <emu-see-also-para op="PropName"></emu-see-also-para>
+      <emu-grammar>AsyncGeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return PropName of |PropertyName|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-definitions-evaluatebody">
+      <h1>Runtime Semantics: EvaluateBody</h1>
+      <p>With parameters _functionObject_ and List _argumentsList_.</p>
+      <emu-grammar>
+        AsyncGeneratorBody : FunctionBody
+      </emu-grammar>
+      <emu-alg>
+        1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
+        1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, `"%AsyncGeneratorPrototype%"`, « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]] »).
+        1. Perform ! AsyncGeneratorStart(_generator_, _FunctionBody_).
+        1. Return Completion{[[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~}.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-definitions-instantiatefunctionobject">
+      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+      <p>With parameter _scope_.</p>
+      <emu-grammar>
+        AsyncGeneratorDeclaration : `async` [no LineTerminator here] `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for |AsyncGeneratorDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _F_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_, _strict_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform ! SetFunctionName(_F_, _name_).
+        1. Return _F_.
+      </emu-alg>
+
+      <emu-grammar>
+        AsyncGeneratorDeclaration : `async` [no LineTerminator here] `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for |AsyncGeneratorDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _F_ be AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_, _strict_).
+        1. Let _prototype_ be ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform SetFunctionName(_F_, `"default"`).
+        1. Return _F_.
+      </emu-alg>
+      <emu-note>
+        <p>An anonymous |AsyncGeneratorDeclaration| can only occur as part of an `export default` declaration.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-definitions-propertydefinitionevaluation">
+      <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
+      <p>With parameter _object_ and _enumerable_.</p>
+      <emu-grammar>
+        AsyncGeneratorMethod : `async` [no LineTerminator here] `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. If the function code for this |AsyncGeneratorMethod| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Method~, |UniqueFormalParameters|, |AsyncGeneratorBody|, _scope_, _strict_).
+        1. Perform ! MakeMethod(_closure_, _object_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform ! SetFunctionName(_closure_, _propKey_).
+        1. Let _desc_ be PropertyDescriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-definitions-evaluation">
+      <h1>Runtime Semantics: Evaluation</h1>
+
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` [no LineTerminator here] `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for this |AsyncGeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_, _strict_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Return _closure_.
+      </emu-alg>
+
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` [no LineTerminator here] `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for this |AsyncGeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
+        1. Let _envRec_ be _funcEnv_'s EnvironmentRecord.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Perform ! _envRec_.CreateImmutableBinding(_name_).
+        1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _funcEnv_, _strict_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform ! SetFunctionName(_closure_, _name_).
+        1. Perform ! _envRec_.InitializeBinding(_name_, _closure_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-note>
+        <p>The |BindingIdentifier| in an |AsyncGeneratorExpression| can be referenced from inside the |AsyncGeneratorExpression|'s |AsyncGeneratorBody| to allow the generator code to call itself recursively. However, unlike in an |AsyncGeneratorDeclaration|, the |BindingIdentifier| in an |AsyncGeneratorExpression| cannot be referenced from and does not affect the scope enclosing the |AsyncGeneratorExpression|.</p>
+      </emu-note>
     </emu-clause>
   </emu-clause>
 
@@ -24707,7 +25246,7 @@
         <!-- es6num="19.2.1.1.1" -->
         <emu-clause id="sec-createdynamicfunction" aoid="CreateDynamicFunction">
           <h1>Runtime Semantics: CreateDynamicFunction( _constructor_, _newTarget_, _kind_, _args_ )</h1>
-          <p>The abstract operation CreateDynamicFunction is called with arguments _constructor_, _newTarget_, _kind_, and _args_. _constructor_ is the constructor function that is performing this action, _newTarget_ is the constructor that `new` was initially applied to, _kind_ is either `"normal"`, `"generator"`, or `"async"`, and _args_ is a List containing the actual argument values that were passed to _constructor_. The following steps are taken:</p>
+          <p>The abstract operation CreateDynamicFunction is called with arguments _constructor_, _newTarget_, _kind_, and _args_. _constructor_ is the constructor function that is performing this action, _newTarget_ is the constructor that `new` was initially applied to, _kind_ is either `"normal"`, `"generator"`, `"async"`, or `"async generator"`, and _args_ is a List containing the actual argument values that were passed to _constructor_. The following steps are taken:</p>
           <emu-alg>
             1. Assert: The execution context stack has at least two elements.
             1. Let _callerContext_ be the second to top element of the execution context stack.
@@ -24723,11 +25262,16 @@
               1. Let _goal_ be the grammar symbol |GeneratorBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, ~Await]|.
               1. Let _fallbackProto_ be `"%Generator%"`.
-            1. Else,
+            1. Else if _kind_ is `"async"`,
               1. Assert: _kind_ is `"async"`.
               1. Let _goal_ be the grammar symbol |AsyncFunctionBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, +Await]|.
               1. Let _fallbackProto_ be `"%AsyncFunctionPrototype%"`.
+            1. Else,
+              1. Assert: _kind_ is `"async generator"`
+              1. Let _goal_ be the grammar symbol |AsyncGeneratorBody|.
+              1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, +Await]|.
+              1. Let _fallbackProto_ be `"%AsyncGenerator%"`.
             1. Let _argCount_ be the number of elements in _args_.
             1. Let _P_ be the empty String.
             1. If _argCount_ = 0, let _bodyText_ be the empty String.
@@ -24753,9 +25297,9 @@
             1. If _parameters_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
             1. If _body_ Contains |SuperProperty| is *true*, throw a *SyntaxError* exception.
             1. If _parameters_ Contains |SuperProperty| is *true*, throw a *SyntaxError* exception.
-            1. If _kind_ is `"generator"`, then
+            1. If _kind_ is `"generator"` or `"async generator"`, then
               1. If _parameters_ Contains |YieldExpression| is *true*, throw a *SyntaxError* exception.
-            1. If _kind_ is `"async"`, then
+            1. If _kind_ is `"async"` or `"async generator"`, then
               1. If _parameters_ Contains |AwaitExpression| is *true*, throw a *SyntaxError* exception.
             1. If _strict_ is *true*, then
               1. If BoundNames of _parameters_ contains any duplicate elements, throw a *SyntaxError* exception.
@@ -24766,6 +25310,9 @@
             1. Perform FunctionInitialize(_F_, ~Normal~, _parameters_, _body_, _scope_).
             1. If _kind_ is `"generator"`, then
               1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
+              1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+            1. Else if _kind_ is `"async generator"`, then
+              1. Let _prototype_ be ObjectCreate(%AsyncGeneratorPrototype%).
               1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
             1. Else if _kind_ is `"normal"`, perform MakeConstructor(_F_).
             1. NOTE: Async functions are not constructable and do not have a [[Construct]] internal method or a `"prototype"` property.
@@ -25161,6 +25708,12 @@
       <emu-clause id="sec-symbol.iterator">
         <h1>Symbol.iterator</h1>
         <p>The initial value of `Symbol.iterator` is the well-known symbol @@iterator (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-symbol.asynciterator">
+        <h1><ins>Symbol.asyncIterator</ins></h1>
+        <p>The initial value of `Symbol.asyncIterator` is the well known symbol @@asyncIterator (<emu-xref href="#table-1-patch"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -36781,6 +37334,91 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
+      <emu-clause id="sec-common-iteration-interfaces">
+        <h1>Common Iteration Interfaces</h1>
+
+        <emu-clause id="sec-asynciterable-interface">
+          <h1><ins>The <i>AsyncIterable</i> Interface</ins></h1>
+          <p>The <i>AsyncIterable</i> interface includes the properties described in <emu-xref href="#table-async-iterable"></emu-xref>:</p>
+          <emu-table id="table-async-iterable" caption="<i>AsyncIterable</i> Interface Required Properties">
+            <table>
+              <tbody>
+              <tr>
+                <th>Property</th>
+                <th>Value</th>
+                <th>Requirements</th>
+              </tr>
+              <tr>
+                <td>`@@asyncIterator`</td>
+                <td>A function that returns an <i>AsyncIterator</i> object.</td>
+                <td>The returned object must conform to the <i>AsyncIterator</i> interface.</td>
+              </tr>
+              </tbody>
+            </table>
+          </emu-table>
+        </emu-clause>
+
+        <emu-clause id="sec-asynciterator-interface">
+          <h1><ins>The <i>AsyncIterator</i> Interface</ins></h1>
+          <p>An object that implements the <i>AsyncIterator</i> interface must include the properties in <emu-xref href="#table-async-iterator-required"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-async-iterator-optional"></emu-xref>.</p>
+          <emu-table id="table-async-iterator-required" caption="<i>AsyncIterator</i> Interface Required Properties">
+            <table>
+              <tbody>
+              <tr>
+                <th>Property</th>
+                <th>Value</th>
+                <th>Requirements</th>
+              </tr>
+              <tr>
+                <td>`next`</td>
+                <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+                <td>
+                  <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose `done` property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose `done` property is *true*. However, this requirement is not enforced.</p>
+
+                  <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </emu-table>
+          <emu-note>
+            <p>Arguments may be passed to the next function but their interpretation and validity is dependent upon the target <i>AsyncIterator</i>. The `for`-`await`-`of` statement and other common users of <em>AsyncIterators</em> do not pass any arguments, so <i>AsyncIterator</i> objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
+          </emu-note>
+          <emu-table id="table-async-iterator-optional" caption="<i>AsyncIterator</i> Interface Optional Properties">
+            <table>
+              <tbody>
+              <tr>
+                <th>Property</th>
+                <th>Value</th>
+                <th>Requirements</th>
+              </tr>
+              <tr>
+                <td>`return`</td>
+                <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+                <td>
+                  <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a `done` property whose value is *true*, and a `value` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
+
+                  <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). If the argument value is used in the typical manner, then if it is a rejected promise, a promise rejected with the same reason should be returned; if it is a fulfilled promise, then its fulfillment value should be used as the `value` property of the returned promise's <i>IteratorResult</i> object fulfillment value. However, these requirements are also not enforced.</p>
+                </td>
+              </tr>
+              <tr>
+                <td>`throw`</td>
+                <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+                <td>
+                  <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to return a rejected promise which rejects with the value passed as the argument.</p>
+
+                  <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a `done` property whose value is *true*. Additionally, it should have a `value` property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </emu-table>
+          <emu-note>
+            <p>Typically callers of these methods should check for their existence before invoking them. Certain ECMAScript language features including `for`-`await`-`of` and `yield*` call these methods after performing an existence check.</p>
+          </emu-note>
+        </emu-clause>
+      </emu-clause>
+
       <!-- es6num="25.1.1.3" -->
       <emu-clause id="sec-iteratorresult-interface">
         <h1>The IteratorResult Interface</h1>
@@ -36846,6 +37484,184 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.iterator]"`.</p>
       </emu-clause>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-asynciteratorprototype">
+    <h1><ins>The %AsyncIteratorPrototype% Object</ins></h1>
+    <p>The value of the [[Prototype]] internal slot of the <dfn>%AsyncIteratorPrototype%</dfn> object is the intrinsic object %ObjectPrototype%. The %AsyncIteratorPrototype% object is an ordinary object. The initial value of the [[Extensible]] internal slot of the %AsyncIteratorPrototype% object is *true*.</p>
+    <emu-note>
+      <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%.The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
+    </emu-note>
+
+    <emu-clause id="sec-asynciteratorprototype-asynciterator">
+      <h1>%AsyncIteratorPrototype% [ @@asyncIterator ] ( )</h1>
+      <p>The following steps are taken:</p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+      <p>The value of the `name` property of this function is `"[Symbol.asyncIterator]"`.</p>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-async-from-sync-iterator-objects">
+    <h1><ins>Async-from-Sync Iterator Objects</ins></h1>
+    <p>An Async-from-Sync Iterator object is an async iterator that adapts a specific synchronous iterator. There is not a named constructor for Async-from-Sync Iterator objects. Instead, Async-from-Sync iterator objects are created by the CreateAsyncFromSyncIterator abstract operation as needed.</p>
+
+    <emu-clause id="sec-createasyncfromsynciterator" aoid="CreateAsyncFromSyncIterator">
+      <h1>CreateAsyncFromSyncIterator(_syncIteratorRecord_) Abstract Operation</h1>
+      <p>The abstract operation CreateAsyncFromSyncIterator is used to create an async iterator Record from a synchronous iterator Record. It performs the following steps:</p>
+      <emu-alg>
+        1. Let _asyncIterator_ be ! ObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
+        1. Set _asyncIterator_.[[SyncIteratorRecord]] to _syncIteratorRecord_.
+        1. Return ? GetIterator(_asyncIterator_, ~async~).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-%asyncfromsynciteratorprototype%-object">
+      <h1>The %AsyncFromSyncIteratorPrototype% Object</h1>
+      <p>All Async-from-Sync Iterator Objects inherit properties from the <dfn>%AsyncFromSyncIteratorPrototype%</dfn> intrinsic object. The %AsyncFromSyncIteratorPrototype% object is an ordinary object and its [[Prototype]] internal slot is the %AsyncIteratorPrototype% intrinsic object. In addition, %AsyncFromSyncIteratorPrototype% has the following properties:</p>
+
+      <emu-clause id="sec-%asyncfromsynciteratorprototype%.next">
+        <h1>%AsyncFromSyncIteratorPrototype%.next ( _value_ )</h1>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
+            1. Let _badIteratorError_ be a new *TypeError* exception.
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
+          1. Let _nextResult_ be IteratorNext(_syncIteratorRecord_, _value_).
+          1. IfAbruptRejectPromise(_nextResult_, _promiseCapability_).
+          1. Let _nextDone_ be IteratorComplete(_nextResult_).
+          1. IfAbruptRejectPromise(_nextDone_, _promiseCapability_).
+          1. Let _nextValue_ be IteratorValue(_nextResult_).
+          1. IfAbruptRejectPromise(_nextValue_, _promiseCapability_).
+          1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
+          1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _nextValue_ &raquo;).
+          1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+          1. Set _onFulfilled_.[[Done]] to _nextDone_.
+          1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
+          1. Return _promiseCapability_.[[Promise]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-%asyncfromsynciteratorprototype%.return">
+        <h1>%AsyncFromSyncIteratorPrototype%.return ( _value_ )</h1>
+
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
+            1. Let _badIteratorError_ be a new *TypeError* exception.
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
+          1. Let _return_ be GetMethod(_syncIterator_, `"return"`).
+          1. IfAbruptRejectPromise(_return_, _promiseCapability_).
+          1. If _return_ is *undefined*, then
+            1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
+            1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _returnResult_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
+          1. IfAbruptRejectPromise(_returnResult_, _promiseCapability_).
+          1. If Type(_returnResult_) is not *Object*,
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _returnDone_ be IteratorComplete(_returnResult_).
+          1. IfAbruptRejectPromise(_returnDone_, _promiseCapability_).
+          1. Let _returnValue_ be IteratorValue(_returnResult_).
+          1. IfAbruptRejectPromise(_returnValue_, _promiseCapability_).
+          1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
+          1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _returnValue_ &raquo;).
+          1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+          1. Set _onFulfilled_.[[Done]] to _returnDone_.
+          1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
+          1. Return _promiseCapability_.[[Promise]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-%asyncfromsynciteratorprototype%.throw">
+        <h1>%AsyncFromSyncIteratorPrototype%.throw ( _value_ )</h1>
+
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
+            1. Let _badIteratorError_ be a new *TypeError* exception.
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
+          1. Let _throw_ be GetMethod(_syncIterator_, `"throw"`).
+          1. IfAbruptRejectPromise(_throw_, _promiseCapability_).
+          1. If _throw_ is *undefined*, then
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _throwResult_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
+          1. IfAbruptRejectPromise(_throwResult_, _promiseCapability_).
+          1. If Type(_throwResult_) is not *Object*,
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _throwDone_ be IteratorComplete(_throwResult_).
+          1. IfAbruptRejectPromise(_throwDone_, _promiseCapability_).
+          1. Let _throwValue_ be IteratorValue(_throwResult_).
+          1. IfAbruptRejectPromise(_throwValue_, _promiseCapability_).
+          1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
+          1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _throwValue_ &raquo;).
+          1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+          1. Set _onFulfilled_.[[Done]] to _throwDone_.
+          1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
+          1. Return _promiseCapability_.[[Promise]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-%asyncfromsynciteratorprototype%-@@tostringtag">
+        <h1>%AsyncFromSyncIteratorPrototype% [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value `"Async-from-Sync Iterator"`.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-async-from-sync-iterator-value-unwrap-functions">
+        <h1>Async-from-Sync Iterator Value Unwrap Functions</h1>
+
+        <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by methods of %AsyncFromSyncIteratorPrototype% when processing the `value` field of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async iterator value unwrap function has a [[Done]] internal slot.</p>
+
+        <p>When an async-from-sync iterator value unwrap function _F_ is called with argument _value_, the following steps are taken:</p>
+
+        <emu-alg>
+          1. Return ! CreateIterResultObject(_value_, _F_.[[Done]]).
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-async-from-sync-iterator-instances">
+      <h1>Properties of Async-from-Sync Iterator Instances</h1>
+      <p>Async-from-Sync Iterator instances are ordinary objects that inherit properties from the %AsyncFromSyncIteratorPrototype% intrinsic object. Async-from-Sync Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-async-from-sync-iterator-internal-slots"></emu-xref>.</p>
+      <emu-table id="table-async-from-sync-iterator-internal-slots" caption="Internal Slots of Async-from-Sync Iterator Instances">
+        <table>
+          <thead>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              [[SyncIteratorRecord]]
+            </td>
+            <td>
+              A Record, of the type returned by GetIterator, representing the original synchronous iterator which is being adapted.
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </emu-table>
     </emu-clause>
   </emu-clause>
 
@@ -36954,6 +37770,100 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's `prototype` property does not have a `constructor` property whose value is the GeneratorFunction instance.</p>
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-asyncgeneratorfunction-objects">
+    <h1>Generator Objects</h1>
+    <p>AsyncGenerator Function objects are functions that are usually created by evaluating |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, and |AsyncGeneratorMethod| syntactic productions. They may also be created by calling the %AsyncGeneratorFunction% intrinsic.</p>
+
+    <emu-clause id="sec-asyncgeneratorfunction-constructor">
+      <h1>The AsyncGeneratorFunction Constructor</h1>
+      <p>The `AsyncGeneratorFunction` constructor is the <dfn>%AsyncGeneratorFunction%</dfn> intrinsic. When `AsyncGeneratorFunction` is called as a function rather than as a constructor, it creates and initializes a new AsyncGeneratorFunction object. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</p>
+      <p>`AsyncGeneratorFunction` is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `AsyncGeneratorFunction` behaviour must include a `super` call to the `AsyncGeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of `AsyncGeneratorFunction`. There is no syntactic means to create instances of `AsyncGeneratorFunction` subclasses.</p>
+
+      <emu-clause id="sec-asyncgeneratorfunction">
+        <h1>AsyncGeneratorFunction ( _p1_, _p2_, ..., _pn_, _body_ )</h1>
+        <p>The last argument specifies the body (executable code) of an async generator function; any preceding arguments specify formal parameters.</p>
+        <p>When the `AsyncGeneratorFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no "_p_" arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+        <emu-alg>
+          1. Let _C_ be the active function object.
+          1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, `"async generator"`, _args_).
+        </emu-alg>
+        <emu-note>
+          <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-asyncgeneratorfunction">
+      <h1>Properties of the AsyncGeneratorFunction Constructor</h1>
+      <p>The `AsyncGeneratorFunction` constructor is a standard built-in function object that inherits from the `Function` constructor. The value of the [[Prototype]] internal slot of the `AsyncGeneratorFunction` constructor is the intrinsic object %Function%.</p>
+      <p>The value of the [[Extensible]] internal slot of the AsyncGeneratorFunction constructor is *true*.</p>
+      <p>The value of the `name` property of the AsyncGeneratorFunction is `"AsyncGeneratorFunction"`.</p>
+      <p>The `AsyncGeneratorFunction` constructor has the following properties:</p>
+
+      <emu-clause id="sec-asyncgeneratorfunction-length">
+        <h1>AsyncGeneratorFunction.length</h1>
+        <p>This is a data property with a value of 1. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-prototype">
+        <h1>AsyncGeneratorFunction.prototype</h1>
+        <p>The initial value of `AsyncGeneratorFunction.prototype` is the intrinsic object <dfn>%AsyncGenerator%</dfn>.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-asyncgeneratorfunction-prototype">
+      <h1>Properties of the AsyncGeneratorFunction Prototype Object</h1>
+      <p>The AsyncGeneratorFunction prototype object is an ordinary object. It is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>. In addition to being the value of the prototype property of the %AsyncGeneratorFunction% intrinsic, it is the %AsyncGenerator% intrinsic.</p>
+      <p>The value of the [[Prototype]] internal slot of the AsyncGeneratorFunction prototype object is the %FunctionPrototype% intrinsic object. The initial value of the [[Extensible]] internal slot of the AsyncGeneratorFunction prototype object is *true*.</p>
+
+      <emu-clause id="sec-asyncgeneratorfunction-prototype-constructor">
+        <h1>AsyncGeneratorFunction.prototype.constructor</h1>
+        <p>The initial value of `AsyncGeneratorFunction.prototype.constructor` is the intrinsic object %AsyncGeneratorFunction%.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-prototype-prototype">
+        <h1>AsyncGeneratorFunction.prototype.prototype</h1>
+        <p>The value of `AsyncGeneratorFunction.prototype.prototype` is the %AsyncGeneratorPrototype% intrinsic object.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-prototype-tostringtag">
+        <h1>AsyncGeneratorFunction.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value `"AsyncGeneratorFunction"`.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgeneratorfunction-instances">
+      <h1>AsyncGeneratorFunction Instances</h1>
+      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is `"generator"`.</p>
+      <p>Each AsyncGeneratorFunction instance has the following own properties:</p>
+
+      <emu-clause id="sec-asyncgeneratorfunction-instance-length">
+        <h1>length</h1>
+        <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the AsyncGeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of an AsyncGeneratorFunction when invoked on a number of arguments other than the number specified by its `length` property depends on the function.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-instance-name">
+        <h1>name</h1>
+        <p>The specification for the `name` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncGeneratorFunction instances.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-instance-prototype">
+        <h1>prototype</h1>
+        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's `prototype` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator object when the generator function object is invoked using [[Call]].</p>
+        <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <emu-note>
+          <p>Unlike function instances, the object that is the value of the an AsyncGeneratorFunction's `prototype` property does not have a `constructor` property whose value is the AsyncGeneratorFunction instance.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -37145,6 +38055,17 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
+      <emu-clause id="sec-getgeneratorkind" aoid="GetGeneratorKind">
+        <h1><ins>GetGeneratorKind ( )</ins></h1>
+        <emu-alg>
+          1. Let _genContext_ be the running execution context.
+          1. If _genContext_ does not have a Generator component, return ~non-generator~.
+          1. Let _generator_ be the Generator component of _genContext_.
+          1. If _generator_ has an [[AsyncGeneratorState]] internal slot, return ~async~.
+          1. Else, return ~normal~.
+        </emu-alg>
+      </emu-clause>
+
       <!-- es6num="25.3.3.5" -->
       <emu-clause id="sec-generatoryield" aoid="GeneratorYield">
         <h1>GeneratorYield ( _iterNextObj_ )</h1>
@@ -37154,6 +38075,7 @@ THH:mm:ss.sss
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
           1. Let _generator_ be the value of the Generator component of _genContext_.
+          1. Assert: GetGeneratorKind() is ~normal~.
           1. Set _generator_.[[GeneratorState]] to `"suspendedYield"`.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
@@ -37163,6 +38085,93 @@ THH:mm:ss.sss
           1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
         </emu-alg>
       </emu-clause>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-asyncgenerator-objects">
+    <h1>AsyncGenerator Objects</h1>
+    <p>An AsyncGenerator object is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
+
+    <p>AsyncGenerator instances directly inherit properties from the object that is the value of the `prototype` property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGeneratorPrototype%.</p>
+
+    <emu-clause id="sec-properties-of-asyncgenerator-prototype">
+      <h1>Properties of AsyncGenerator Prototype</h1>
+      <p>The AsyncGenerator prototype object is the <dfn>%AsyncGeneratorPrototype%</dfn> intrinsic. It is also the initial value of the `prototype` property of the %AsyncGenerator% intrinsic (the AsyncGeneratorFunction.prototype).</p>
+      <p>The AsyncGenerator prototype is an ordinary object. It is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</p>
+      <p>The value of the [[Prototype]] internal slot of the AsyncGenerator prototype object is the intrinsic object %AsyncIteratorPrototype%. The initial value of the [[Extensible]] internal slot of the AsyncGenerator prototype object is *true*.</p>
+      <p>All AsyncGenerator instances indirectly inherit properties of the AsyncGenerator prototype object.</p>
+
+      <emu-clause id="sec-asyncgenerator-prototype-constructor">
+        <h1>AsyncGenerator.prototype.constructor</h1>
+        <p>The initial value of `AsyncGenerator.prototype.constructor` is the intrinsic object %AsyncGenerator%.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgenerator-prototype-next">
+        <h1>AsyncGenerator.prototype.next ( _value_ )</h1>
+        <emu-alg>
+          1. Let _generator_ be the `this` value.
+          1. Let _completion_ be NormalCompletion(_value_).
+          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgenerator-prototype-return">
+        <h1>AsyncGenerator.prototype.return ( _value_ )</h1>
+        <emu-alg>
+          1. Let _generator_ be the `this` value.
+          1. Let _completion_ be Completion{[[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~}.
+          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgenerator-prototype-throw">
+        <h1>AsyncGenerator.prototype.throw ( _exception_ )</h1>
+        <emu-alg>
+          1. Let _generator_ be the `this` value.
+          1. Let _completion_ be Completion{[[Type]]: ~throw~, [[Value]]: _exception_, [[Target]]: ~empty~}.
+          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgenerator-prototype-tostringtag">
+        <h1>AsyncGenerator.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value `"AsyncGenerator"`.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-asyncgenerator-intances">
+      <h1>Properties of AsyncGenerator Instances</h1>
+      <p>AsyncGenerator instances are initially created with the internal slots described below:</p>
+      <emu-table id="table-internal-slots-of-asyncgenerator-instances" caption="Internal Slots of AsyncGenerator Instances">
+        <table>
+          <tbody>
+          <tr>
+            <th>Internal Slot</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>[[AsyncGeneratorState]]</td>
+            <td>The current execution state of the async generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, `"awaiting-return"`, and `"completed"`.</td>
+          </tr>
+          <tr>
+            <td>[[AsyncGeneratorContext]]</td>
+            <td>The execution context that is used when executing the code of this async generator.</td>
+          </tr>
+          <tr>
+            <td>[[AsyncGeneratorQueue]]</td>
+            <td>A List of AsyncGeneratorRequest records which represent requests to resume the async generator.</td>
+          </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-abstract-operations">
+      <h1>AsyncGenerator Abstract Operations</h1>
+      <emu-import href="./abstract-operations.html"></emu-import>
     </emu-clause>
   </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -19875,7 +19875,7 @@
   <emu-clause id="sec-async-generator-function-definitions">
     <h1>Async Generator Function Definitions</h1>
     <h2>Syntax</h2>
-    <emu-grammar>
+    <emu-grammar type="definition">
       AsyncGeneratorMethod[Yield, Await] :
         `async` [no LineTerminator here] `*` PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
 

--- a/spec.html
+++ b/spec.html
@@ -19911,7 +19911,7 @@
 
         AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <ul>
         <li>If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>

--- a/spec.html
+++ b/spec.html
@@ -17226,7 +17226,7 @@
       <!-- es6num="13.7.5.13" -->
       <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" aoid="ForIn/OfBodyEvaluation">
         <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ])</h1>
-        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _lhsKind_, labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~normal~ or ~async~.</p>
+        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _lhsKind_, _labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~normal~ or ~async~.</p>
         <emu-alg>
           1. If _iteratorKind_ is not present, let _iteratorKind_ be ~normal~.
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.

--- a/spec.html
+++ b/spec.html
@@ -4967,6 +4967,7 @@
       <p>The abstract operation GetIterator with argument _obj_ and optional arguments _hint_ and _method_ performs the following steps:</p>
       <emu-alg>
         1. If _hint_ is not present, set _hint_ to ~sync~.
+        1. Assert: _hint_ is either ~sync~ or ~async~.
         1. If _method_ is not present, then
           1. If _hint_ is ~async~, then
             1. Set _method_ to ? GetMethod(_obj_, @@asyncIterator).

--- a/spec.html
+++ b/spec.html
@@ -4959,7 +4959,7 @@
 
     <!-- es6num="7.4.1" -->
     <emu-clause id="sec-getiterator" aoid="GetIterator">
-      <h1>GetIterator ( _obj_ [ , _hint_ ] [ , _method_ ] )</h1>
+      <h1>GetIterator ( _obj_ [ , _hint_ [ , _method_ ] ] )</h1>
       <p>The abstract operation GetIterator with argument _obj_ and optional arguments _hint_ and _method_ performs the following steps:</p>
       <emu-alg>
         1. If _hint_ was not passed, let _hint_ be ~normal~.

--- a/spec.html
+++ b/spec.html
@@ -25688,6 +25688,12 @@
         </emu-table>
       </emu-clause>
 
+      <emu-clause id="sec-symbol.asynciterator">
+        <h1>Symbol.asyncIterator</h1>
+        <p>The initial value of `Symbol.asyncIterator` is the well known symbol @@asyncIterator (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
+
       <!-- es6num="19.4.2.2" -->
       <emu-clause id="sec-symbol.hasinstance">
         <h1>Symbol.hasInstance</h1>
@@ -25706,12 +25712,6 @@
       <emu-clause id="sec-symbol.iterator">
         <h1>Symbol.iterator</h1>
         <p>The initial value of `Symbol.iterator` is the well-known symbol @@iterator (<emu-xref href="#table-1"></emu-xref>).</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-symbol.asynciterator">
-        <h1>Symbol.asyncIterator</h1>
-        <p>The initial value of `Symbol.asyncIterator` is the well known symbol @@asyncIterator (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -3061,7 +3061,7 @@
           1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#await-rejected" title></emu-xref>.
           1. Let _onRejected_ be CreateBuiltinFunction(_realm_, _stepsRejected_, %FunctionPrototype%, &laquo; [[AsyncContext]] &raquo;).
           1. Set _onRejected_.[[AsyncContext]] to _asyncContext_.
-          1. Let _throwawayCapability_ be NewPromiseCapability(%Promise%).
+          1. Let _throwawayCapability_ be ! NewPromiseCapability(%Promise%).
           1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
           1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
           1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
@@ -38286,7 +38286,7 @@ THH:mm:ss.sss
                 1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
                 1. Let _onRejected_ be CreateBuiltinFunction(_realm_, _stepsRejected_, %FunctionPrototype%, &laquo; [[Generator]] &raquo;).
                 1. Set _onRejected_.[[Generator]] to _generator_.
-                1. Let _throwawayCapability_ be NewPromiseCapability(%Promise%).
+                1. Let _throwawayCapability_ be ! NewPromiseCapability(%Promise%).
                 1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
                 1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
                 1. Return *undefined*.

--- a/spec.html
+++ b/spec.html
@@ -4964,9 +4964,9 @@
       <emu-alg>
         1. If _hint_ is not present, let _hint_ be ~normal~.
         1. If _method_ is not present, then
-          1. If _hint_ is ~async~,
+          1. If _hint_ is ~async~, then
             1. Set _method_ to ? GetMethod(_obj_, @@asyncIterator).
-            1. If _method_ is *undefined*,
+            1. If _method_ is *undefined*, then
               1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
               1. Let _syncIteratorRecord_ be ? GetIterator(_obj_, ~normal~, _syncMethod_).
               1. Return ? CreateAsyncFromSyncIterator(_syncIteratorRecord_).
@@ -19856,7 +19856,7 @@
           1. Else,
             1. Assert: _received_.[[Type]] is ~return~.
             1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
-            1. If _return_ is *undefined*, then:
+            1. If _return_ is *undefined*, then
               1. If _generatorKind_ is ~async~, then set _received_.[[Value]] to ? Await(_received_.[[Value]]).
               1. Return Completion(_received_).
             1. Let _innerReturnResult_ be ? Call(_return_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
@@ -25262,7 +25262,7 @@
               1. Let _goal_ be the grammar symbol |GeneratorBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, ~Await]|.
               1. Let _fallbackProto_ be `"%Generator%"`.
-            1. Else if _kind_ is `"async"`,
+            1. Else if _kind_ is `"async"`, then
               1. Assert: _kind_ is `"async"`.
               1. Let _goal_ be the grammar symbol |AsyncFunctionBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, +Await]|.
@@ -37561,7 +37561,7 @@ THH:mm:ss.sss
               1. Return _promiseCapability_.[[Promise]].
             1. Let _returnResult_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
             1. IfAbruptRejectPromise(_returnResult_, _promiseCapability_).
-            1. If Type(_returnResult_) is not *Object*,
+            1. If Type(_returnResult_) is not *Object*, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _returnDone_ be IteratorComplete(_returnResult_).
@@ -37595,7 +37595,7 @@ THH:mm:ss.sss
               1. Return _promiseCapability_.[[Promise]].
             1. Let _throwResult_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
             1. IfAbruptRejectPromise(_throwResult_, _promiseCapability_).
-            1. If Type(_throwResult_) is not *Object*,
+            1. If Type(_throwResult_) is not *Object*, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a *TypeError* exception &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _throwDone_ be IteratorComplete(_throwResult_).
@@ -38265,7 +38265,7 @@ THH:mm:ss.sss
               1. Set _generator_.[[AsyncGeneratorState]] to `"completed"`.
               1. Set _state_ to `"completed"`.
             1. If _state_ is `"completed"`, then
-              1. If _completion_.[[Type]] is ~return~:
+              1. If _completion_.[[Type]] is ~return~, then
                 1. Set _generator_.[[AsyncGeneratorState]] to `"awaiting-return"`.
                 1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
                 1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
@@ -38280,7 +38280,7 @@ THH:mm:ss.sss
                 1. Assert: _completion_.[[Type]] is ~throw~.
                 1. Perform ! AsyncGeneratorReject(_generator_, _completion_.[[Value]]).
                 1. Return *undefined*.
-          1. Else if _state_ is `"completed"`, then return ! AsyncGeneratorResolve(_generator_, *undefined*, *true*).
+          1. Else if _state_ is `"completed"`, return ! AsyncGeneratorResolve(_generator_, *undefined*, *true*).
           1. Assert: _state_ is either `"suspendedStart"` or `"suspendedYield"`.
           1. Let _genContext_ be _generator_.[[AsyncGeneratorContext]].
           1. Let _callerContext_ be the running execution context.

--- a/spec.html
+++ b/spec.html
@@ -37504,7 +37504,7 @@ THH:mm:ss.sss
       <p>An Async-from-Sync Iterator object is an async iterator that adapts a specific synchronous iterator. There is not a named constructor for Async-from-Sync Iterator objects. Instead, Async-from-Sync iterator objects are created by the CreateAsyncFromSyncIterator abstract operation as needed.</p>
 
       <emu-clause id="sec-createasyncfromsynciterator" aoid="CreateAsyncFromSyncIterator">
-        <h1>CreateAsyncFromSyncIterator(_syncIteratorRecord_) Abstract Operation</h1>
+        <h1>CreateAsyncFromSyncIterator ( _syncIteratorRecord_ )</h1>
         <p>The abstract operation CreateAsyncFromSyncIterator is used to create an async iterator Record from a synchronous iterator Record. It performs the following steps:</p>
         <emu-alg>
           1. Let _asyncIterator_ be ! ObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).

--- a/spec.html
+++ b/spec.html
@@ -4966,13 +4966,13 @@
       <h1>GetIterator ( _obj_ [ , _hint_ [ , _method_ ] ] )</h1>
       <p>The abstract operation GetIterator with argument _obj_ and optional arguments _hint_ and _method_ performs the following steps:</p>
       <emu-alg>
-        1. If _hint_ is not present, set _hint_ to ~normal~.
+        1. If _hint_ is not present, set _hint_ to ~sync~.
         1. If _method_ is not present, then
           1. If _hint_ is ~async~, then
             1. Set _method_ to ? GetMethod(_obj_, @@asyncIterator).
             1. If _method_ is *undefined*, then
               1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
-              1. Let _syncIteratorRecord_ be ? GetIterator(_obj_, ~normal~, _syncMethod_).
+              1. Let _syncIteratorRecord_ be ? GetIterator(_obj_, ~sync~, _syncMethod_).
               1. Return ? CreateAsyncFromSyncIterator(_syncIteratorRecord_).
           1. Otherwise, set _method_ to ? GetMethod(_obj_, @@iterator).
         1. Let _iterator_ be ? Call(_method_, _obj_).
@@ -17218,7 +17218,7 @@
           1. Else,
             1. Assert: _iterationKind_ is ~iterate~.
             1. If _iterationKind_ is ~async-iterate~, let _iteratorHint_ be ~async~.
-            1. Else, let _iteratorHint_ be ~normal~.
+            1. Else, let _iteratorHint_ be ~sync~.
             1. Return ? GetIterator(_exprValue_, _iteratorHint_).
         </emu-alg>
       </emu-clause>
@@ -17226,9 +17226,9 @@
       <!-- es6num="13.7.5.13" -->
       <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" aoid="ForIn/OfBodyEvaluation">
         <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ])</h1>
-        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~normal~ or ~async~.</p>
+        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~sync~ or ~async~.</p>
         <emu-alg>
-          1. If _iteratorKind_ is not present, set _iteratorKind_ to ~normal~.
+          1. If _iteratorKind_ is not present, set _iteratorKind_ to ~sync~.
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _V_ be *undefined*.
           1. Let _destructuring_ be IsDestructuring of _lhs_.
@@ -32157,7 +32157,7 @@ THH:mm:ss.sss
               1. Let _A_ be ? Construct(_C_).
             1. Else,
               1. Let _A_ be ! ArrayCreate(0).
-            1. Let _iteratorRecord_ be ? GetIterator(_items_, ~normal~, _usingIterator_).
+            1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~, _usingIterator_).
             1. Let _k_ be 0.
             1. Repeat,
               1. If _k_ &ge; 2<sup>53</sup>-1, then
@@ -33788,7 +33788,7 @@ THH:mm:ss.sss
           <h1>Runtime Semantics: IterableToList( _items_, _method_ )</h1>
           <p>The abstract operation IterableToList performs the following steps:</p>
           <emu-alg>
-            1. Let _iteratorRecord_ be ? GetIterator(_items_, ~normal~, _method_).
+            1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~, _method_).
             1. Let _values_ be a new empty List.
             1. Let _next_ be *true*.
             1. Repeat, while _next_ is not *false*
@@ -38068,7 +38068,7 @@ THH:mm:ss.sss
           1. If _genContext_ does not have a Generator component, return ~non-generator~.
           1. Let _generator_ be the Generator component of _genContext_.
           1. If _generator_ has an [[AsyncGeneratorState]] internal slot, return ~async~.
-          1. Else, return ~normal~.
+          1. Else, return ~sync~.
         </emu-alg>
       </emu-clause>
 
@@ -38081,7 +38081,7 @@ THH:mm:ss.sss
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
           1. Let _generator_ be the value of the Generator component of _genContext_.
-          1. Assert: GetGeneratorKind() is ~normal~.
+          1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _generator_.[[GeneratorState]] to `"suspendedYield"`.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:

--- a/spec.html
+++ b/spec.html
@@ -4978,7 +4978,7 @@
     <!-- es6num="7.4.1" -->
     <emu-clause id="sec-getiterator" aoid="GetIterator">
       <h1>GetIterator ( _obj_ [ , _hint_ ] [ , _method_ ] )</h1>
-      <p>The abstract operation GetIterator with argument _obj_ and optional argument _method_ performs the following steps:</p>
+      <p>The abstract operation GetIterator with argument _obj_ and optional arguments _hint_ and _method_ performs the following steps:</p>
       <emu-alg>
         1. If _hint_ was not passed, let _hint_ be ~normal~.
         1. If _method_ is not present, then
@@ -32149,7 +32149,7 @@ THH:mm:ss.sss
               1. Let _A_ be ? Construct(_C_).
             1. Else,
               1. Let _A_ be ! ArrayCreate(0).
-            1. Let _iteratorRecord_ be ? GetIterator(_items_, _usingIterator_).
+            1. Let _iteratorRecord_ be ? GetIterator(_items_, ~normal~, _usingIterator_).
             1. Let _k_ be 0.
             1. Repeat,
               1. If _k_ &ge; 2<sup>53</sup>-1, then
@@ -33780,7 +33780,7 @@ THH:mm:ss.sss
           <h1>Runtime Semantics: IterableToList( _items_, _method_ )</h1>
           <p>The abstract operation IterableToList performs the following steps:</p>
           <emu-alg>
-            1. Let _iteratorRecord_ be ? GetIterator(_items_, _method_).
+            1. Let _iteratorRecord_ be ? GetIterator(_items_, ~normal~, _method_).
             1. Let _values_ be a new empty List.
             1. Let _next_ be *true*.
             1. Repeat, while _next_ is not *false*

--- a/spec.html
+++ b/spec.html
@@ -38171,7 +38171,204 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-asyncgenerator-abstract-operations">
       <h1>AsyncGenerator Abstract Operations</h1>
-      <emu-import href="./abstract-operations.html"></emu-import>
+      <emu-clause id="sec-asyncgeneratorrequest-records">
+        <h1>AsyncGeneratorRequest Records</h1>
+        <p>The AsyncGeneratorRequest is a Record value used to store information about how an async generator should be resumed and contains capabilities for fulfilling or rejecting the corresponding promise.</p>
+        <p>They have the following fields:</p>
+        <emu-table caption="AsyncGeneratorRequest Record Fields">
+          <table>
+            <tbody>
+            <tr>
+              <th>Field Name</th>
+              <th>Value</th>
+              <th>Meaning</th>
+            </tr>
+            <tr>
+              <td>[[Completion]]</td>
+              <td>A Completion record</td>
+              <td>The completion which should be used to resume the async generator.</td>
+            </tr>
+            <tr>
+              <td>[[Capability]]</td>
+              <td>A PromiseCapability record</td>
+              <td>The promise capabilities associated with this request.</td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorstart" aoid="AsyncGeneratorStart">
+        <h1>AsyncGeneratorStart ( _generator_, _generatorBody_ )</h1>
+        <emu-alg>
+          1. Assert: _generator_ is an AsyncGenerator instance.
+          1. Assert: _generator_.[[AsyncGeneratorState]] is *undefined*.
+          1. Let _genContext_ be the running execution context.
+          1. Set the Generator component of _genContext_ to _generator_.
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+            1. Let _result_ be the result of evaluating _generatorBody_.
+            1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
+            1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Set _generator_.[[AsyncGeneratorState]] to `"completed"`.
+            1. If _result_ is a normal completion, let _resultValue_ be *undefined*.
+            1. Else,
+              1. Let _resultValue_ be _result_.[[Value]].
+              1. If _result_.[[Type]] is not ~return~, then
+                1. Return ! AsyncGeneratorReject(_generator_, _resultValue_).
+            1. Return ! AsyncGeneratorResolve(_generator_, _resultValue_, *true*).
+          1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
+          1. Set _generator_.[[AsyncGeneratorState]] to `"suspendedStart"`.
+          1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
+          1. Return *undefined*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorresolve" aoid="AsyncGeneratorResolve">
+        <h1>AsyncGeneratorResolve ( _generator_, _value_, _done_ )</h1>
+        <emu-alg>
+          1. Assert: _generator_ is an AsyncGenerator instance.
+          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
+          1. Assert: _queue_ is not an empty List.
+          1. Remove the first element from _queue_ and let _next_ be the value of that element.
+          1. Let _promiseCapability_ be _next_.[[Capability]].
+          1. Let _iteratorResult_ be ! CreateIterResultObject(_value_, _done_).
+          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iteratorResult_ &raquo;).
+          1. Perform ! AsyncGeneratorResumeNext(_generator_).
+          1. Return *undefined*.
+        </emu-clause>
+      </emu-alg>
+
+      <emu-clause id="sec-asyncgeneratorreject" aoid="AsyncGeneratorReject">
+        <h1>AsyncGeneratorReject ( _generator_, _exception_ )</h1>
+        <emu-alg>
+          1. Assert: _generator_ is an AsyncGenerator instance.
+          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
+          1. Assert: _queue_ is not an empty List.
+          1. Remove the first element from _queue_ and let _next_ be the value of that element.
+          1. Let _promiseCapability_ be _next_.[[Capability]].
+          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _exception_ »).
+          1. Perform ! AsyncGeneratorResumeNext(_generator_).
+          1. Return *undefined*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorresumenext" aoid="AsyncGeneratorResumeNext">
+        <h1>AsyncGeneratorResumeNext ( _generator_ )</h1>
+        <emu-alg>
+          1. Assert: _generator_ is an AsyncGenerator instance.
+          1. Let _state_ be _generator_.[[AsyncGeneratorState]].
+          1. Assert: _state_ is not `"executing"`.
+          1. If _state_ is `"awaiting-return"`, return *undefined*.
+          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
+          1. If _queue_ is an empty List, return *undefined*.
+          1. Let _next_ be the value of the first element of _queue_.
+          1. Assert: _next_ is an AsyncGeneratorRequest record.
+          1. Let _completion_ be _next_.[[Completion]].
+          1. If _completion_ is an abrupt completion, then
+            1. If _state_ is `"suspendedStart"`, then
+              1. Set _generator_.[[AsyncGeneratorState]] to `"completed"`.
+              1. Set _state_ to `"completed"`.
+            1. If _state_ is `"completed"`, then
+              1. If _completion_.[[Type]] is ~return~:
+                1. Set _generator_.[[AsyncGeneratorState]] to `"awaiting-return"`.
+                1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _completion_.[[Value]] »).
+                1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
+                1. Let _onRejected_ be a new built-in function object as defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
+                1. Set _onFulfilled_ and _onRejected_'s [[Generator]] internal slots to _generator_.
+                1. Let _throwawayCapability_ be NewPromiseCapability(%Promise%).
+                1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
+                1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
+                1. Return *undefined*.
+              1. Else,
+                1. Assert: _completion_.[[Type]] is ~throw~.
+                1. Perform ! AsyncGeneratorReject(_generator_, _completion_.[[Value]]).
+                1. Return *undefined*.
+          1. Else if _state_ is `"completed"`, then return ! AsyncGeneratorResolve(_generator_, *undefined*, *true*).
+          1. Assert: _state_ is either `"suspendedStart"` or `"suspendedYield"`.
+          1. Let _genContext_ be _generator_.[[AsyncGeneratorContext]].
+          1. Let _callerContext_ be the running execution context.
+          1. Suspend _callerContext_.
+          1. Set _generator_.[[AsyncGeneratorState]] to `"executing"`.
+          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
+          1. Resume the suspended evaluation of _genContext_ using _completion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
+          1. Assert: _result_ is never an abrupt completion.
+          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _callerContext_ is the currently running execution context.
+          1. Return *undefined*.
+        </emu-alg>
+
+        <emu-clause id="async-generator-resume-next-return-processor-fulfilled">
+          <h1>AsyncGeneratorResumeNext Return Processor Fulfilled Functions</h1>
+
+          <p>An AsyncGeneratorResumeNext return processor fulfilled function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor fulfilled function has a [[Generator]] internal slot.</p>
+
+          <p>When an AsyncGeneratorResumeNext return processor fulfilled function _F_ is called with argument _value_, the following steps are taken:</p>
+
+          <emu-alg>
+            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to `"completed"`.
+            1. Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
+          </emu-alg>
+
+          <p>The `length` property of an AsyncGeneratorResumeNext return processor fulfilled function is 1.</p>
+        </emu-clause>
+
+        <emu-clause id="async-generator-resume-next-return-processor-rejected">
+          <h1>AsyncGeneratorResumeNext Return Processor Rejected Functions</h1>
+
+          <p>An AsyncGeneratorResumeNext return processor rejected function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor rejected function has a [[Generator]] internal slot.</p>
+
+          <p>When an AsyncGeneratorResumeNext return processor rejected function _F_ is called with argument _reason_, the following steps are taken:</p>
+
+          <emu-alg>
+            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to `"completed"`.
+            1. Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
+          </emu-alg>
+
+          <p>The `length` property of an AsyncGeneratorResumeNext return processor rejected function is 1.</p>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorenqueue" aoid="AsyncGeneratorEnqueue">
+        <h1>AsyncGeneratorEnqueue ( _generator_, _completion_ )</h1>
+        <emu-alg>
+          1. Assert: _completion_ is a Completion Record.
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. If Type(_generator_) is not Object, or if _generator_ does not have an [[AsyncGeneratorState]] internal slot, then
+            1. Let _badGeneratorError_ be a new *TypeError* exception.
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badGeneratorError_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
+          1. Let _request_ be AsyncGeneratorRequest{[[Completion]]: _completion_, [[Capability]]: _promiseCapability_}.
+          1. Append _request_ to the end of _queue_.
+          1. Let _state_ be _generator_.[[AsyncGeneratorState]].
+          1. If _state_ is not `"executing"`, then
+            1. Perform ! AsyncGeneratorResumeNext(_generator_).
+          1. Return _promiseCapability_.[[Promise]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratoryield" aoid="AsyncGeneratorYield">
+        <h1><ins>AsyncGeneratorYield ( _value_ )</ins></h1>
+        <p>The abstract operation AsyncGeneratorYield with argument _value_ performs the following steps:</p>
+        <emu-alg>
+          1. Let _genContext_ be the running execution context.
+          1. Assert: _genContext_ is the execution context of a generator.
+          1. Let _generator_ be the value of the Generator component of _genContext_.
+          1. Assert: GetGeneratorKind() is ~async~.
+          1. Set _value_ to ? Await(_value_).
+          1. Set _generator_.[[AsyncGeneratorState]] to `"suspendedYield"`.
+          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
+            1. If _resumptionValue_.[[Type]] is not ~return~, return Completion(_resumptionValue_).
+            1. Let _awaited_ be Await(_resumptionValue_.[[Value]]).
+            1. If _awaited_.[[Type]] is ~throw~, return Completion(_awaited_).
+            1. Assert: _awaited_.[[Type]] is ~normal~.
+            1. Return Completion{[[Type]]: ~return~, [[Value]]: _awaited_.[[Value]], [[Target]]: ~empty~}.
+            1. NOTE: When one of the above steps returns, it returns to the evaluation of the |YieldExpression| production that originally called this abstract operation.
+          1. Return ! AsyncGeneratorResolve(_generator_, _value_, *false*).
+          1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -37524,7 +37524,7 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
               1. Let _invalidIteratorError_ be a newly created *TypeError* object.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_  &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
             1. Let _nextResult_ be IteratorNext(_syncIteratorRecord_, _value_).
@@ -37550,7 +37550,7 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
               1. Let _invalidIteratorError_ be a newly created *TypeError* object.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
             1. Let _return_ be GetMethod(_syncIterator_, `"return"`).
@@ -37585,7 +37585,7 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
               1. Let _invalidIteratorError_ be a newly created *TypeError* object.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badIteratorError_ &raquo;).
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
             1. Let _throw_ be GetMethod(_syncIterator_, `"throw"`).

--- a/spec.html
+++ b/spec.html
@@ -7660,7 +7660,7 @@
 
     <emu-clause id="sec-asyncgeneratorfunctioncreate" aoid="AsyncGeneratorFunctionCreate">
       <h1>AsyncGeneratorFunctionCreate (_kind_, _ParameterList_, _Body_, _Scope_, _Strict_)</h1>
-      <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list production specified by _ParameterList_, a body production specified by _Body_, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. AsyncGeneratorFunctionCreate performs the following steps:</p>
+      <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. AsyncGeneratorFunctionCreate performs the following steps:</p>
       <emu-alg>
         1. Let _functionPrototype_ be the intrinsic object %AsyncGenerator%.
         1. Let _F_ be ! FunctionAllocate(_functionPrototype_, _Strict_, `"generator"`).

--- a/spec.html
+++ b/spec.html
@@ -17226,7 +17226,7 @@
       <!-- es6num="13.7.5.13" -->
       <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" aoid="ForIn/OfBodyEvaluation">
         <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ])</h1>
-        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _lhsKind_, _labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~normal~ or ~async~.</p>
+        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~normal~ or ~async~.</p>
         <emu-alg>
           1. If _iteratorKind_ is not present, let _iteratorKind_ be ~normal~.
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.

--- a/spec.html
+++ b/spec.html
@@ -983,17 +983,6 @@
           <table>
             <tbody>
             <tr>
-              <td>
-                @@asyncIterator
-              </td>
-              <td>
-                `"Symbol.asyncIterator"`
-              </td>
-              <td>
-                A method that returns the default AsyncIterator for an object. Called by the semantics of the `for`-`await`-`of` statement.
-              </td>
-            </tr>
-            <tr>
               <th>
                 Specification Name
               </th>
@@ -1003,6 +992,17 @@
               <th>
                 Value and Purpose
               </th>
+            </tr>
+            <tr>
+              <td>
+                @@asyncIterator
+              </td>
+              <td>
+                `"Symbol.asyncIterator"`
+              </td>
+              <td>
+                A method that returns the default AsyncIterator for an object. Called by the semantics of the `for`-`await`-`of` statement.
+              </td>
             </tr>
             <tr>
               <td>

--- a/spec.html
+++ b/spec.html
@@ -4966,7 +4966,7 @@
       <h1>GetIterator ( _obj_ [ , _hint_ [ , _method_ ] ] )</h1>
       <p>The abstract operation GetIterator with argument _obj_ and optional arguments _hint_ and _method_ performs the following steps:</p>
       <emu-alg>
-        1. If _hint_ is not present, let _hint_ be ~normal~.
+        1. If _hint_ is not present, set _hint_ to ~normal~.
         1. If _method_ is not present, then
           1. If _hint_ is ~async~, then
             1. Set _method_ to ? GetMethod(_obj_, @@asyncIterator).
@@ -17228,7 +17228,7 @@
         <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ])</h1>
         <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~normal~ or ~async~.</p>
         <emu-alg>
-          1. If _iteratorKind_ is not present, let _iteratorKind_ be ~normal~.
+          1. If _iteratorKind_ is not present, set _iteratorKind_ to ~normal~.
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _V_ be *undefined*.
           1. Let _destructuring_ be IsDestructuring of _lhs_.
@@ -17285,7 +17285,7 @@
                 1. Return Completion(UpdateEmpty(_result_, _V_)).
               1. Else,
                 1. Assert: _iterationKind_ is ~iterate~.
-                1. Let _status_ be UpdateEmpty(_result_, _V_).
+                1. Set _status_ to UpdateEmpty(_result_, _V_).
                 1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
                 1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
@@ -19836,8 +19836,8 @@
             1. Let _done_ be ? IteratorComplete(_innerResult_).
             1. If _done_ is *true*, then
               1. Return ? IteratorValue(_innerResult_).
-            1. If _generatorKind_ is ~async~, then let _received_ be AsyncGeneratorYield(? IteratorValue(_innerResult_)).
-            1. Else, let _received_ be GeneratorYield(_innerResult_).
+            1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+            1. Else, set _received_ to GeneratorYield(_innerResult_).
           1. Else if _received_.[[Type]] is ~throw~, then
             1. Let _throw_ be ? GetMethod(_iterator_, `"throw"`).
             1. If _throw_ is not *undefined*, then
@@ -19848,8 +19848,8 @@
               1. Let _done_ be ? IteratorComplete(_innerResult_).
               1. If _done_ is *true*, then
                 1. Return ? IteratorValue(_innerResult_).
-              1. If _generatorKind_ is ~async~, then let _received_ be AsyncGeneratorYield(? IteratorValue(_innerResult_)).
-              1. Else, let _received_ be GeneratorYield(_innerResult_).
+              1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+              1. Else, set _received_ to GeneratorYield(_innerResult_).
             1. Else,
               1. NOTE: If _iterator_ does not have a `throw` method, this throw is going to terminate the `yield*` loop. But first we need to give _iterator_ a chance to clean up.
               1. Let _closeCompletion_ be Completion{[[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~}.
@@ -19870,8 +19870,8 @@
             1. If _done_ is *true*, then
               1. Let _value_ be ? IteratorValue(_innerReturnResult_).
               1. Return Completion{[[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~}.
-            1. If _generatorKind_ is ~async~, then let _received_ be AsyncGeneratorYield(? IteratorValue(_innerResult_)).
-            1. Else, let _received_ be GeneratorYield(_innerResult_).
+            1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+            1. Else, set _received_ to GeneratorYield(_innerResult_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -19870,8 +19870,8 @@
             1. If _done_ is *true*, then
               1. Let _value_ be ? IteratorValue(_innerReturnResult_).
               1. Return Completion{[[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~}.
-            1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
-            1. Else, set _received_ to GeneratorYield(_innerResult_).
+            1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerReturnResult_)).
+            1. Else, set _received_ to GeneratorYield(_innerReturnResult_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -37332,89 +37332,85 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-common-iteration-interfaces">
-        <h1>Common Iteration Interfaces</h1>
+      <emu-clause id="sec-asynciterable-interface">
+        <h1>The <i>AsyncIterable</i> Interface</h1>
+        <p>The <i>AsyncIterable</i> interface includes the properties described in <emu-xref href="#table-async-iterable"></emu-xref>:</p>
+        <emu-table id="table-async-iterable" caption="<i>AsyncIterable</i> Interface Required Properties">
+          <table>
+            <tbody>
+            <tr>
+              <th>Property</th>
+              <th>Value</th>
+              <th>Requirements</th>
+            </tr>
+            <tr>
+              <td>`@@asyncIterator`</td>
+              <td>A function that returns an <i>AsyncIterator</i> object.</td>
+              <td>The returned object must conform to the <i>AsyncIterator</i> interface.</td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+      </emu-clause>
 
-        <emu-clause id="sec-asynciterable-interface">
-          <h1>The <i>AsyncIterable</i> Interface</h1>
-          <p>The <i>AsyncIterable</i> interface includes the properties described in <emu-xref href="#table-async-iterable"></emu-xref>:</p>
-          <emu-table id="table-async-iterable" caption="<i>AsyncIterable</i> Interface Required Properties">
-            <table>
-              <tbody>
-              <tr>
-                <th>Property</th>
-                <th>Value</th>
-                <th>Requirements</th>
-              </tr>
-              <tr>
-                <td>`@@asyncIterator`</td>
-                <td>A function that returns an <i>AsyncIterator</i> object.</td>
-                <td>The returned object must conform to the <i>AsyncIterator</i> interface.</td>
-              </tr>
-              </tbody>
-            </table>
-          </emu-table>
-        </emu-clause>
+      <emu-clause id="sec-asynciterator-interface">
+        <h1>The <i>AsyncIterator</i> Interface</h1>
+        <p>An object that implements the <i>AsyncIterator</i> interface must include the properties in <emu-xref href="#table-async-iterator-required"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-async-iterator-optional"></emu-xref>.</p>
+        <emu-table id="table-async-iterator-required" caption="<i>AsyncIterator</i> Interface Required Properties">
+          <table>
+            <tbody>
+            <tr>
+              <th>Property</th>
+              <th>Value</th>
+              <th>Requirements</th>
+            </tr>
+            <tr>
+              <td>`next`</td>
+              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>
+                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose `done` property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose `done` property is *true*. However, this requirement is not enforced.</p>
 
-        <emu-clause id="sec-asynciterator-interface">
-          <h1>The <i>AsyncIterator</i> Interface</h1>
-          <p>An object that implements the <i>AsyncIterator</i> interface must include the properties in <emu-xref href="#table-async-iterator-required"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-async-iterator-optional"></emu-xref>.</p>
-          <emu-table id="table-async-iterator-required" caption="<i>AsyncIterator</i> Interface Required Properties">
-            <table>
-              <tbody>
-              <tr>
-                <th>Property</th>
-                <th>Value</th>
-                <th>Requirements</th>
-              </tr>
-              <tr>
-                <td>`next`</td>
-                <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
-                <td>
-                  <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose `done` property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose `done` property is *true*. However, this requirement is not enforced.</p>
+                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+        <emu-note>
+          <p>Arguments may be passed to the next function but their interpretation and validity is dependent upon the target <i>AsyncIterator</i>. The `for`-`await`-`of` statement and other common users of <em>AsyncIterators</em> do not pass any arguments, so <i>AsyncIterator</i> objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
+        </emu-note>
+        <emu-table id="table-async-iterator-optional" caption="<i>AsyncIterator</i> Interface Optional Properties">
+          <table>
+            <tbody>
+            <tr>
+              <th>Property</th>
+              <th>Value</th>
+              <th>Requirements</th>
+            </tr>
+            <tr>
+              <td>`return`</td>
+              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>
+                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a `done` property whose value is *true*, and a `value` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
 
-                  <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
-                </td>
-              </tr>
-              </tbody>
-            </table>
-          </emu-table>
-          <emu-note>
-            <p>Arguments may be passed to the next function but their interpretation and validity is dependent upon the target <i>AsyncIterator</i>. The `for`-`await`-`of` statement and other common users of <em>AsyncIterators</em> do not pass any arguments, so <i>AsyncIterator</i> objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
-          </emu-note>
-          <emu-table id="table-async-iterator-optional" caption="<i>AsyncIterator</i> Interface Optional Properties">
-            <table>
-              <tbody>
-              <tr>
-                <th>Property</th>
-                <th>Value</th>
-                <th>Requirements</th>
-              </tr>
-              <tr>
-                <td>`return`</td>
-                <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
-                <td>
-                  <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a `done` property whose value is *true*, and a `value` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
+                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). If the argument value is used in the typical manner, then if it is a rejected promise, a promise rejected with the same reason should be returned; if it is a fulfilled promise, then its fulfillment value should be used as the `value` property of the returned promise's <i>IteratorResult</i> object fulfillment value. However, these requirements are also not enforced.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>`throw`</td>
+              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>
+                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to return a rejected promise which rejects with the value passed as the argument.</p>
 
-                  <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). If the argument value is used in the typical manner, then if it is a rejected promise, a promise rejected with the same reason should be returned; if it is a fulfilled promise, then its fulfillment value should be used as the `value` property of the returned promise's <i>IteratorResult</i> object fulfillment value. However, these requirements are also not enforced.</p>
-                </td>
-              </tr>
-              <tr>
-                <td>`throw`</td>
-                <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
-                <td>
-                  <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to return a rejected promise which rejects with the value passed as the argument.</p>
-
-                  <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a `done` property whose value is *true*. Additionally, it should have a `value` property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
-                </td>
-              </tr>
-              </tbody>
-            </table>
-          </emu-table>
-          <emu-note>
-            <p>Typically callers of these methods should check for their existence before invoking them. Certain ECMAScript language features including `for`-`await`-`of` and `yield*` call these methods after performing an existence check.</p>
-          </emu-note>
-        </emu-clause>
+                <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a `done` property whose value is *true*. Additionally, it should have a `value` property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+        <emu-note>
+          <p>Typically callers of these methods should check for their existence before invoking them. Certain ECMAScript language features including `for`-`await`-`of` and `yield*` call these methods after performing an existence check.</p>
+        </emu-note>
       </emu-clause>
 
       <!-- es6num="25.1.1.3" -->

--- a/spec.html
+++ b/spec.html
@@ -3054,9 +3054,13 @@
           1. Let _asyncContext_ be the running execution context.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _promise_ &raquo;).
-          1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#await-fulfilled" title></emu-xref>.
-          1. Let _onRejected_ be a new built-in function object as defined in <emu-xref href="#await-rejected" title></emu-xref>.
-          1. Set _onFulfilled_ and _onRejected_'s [[AsyncContext]] internal slots to _asyncContext_.
+          1. Let _realm_ be the current Realm Record.
+          1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#await-fulfilled" title></emu-xref>.
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_realm_, _stepsFulfilled_, %FunctionPrototype%, &laquo; [[AsyncContext]] &raquo;).
+          1. Set _onFulfilled_.[[AsyncContext]] to _asyncContext_.
+          1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#await-rejected" title></emu-xref>.
+          1. Let _onRejected_ be CreateBuiltinFunction(_realm_, _stepsRejected_, %FunctionPrototype%, &laquo; [[AsyncContext]] &raquo;).
+          1. Set _onRejected_.[[AsyncContext]] to _asyncContext_.
           1. Let _throwawayCapability_ be NewPromiseCapability(%Promise%).
           1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
           1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
@@ -37535,7 +37539,9 @@ THH:mm:ss.sss
             1. IfAbruptRejectPromise(_nextValue_, _promiseCapability_).
             1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
             1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _nextValue_ &raquo;).
-            1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Let _realm_ be the current Realm Record.
+            1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Let _onFulfilled_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[Done]] &raquo;).
             1. Set _onFulfilled_.[[Done]] to _nextDone_.
             1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
             1. Return _promiseCapability_.[[Promise]].
@@ -37570,7 +37576,9 @@ THH:mm:ss.sss
             1. IfAbruptRejectPromise(_returnValue_, _promiseCapability_).
             1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
             1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _returnValue_ &raquo;).
-            1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Let _realm_ be the current Realm Record.
+            1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Let _onFulfilled_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[Done]] &raquo;).
             1. Set _onFulfilled_.[[Done]] to _returnDone_.
             1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
             1. Return _promiseCapability_.[[Promise]].
@@ -37604,7 +37612,9 @@ THH:mm:ss.sss
             1. IfAbruptRejectPromise(_throwValue_, _promiseCapability_).
             1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
             1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _throwValue_ &raquo;).
-            1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Let _realm_ be the current Realm Record.
+            1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+            1. Let _onFulfilled_ be CreateBuiltinFunction(_realm_, _steps_, %FunctionPrototype%, &laquo; [[Done]] &raquo;).
             1. Set _onFulfilled_.[[Done]] to _throwDone_.
             1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
             1. Return _promiseCapability_.[[Promise]].
@@ -38269,9 +38279,13 @@ THH:mm:ss.sss
                 1. Set _generator_.[[AsyncGeneratorState]] to `"awaiting-return"`.
                 1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
                 1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
-                1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
-                1. Let _onRejected_ be a new built-in function object as defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
-                1. Set _onFulfilled_ and _onRejected_'s [[Generator]] internal slots to _generator_.
+                1. Let _realm_ be the current Realm Record.
+                1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
+                1. Let _onFulfilled_ be CreateBuiltinFunction(_realm_, _stepsFulfilled_, %FunctionPrototype%, &laquo; [[Generator]] &raquo;).
+                1. Set _onFulfilled_.[[Generator]] to _generator_.
+                1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
+                1. Let _onRejected_ be CreateBuiltinFunction(_realm_, _stepsRejected_, %FunctionPrototype%, &laquo; [[Generator]] &raquo;).
+                1. Set _onRejected_.[[Generator]] to _generator_.
                 1. Let _throwawayCapability_ be NewPromiseCapability(%Promise%).
                 1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
                 1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).

--- a/spec.html
+++ b/spec.html
@@ -37528,7 +37528,7 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. If Type(_O_) is not Object, or if _O_ does not have a [[SyncIteratorRecord]] internal slot, then
               1. Let _invalidIteratorError_ be a newly created *TypeError* object.
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_  &raquo;).
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
             1. Let _nextResult_ be IteratorNext(_syncIteratorRecord_, _value_).

--- a/spec.html
+++ b/spec.html
@@ -20039,7 +20039,7 @@
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, `"%AsyncGeneratorPrototype%"`, &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]] &raquo;).
-        1. Perform ! AsyncGeneratorStart(_generator_, _FunctionBody_).
+        1. Perform ! AsyncGeneratorStart(_generator_, |FunctionBody|).
         1. Return Completion{[[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~}.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -19898,7 +19898,7 @@
 
     <emu-clause id="sec-async-generator-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>AsyncGeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <ul>
         <li>It is a Syntax Error if HasDirectSuper of |AsyncGeneratorMethod| is *true*.</li>
         <li>It is a Syntax Error if |UniqueFormalParameters| Contains |YieldExpression| is *true*.</li>
@@ -19907,11 +19907,11 @@
         <li>It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
       </ul>
       <emu-grammar>
-        AsyncGeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncGeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncGeneratorDeclaration : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <ul>
         <li>If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
@@ -19930,11 +19930,11 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar>AsyncGeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return &laquo; `"*default*"` &raquo;.
       </emu-alg>
@@ -19947,7 +19947,7 @@
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
       </emu-alg>
@@ -19958,11 +19958,11 @@
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
       <emu-grammar>
-        AsyncGeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncGeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncGeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -19975,7 +19975,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |AsyncGeneratorBody| Contains |SuperCall|.
@@ -19985,11 +19985,11 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorExpression : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>AsyncGeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19999,9 +19999,9 @@
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
       <emu-grammar>
-        AsyncGeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncGeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -20011,7 +20011,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -20020,7 +20020,7 @@
     <emu-clause id="sec-generator-function-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return PropName of |PropertyName|.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -7584,16 +7584,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-asyncgeneratorfunctioncreate" aoid="AsyncGeneratorFunctionCreate">
-      <h1>AsyncGeneratorFunctionCreate (_kind_, _ParameterList_, _Body_, _Scope_, _Strict_)</h1>
-      <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list production specified by _ParameterList_, a body production specified by _Body_, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. AsyncGeneratorFunctionCreate performs the following steps:</p>
-      <emu-alg>
-        1. Let _functionPrototype_ be the intrinsic object %AsyncGenerator%.
-        1. Let _F_ be ! FunctionAllocate(_functionPrototype_, _Strict_, `"generator"`).
-        1. Return ! FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
-      </emu-alg>
-    </emu-clause>
-
     <!-- es6num="9.2.3" -->
     <emu-clause id="sec-functionallocate" aoid="FunctionAllocate">
       <h1>FunctionAllocate ( _functionPrototype_, _strict_, _functionKind_ )</h1>
@@ -7661,6 +7651,16 @@
         1. Let _functionPrototype_ be the intrinsic object %Generator%.
         1. Let _F_ be FunctionAllocate(_functionPrototype_, _Strict_, `"generator"`).
         1. Return FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgeneratorfunctioncreate" aoid="AsyncGeneratorFunctionCreate">
+      <h1>AsyncGeneratorFunctionCreate (_kind_, _ParameterList_, _Body_, _Scope_, _Strict_)</h1>
+      <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list production specified by _ParameterList_, a body production specified by _Body_, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. AsyncGeneratorFunctionCreate performs the following steps:</p>
+      <emu-alg>
+        1. Let _functionPrototype_ be the intrinsic object %AsyncGenerator%.
+        1. Let _F_ be ! FunctionAllocate(_functionPrototype_, _Strict_, `"generator"`).
+        1. Return ! FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
     </emu-clause>
 
@@ -17282,7 +17282,9 @@
                 1. Return Completion(UpdateEmpty(_result_, _V_)).
               1. Else,
                 1. Assert: _iterationKind_ is ~iterate~.
-                1. Return ? IteratorClose(_iteratorRecord_, UpdateEmpty(_result_, _V_)).
+                1. Let _status_ be UpdateEmpty(_result_, _V_).
+                1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
+                1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -14948,14 +14948,7 @@
     BreakableStatement[Yield, Await, Return] :
       IterationStatement[?Yield, ?Await, ?Return]
       SwitchStatement[?Yield, ?Await, ?Return]
-
-    ReturnStatement[Yield, Await] :
-      `return` `;`
-      `return` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
   </emu-grammar>
-  <emu-note>
-    <p>A `return` statement causes a function to cease execution and return a value to the caller. If |Expression| is omitted, the return value is *undefined*. Otherwise, the return value is the value of |Expression|.</p>
-  </emu-note>
 
   <!-- es6num="13.1" -->
   <emu-clause id="sec-statement-semantics">

--- a/spec.html
+++ b/spec.html
@@ -4962,7 +4962,7 @@
       <h1>GetIterator ( _obj_ [ , _hint_ [ , _method_ ] ] )</h1>
       <p>The abstract operation GetIterator with argument _obj_ and optional arguments _hint_ and _method_ performs the following steps:</p>
       <emu-alg>
-        1. If _hint_ was not passed, let _hint_ be ~normal~.
+        1. If _hint_ is not present, let _hint_ be ~normal~.
         1. If _method_ is not present, then
           1. If _hint_ is ~async~,
             1. Set _method_ to ? GetMethod(_obj_, @@asyncIterator).
@@ -17224,7 +17224,7 @@
         <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ])</h1>
         <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _lhsKind_, labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~normal~ or ~async~.</p>
         <emu-alg>
-          1. If _iteratorKind_ was not passed, let _iteratorKind_ be ~normal~.
+          1. If _iteratorKind_ is not present, let _iteratorKind_ be ~normal~.
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _V_ be *undefined*.
           1. Let _destructuring_ be IsDestructuring of _lhs_.

--- a/spec.html
+++ b/spec.html
@@ -37770,7 +37770,7 @@ THH:mm:ss.sss
   </emu-clause>
 
   <emu-clause id="sec-asyncgeneratorfunction-objects">
-    <h1>Generator Objects</h1>
+    <h1>AsyncGeneratorFunction Objects</h1>
     <p>AsyncGenerator Function objects are functions that are usually created by evaluating |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, and |AsyncGeneratorMethod| syntactic productions. They may also be created by calling the %AsyncGeneratorFunction% intrinsic.</p>
 
     <emu-clause id="sec-asyncgeneratorfunction-constructor">


### PR DESCRIPTION
This supersedes @zbraniecki's #1063. The individual commits are just to show the delta from that.

One potential question for the editor is the ordering of sections within 25 (Control Abstraction Objects). I went with

- Iteration
- GeneratorFunction Objects
- **AsyncGeneratorFunction Objects**
- Generator Objects
- **AsyncGenerator Objects**
- Promise Objects
- AsyncFunction Objects

but I can also see an argument for keeping the two new sections together, perhaps even after the AsyncFunction Objects section.

(Closes #1063)