### PR TITLE
Normative: Remove ToUint32 from array literal evaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12637,51 +12637,57 @@
           `...` AssignmentExpression[+In, ?Yield, ?Await]
       </emu-grammar>
 
-      <emu-clause id="sec-static-semantics-elisionwidth">
-        <h1>Static Semantics: ElisionWidth</h1>
-        <emu-grammar>Elision : `,`</emu-grammar>
-        <emu-alg>
-          1. Return the numeric value 1.
-        </emu-alg>
-        <emu-grammar>Elision : Elision `,`</emu-grammar>
-        <emu-alg>
-          1. Let _preceding_ be the ElisionWidth of |Elision|.
-          1. Return _preceding_ + 1.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-runtime-semantics-arrayaccumulation">
         <h1>Runtime Semantics: ArrayAccumulation</h1>
         <p>With parameters _array_ and _nextIndex_.</p>
+        <emu-grammar>Elision : `,`</emu-grammar>
+        <emu-alg>
+          1. Let _len_ be _nextIndex_ + 1.
+          1. Perform ? Set(_array_, `"length"`, _len_, *true*).
+          1. NOTE: The above Set throws if _len_ exceeds 2<sup>32</sup>-1.
+          1. Return _len_.
+        </emu-alg>
+        <emu-grammar>Elision : Elision `,`</emu-grammar>
+        <emu-alg>
+          1. Return the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_ + 1.
+        </emu-alg>
         <emu-grammar>ElementList : Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
+          1. If |Elision| is present, then
+            1. Let _nextIndex_ be the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. ReturnIfAbrupt(_nextIndex_).
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
-          1. Let _created_ be CreateDataProperty(_array_, ToString(ToUint32(_nextIndex_ + _padding_)), _initValue_).
-          1. Assert: _created_ is *true*.
-          1. Return _nextIndex_ + _padding_ + 1.
+          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(_nextIndex_), _initValue_).
+          1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
         <emu-alg>
-          1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
-          1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _nextIndex_ + _padding_.
+          1. If |Elision| is present, then
+            1. Let _nextIndex_ be the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. ReturnIfAbrupt(_nextIndex_).
+          1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _nextIndex_.
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _postIndex_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
-          1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
+          1. Let _nextIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
+          1. ReturnIfAbrupt(_nextIndex_).
+          1. If |Elision| is present, then
+            1. Let _nextIndex_ be the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. ReturnIfAbrupt(_nextIndex_).
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
-          1. Let _created_ be CreateDataProperty(_array_, ToString(ToUint32(_postIndex_ + _padding_)), _initValue_).
-          1. Assert: _created_ is *true*.
-          1. Return _postIndex_ + _padding_ + 1.
+          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(_nextIndex_), _initValue_).
+          1. Return _nextIndex_+1.
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
         <emu-alg>
-          1. Let _postIndex_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
-          1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
-          1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _postIndex_ + _padding_.
+          1. Let _nextIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
+          1. ReturnIfAbrupt(_nextIndex_).
+          1. If |Elision| is present, then
+            1. Let _nextIndex_ be the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. ReturnIfAbrupt(_nextIndex_).
+          1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _nextIndex_.
         </emu-alg>
         <emu-grammar>SpreadElement : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -12692,8 +12698,7 @@
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _nextIndex_.
             1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Let _status_ be CreateDataProperty(_array_, ToString(ToUint32(_nextIndex_)), _nextValue_).
-            1. Assert: _status_ is *true*.
+            1. Let _status_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(_nextIndex_), _nextValue_).
             1. Set _nextIndex_ to _nextIndex_ + 1.
         </emu-alg>
         <emu-note>
@@ -12706,26 +12711,26 @@
         <emu-grammar>ArrayLiteral : `[` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _pad_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
-          1. Perform Set(_array_, `"length"`, ToUint32(_pad_), *false*).
-          1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
+          1. If |Elision| is present, then
+            1. Let _len_ be the result of performing ArrayAccumulation for |Elision| with arguments _array_ and 0.
+            1. ReturnIfAbrupt(_len_).
           1. Return _array_.
         </emu-alg>
         <emu-grammar>ArrayLiteral : `[` ElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _len_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and 0.
-          1. Perform Set(_array_, `"length"`, ToUint32(_len_), *false*).
-          1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
+          1. Let _len_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
+          1. ReturnIfAbrupt(_len_).
           1. Return _array_.
         </emu-alg>
         <emu-grammar>ArrayLiteral : `[` ElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _len_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and 0.
-          1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
-          1. Perform Set(_array_, `"length"`, ToUint32(_padding_ + _len_), *false*).
-          1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
+          1. Let _nextIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
+          1. ReturnIfAbrupt(_nextIndex_).
+          1. If |Elision| is present, then
+            1. Let _len_ be the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. ReturnIfAbrupt(_len_).
           1. Return _array_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Previously, array literals (including spreads) had their indices and
lengths calculated with a ToUint32 operation. As Georg Neis noted
in #1095, such a calculation isn't quite right, as 2**32-1 is not
an array index. These semantics are unlikely to be observable in many
current JavaScript implementations due to resource limitations, but
the strange behavior may appear in future, resource-rich
implementations.

This patch specifies Georg Neis's suggestion for semantics: to write to
the length just in the case of elisions (regardless of where they are in
the Array literal), and don't bother to write to the length for writes for
ordinary elements (as Array indices will already lead to length updates).

As a bonus, the semantics for Array literals are singificantly simplified, involving
just one syntax-directed operation and pass rather than two. Note that, as before,
too-long Array literals throw only as a runtime exception, not as an early error.
This patch includes appropriate use of ? and ! in modified operations.

cc @allenwb @GeorgNeis @anba 