### PR TITLE
Normative: add explicit "length" property info for ThenFinally/CatchFinally

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37657,17 +37657,17 @@ THH:mm:ss.sss
               1. Let _thenFinally_ be _onFinally_.
               1. Let _catchFinally_ be _onFinally_.
           1. Else,
-              1. Let _thenFinally_ be a new built-in function object as defined in <emu-xref href="#sec-thenfinallyfunction">ThenFinally Function</emu-xref>.
-              1. Let _catchFinally_ be a new built-in function object as defined in <emu-xref href="#sec-catchfinallyfunction">CatchFinally Function</emu-xref>.
+              1. Let _thenFinally_ be a new built-in function object as defined in <emu-xref href="#sec-thenfinallyfunctions" title></emu-xref>.
+              1. Let _catchFinally_ be a new built-in function object as defined in <emu-xref href="#sec-catchfinallyfunctions" title></emu-xref>.
               1. Set _thenFinally_ and _catchFinally_'s [[Constructor]] internal slots to _C_.
               1. Set _thenFinally_ and _catchFinally_'s [[OnFinally]] internal slots to _onFinally_.
           1. Return ? Invoke(_promise_, `"then"`, &laquo; _thenFinally_, _catchFinally_ &raquo;).
         </emu-alg>
 
-        <emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
-          <h1>ThenFinally Function</h1>
-          <p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
-          <p>When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:</p>
+        <emu-clause id="sec-thenfinallyfunctions">
+          <h1>Then Finally Functions</h1>
+          <p>A Then Finally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+          <p>When a Then Finally function _F_ is called with argument _value_, the following steps are taken:</p>
           <emu-alg>
               1. Let _onFinally_ be _F_.[[OnFinally]].
               1. Assert: IsCallable(_onFinally_) is *true*.
@@ -37678,24 +37678,26 @@ THH:mm:ss.sss
               1. Let _valueThunk_ be equivalent to a function that returns _value_.
               1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_ &raquo;).
           </emu-alg>
-      </emu-clause>
+          <p>The `length` property of a Then Finally function is *1*.</p>
+        </emu-clause>
 
-      <emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
-        <h1>CatchFinally Function</h1>
-        <p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
-        <p>When a CatchFinally function _F_ is called with argument _reason_, the following steps are taken:</p>
-        <emu-alg>
-            1. Let _onFinally_ be _F_.[[OnFinally]].
-            1. Assert: IsCallable(_onFinally_) is *true*.
-            1. Let _result_ be ? Call(_onFinally_, *undefined*).
-            1. Let _C_ be _F_.[[Constructor]].
-            1. Assert: IsConstructor(_C_) is *true*.
-            1. Let _promise_ be ? PromiseResolve(_C_, _result_).
-            1. Let _thrower_ be equivalent to a function that throws _reason_.
-            1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_ &raquo;).
-        </emu-alg>
+        <emu-clause id="sec-catchfinallyfunctions">
+          <h1>Catch Finally Functions</h1>
+          <p>A Catch Finally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+          <p>When a Catch Finally function _F_ is called with argument _reason_, the following steps are taken:</p>
+          <emu-alg>
+              1. Let _onFinally_ be _F_.[[OnFinally]].
+              1. Assert: IsCallable(_onFinally_) is *true*.
+              1. Let _result_ be ? Call(_onFinally_, *undefined*).
+              1. Let _C_ be _F_.[[Constructor]].
+              1. Assert: IsConstructor(_C_) is *true*.
+              1. Let _promise_ be ? PromiseResolve(_C_, _result_).
+              1. Let _thrower_ be equivalent to a function that throws _reason_.
+              1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_ &raquo;).
+          </emu-alg>
+          <p>The `length` property of a Catch Finally function is *1*.</p>
+        </emu-clause>
       </emu-clause>
-    </emu-clause>
 
       <!-- es6num="25.4.5.3" -->
       <emu-clause id="sec-promise.prototype.then">


### PR DESCRIPTION
Fixes #1078

cc @anba

Technically this might be a normative bugfix?

(I also fixed the whitespace on the CatchFinally emu-clause)