### PR TITLE
Normative: FlagText allows s

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12143,7 +12143,7 @@
             It is a Syntax Error if BodyText of |RegularExpressionLiteral| cannot be recognized using the goal symbol |Pattern| of the ECMAScript RegExp grammar specified in <emu-xref href="#sec-patterns"></emu-xref>.
           </li>
           <li>
-            It is a Syntax Error if FlagText of |RegularExpressionLiteral| contains any code points other than `"g"`, `"i"`, `"m"`, `"u"`, or `"y"`, or if it contains the same code point more than once.
+            It is a Syntax Error if FlagText of |RegularExpressionLiteral| contains any code points other than `"g"`, `"i"`, `"m"`, `"s"`, `"u"`, or `"y"`, or if it contains the same code point more than once.
           </li>
         </ul>
       </emu-clause>


### PR DESCRIPTION
This PR fixes an oversight.

[12.2.8.1 Static Semantics: Early Errors](https://www.ecma-international.org/ecma-262/8.0/#sec-primary-expression-regular-expression-literals-static-semantics-early-errors) disallows `s` flag currently. But it should allow `s` flag since #1028.