### PR TITLE
Normative: Redefine CatchParameter as FormalParameter

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18287,8 +18287,7 @@
         `finally` Block[?Yield, ?Await, ?Return]
 
       CatchParameter[Yield, Await] :
-        BindingIdentifier[?Yield, ?Await]
-        BindingPattern[?Yield, ?Await]
+        FormalParameter[?Yield, ?Await]
     </emu-grammar>
     <emu-note>
       <p>The `try` statement encloses a block of code in which an exceptional condition can occur, such as a runtime error or a `throw` statement. The `catch` clause provides the exception-handling code. When a catch clause catches an exception, its |CatchParameter| is bound to that exception.</p>


### PR DESCRIPTION
This change removes default value restriction for catch parameter.

Closes https://github.com/tc39/ecma262/issues/1121