### PR TITLE
Normative: Make array spread accept nullish values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11587,6 +11587,7 @@
         <emu-alg>
           1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
+          1. If _spreadObj_ is either *null* or *undefined*, return.
           1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).


### PR DESCRIPTION
Previously, `[42, ...undefined]` threw a TypeError exception.

The object spread proposal has the more useful behavior of silently ignoring `null` and `undefined` values, e.g. `{ a: 42, ...undefined }` results in `{ a: 42 }` instead of throwing an exception.

This patch applies the same concept to array spread, making `[42, ...undefined]` result in `[42]`.