### PR TITLE
Editorial: use <ul> to list characteristics of intrinsics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26215,8 +26215,14 @@
     <!-- es6num="20.1.1" -->
     <emu-clause id="sec-number-constructor">
       <h1>The Number Constructor</h1>
-      <p>The Number constructor is the <dfn>%Number%</dfn> intrinsic object and the initial value of the `Number` property of the global object. When called as a constructor, it creates and initializes a new Number object. When `Number` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `Number` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behaviour must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</p>
+      <p>The Number constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Number%</dfn>.</li>
+        <li>is the initial value of the `Number` property of the global object.</li>
+        <li>creates and initializes a new Number object when called as a constructor.</li>
+        <li>performs a type conversion when called as a function rather than as a constructor.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behaviour must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</li>
+      </ul>
 
       <!-- es6num="20.1.1.1" -->
       <emu-clause id="sec-number-constructor-number-value">
@@ -26236,8 +26242,11 @@
     <!-- es6num="20.1.2" -->
     <emu-clause id="sec-properties-of-the-number-constructor">
       <h1>Properties of the Number Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Number constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Number constructor has the following properties:</p>
+      <p>The Number constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="20.1.2.1" -->
       <emu-clause id="sec-number.epsilon">
@@ -26377,8 +26386,13 @@
     <!-- es6num="20.1.3" -->
     <emu-clause id="sec-properties-of-the-number-prototype-object">
       <h1>Properties of the Number Prototype Object</h1>
-      <p>The Number prototype object is the intrinsic object <dfn>%NumberPrototype%</dfn>. The Number prototype object is an ordinary object. The Number prototype object is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</p>
-      <p>The value of the [[Prototype]] internal slot of the Number prototype object is the intrinsic object %ObjectPrototype%.</p>
+      <p>The Number prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%NumberPrototype%</dfn>.</li>
+        <li>is an ordinary object.</li>
+        <li>is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      </ul>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
       <p>The abstract operation <dfn id="sec-thisnumbervalue" aoid="thisNumberValue">thisNumberValue</dfn>(_value_) performs the following steps:</p>
       <emu-alg>
@@ -26573,9 +26587,16 @@
   <!-- es6num="20.2" -->
   <emu-clause id="sec-math-object">
     <h1>The Math Object</h1>
-    <p>The Math object is the <dfn>%Math%</dfn> intrinsic object and the initial value of the `Math` property of the global object. The Math object is a single ordinary object.</p>
-    <p>The value of the [[Prototype]] internal slot of the Math object is the intrinsic object %ObjectPrototype%.</p>
-    <p>The Math object is not a function object. It does not have a [[Construct]] internal method; it is not possible to use the Math object as a constructor with the `new` operator. The Math object also does not have a [[Call]] internal method; it is not possible to invoke the Math object as a function.</p>
+    <p>The Math object:</p>
+    <ul>
+      <li>is the intrinsic object <dfn>%Math%</dfn>.</li>
+      <li>is the initial value of the `Math` property of the global object.</li>
+      <li>is an ordinary object.</li>
+      <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      <li>is not a function object.</li>
+      <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
+      <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
+    </ul>
     <emu-note>
       <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; has a technical meaning defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>.</p>
     </emu-note>
@@ -27886,10 +27907,16 @@ THH:mm:ss.sss
     <!-- es6num="20.3.2" -->
     <emu-clause id="sec-date-constructor">
       <h1>The Date Constructor</h1>
-      <p>The Date constructor is the <dfn>%Date%</dfn> intrinsic object and the initial value of the `Date` property of the global object. When called as a constructor it creates and initializes a new Date object. When `Date` is called as a function rather than as a constructor, it returns a String representing the current time (UTC).</p>
-      <p>The `Date` constructor is a single function whose behaviour is overloaded based upon the number and types of its arguments.</p>
-      <p>The `Date` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behaviour must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</p>
-      <p>The `length` property of the `Date` constructor function is 7.</p>
+      <p>The Date constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Date%</dfn>.</li>
+        <li>is the initial value of the `Date` property of the global object.</li>
+        <li>creates and initializes a new Date object when called as a constructor.</li>
+        <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
+        <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behaviour must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
+        <li>has a `length` property whose value is 7.</li>
+      </ul>
 
       <!-- es6num="20.3.2.1" -->
       <emu-clause id="sec-date-year-month-date-hours-minutes-seconds-ms">
@@ -27967,8 +27994,11 @@ THH:mm:ss.sss
     <!-- es6num="20.3.3" -->
     <emu-clause id="sec-properties-of-the-date-constructor">
       <h1>Properties of the Date Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Date constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Date constructor has the following properties:</p>
+      <p>The Date constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="20.3.3.1" -->
       <emu-clause id="sec-date.now">
@@ -28026,8 +28056,13 @@ THH:mm:ss.sss
     <!-- es6num="20.3.4" -->
     <emu-clause id="sec-properties-of-the-date-prototype-object">
       <h1>Properties of the Date Prototype Object</h1>
-      <p>The Date prototype object is the intrinsic object <dfn>%DatePrototype%</dfn>. The Date prototype object is itself an ordinary object. It is not a Date instance and does not have a [[DateValue]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the Date prototype object is the intrinsic object %ObjectPrototype%.</p>
+      <p>The Date prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%DatePrototype%</dfn>.</li>
+        <li>is itself an ordinary object.</li>
+        <li>is not a Date instance and does not have a [[DateValue]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      </ul>
       <p>Unless explicitly defined otherwise, the methods of the Date prototype object defined below are not generic and the *this* value passed to them must be an object that has a [[DateValue]] internal slot that has been initialized to a time value.</p>
       <p>The abstract operation <dfn id="sec-thistimevalue" aoid="thisTimeValue">thisTimeValue</dfn>(_value_) performs the following steps:</p>
       <emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -32255,10 +32255,16 @@ THH:mm:ss.sss
     <!-- es6num="22.1.1" -->
     <emu-clause id="sec-array-constructor">
       <h1>The Array Constructor</h1>
-      <p>The Array constructor is the <dfn>%Array%</dfn> intrinsic object and the initial value of the `Array` property of the global object. When called as a constructor it creates and initializes a new Array exotic object. When `Array` is called as a function rather than as a constructor, it also creates and initializes a new Array object. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</p>
-      <p>The `Array` constructor is a single function whose behaviour is overloaded based upon the number and types of its arguments.</p>
-      <p>The `Array` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behaviour must include a `super` call to the `Array` constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their `this` value being an Array exotic object.</p>
-      <p>The `length` property of the `Array` constructor function is 1.</p>
+      <p>The Array constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Array%</dfn>.</li>
+        <li>is the initial value of the `Array` property of the global object.</li>
+        <li>creates and initializes a new Array exotic object when called as a constructor.</li>
+        <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
+        <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behaviour must include a `super` call to the `Array` constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their `this` value being an Array exotic object.</li>
+        <li>has a `length` property whose value is 1.</li>
+      </ul>
 
       <!-- es6num="22.1.1.1" -->
       <emu-clause id="sec-array-constructor-array">
@@ -32323,8 +32329,11 @@ THH:mm:ss.sss
     <!-- es6num="22.1.2" -->
     <emu-clause id="sec-properties-of-the-array-constructor">
       <h1>Properties of the Array Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Array constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Array constructor has the following properties:</p>
+      <p>The Array constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="22.1.2.1" -->
       <emu-clause id="sec-array.from">
@@ -32449,8 +32458,13 @@ THH:mm:ss.sss
     <!-- es6num="22.1.3" -->
     <emu-clause id="sec-properties-of-the-array-prototype-object">
       <h1>Properties of the Array Prototype Object</h1>
-      <p>The Array prototype object is the intrinsic object <dfn>%ArrayPrototype%</dfn>. The Array prototype object is an Array exotic object and has the internal methods specified for such objects. It has a `length` property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-      <p>The value of the [[Prototype]] internal slot of the Array prototype object is the intrinsic object %ObjectPrototype%.</p>
+      <p>The Array prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%ArrayPrototype%</dfn>.</li>
+        <li>is an Array exotic object and has the internal methods specified for such objects.</li>
+        <li>has a `length` property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      </ul>
       <emu-note>
         <p>The Array prototype object is specified to be an Array exotic object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
       </emu-note>
@@ -33586,7 +33600,13 @@ THH:mm:ss.sss
       <!-- es6num="22.1.5.2" -->
       <emu-clause id="sec-%arrayiteratorprototype%-object">
         <h1>The %ArrayIteratorPrototype% Object</h1>
-        <p>All Array Iterator Objects inherit properties from the %ArrayIteratorPrototype% intrinsic object. The <dfn>%ArrayIteratorPrototype%</dfn> object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object. In addition, %ArrayIteratorPrototype% has the following properties:</p>
+        <p>The <dfn>%ArrayIteratorPrototype%</dfn> object:</p>
+        <ul>
+          <li>has properties that are inherited by all Array Iterator Objects.</li>
+          <li>is an ordinary object.</li>
+          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has the following properties:</li>
+        </ul>
 
         <!-- es6num="22.1.5.2.1" -->
         <emu-clause id="sec-%arrayiteratorprototype%.next">
@@ -33904,8 +33924,14 @@ THH:mm:ss.sss
     <!-- es6num="22.2.1" -->
     <emu-clause id="sec-%typedarray%-intrinsic-object">
       <h1>The %TypedArray% Intrinsic Object</h1>
-      <p>The <dfn>%TypedArray%</dfn> intrinsic object is a constructor function object that all of the _TypedArray_ constructor objects inherit from. %TypedArray% and its corresponding prototype object provide common properties that are inherited by all _TypedArray_ constructors and their instances. The %TypedArray% intrinsic does not have a global name or appear as a property of the global object.</p>
-      <p>The %TypedArray% intrinsic function object acts as the abstract superclass of the various _TypedArray_ constructors. Because it is an abstract class constructor it will throw an error when invoked. The _TypedArray_ constructors do not perform a `super` call to it.</p>
+      <p>The <dfn>%TypedArray%</dfn> intrinsic object:</p>
+      <ul>
+        <li>is a constructor function object that all of the _TypedArray_ constructor objects inherit from.</li>
+        <li>along with its corresponding prototype object, provides common properties that are inherited by all _TypedArray_ constructors and their instances.</li>
+        <li>does not have a global name or appear as a property of the global object.</li>
+        <li>acts as the abstract superclass of the various _TypedArray_ constructors.</li>
+        <li>will throw an error when invoked, because it is an abstract class constructor. The _TypedArray_ constructors do not perform a `super` call to it.</li>
+      </ul>
 
       <!-- es6num="22.2.4.1" -->
       <emu-clause id="sec-%typedarray%">
@@ -33922,9 +33948,12 @@ THH:mm:ss.sss
     <!-- es6num="22.2.2" -->
     <emu-clause id="sec-properties-of-the-%typedarray%-intrinsic-object">
       <h1>Properties of the %TypedArray% Intrinsic Object</h1>
-      <p>The value of the [[Prototype]] internal slot of %TypedArray% is the intrinsic object %FunctionPrototype%.</p>
-      <p>The `name` property of the %TypedArray% constructor function is `"TypedArray"`.</p>
-      <p>The %TypedArray% constructor has the following properties:</p>
+      <p>The %TypedArray% intrinsic object:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a `name` property whose value is `"TypedArray"`.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="22.2.2.1" -->
       <emu-clause id="sec-%typedarray%.from">
@@ -34034,7 +34063,12 @@ THH:mm:ss.sss
     <!-- es6num="22.2.3" -->
     <emu-clause id="sec-properties-of-the-%typedarrayprototype%-object">
       <h1>Properties of the %TypedArrayPrototype% Object</h1>
-      <p>The value of the [[Prototype]] internal slot of the <dfn>%TypedArrayPrototype%</dfn> object is the intrinsic object %ObjectPrototype%. The %TypedArrayPrototype% object is an ordinary object. It does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</p>
+      <p>The <dfn>%TypedArrayPrototype%</dfn> object:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</li>
+      </ul>
 
       <!-- es6num="22.2.3.1" -->
       <emu-clause id="sec-get-%typedarray%.prototype.buffer">
@@ -34604,11 +34638,14 @@ THH:mm:ss.sss
     <!-- es6num="22.2.4" -->
     <emu-clause id="sec-typedarray-constructors">
       <h1>The _TypedArray_ Constructors</h1>
-      <p>Each of the _TypedArray_ constructor objects is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-49"></emu-xref>.</p>
-      <p>The _TypedArray_ intrinsic constructor functions are single functions whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</p>
-      <p>The _TypedArray_ constructors are not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The _TypedArray_ constructors are designed to be subclassable. They may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the `%TypedArray%.prototype` built-in methods.</p>
-      <p>The `length` property of the _TypedArray_ constructor function is 3.</p>
+      <p>Each _TypedArray_ constructor:</p>
+      <ul>
+        <li>is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-49"></emu-xref>.</li>
+        <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the `%TypedArray%.prototype` built-in methods.</li>
+        <li>has a `length` property whose value is 3.</li>
+      </ul>
 
       <!-- es6num="22.2.4.1" -->
       <emu-clause id="sec-typedarray">
@@ -34817,9 +34854,12 @@ THH:mm:ss.sss
     <!-- es6num="22.2.5" -->
     <emu-clause id="sec-properties-of-the-typedarray-constructors">
       <h1>Properties of the _TypedArray_ Constructors</h1>
-      <p>The value of the [[Prototype]] internal slot of each _TypedArray_ constructor is the %TypedArray% intrinsic object.</p>
-      <p>Each _TypedArray_ constructor has a `name` property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-49"></emu-xref>.</p>
-      <p>Each _TypedArray_ constructor has the following properties:</p>
+      <p>Each _TypedArray_ constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %TypedArray%.</li>
+        <li>has a `name` property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-49"></emu-xref>.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="22.2.5.1" -->
       <emu-clause id="sec-typedarray.bytes_per_element">
@@ -34839,7 +34879,12 @@ THH:mm:ss.sss
     <!-- es6num="22.2.6" -->
     <emu-clause id="sec-properties-of-typedarray-prototype-objects">
       <h1>Properties of the _TypedArray_ Prototype Objects</h1>
-      <p>The value of the [[Prototype]] internal slot of a _TypedArray_ prototype object is the intrinsic object %TypedArrayPrototype%. A _TypedArray_ prototype object is an ordinary object. It does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</p>
+      <p>Each _TypedArray_ prototype object:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %TypedArrayPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</li>
+      </ul>
 
       <!-- es6num="22.2.6.1" -->
       <emu-clause id="sec-typedarray.prototype.bytes_per_element">

--- a/spec.html
+++ b/spec.html
@@ -36190,8 +36190,14 @@ THH:mm:ss.sss
     <!-- es6num="24.1.2" -->
     <emu-clause id="sec-arraybuffer-constructor">
       <h1>The ArrayBuffer Constructor</h1>
-      <p>The ArrayBuffer constructor is the <dfn>%ArrayBuffer%</dfn> intrinsic object and the initial value of the `ArrayBuffer` property of the global object. When called as a constructor it creates and initializes a new ArrayBuffer object. `ArrayBuffer` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `ArrayBuffer` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behaviour must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</p>
+      <p>The ArrayBuffer constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%ArrayBuffer%</dfn>.</li>
+        <li>is the initial value of the `ArrayBuffer` property of the global object.</li>
+        <li>creates and initializes a new ArrayBuffer object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behaviour must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
+      </ul>
 
       <!-- es6num="24.1.2.1" -->
       <emu-clause id="sec-arraybuffer-length">
@@ -36208,8 +36214,11 @@ THH:mm:ss.sss
     <!-- es6num="24.1.3" -->
     <emu-clause id="sec-properties-of-the-arraybuffer-constructor">
       <h1>Properties of the ArrayBuffer Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the ArrayBuffer constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The ArrayBuffer constructor has the following properties:</p>
+      <p>The ArrayBuffer constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="24.1.3.1" -->
       <emu-clause id="sec-arraybuffer.isview">
@@ -36246,7 +36255,13 @@ THH:mm:ss.sss
     <!-- es6num="24.1.4" -->
     <emu-clause id="sec-properties-of-the-arraybuffer-prototype-object">
       <h1>Properties of the ArrayBuffer Prototype Object</h1>
-      <p>The ArrayBuffer prototype object is the intrinsic object <dfn>%ArrayBufferPrototype%</dfn>. The value of the [[Prototype]] internal slot of the ArrayBuffer prototype object is the intrinsic object %ObjectPrototype%. The ArrayBuffer prototype object is an ordinary object. It does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</p>
+      <p>The ArrayBuffer prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%ArrayBufferPrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
+      </ul>
 
       <!-- es6num="24.1.4.1" -->
       <emu-clause id="sec-get-arraybuffer.prototype.bytelength">
@@ -36353,8 +36368,14 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-sharedarraybuffer-constructor">
       <h1>The SharedArrayBuffer Constructor</h1>
-      <p>The SharedArrayBuffer constructor is the <dfn>%SharedArrayBuffer%</dfn> intrinsic object and the initial value of the `SharedArrayBuffer` property of the global object. When called as a constructor it creates and initializes a new SharedArrayBuffer object. `SharedArrayBuffer` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `SharedArrayBuffer` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `SharedArrayBuffer` behaviour must include a `super` call to the `SharedArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</p>
+      <p>The SharedArrayBuffer constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%SharedArrayBuffer%</dfn>.</li>
+        <li>is the initial value of the `SharedArrayBuffer` property of the global object.</li>
+        <li>creates and initializes a new SharedArrayBuffer object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `SharedArrayBuffer` behaviour must include a `super` call to the `SharedArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
+      </ul>
 
       <emu-note>
         <p>Unlike an `ArrayBuffer`, a `SharedArrayBuffer` cannot become detached, and its internal [[ArrayBufferData]] slot is never *null*.</p>
@@ -36373,8 +36394,11 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-sharedarraybuffer-constructor">
       <h1>Properties of the SharedArrayBuffer Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the SharedArrayBuffer constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The SharedArrayBuffer constructor has the following properties:</p>
+      <p>The SharedArrayBuffer constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <emu-clause id="sec-sharedarraybuffer.prototype">
         <h1>SharedArrayBuffer.prototype</h1>
@@ -36394,7 +36418,13 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-sharedarraybuffer-prototype-object">
       <h1>Properties of the SharedArrayBuffer Prototype Object</h1>
-      <p>The SharedArrayBuffer prototype object is the intrinsic object <dfn>%SharedArrayBufferPrototype%</dfn>. The value of the [[Prototype]] internal slot of the SharedArrayBuffer prototype object is the intrinsic object %ObjectPrototype%. The SharedArrayBuffer prototype object is an ordinary object. It does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</p>
+      <p>The SharedArrayBuffer prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%SharedArrayBufferPrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
+      </ul>
 
       <emu-clause id="sec-get-sharedarraybuffer.prototype.bytelength">
         <h1>get SharedArrayBuffer.prototype.byteLength</h1>
@@ -36513,8 +36543,14 @@ THH:mm:ss.sss
     <!-- es6num="24.2.2" -->
     <emu-clause id="sec-dataview-constructor">
       <h1>The DataView Constructor</h1>
-      <p>The DataView constructor is the <dfn>%DataView%</dfn> intrinsic object and the initial value of the `DataView` property of the global object. When called as a constructor it creates and initializes a new DataView object. `DataView` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `DataView` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behaviour must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</p>
+      <p>The DataView constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%DataView%</dfn>.</li>
+        <li>is the initial value of the `DataView` property of the global object.</li>
+        <li>creates and initializes a new DataView object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behaviour must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
+      </ul>
 
       <!-- es6num="24.2.2.1" -->
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
@@ -36545,8 +36581,11 @@ THH:mm:ss.sss
     <!-- es6num="24.2.3" -->
     <emu-clause id="sec-properties-of-the-dataview-constructor">
       <h1>Properties of the DataView Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the `DataView` constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The DataView constructor has the following properties:</p>
+      <p>The DataView constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="24.2.3.1" -->
       <emu-clause id="sec-dataview.prototype">
@@ -36559,7 +36598,13 @@ THH:mm:ss.sss
     <!-- es6num="24.2.4" -->
     <emu-clause id="sec-properties-of-the-dataview-prototype-object">
       <h1>Properties of the DataView Prototype Object</h1>
-      <p>The DataView prototype object is the intrinsic object <dfn>%DataViewPrototype%</dfn>. The value of the [[Prototype]] internal slot of the DataView prototype object is the intrinsic object %ObjectPrototype%. The DataView prototype object is an ordinary object. It does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</p>
+      <p>The DataView prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%DataViewPrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</li>
+      </ul>
 
       <!-- es6num="24.2.4.1" -->
       <emu-clause id="sec-get-dataview.prototype.buffer">
@@ -36805,11 +36850,16 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-atomics-object">
     <h1>The Atomics Object</h1>
-    <p>The Atomics object is the <dfn>%Atomics%</dfn> intrinsic object and the initial value of the `Atomics` property of the global object. The Atomics object is a single ordinary object.</p>
+    <p>The Atomics object:</p>
+    <ul>
+      <li>is the intrinsic object <dfn>%Atomics%</dfn>.</li>
+      <li>is the initial value of the `Atomics` property of the global object.</li>
+      <li>is an ordinary object.</li>
+      <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
+      <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
+    </ul>
     <p>The Atomics object provides functions that operate indivisibly (atomically) on shared memory array cells as well as functions that let agents wait for and dispatch primitive events.  When used with discipline, the Atomics functions allow multi-agent programs that communicate through shared memory to execute in a well-understood order even on parallel CPUs. The rules that govern shared-memory communication are provided by the memory model, defined below.</p>
-    <p>The value of the [[Prototype]] internal slot of the Atomics object is the intrinsic object %ObjectPrototype%.</p>
-    <p>The Atomics object does not have a [[Construct]] internal method; it is not possible to use the Atomics object as a constructor with the `new` operator.</p>
-    <p>The Atomics object does not have a [[Call]] internal method; it is not possible to invoke the Atomics object as a function.</p>
     <emu-note>
       <p>For informative guidelines for programming and implementing shared memory in ECMAScript, please see the notes at the end of the memory model section.</p>
     </emu-note>
@@ -37162,11 +37212,18 @@ THH:mm:ss.sss
   <!-- es6num="24.3" -->
   <emu-clause id="sec-json-object">
     <h1>The JSON Object</h1>
-    <p>The JSON object is the <dfn>%JSON%</dfn> intrinsic object and the initial value of the `JSON` property of the global object. The JSON object is a single ordinary object that contains two functions, `parse` and `stringify`, that are used to parse and construct JSON texts. The JSON Data Interchange Format is defined in ECMA-404. The JSON interchange format used in this specification is exactly that described by ECMA-404.</p>
-    <p>Conforming implementations of `JSON.parse` and `JSON.stringify` must support the exact interchange format described in the ECMA-404 specification without any deletions or extensions to the format.</p>
-    <p>The value of the [[Prototype]] internal slot of the JSON object is the intrinsic object %ObjectPrototype%. The value of the [[Extensible]] internal slot of the JSON object is set to *true*.</p>
-    <p>The JSON object does not have a [[Construct]] internal method; it is not possible to use the JSON object as a constructor with the `new` operator.</p>
-    <p>The JSON object does not have a [[Call]] internal method; it is not possible to invoke the JSON object as a function.</p>
+    <p>The JSON object:</p>
+    <ul>
+      <li>is the intrinsic object <dfn>%JSON%</dfn>.</li>
+      <li>is the initial value of the `JSON` property of the global object.</li>
+      <li>is an ordinary object.</li>
+      <li>contains two functions, `parse` and `stringify`, that are used to parse and construct JSON texts.</li>
+      <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      <li>has an [[Extensible]] internal slot whose value is *true*.</li>
+      <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
+      <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
+    </ul>
+    <p>The JSON Data Interchange Format is defined in ECMA-404. The JSON interchange format used in this specification is exactly that described by ECMA-404. Conforming implementations of `JSON.parse` and `JSON.stringify` must support the exact interchange format described in the ECMA-404 specification without any deletions or extensions to the format.</p>
 
     <!-- es6num="24.3.1" -->
     <emu-clause id="sec-json.parse">

--- a/spec.html
+++ b/spec.html
@@ -39755,9 +39755,16 @@ THH:mm:ss.sss
   <!-- es6num="26.1" -->
   <emu-clause id="sec-reflect-object">
     <h1>The Reflect Object</h1>
-    <p>The Reflect object is the <dfn>%Reflect%</dfn> intrinsic object and the initial value of the `Reflect` property of the global object. The Reflect object is an ordinary object.</p>
-    <p>The value of the [[Prototype]] internal slot of the Reflect object is the intrinsic object %ObjectPrototype%.</p>
-    <p>The Reflect object is not a function object. It does not have a [[Construct]] internal method; it is not possible to use the Reflect object as a constructor with the `new` operator. The Reflect object also does not have a [[Call]] internal method; it is not possible to invoke the Reflect object as a function.</p>
+    <p>The Reflect object:</p>
+    <ul>
+      <li>is the intrinsic object <dfn>%Reflect%</dfn>.</li>
+      <li>is the initial value of the `Reflect` property of the global object.</li>
+      <li>is an ordinary object.</li>
+      <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      <li>is not a function object.</li>
+      <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
+      <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
+    </ul>
 
     <!-- es6num="26.1.1" -->
     <emu-clause id="sec-reflect.apply">
@@ -39916,7 +39923,13 @@ THH:mm:ss.sss
     <!-- es6num="26.2.1" -->
     <emu-clause id="sec-proxy-constructor">
       <h1>The Proxy Constructor</h1>
-      <p>The Proxy constructor is the <dfn>%Proxy%</dfn> intrinsic object and the initial value of the `Proxy` property of the global object. When called as a constructor it creates and initializes a new proxy exotic object. `Proxy` is not intended to be called as a function and will throw an exception when called in that manner.</p>
+      <p>The Proxy constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Proxy%</dfn>.</li>
+        <li>is the initial value of the `Proxy` property of the global object.</li>
+        <li>creates and initializes a new proxy exotic object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+      </ul>
 
       <!-- es6num="26.2.1.1" -->
       <emu-clause id="sec-proxy-target-handler">
@@ -39932,9 +39945,12 @@ THH:mm:ss.sss
     <!-- es6num="26.2.2" -->
     <emu-clause id="sec-properties-of-the-proxy-constructor">
       <h1>Properties of the Proxy Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the `Proxy` constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The `Proxy` constructor does not have a `prototype` property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</p>
-      <p>The `Proxy` constructor has the following properties:</p>
+      <p>The Proxy constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>does not have a `prototype` property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="26.2.2.1" -->
       <emu-clause id="sec-proxy.revocable">

--- a/spec.html
+++ b/spec.html
@@ -23898,11 +23898,14 @@
 <!-- es6num="18" -->
 <emu-clause id="sec-global-object">
   <h1>The Global Object</h1>
-  <p>The unique <dfn>global object</dfn> is created before control enters any execution context.</p>
-  <p>The global object does not have a [[Construct]] internal method; it is not possible to use the global object as a constructor with the `new` operator.</p>
-  <p>The global object does not have a [[Call]] internal method; it is not possible to invoke the global object as a function.</p>
-  <p>The value of the [[Prototype]] internal slot of the global object is implementation-dependent.</p>
-  <p>In addition to the properties defined in this specification the global object may have additional host defined properties. This may include a property whose value is the global object itself; for example, in the HTML document object model the `window` property of the global object is the global object itself.</p>
+  <p>The <dfn>global object</dfn>:</p>
+  <ul>
+    <li>is created before control enters any execution context.</li>
+    <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
+    <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
+    <li>has a [[Prototype]] internal slot whose value is implementation-dependent.</li>
+    <li>may have host defined properties in addition to the properties defined in this specification. This may include a property whose value is the global object itself; for example, in the HTML document object model the `window` property of the global object is the global object itself.</li>
+  </ul>
 
   <!-- es6num="18.1" -->
   <emu-clause id="sec-value-properties-of-the-global-object">

--- a/spec.html
+++ b/spec.html
@@ -37831,7 +37831,12 @@ THH:mm:ss.sss
     <!-- es6num="25.1.2" -->
     <emu-clause id="sec-%iteratorprototype%-object">
       <h1>The %IteratorPrototype% Object</h1>
-      <p>The value of the [[Prototype]] internal slot of the <dfn>%IteratorPrototype%</dfn> object is the intrinsic object %ObjectPrototype%. The %IteratorPrototype% object is an ordinary object. The initial value of the [[Extensible]] internal slot of the %IteratorPrototype% object is *true*.</p>
+      <p>The <dfn>%IteratorPrototype%</dfn> object:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+      </ul>
       <emu-note>
         <p>All objects defined in this specification that implement the Iterator interface also inherit from %IteratorPrototype%. ECMAScript code may also define objects that inherit from %IteratorPrototype%.The %IteratorPrototype% object provides a place where additional methods that are applicable to all iterator objects may be added.</p>
         <p>The following expression is one way that ECMAScript code can access the %IteratorPrototype% object:</p>
@@ -37851,7 +37856,12 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-asynciteratorprototype">
       <h1>The %AsyncIteratorPrototype% Object</h1>
-      <p>The value of the [[Prototype]] internal slot of the <dfn>%AsyncIteratorPrototype%</dfn> object is the intrinsic object %ObjectPrototype%. The %AsyncIteratorPrototype% object is an ordinary object. The initial value of the [[Extensible]] internal slot of the %AsyncIteratorPrototype% object is *true*.</p>
+      <p>The <dfn>%AsyncIteratorPrototype%</dfn> object:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+      </ul>
       <emu-note>
         <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%.The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
       </emu-note>
@@ -37882,7 +37892,13 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%asyncfromsynciteratorprototype%-object">
         <h1>The %AsyncFromSyncIteratorPrototype% Object</h1>
-        <p>All Async-from-Sync Iterator Objects inherit properties from the <dfn>%AsyncFromSyncIteratorPrototype%</dfn> intrinsic object. The %AsyncFromSyncIteratorPrototype% object is an ordinary object and its [[Prototype]] internal slot is the %AsyncIteratorPrototype% intrinsic object. In addition, %AsyncFromSyncIteratorPrototype% has the following properties:</p>
+        <p>The <dfn>%AsyncFromSyncIteratorPrototype%</dfn> object:</p>
+        <ul>
+          <li>has properties that are inherited by all Async-from-Sync Iterator Objects.</li>
+          <li>is an ordinary object.</li>
+          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %AsyncIteratorPrototype%.</li>
+          <li>has the following properties:</li>
+        </ul>
 
         <emu-clause id="sec-%asyncfromsynciteratorprototype%.next">
           <h1>%AsyncFromSyncIteratorPrototype%.next ( _value_ )</h1>
@@ -38042,8 +38058,12 @@ THH:mm:ss.sss
     <!-- es6num="25.2.1" -->
     <emu-clause id="sec-generatorfunction-constructor">
       <h1>The GeneratorFunction Constructor</h1>
-      <p>The `GeneratorFunction` constructor is the <dfn>%GeneratorFunction%</dfn> intrinsic. When `GeneratorFunction` is called as a function rather than as a constructor, it creates and initializes a new GeneratorFunction object. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</p>
-      <p>`GeneratorFunction` is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `GeneratorFunction` behaviour must include a `super` call to the `GeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of `GeneratorFunction`. There is no syntactic means to create instances of `GeneratorFunction` subclasses.</p>
+      <p>The GeneratorFunction constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%GeneratorFunction%</dfn>.</li>
+        <li>creates and initializes a new GeneratorFunction object when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `GeneratorFunction` behaviour must include a `super` call to the `GeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of `GeneratorFunction`. There is no syntactic means to create instances of `GeneratorFunction` subclasses.</li>
+      </ul>
 
       <!-- es6num="25.2.1.1" -->
       <emu-clause id="sec-generatorfunction">
@@ -38064,10 +38084,14 @@ THH:mm:ss.sss
     <!-- es6num="25.2.2" -->
     <emu-clause id="sec-properties-of-the-generatorfunction-constructor">
       <h1>Properties of the GeneratorFunction Constructor</h1>
-      <p>The `GeneratorFunction` constructor is a standard built-in function object that inherits from the `Function` constructor. The value of the [[Prototype]] internal slot of the `GeneratorFunction` constructor is the intrinsic object %Function%.</p>
-      <p>The value of the [[Extensible]] internal slot of the GeneratorFunction constructor is *true*.</p>
-      <p>The value of the `name` property of the GeneratorFunction constructor is `"GeneratorFunction"`.</p>
-      <p>The `GeneratorFunction` constructor has the following properties:</p>
+      <p>The GeneratorFunction constructor:</p>
+      <ul>
+        <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
+        <li>has an [[Extensible]] internal slot whose value is *true*.</li>
+        <li>has a `name` property whose value is `"GeneratorFunction"`.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="25.2.2.1" -->
       <emu-clause id="sec-generatorfunction.length">
@@ -38086,8 +38110,15 @@ THH:mm:ss.sss
     <!-- es6num="25.2.3" -->
     <emu-clause id="sec-properties-of-the-generatorfunction-prototype-object">
       <h1>Properties of the GeneratorFunction Prototype Object</h1>
-      <p>The GeneratorFunction prototype object is an ordinary object. It is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-56"></emu-xref>. In addition to being the value of the prototype property of the %GeneratorFunction% intrinsic, it is the <dfn>%Generator%</dfn> intrinsic (see Figure 2).</p>
-      <p>The value of the [[Prototype]] internal slot of the GeneratorFunction prototype object is the %FunctionPrototype% intrinsic object. The initial value of the [[Extensible]] internal slot of the GeneratorFunction prototype object is *true*.</p>
+      <p>The GeneratorFunction prototype object:</p>
+      <ul>
+        <li>is an ordinary object.</li>
+        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-56"></emu-xref>.</li>
+        <li>is the value of the `prototype` property of the intrinsic object %GeneratorFunction%.</li>
+        <li>is the intrinsic object <dfn>%Generator%</dfn> (see Figure 2).</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+      </ul>
 
       <!-- es6num="25.2.3.1" -->
       <emu-clause id="sec-generatorfunction.prototype.constructor">
@@ -38147,8 +38178,12 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-asyncgeneratorfunction-constructor">
       <h1>The AsyncGeneratorFunction Constructor</h1>
-      <p>The `AsyncGeneratorFunction` constructor is the <dfn>%AsyncGeneratorFunction%</dfn> intrinsic. When `AsyncGeneratorFunction` is called as a function rather than as a constructor, it creates and initializes a new AsyncGeneratorFunction object. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</p>
-      <p>`AsyncGeneratorFunction` is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `AsyncGeneratorFunction` behaviour must include a `super` call to the `AsyncGeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of `AsyncGeneratorFunction`. There is no syntactic means to create instances of `AsyncGeneratorFunction` subclasses.</p>
+      <p>The AsyncGeneratorFunction constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%AsyncGeneratorFunction%</dfn>.</li>
+        <li>creates and initializes a new AsyncGeneratorFunction object when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `AsyncGeneratorFunction` behaviour must include a `super` call to the `AsyncGeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of `AsyncGeneratorFunction`. There is no syntactic means to create instances of `AsyncGeneratorFunction` subclasses.</li>
+      </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction">
         <h1>AsyncGeneratorFunction ( _p1_, _p2_, ..., _pn_, _body_ )</h1>
@@ -38167,10 +38202,14 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-asyncgeneratorfunction">
       <h1>Properties of the AsyncGeneratorFunction Constructor</h1>
-      <p>The `AsyncGeneratorFunction` constructor is a standard built-in function object that inherits from the `Function` constructor. The value of the [[Prototype]] internal slot of the `AsyncGeneratorFunction` constructor is the intrinsic object %Function%.</p>
-      <p>The value of the [[Extensible]] internal slot of the AsyncGeneratorFunction constructor is *true*.</p>
-      <p>The value of the `name` property of the AsyncGeneratorFunction constructor is `"AsyncGeneratorFunction"`.</p>
-      <p>The `AsyncGeneratorFunction` constructor has the following properties:</p>
+      <p>The AsyncGeneratorFunction constructor:</p>
+      <ul>
+        <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
+        <li>has an [[Extensible]] internal slot whose value is *true*.</li>
+        <li>has a `name` property whose value is `"AsyncGeneratorFunction"`.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction-length">
         <h1>AsyncGeneratorFunction.length</h1>
@@ -38186,8 +38225,15 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-asyncgeneratorfunction-prototype">
       <h1>Properties of the AsyncGeneratorFunction Prototype Object</h1>
-      <p>The AsyncGeneratorFunction prototype object is an ordinary object. It is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>. In addition to being the value of the prototype property of the %AsyncGeneratorFunction% intrinsic, it is the %AsyncGenerator% intrinsic.</p>
-      <p>The value of the [[Prototype]] internal slot of the AsyncGeneratorFunction prototype object is the %FunctionPrototype% intrinsic object. The initial value of the [[Extensible]] internal slot of the AsyncGeneratorFunction prototype object is *true*.</p>
+      <p>The AsyncGeneratorFunction prototype object:</p>
+      <ul>
+        <li>is an ordinary object.</li>
+        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
+        <li>is the value of the `prototype` property of the intrinsic object %AsyncGeneratorFunction%.</li>
+        <li>is the intrinsic object %AsyncGenerator%.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+      </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype-constructor">
         <h1>AsyncGeneratorFunction.prototype.constructor</h1>
@@ -38244,10 +38290,16 @@ THH:mm:ss.sss
     <!-- es6num="25.3.1" -->
     <emu-clause id="sec-properties-of-generator-prototype">
       <h1>Properties of the Generator Prototype Object</h1>
-      <p>The Generator prototype object is the <dfn>%GeneratorPrototype%</dfn> intrinsic. It is also the initial value of the `prototype` property of the %Generator% intrinsic (the GeneratorFunction.prototype).</p>
-      <p>The Generator prototype object is an ordinary object. It is not a Generator instance and does not have a [[GeneratorState]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the Generator prototype object is the intrinsic object %IteratorPrototype%. The initial value of the [[Extensible]] internal slot of the Generator prototype object is *true*.</p>
-      <p>All Generator instances indirectly inherit properties of the Generator prototype object.</p>
+      <p>The Generator prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%GeneratorPrototype%</dfn>.</li>
+        <li>is the initial value of the `prototype` property of the intrinsic object %Generator% (the GeneratorFunction.prototype).</li>
+        <li>is an ordinary object.</li>
+        <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+        <li>has properties that are indirectly inherited by all Generator instances.</li>
+      </ul>
 
       <!-- es6num="25.3.1.1" -->
       <emu-clause id="sec-generator.prototype.constructor">
@@ -38462,10 +38514,16 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-asyncgenerator-prototype">
       <h1>Properties of the AsyncGenerator Prototype Object</h1>
-      <p>The AsyncGenerator prototype object is the <dfn>%AsyncGeneratorPrototype%</dfn> intrinsic. It is also the initial value of the `prototype` property of the %AsyncGenerator% intrinsic (the AsyncGeneratorFunction.prototype).</p>
-      <p>The AsyncGenerator prototype object is an ordinary object. It is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the AsyncGenerator prototype object is the intrinsic object %AsyncIteratorPrototype%. The initial value of the [[Extensible]] internal slot of the AsyncGenerator prototype object is *true*.</p>
-      <p>All AsyncGenerator instances indirectly inherit properties of the AsyncGenerator prototype object.</p>
+      <p>The AsyncGenerator prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%AsyncGeneratorPrototype%</dfn>.</li>
+        <li>is the initial value of the `prototype` property of the intrinsic object %AsyncGenerator% (the AsyncGeneratorFunction.prototype).</li>
+        <li>is an ordinary object.</li>
+        <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %AsyncIteratorPrototype%.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+        <li>has properties that are indirectly inherited by all AsyncGenerator instances.</li>
+      </ul>
 
       <emu-clause id="sec-asyncgenerator-prototype-constructor">
         <h1>AsyncGenerator.prototype.constructor</h1>
@@ -39120,8 +39178,14 @@ THH:mm:ss.sss
     <!-- es6num="25.4.3" -->
     <emu-clause id="sec-promise-constructor">
       <h1>The Promise Constructor</h1>
-      <p>The Promise constructor is the <dfn>%Promise%</dfn> intrinsic object and the initial value of the `Promise` property of the global object. When called as a constructor it creates and initializes a new Promise object. `Promise` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Promise` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behaviour must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</p>
+      <p>The Promise constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Promise%</dfn>.</li>
+        <li>is the initial value of the `Promise` property of the global object.</li>
+        <li>creates and initializes a new Promise object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behaviour must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
+      </ul>
 
       <!-- es6num="25.4.3.1" -->
       <emu-clause id="sec-promise-executor">
@@ -39153,8 +39217,11 @@ THH:mm:ss.sss
     <!-- es6num="25.4.4" -->
     <emu-clause id="sec-properties-of-the-promise-constructor">
       <h1>Properties of the Promise Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the `Promise` constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Promise constructor has the following properties:</p>
+      <p>The Promise constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="25.4.4.1" -->
       <emu-clause id="sec-promise.all">
@@ -39356,7 +39423,13 @@ THH:mm:ss.sss
     <!-- es6num="25.4.5" -->
     <emu-clause id="sec-properties-of-the-promise-prototype-object">
       <h1>Properties of the Promise Prototype Object</h1>
-      <p>The Promise prototype object is the intrinsic object <dfn>%PromisePrototype%</dfn>. The value of the [[Prototype]] internal slot of the Promise prototype object is the intrinsic object %ObjectPrototype%. The Promise prototype object is an ordinary object. It does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</p>
+      <p>The Promise prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%PromisePrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</li>
+      </ul>
 
       <!-- es6num="25.4.5.1" -->
       <emu-clause id="sec-promise.prototype.catch">
@@ -39551,9 +39624,13 @@ THH:mm:ss.sss
     <emu-clause id="sec-async-function-constructor">
       <h1>The AsyncFunction Constructor</h1>
 
-      <p>The `AsyncFunction` constructor is the <dfn>%AsyncFunction%</dfn> intrinsic object and is a subclass of `Function`. When `AsyncFunction` is called as a function rather than as a constructor, it creates and initializes a new AsyncFunction object. Thus the function call `AsyncFunction(&hellip;)` is equivalent to the object creation expression `new AsyncFunction(&hellip;)` with the same arguments.</p>
-
-      <p>The `AsyncFunction` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the `AsyncFunction` constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour.</p>
+      <p>The AsyncFunction constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%AsyncFunction%</dfn>.</li>
+        <li>is a subclass of `Function`.</li>
+        <li>creates and initializes a new AsyncFunction object when called as a function rather than as a constructor. Thus the function call `AsyncFunction(&hellip;)` is equivalent to the object creation expression `new AsyncFunction(&hellip;)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the `AsyncFunction` constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour.</li>
+      </ul>
 
       <emu-clause id="sec-async-function-constructor-arguments">
         <h1>AsyncFunction( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
@@ -39574,13 +39651,14 @@ THH:mm:ss.sss
     <emu-clause id="sec-async-function-constructor-properties">
       <h1>Properties of the AsyncFunction Constructor</h1>
 
-      <p>The AsyncFunction constructor is a standard built-in function object that inherits from the `Function` constructor. The value of the [[Prototype]] internal slot of the AsyncFunction constructor is the intrinsic object %Function%.</p>
-
-      <p>The value of the [[Extensible]] internal slot of the AsyncFunction constructor is *true*.</p>
-
-      <p>The value of the `name` property of the AsyncFunction constructor is `"AsyncFunction"`.</p>
-
-      <p>The AsyncFunction constructor has the following properties:</p>
+      <p>The AsyncFunction constructor:</p>
+      <ul>
+        <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
+        <li>has an [[Extensible]] internal slot whose value is *true*.</li>
+        <li>has a `name` property whose value is `"AsyncFunction"`.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <emu-clause id="sec-async-function-constructor-length">
         <h1>AsyncFunction.length</h1>
@@ -39596,9 +39674,15 @@ THH:mm:ss.sss
     </emu-clause>
     <emu-clause id="sec-sync-function-prototype-properties">
       <h1>Properties of the AsyncFunction Prototype Object</h1>
-      <p>The AsyncFunction prototype object is an ordinary object. It is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>. In addition to being the value of the prototype property of the %AsyncFunction% intrinsic, it is the <dfn>%AsyncFunctionPrototype%</dfn> intrinsic.</p>
-
-      <p>The value of the [[Prototype]] internal slot of the AsyncFunction prototype object is the %FunctionPrototype% intrinsic object. The initial value of the [[Extensible]] internal slot of the AsyncFunction prototype object is *true*.</p>
+      <p>The AsyncFunction prototype object:</p>
+      <ul>
+        <li>is an ordinary object.</li>
+        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</li>
+        <li>is the value of the `prototype` property of the intrinsic object %AsyncFunction%.</li>
+        <li>is the intrinsic object <dfn>%AsyncFunctionPrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+      </ul>
 
       <emu-clause id="sec-async-function-prototype-properties-constructor">
         <h1>AsyncFunction.prototype.constructor</h1>

--- a/spec.html
+++ b/spec.html
@@ -28940,8 +28940,14 @@ THH:mm:ss.sss
     <!-- es6num="21.1.1" -->
     <emu-clause id="sec-string-constructor">
       <h1>The String Constructor</h1>
-      <p>The String constructor is the <dfn>%String%</dfn> intrinsic object and the initial value of the `String` property of the global object. When called as a constructor it creates and initializes a new String object. When `String` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `String` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behaviour must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</p>
+      <p>The String constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%String%</dfn>.</li>
+        <li>is the initial value of the `String` property of the global object.</li>
+        <li>creates and initializes a new String object when called as a constructor.</li>
+        <li>performs a type conversion when called as a function rather than as a constructor.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behaviour must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</li>
+      </ul>
 
       <!-- es6num="21.1.1.1" -->
       <emu-clause id="sec-string-constructor-string-value">
@@ -28961,8 +28967,11 @@ THH:mm:ss.sss
     <!-- es6num="21.1.2" -->
     <emu-clause id="sec-properties-of-the-string-constructor">
       <h1>Properties of the String Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the String constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The String constructor has the following properties:</p>
+      <p>The String constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="21.1.2.1" -->
       <emu-clause id="sec-string.fromcharcode">
@@ -29045,8 +29054,14 @@ THH:mm:ss.sss
     <!-- es6num="21.1.3" -->
     <emu-clause id="sec-properties-of-the-string-prototype-object">
       <h1>Properties of the String Prototype Object</h1>
-      <p>The String prototype object is the intrinsic object <dfn>%StringPrototype%</dfn>. The String prototype object is a String exotic object and has the internal methods specified for such objects. It has a [[StringData]] internal slot with the value *""*. It has a `length` property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-      <p>The value of the [[Prototype]] internal slot of the String prototype object is the intrinsic object %ObjectPrototype%.</p>
+      <p>The String prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%StringPrototype%</dfn>.</li>
+        <li>is a String exotic object and has the internal methods specified for such objects.</li>
+        <li>has a [[StringData]] internal slot whose value is *""*.</li>
+        <li>has a `length` property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      </ul>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
       <p>The abstract operation <dfn id="sec-thisstringvalue" aoid="thisStringValue">thisStringValue</dfn>(_value_) performs the following steps:</p>
       <emu-alg>
@@ -29865,7 +29880,13 @@ THH:mm:ss.sss
       <!-- es6num="21.1.5.2" -->
       <emu-clause id="sec-%stringiteratorprototype%-object">
         <h1>The %StringIteratorPrototype% Object</h1>
-        <p>All String Iterator Objects inherit properties from the <dfn>%StringIteratorPrototype%</dfn> intrinsic object. The %StringIteratorPrototype% object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object. In addition, %StringIteratorPrototype% has the following properties:</p>
+        <p>The <dfn>%StringIteratorPrototype%</dfn> object:</p>
+        <ul>
+          <li>has properties that are inherited by all String Iterator Objects.</li>
+          <li>is an ordinary object.</li>
+          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has the following properties:</li>
+        </ul>
 
         <!-- es6num="21.1.5.2.1" -->
         <emu-clause id="sec-%stringiteratorprototype%.next">
@@ -31566,8 +31587,13 @@ THH:mm:ss.sss
     <!-- es6num="21.2.3" -->
     <emu-clause id="sec-regexp-constructor">
       <h1>The RegExp Constructor</h1>
-      <p>The RegExp constructor is the <dfn>%RegExp%</dfn> intrinsic object and the initial value of the `RegExp` property of the global object. When `RegExp` is called as a function rather than as a constructor, it creates and initializes a new RegExp object. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</p>
-      <p>The `RegExp` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behaviour must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</p>
+      <p>The RegExp constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%RegExp%</dfn>.</li>
+        <li>is the initial value of the `RegExp` property of the global object.</li>
+        <li>creates and initializes a new RegExp object when called as a function rather than as a constructor. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behaviour must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</li>
+      </ul>
 
       <!-- es6num="21.2.3.1" -->
       <emu-clause id="sec-regexp-pattern-flags">
@@ -31667,8 +31693,11 @@ THH:mm:ss.sss
     <!-- es6num="21.2.4" -->
     <emu-clause id="sec-properties-of-the-regexp-constructor">
       <h1>Properties of the RegExp Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the RegExp constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The RegExp constructor has the following properties:</p>
+      <p>The RegExp constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="21.2.4.1" -->
       <emu-clause id="sec-regexp.prototype">
@@ -31694,8 +31723,13 @@ THH:mm:ss.sss
     <!-- es6num="21.2.5" -->
     <emu-clause id="sec-properties-of-the-regexp-prototype-object">
       <h1>Properties of the RegExp Prototype Object</h1>
-      <p>The RegExp prototype object is the intrinsic object <dfn>%RegExpPrototype%</dfn>. The RegExp prototype object is an ordinary object. It is not a RegExp instance and does not have a [[RegExpMatcher]] internal slot or any of the other internal slots of RegExp instance objects.</p>
-      <p>The value of the [[Prototype]] internal slot of the RegExp prototype object is the intrinsic object %ObjectPrototype%.</p>
+      <p>The RegExp prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%RegExpPrototype%</dfn>.</li>
+        <li>is an ordinary object.</li>
+        <li>is not a RegExp instance and does not have a [[RegExpMatcher]] internal slot or any of the other internal slots of RegExp instance objects.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      </ul>
       <emu-note>
         <p>The RegExp prototype object does not have a `valueOf` property of its own; however, it inherits the `valueOf` property from the Object prototype object.</p>
       </emu-note>

--- a/spec.html
+++ b/spec.html
@@ -34921,8 +34921,14 @@ THH:mm:ss.sss
     <!-- es6num="23.1.1" -->
     <emu-clause id="sec-map-constructor">
       <h1>The Map Constructor</h1>
-      <p>The Map constructor is the <dfn>%Map%</dfn> intrinsic object and the initial value of the `Map` property of the global object. When called as a constructor it creates and initializes a new Map object. `Map` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Map` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behaviour must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</p>
+      <p>The Map constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Map%</dfn>.</li>
+        <li>is the initial value of the `Map` property of the global object.</li>
+        <li>creates and initializes a new Map object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behaviour must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
+      </ul>
 
       <!-- es6num="23.1.1.1" -->
       <emu-clause id="sec-map-iterable">
@@ -34960,8 +34966,11 @@ THH:mm:ss.sss
     <!-- es6num="23.1.2" -->
     <emu-clause id="sec-properties-of-the-map-constructor">
       <h1>Properties of the Map Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Map constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Map constructor has the following properties:</p>
+      <p>The Map constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="23.1.2.1" -->
       <emu-clause id="sec-map.prototype">
@@ -34987,7 +34996,13 @@ THH:mm:ss.sss
     <!-- es6num="23.1.3" -->
     <emu-clause id="sec-properties-of-the-map-prototype-object">
       <h1>Properties of the Map Prototype Object</h1>
-      <p>The Map prototype object is the intrinsic object <dfn>%MapPrototype%</dfn>. The value of the [[Prototype]] internal slot of the Map prototype object is the intrinsic object %ObjectPrototype%. The Map prototype object is an ordinary object. It does not have a [[MapData]] internal slot.</p>
+      <p>The Map prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%MapPrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have a [[MapData]] internal slot.</li>
+      </ul>
 
       <!-- es6num="23.1.3.1" -->
       <emu-clause id="sec-map.prototype.clear">
@@ -35198,7 +35213,13 @@ THH:mm:ss.sss
       <!-- es6num="23.1.5.2" -->
       <emu-clause id="sec-%mapiteratorprototype%-object">
         <h1>The %MapIteratorPrototype% Object</h1>
-        <p>All Map Iterator Objects inherit properties from the <dfn>%MapIteratorPrototype%</dfn> intrinsic object. The %MapIteratorPrototype% intrinsic object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object. In addition, %MapIteratorPrototype% has the following properties:</p>
+        <p>The <dfn>%MapIteratorPrototype%</dfn> object:</p>
+        <ul>
+          <li>has properties that are inherited by all Map Iterator Objects.</li>
+          <li>is an ordinary object.</li>
+          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has the following properties:</li>
+        </ul>
 
         <!-- es6num="23.1.5.2.1" -->
         <emu-clause id="sec-%mapiteratorprototype%.next">
@@ -35294,8 +35315,14 @@ THH:mm:ss.sss
     <!-- es6num="23.2.1" -->
     <emu-clause id="sec-set-constructor">
       <h1>The Set Constructor</h1>
-      <p>The Set constructor is the <dfn>%Set%</dfn> intrinsic object and the initial value of the `Set` property of the global object. When called as a constructor it creates and initializes a new Set object. `Set` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `Set` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behaviour must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</p>
+      <p>The Set constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Set%</dfn>.</li>
+        <li>is the initial value of the `Set` property of the global object.</li>
+        <li>creates and initializes a new Set object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behaviour must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
+      </ul>
 
       <!-- es6num="23.2.1.1" -->
       <emu-clause id="sec-set-iterable">
@@ -35323,8 +35350,11 @@ THH:mm:ss.sss
     <!-- es6num="23.2.2" -->
     <emu-clause id="sec-properties-of-the-set-constructor">
       <h1>Properties of the Set Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Set constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Set constructor has the following properties:</p>
+      <p>The Set constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="23.2.2.1" -->
       <emu-clause id="sec-set.prototype">
@@ -35350,7 +35380,13 @@ THH:mm:ss.sss
     <!-- es6num="23.2.3" -->
     <emu-clause id="sec-properties-of-the-set-prototype-object">
       <h1>Properties of the Set Prototype Object</h1>
-      <p>The Set prototype object is the intrinsic object <dfn>%SetPrototype%</dfn>. The value of the [[Prototype]] internal slot of the Set prototype object is the intrinsic object %ObjectPrototype%. The Set prototype object is an ordinary object. It does not have a [[SetData]] internal slot.</p>
+      <p>The Set prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%SetPrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have a [[SetData]] internal slot.</li>
+      </ul>
 
       <!-- es6num="23.2.3.1" -->
       <emu-clause id="sec-set.prototype.add">
@@ -35546,7 +35582,13 @@ THH:mm:ss.sss
       <!-- es6num="23.2.5.2" -->
       <emu-clause id="sec-%setiteratorprototype%-object">
         <h1>The %SetIteratorPrototype% Object</h1>
-        <p>All Set Iterator Objects inherit properties from the <dfn>%SetIteratorPrototype%</dfn> intrinsic object. The %SetIteratorPrototype% intrinsic object is an ordinary object and its [[Prototype]] internal slot is the %IteratorPrototype% intrinsic object. In addition, %SetIteratorPrototype% has the following properties:</p>
+        <p>The <dfn>%SetIteratorPrototype%</dfn> object:</p>
+        <ul>
+          <li>has properties that are inherited by all Set Iterator Objects.</li>
+          <li>is an ordinary object.</li>
+          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has the following properties:</li>
+        </ul>
 
         <!-- es6num="23.2.5.2.1" -->
         <emu-clause id="sec-%setiteratorprototype%.next">
@@ -35645,8 +35687,14 @@ THH:mm:ss.sss
     <!-- es6num="23.3.1" -->
     <emu-clause id="sec-weakmap-constructor">
       <h1>The WeakMap Constructor</h1>
-      <p>The WeakMap constructor is the <dfn>%WeakMap%</dfn> intrinsic object and the initial value of the `WeakMap` property of the global object. When called as a constructor it creates and initializes a new WeakMap object. `WeakMap` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `WeakMap` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behaviour must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</p>
+      <p>The WeakMap constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%WeakMap%</dfn>.</li>
+        <li>is the initial value of the `WeakMap` property of the global object.</li>
+        <li>creates and initializes a new WeakMap object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behaviour must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
+      </ul>
 
       <!-- es6num="23.3.1.1" -->
       <emu-clause id="sec-weakmap-iterable">
@@ -35684,8 +35732,11 @@ THH:mm:ss.sss
     <!-- es6num="23.3.2" -->
     <emu-clause id="sec-properties-of-the-weakmap-constructor">
       <h1>Properties of the WeakMap Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the WeakMap constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The WeakMap constructor has the following properties:</p>
+      <p>The WeakMap constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="23.3.2.1" -->
       <emu-clause id="sec-weakmap.prototype">
@@ -35698,7 +35749,13 @@ THH:mm:ss.sss
     <!-- es6num="23.3.3" -->
     <emu-clause id="sec-properties-of-the-weakmap-prototype-object">
       <h1>Properties of the WeakMap Prototype Object</h1>
-      <p>The WeakMap prototype object is the intrinsic object <dfn>%WeakMapPrototype%</dfn>. The value of the [[Prototype]] internal slot of the WeakMap prototype object is the intrinsic object %ObjectPrototype%. The WeakMap prototype object is an ordinary object. It does not have a [[WeakMapData]] internal slot.</p>
+      <p>The WeakMap prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%WeakMapPrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have a [[WeakMapData]] internal slot.</li>
+      </ul>
 
       <!-- es6num="23.3.3.1" -->
       <emu-clause id="sec-weakmap.prototype.constructor">
@@ -35808,8 +35865,14 @@ THH:mm:ss.sss
     <!-- es6num="23.4.1" -->
     <emu-clause id="sec-weakset-constructor">
       <h1>The WeakSet Constructor</h1>
-      <p>The WeakSet constructor is the <dfn>%WeakSet%</dfn> intrinsic object and the initial value of the `WeakSet` property of the global object. When called as a constructor it creates and initializes a new WeakSet object. `WeakSet` is not intended to be called as a function and will throw an exception when called in that manner.</p>
-      <p>The `WeakSet` constructor is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behaviour must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</p>
+      <p>The WeakSet constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%WeakSet%</dfn>.</li>
+        <li>is the initial value of the `WeakSet` property of the global object.</li>
+        <li>creates and initializes a new WeakSet object when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behaviour must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
+      </ul>
 
       <!-- es6num="23.4.1.1" -->
       <emu-clause id="sec-weakset-iterable">
@@ -35837,8 +35900,11 @@ THH:mm:ss.sss
     <!-- es6num="23.4.2" -->
     <emu-clause id="sec-properties-of-the-weakset-constructor">
       <h1>Properties of the WeakSet Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the WeakSet constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The WeakSet constructor has the following properties:</p>
+      <p>The WeakSet constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="23.4.2.1" -->
       <emu-clause id="sec-weakset.prototype">
@@ -35851,7 +35917,13 @@ THH:mm:ss.sss
     <!-- es6num="23.4.3" -->
     <emu-clause id="sec-properties-of-the-weakset-prototype-object">
       <h1>Properties of the WeakSet Prototype Object</h1>
-      <p>The WeakSet prototype object is the intrinsic object <dfn>%WeakSetPrototype%</dfn>. The value of the [[Prototype]] internal slot of the WeakSet prototype object is the intrinsic object %ObjectPrototype%. The WeakSet prototype object is an ordinary object. It does not have a [[WeakSetData]] internal slot.</p>
+      <p>The WeakSet prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%WeakSetPrototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have a [[WeakSetData]] internal slot.</li>
+      </ul>
 
       <!-- es6num="23.4.3.1" -->
       <emu-clause id="sec-weakset.prototype.add">

--- a/spec.html
+++ b/spec.html
@@ -24824,8 +24824,14 @@
     <!-- es6num="19.1.1" -->
     <emu-clause id="sec-object-constructor">
       <h1>The Object Constructor</h1>
-      <p>The Object constructor is the <dfn>%Object%</dfn> intrinsic object and the initial value of the `Object` property of the global object. When called as a constructor it creates a new ordinary object. When `Object` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `Object` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition.</p>
+      <p>The Object constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Object%</dfn>.</li>
+        <li>is the initial value of the `Object` property of the global object.</li>
+        <li>creates a new ordinary object when called as a constructor.</li>
+        <li>performs a type conversion when called as a function rather than as a constructor.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition.</li>
+      </ul>
 
       <!-- es6num="19.1.1.1" -->
       <emu-clause id="sec-object-value">
@@ -24844,8 +24850,12 @@
     <!-- es6num="19.1.2" -->
     <emu-clause id="sec-properties-of-the-object-constructor">
       <h1>Properties of the Object Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Object constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>Besides the `length` property, the Object constructor has the following properties:</p>
+      <p>The Object constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a `length` property.</li>
+        <li>has the following additional properties:</li>
+      </ul>
 
       <!-- es6num="19.1.2.1" -->
       <emu-clause id="sec-object.assign">
@@ -25129,8 +25139,13 @@
     <!-- es6num="19.1.3" -->
     <emu-clause id="sec-properties-of-the-object-prototype-object">
       <h1>Properties of the Object Prototype Object</h1>
-      <p>The Object prototype object is the intrinsic object <dfn>%ObjectPrototype%</dfn>. The Object prototype object is an immutable prototype exotic object.</p>
-      <p>The value of the [[Prototype]] internal slot of the Object prototype object is *null* and the initial value of the [[Extensible]] internal slot is *true*.</p>
+      <p>The Object prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%ObjectPrototype%</dfn>.</li>
+        <li>is an immutable prototype exotic object.</li>
+        <li>has a [[Prototype]] internal slot whose value is *null*.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+      </ul>
 
       <!-- es6num="19.1.3.1" -->
       <emu-clause id="sec-object.prototype.constructor">
@@ -25259,8 +25274,13 @@
     <!-- es6num="19.2.1" -->
     <emu-clause id="sec-function-constructor">
       <h1>The Function Constructor</h1>
-      <p>The Function constructor is the <dfn>%Function%</dfn> intrinsic object and the initial value of the `Function` property of the global object. When `Function` is called as a function rather than as a constructor, it creates and initializes a new function object. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</p>
-      <p>The `Function` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction`, `AsyncFunction`, and `AsyncGeneratorFunction` subclasses.</p>
+      <p>The Function constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Function%</dfn>.</li>
+        <li>is the initial value of the `Function` property of the global object.</li>
+        <li>creates and initializes a new function object when called as a function rather than as a constructor. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction`, `AsyncFunction`, and `AsyncGeneratorFunction` subclasses.</li>
+      </ul>
 
       <!-- es6num="19.2.1.1" -->
       <emu-clause id="sec-function-p1-p2-pn-body">
@@ -25367,9 +25387,13 @@
     <!-- es6num="19.2.2" -->
     <emu-clause id="sec-properties-of-the-function-constructor">
       <h1>Properties of the Function Constructor</h1>
-      <p>The Function constructor is itself a built-in function object. The value of the [[Prototype]] internal slot of the Function constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The value of the [[Extensible]] internal slot of the Function constructor is *true*.</p>
-      <p>The Function constructor has the following properties:</p>
+      <p>The Function constructor:</p>
+      <ul>
+        <li>is itself a built-in function object.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has an [[Extensible]] internal slot whose value is *true*.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="19.2.2.1" -->
       <emu-clause id="sec-function.length">
@@ -25388,14 +25412,21 @@
     <!-- es6num="19.2.3" -->
     <emu-clause id="sec-properties-of-the-function-prototype-object">
       <h1>Properties of the Function Prototype Object</h1>
-      <p>The Function prototype object is the intrinsic object <dfn>%FunctionPrototype%</dfn>. The Function prototype object is itself a built-in function object. When invoked, it accepts any arguments and returns *undefined*. It does not have a [[Construct]] internal method so it is not a constructor.</p>
+      <p>The Function prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%FunctionPrototype%</dfn>.</li>
+        <li>is itself a built-in function object.</li>
+        <li>accepts any arguments and returns *undefined* when invoked.</li>
+        <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
+        <li>does not have a `prototype` property.</li>
+        <li>has a `length` property whose value is 0.</li>
+        <li>has a `name` property whose value is the empty String.</li>
+      </ul>
       <emu-note>
         <p>The Function prototype object is specified to be a function object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
       </emu-note>
-      <p>The value of the [[Prototype]] internal slot of the Function prototype object is the intrinsic object %ObjectPrototype%. The initial value of the [[Extensible]] internal slot of the Function prototype object is *true*.</p>
-      <p>The Function prototype object does not have a `prototype` property.</p>
-      <p>The value of the `length` property of the Function prototype object is 0.</p>
-      <p>The value of the `name` property of the Function prototype object is the empty String.</p>
 
       <!-- es6num="19.2.3.1" -->
       <emu-clause id="sec-function.prototype.apply">
@@ -25565,8 +25596,14 @@
     <!-- es6num="19.3.1" -->
     <emu-clause id="sec-boolean-constructor">
       <h1>The Boolean Constructor</h1>
-      <p>The Boolean constructor is the <dfn>%Boolean%</dfn> intrinsic object and the initial value of the `Boolean` property of the global object. When called as a constructor it creates and initializes a new Boolean object. When `Boolean` is called as a function rather than as a constructor, it performs a type conversion.</p>
-      <p>The `Boolean` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behaviour must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</p>
+      <p>The Boolean constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Boolean%</dfn>.</li>
+        <li>is the initial value of the `Boolean` property of the global object.</li>
+        <li>creates and initializes a new Boolean object when called as a constructor.</li>
+        <li>performs a type conversion when called as a function rather than as a constructor.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behaviour must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</li>
+      </ul>
 
       <!-- es6num="19.3.1.1" -->
       <emu-clause id="sec-boolean-constructor-boolean-value">
@@ -25585,8 +25622,11 @@
     <!-- es6num="19.3.2" -->
     <emu-clause id="sec-properties-of-the-boolean-constructor">
       <h1>Properties of the Boolean Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Boolean constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Boolean constructor has the following properties:</p>
+      <p>The Boolean constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="19.3.2.1" -->
       <emu-clause id="sec-boolean.prototype">
@@ -25599,8 +25639,13 @@
     <!-- es6num="19.3.3" -->
     <emu-clause id="sec-properties-of-the-boolean-prototype-object">
       <h1>Properties of the Boolean Prototype Object</h1>
-      <p>The Boolean prototype object is the intrinsic object <dfn>%BooleanPrototype%</dfn>. The Boolean prototype object is an ordinary object. The Boolean prototype object is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</p>
-      <p>The value of the [[Prototype]] internal slot of the Boolean prototype object is the intrinsic object %ObjectPrototype%.</p>
+      <p>The Boolean prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%BooleanPrototype%</dfn>.</li>
+        <li>is an ordinary object.</li>
+        <li>is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      </ul>
 
       <p>The abstract operation <dfn id="sec-thisbooleanvalue" aoid="thisBooleanValue">thisBooleanValue</dfn>(_value_) performs the following steps:</p>
       <emu-alg>
@@ -25651,8 +25696,15 @@
     <!-- es6num="19.4.1" -->
     <emu-clause id="sec-symbol-constructor">
       <h1>The Symbol Constructor</h1>
-      <p>The Symbol constructor is the <dfn>%Symbol%</dfn> intrinsic object and the initial value of the `Symbol` property of the global object. When `Symbol` is called as a function, it returns a new Symbol value.</p>
-      <p>The `Symbol` constructor is not intended to be used with the `new` operator or to be subclassed. It may be used as the value of an `extends` clause of a class definition but a `super` call to the `Symbol` constructor will cause an exception.</p>
+      <p>The Symbol constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Symbol%</dfn>.</li>
+        <li>is the initial value of the `Symbol` property of the global object.</li>
+        <li>returns a new Symbol value when called as a function.</li>
+        <li>is not intended to be used with the `new` operator.</li>
+        <li>is not intended to be subclassed.</li>
+        <li>may be used as the value of an `extends` clause of a class definition but a `super` call to it will cause an exception.</li>
+      </ul>
 
       <!-- es6num="19.4.1.1" -->
       <emu-clause id="sec-symbol-description">
@@ -25670,8 +25722,11 @@
     <!-- es6num="19.4.2" -->
     <emu-clause id="sec-properties-of-the-symbol-constructor">
       <h1>Properties of the Symbol Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Symbol constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Symbol constructor has the following properties:</p>
+      <p>The Symbol constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <emu-clause id="sec-symbol.asynciterator">
         <h1>Symbol.asyncIterator</h1>
@@ -25835,8 +25890,13 @@
     <!-- es6num="19.4.3" -->
     <emu-clause id="sec-properties-of-the-symbol-prototype-object">
       <h1>Properties of the Symbol Prototype Object</h1>
-      <p>The Symbol prototype object is the intrinsic object <dfn>%SymbolPrototype%</dfn>. The Symbol prototype object is an ordinary object. It is not a Symbol instance and does not have a [[SymbolData]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the Symbol prototype object is the intrinsic object %ObjectPrototype%.</p>
+      <p>The Symbol prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%SymbolPrototype%</dfn>.</li>
+        <li>is an ordinary object.</li>
+        <li>is not a Symbol instance and does not have a [[SymbolData]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      </ul>
 
       <p>The abstract operation <dfn id="sec-thissymbolvalue" aoid="thisSymbolValue">thisSymbolValue</dfn>(_value_) performs the following steps:</p>
       <emu-alg>
@@ -25920,8 +25980,13 @@
     <!-- es6num="19.5.1" -->
     <emu-clause id="sec-error-constructor">
       <h1>The Error Constructor</h1>
-      <p>The Error constructor is the <dfn>%Error%</dfn> intrinsic object and the initial value of the `Error` property of the global object. When `Error` is called as a function rather than as a constructor, it creates and initializes a new Error object. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</p>
-      <p>The `Error` constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</p>
+      <p>The Error constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Error%</dfn>.</li>
+        <li>is the initial value of the `Error` property of the global object.</li>
+        <li>creates and initializes a new Error object when called as a function rather than as a constructor. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
+      </ul>
 
       <!-- es6num="19.5.1.1" -->
       <emu-clause id="sec-error-message">
@@ -25942,8 +26007,11 @@
     <!-- es6num="19.5.2" -->
     <emu-clause id="sec-properties-of-the-error-constructor">
       <h1>Properties of the Error Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the Error constructor is the intrinsic object %FunctionPrototype%.</p>
-      <p>The Error constructor has the following properties:</p>
+      <p>The Error constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
 
       <!-- es6num="19.5.2.1" -->
       <emu-clause id="sec-error.prototype">
@@ -25956,8 +26024,13 @@
     <!-- es6num="19.5.3" -->
     <emu-clause id="sec-properties-of-the-error-prototype-object">
       <h1>Properties of the Error Prototype Object</h1>
-      <p>The Error prototype object is the intrinsic object <dfn>%ErrorPrototype%</dfn>. The Error prototype object is an ordinary object. It is not an Error instance and does not have an [[ErrorData]] internal slot.</p>
-      <p>The value of the [[Prototype]] internal slot of the Error prototype object is the intrinsic object %ObjectPrototype%.</p>
+      <p>The Error prototype object:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%ErrorPrototype%</dfn>.</li>
+        <li>is an ordinary object.</li>
+        <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      </ul>
 
       <!-- es6num="19.5.3.1" -->
       <emu-clause id="sec-error.prototype.constructor">
@@ -26052,8 +26125,11 @@
       <!-- es6num="19.5.6.1" -->
       <emu-clause id="sec-nativeerror-constructors">
         <h1>The _NativeError_ Constructors</h1>
-        <p>When a _NativeError_ constructor is called as a function rather than as a constructor, it creates and initializes a new _NativeError_ object. A call of the object as a function is equivalent to calling it as a constructor with the same arguments. Thus the function call <code><var>NativeError</var>(&hellip;)</code> is equivalent to the object creation expression <code>new <var>NativeError</var>(&hellip;)</code> with the same arguments.</p>
-        <p>Each _NativeError_ constructor is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</p>
+        <p>Each _NativeError_ constructor:</p>
+        <ul>
+          <li>creates and initializes a new _NativeError_ object when called as a function rather than as a constructor. A call of the object as a function is equivalent to calling it as a constructor with the same arguments. Thus the function call <code><var>NativeError</var>(&hellip;)</code> is equivalent to the object creation expression <code>new <var>NativeError</var>(&hellip;)</code> with the same arguments.</li>
+          <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
+        </ul>
 
         <!-- es6num="19.5.6.1.1" -->
         <emu-clause id="sec-nativeerror">
@@ -26075,9 +26151,12 @@
       <!-- es6num="19.5.6.2" -->
       <emu-clause id="sec-properties-of-the-nativeerror-constructors">
         <h1>Properties of the _NativeError_ Constructors</h1>
-        <p>The value of the [[Prototype]] internal slot of a _NativeError_ constructor is the intrinsic object %Error%.</p>
-        <p>Each _NativeError_ constructor has a `name` property whose value is the String value `"<var>NativeError</var>"`.</p>
-        <p>Each _NativeError_ constructor has the following properties:</p>
+        <p>Each _NativeError_ constructor:</p>
+        <ul>
+          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Error%.</li>
+          <li>has a `name` property whose value is the String value `"<var>NativeError</var>"`.</li>
+          <li>has the following properties:</li>
+        </ul>
 
         <!-- es6num="19.5.6.2.1" -->
         <emu-clause id="sec-nativeerror.prototype">
@@ -26090,8 +26169,12 @@
       <!-- es6num="19.5.6.3" -->
       <emu-clause id="sec-properties-of-the-nativeerror-prototype-objects">
         <h1>Properties of the _NativeError_ Prototype Objects</h1>
-        <p>Each _NativeError_ prototype object is an ordinary object. It is not an Error instance and does not have an [[ErrorData]] internal slot.</p>
-        <p>The value of the [[Prototype]] internal slot of each _NativeError_ prototype object is the intrinsic object %ErrorPrototype%.</p>
+        <p>Each _NativeError_ prototype object:</p>
+        <ul>
+          <li>is an ordinary object.</li>
+          <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
+          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ErrorPrototype%.</li>
+        </ul>
 
         <!-- es6num="19.5.6.3.1" -->
         <emu-clause id="sec-nativeerror.prototype.constructor">


### PR DESCRIPTION
[Note that, currently, the first 8 commits listed for this PR actually belong to PR #1122. If/when that's merged, I think they'll disappear from here.]

For many intrinsics (the constructors, the prototype objects, and a few others), there are blocks of text that specify (what I'm calling here) their 'characteristics'. (Elsewhere I'd say 'properties', but in ES that word is already taken.) This PR converts each of those blocks from paragraphs to a bulleted list.

Mainly, I think the result is more readable (both by humans and software). Implementers and testers can (more easily) treat it as a checklist of items to implement and test.

The commit could be merged as is. However, there are variations/extensions that you might like to consider/discuss/request.

(1)
Grammatically speaking, each `<li>` is a predicate, where the corresponding subject is factored out into the line preceding the `<ul>`. Instead, you might prefer that each `<li>` be a complete sentence. E.g.,
```
    The Array constructor has the following characteristics:
      - It is the intrinsic object <dfn>%Array%</dfn>.
      - It is the initial value of the `Array` property of the global object.
      - etc
```

One advantage of this approach is that it lets you use more 'natural' wording.  E.g., instead of
      `- has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.`
you can say:
     ` - The value of its [[Prototype]] internal slot is the intrinsic object %FunctionPrototype%.`
(which is more like how the spec currently structures that statement).

(2)
For intrinsic objects that are constructors, their characteristics are split over 2 clauses (typically "The Foo Constructor" and "Properties of the Foo Constructor"). You might like to combine these 2 blocks so that all the characteristics appear in one place. (The clauses would still be separate.)

(3)
The characteristics of an intrinsic are mostly given in (a subset of) the following order:
   - If it's a well-known intrinsic, what is its Table 7 name?
   - If it has a global name, what's that?
   - Is it the value of some property of some other intrinsic?
   - What kind of object is it?
   - Can it be used as a constructor, and if so, what does that do?
   - Can it be called as a function, and if so, what does that do?
   - If it's a constructor, is it subclassable?
   - What is the value of its [[Prototype]]?
   - What is the value of its [[Extensible]]?
   - What are its data properties?

However, there are exceptions to this order. You might like the order to be standardized (either to the above, or something else).

(4)
You might like to introduce special markup/markdown for these blocks (e.g., `<emu-intrinsic>`), making them more machine-readable, which could be useful to implementers and testers, and would allow for specialized rendering in the HTML version of the spec.

(5)
As a follow-up to the discussion re PR #1122, you might like to use these blocks to make the per-Realm-ness of intrinsics more explicit. E.g., starting each block with:
    `Within each Realm, the Foo constructor:`
or
    `Every Realm has a Foo constructor, with the following characteristics:`


