### PR TITLE
Normative: Expand text included in "function code"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9371,7 +9371,7 @@
         <em>Eval code</em> is the source text supplied to the built-in `eval` function. More precisely, if the parameter to the built-in `eval` function is a String, it is treated as an ECMAScript |Script|. The eval code for a particular invocation of `eval` is the global code portion of that |Script|.
       </li>
       <li>
-        <em>Function code</em> is source text that is parsed to supply the value of the [[ECMAScriptCode]] and [[FormalParameters]] internal slots (see <emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) of an ECMAScript function object. The function code of a particular ECMAScript function does not include any source text that is parsed as the function code of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
+        <em>Function code</em> is source text that is parsed to supply the value of the [[ECMAScriptCode]] and [[FormalParameters]] internal slots (see <emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) of an ECMAScript function object, along with the |BindingIdentifier| of |FunctionExpression|s, |GeneratorExpression|s, and |AsyncFunctionExpression|s (if present). The function code of a particular ECMAScript function does not include any source text that is parsed as the function code of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
       </li>
       <li>
         <em>Module code</em> is source text that is code that is provided as a |ModuleBody|. It is the code that is directly evaluated when a module is initialized. The module code of a particular module does not include any source text that is parsed as part of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
@@ -9380,6 +9380,10 @@
     <emu-note>
       <p>Function code is generally provided as the bodies of Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>), Arrow Function Definitions (<emu-xref href="#sec-arrow-function-definitions"></emu-xref>), Method Definitions (<emu-xref href="#sec-method-definitions"></emu-xref>), Generator Definitions (<emu-xref href="#sec-generator-function-definitions"></emu-xref>), Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>), and Async Arrow Functions (<emu-xref href="#sec-async-arrow-function-definitions"></emu-xref>). Function code is also derived from the arguments to the `Function` constructor (<emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>), the `GeneratorFunction` constructor (<emu-xref href="#sec-generatorfunction"></emu-xref>), and the `AsyncFunction` constructor (<emu-xref href="#sec-async-function-constructor-arguments"></emu-xref>).</p>
     </emu-note>
+    <emu-note>
+      <p>Function code includes the |BindingIdentifier| of function expressions because of the effect that the identifier has on the lexical environment of such functions.</p>
+    </emu-note>
+
 
     <!-- es6num="10.2.1" -->
     <emu-clause id="sec-strict-mode-code">


### PR DESCRIPTION
Previously reported at https://bugs.ecmascript.org/show_bug.cgi?id=4243 This patch is at attempt to implement the solution agreed upon there. (I think this issue was simply overshadowed by a related discussion on non-simple parameter lists, which ultimately lead to the restriction introduced in ES2016.)

The current specification text allows both of the following forms:

    function static() { 'use strict'; }
    (function static() { 'use strict'; });

Existing implementations violate that text by producing parsing errors for both.

With this patch applied, only the FunctionExpression will be disallowed, so implementations will continue to be in violation of the spec.