### PR TITLE
[Idea] Avoid redundant HostPromiseRejectionTrackerEvents

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37304,7 +37304,6 @@ THH:mm:ss.sss
           1. Set _promise_.[[PromiseFulfillReactions]] to *undefined*.
           1. Set _promise_.[[PromiseRejectReactions]] to *undefined*.
           1. Set _promise_.[[PromiseState]] to `"rejected"`.
-          1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
           1. Return TriggerPromiseReactions(_reactions_, _reason_).
         </emu-alg>
       </emu-clause>
@@ -37361,6 +37360,7 @@ THH:mm:ss.sss
             1. If _type_ is `"Fulfill"`, let _handlerResult_ be NormalCompletion(_argument_).
             1. Else,
               1. Assert: _type_ is `"Reject"`.
+              1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
               1. Let _handlerResult_ be Completion {[[Type]]: ~throw~, [[Value]]: _argument_, [[Target]]: ~empty~}.
           1. Else, let _handlerResult_ be Call(_handler_, *undefined*, &laquo; _argument_ &raquo;).
           1. If _handlerResult_ is an abrupt completion, then
@@ -37734,7 +37734,6 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: The value of _promise_.[[PromiseState]] is `"rejected"`.
               1. Let _reason_ be _promise_.[[PromiseResult]].
-              1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _rejectReaction_, _reason_ &raquo;).
             1. Set _promise_.[[PromiseIsHandled]] to *true*.
             1. Return _resultCapability_.[[Promise]].


### PR DESCRIPTION
context: https://twitter.com/bmeurer/status/960440074574934016

cc @bmeurer / @domenic  / @littledan 

## Motivation

To mitigate a performance concern @bmeurer [raised](https://twitter.com/bmeurer/status/960440074574934016), related to what I believe redundant HostPromiseRejectionTracker events.

Lets discuss!

## Changes
This does change behavior slightly:

* Rejections which become handled before the rejections PromiseReactionJob runs will no longer be visible to the HostPromiseRejectionTracker.
* The HostPromiseRejectTracker no longer being informed synchronously, rather being informed during the associated PromiseReactionJob.

On a positive note, there should be nearly no overhead in this approach.

### Example:

```js
Promise.reject().catch();
```

Would previously emit paired `reject` and `handle` events, and now emits neither.

Some in-the-wild code: https://github.com/nodejs/node/blob/d62566e1b1bb4734635d51d53c16f6efa3a7f5b5/lib/internal/process/promises.js#L26-L42

I believe would continue to function as implemented, the difference being `maybeUnhandledPromises` would not contain promises which have become handled  by the time their PromiseReactionJob has been processed.