### PR TITLE
Editorial: use "is 0" instead of "is zero" for consistency

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4197,7 +4197,7 @@
               String
             </td>
             <td>
-              If _argument_ is the empty String (its length is zero), return *false*; otherwise return *true*.
+              If _argument_ is the empty String (its length is 0), return *false*; otherwise return *true*.
             </td>
           </tr>
           <tr>
@@ -11235,7 +11235,7 @@
     <emu-clause id="sec-literals-string-literals">
       <h1>String Literals</h1>
       <emu-note>
-        <p>A string literal is zero or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encodecodepoint"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
+        <p>A string literal is 0 or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encodecodepoint"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">


### PR DESCRIPTION
Discovered [here](https://github.com/keithamus/proposal-array-last/pull/9#discussion_r164578959).

The spec seems to use `is 0` most often for comparing to zero, specifically with the results of a `ToLength` call, which can not return anything `<= 0` besides positive zero.

An equally valid and consistent alternative would be replacing all the `is 0` instances with `is zero`, if we'd find that clearer.