### PR TITLE
Editorial: rename EnumerableOwnProperties to EnumerableOwnPropertyNames

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "SEE LICENSE IN https://tc39.github.io/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.github.io/ecma262/",
   "dependencies": {
-    "ecmarkup": "^3.11.5"
+    "ecmarkup": "^3.12.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.0.0"

--- a/spec.html
+++ b/spec.html
@@ -4881,9 +4881,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-enumerableownproperties" aoid="EnumerableOwnProperties">
-      <h1>EnumerableOwnProperties ( _O_, _kind_ )</h1>
-      <p>When the abstract operation EnumerableOwnProperties is called with Object _O_ and String _kind_ the following steps are taken:</p>
+    <emu-clause id="sec-enumerableownpropertynames" aoid="EnumerableOwnPropertyNames" oldids="sec-enumerableownproperties">
+      <h1>EnumerableOwnPropertyNames ( _O_, _kind_ )</h1>
+      <p>When the abstract operation EnumerableOwnPropertyNames is called with Object _O_ and String _kind_ the following steps are taken:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Let _ownKeys_ be ? _O_.[[OwnPropertyKeys]]().
@@ -24898,7 +24898,7 @@
         <p>When the `entries` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, *"key+value"*).
+          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, *"key+value"*).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -25030,7 +25030,7 @@
         <p>When the `keys` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, *"key"*).
+          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, *"key"*).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -25085,7 +25085,7 @@
         <p>When the `values` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnProperties(_obj_, *"value"*).
+          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, *"value"*).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -36919,7 +36919,7 @@ THH:mm:ss.sss
                   1. NOTE: This algorithm intentionally does not throw an exception if CreateDataProperty returns *false*.
                 1. Add 1 to _I_.
             1. Else,
-              1. Let _keys_ be ? EnumerableOwnProperties(_val_, *"key"*).
+              1. Let _keys_ be ? EnumerableOwnPropertyNames(_val_, *"key"*).
               1. For each String _P_ in _keys_, do
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_).
                 1. If _newElement_ is *undefined*, then
@@ -37136,7 +37136,7 @@ THH:mm:ss.sss
           1. If _PropertyList_ is not *undefined*, then
             1. Let _K_ be _PropertyList_.
           1. Else,
-            1. Let _K_ be ? EnumerableOwnProperties(_value_, *"key"*).
+            1. Let _K_ be ? EnumerableOwnPropertyNames(_value_, *"key"*).
           1. Let _partial_ be a new empty List.
           1. For each element _P_ of _K_, do
             1. Let _strP_ be ? SerializeJSONProperty(_P_, _value_).


### PR DESCRIPTION
See issue #1110.