### PR TITLE
Normative: add RegExp lookbehind to annex-B

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40776,6 +40776,8 @@ THH:mm:ss.sss
           [+U] `(` `?` `=` Disjunction[+U, ?N] `)`
           [+U] `(` `?` `!` Disjunction[+U, ?N] `)`
           [~U] QuantifiableAssertion[?N]
+          `(` `?` `&lt;=` Disjunction[?U, ?N] `)`
+          `(` `?` `&lt;!` Disjunction[?U, ?N] `)`
 
         QuantifiableAssertion[N] ::
           `(` `?` `=` Disjunction[~U, ?N] `)`


### PR DESCRIPTION
This PR adds the syntax of RegExp Lookbehind Assertions into B.1.4 Regular Expressions Patterns section.

Since #1029 didn't look to update the Annex-B section but I think it's needed (https://github.com/tc39/ecma262/pull/1029#issuecomment-364003143).

I apologize if it's intentional.