### PR TITLE
release-fix: 2018 is missing the js and css files from the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "The ECMAScript specification",
   "scripts": {
-    "build-es2018": "git remote remove origin && git remote add origin \"git@github.com:$TRAVIS_REPO_SLUG.git\" && git fetch --quiet origin && git checkout --quiet es2018 && mkdir \"out/2018\" && cp -R img \"out/2018\" && ecmarkup --verbose spec.html out/2018/index.html && git checkout --quiet test-travis",
+    "build-es2018": "git remote remove origin && git remote add origin \"git@github.com:$TRAVIS_REPO_SLUG.git\" && git fetch --quiet origin && git checkout --quiet es2018 && mkdir \"out/2018\" && cp -R img \"out/2018\" && ecmarkup --verbose spec.html out/2018/index.html --css out/2018/ecmarkup.css --js out/2018/ecmarkup.js && git checkout --quiet test-travis",
     "build-master": "mkdir out && cp -R img out && ecmarkup --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
     "build": "npm run clean && npm run build-master",
     "build-travis": "npm run clean && npm run build-master && npm run build-es2018",


### PR DESCRIPTION
https://tc39.github.io/ecma262/2018/ is missing styles and search is not working due to missing resources.

@bterlson we have encountered this very same issue during the 402 release. this fix seems to do the trick for me.