### PR TITLE
Normative: Strengthen Atomics.wait/notify synchronization to the level of other Atomics operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6714,7 +6714,7 @@
       <p>Examples of that type of termination are: operating systems or users terminating agents that are running in separate processes; the embedding itself terminating an agent that is running in-process with the other agents when per-agent resource accounting indicates that the agent is runaway.</p>
     </emu-note>
 
-    <p>Prior to any evaluation of any ECMAScript code by any agent in a cluster, the [[CandidateExecution]] field of the Agent Record for all agents in the cluster is set to the initial candidate execution. The initial candidate execution is an empty candidate execution whose [[EventsRecords]] field is a List containing, for each agent, an Agent Events Record whose [[AgentSignifier]] field is that agent's signifier and whose [[EventList]] field is an empty List.</p>
+    <p>Prior to any evaluation of any ECMAScript code by any agent in a cluster, the [[CandidateExecution]] field of the Agent Record for all agents in the cluster is set to the initial candidate execution. The initial candidate execution is an empty candidate execution whose [[EventsRecords]] field is a List containing, for each agent, an Agent Events Record whose [[AgentSignifier]] field is that agent's signifier, and whose [[EventList]] and [[AgentSynchronizesWith]] fields are empty Lists.</p>
 
     <emu-note>
       <p>All agents in an agent cluster share the same candidate execution in its Agent Record's [[CandidateExecution]] field. The candidate execution is a specification mechanism used by the memory model.</p>
@@ -35537,6 +35537,15 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is on the list of waiters in _WL_.
+          1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+          1. Let _eventsRecord_ be the Agent Events Record in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
+          1. Let _agentSynchronizesWith_ be _eventsRecord_.[[AgentSynchronizesWith]].
+          1. Let _notifierEventList_ be _eventsRecord_.[[EventList]].
+          1. Let _waiterEventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is _W_.
+          1. Let _notifyEvent_ and _waitEvent_ be new Synchronize events.
+          1. Append _notifyEvent_ to _notifierEventList_.
+          1. Append _waitEvent_ to _waiterEventList_.
+          1. Append (_notifierEvent_, _waitEvent_) to _agentSynchronizesWith_.
           1. Notify the agent _W_.
         </emu-alg>
         <emu-note>
@@ -38617,12 +38626,13 @@ The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operat
     </emu-table>
 
     <p>These events are introduced by abstract operations or by methods on the Atomics object.</p>
-    <p>In addition to Shared Data Block events, there are host-specific events.</p>
+    <p>Some operations may also introduce <dfn>Synchronize</dfn> events. A <dfn>Synchronize event</dfn> has no fields, and exists purely to directly constrain the permitted orderings of other events.</p>
+    <p>In addition to Shared Data Block and Synchronize events, there are host-specific events.</p>
     <p>Let the range of a ReadSharedMemory, WriteSharedMemory, or ReadModifyWriteSharedMemory event be the Set of contiguous integers from its [[ByteIndex]] to [[ByteIndex]] + [[ElementSize]] - 1. Two events' ranges are equal when the events have the same [[Block]], and the ranges are element-wise equal. Two events' ranges are overlapping when the events have the same [[Block]], the ranges are not equal and their intersection is non-empty. Two events' ranges are disjoint when the events do not have the same [[Block]] or their ranges are neither equal nor overlapping.</p>
     <emu-note>
       <p>Examples of host-specific synchronizing events that should be accounted for are: sending a SharedArrayBuffer from one agent to another (e.g., by `postMessage` in a browser), starting and stopping agents, and communicating within the agent cluster via channels other than shared memory. It is assumed those events are appended to agent-order during evaluation like the other SharedArrayBuffer events.</p>
     </emu-note>
-    <p>Shared Data Block events are ordered within candidate executions by the relations defined below.</p>
+    <p>Events are ordered within candidate executions by the relations defined below.</p>
   </emu-clause>
 
   <emu-clause id="sec-agent-event-records">
@@ -38645,6 +38655,11 @@ The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operat
             <td>[[EventList]]</td>
             <td>A List of events</td>
             <td>Events are appended to the list during evaluation.</td>
+          </tr>
+          <tr>
+            <td>[[AgentSynchronizesWith]]</td>
+            <td>A List of pairs of Synchronize events</td>
+            <td>Synchronize relationships introduced by the operational semantics.</td>
           </tr>
         </tbody>
       </table>
@@ -38760,6 +38775,17 @@ The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operat
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-synchronizeeventset" aoid="SynchronizeEventSet">
+      <h1>SynchronizeEventSet( _execution_ )</h1>
+      <p>The abstract operation SynchronizeEventSet takes one argument, a candidate execution _execution_. It performs the following steps:</p>
+      <emu-alg>
+        1. Let _events_ be an empty Set.
+        1. For each event _E_ in EventSet(_execution_), do
+          1. If _E_ is a Synchronize event, add _E_ to _events_.
+        1. Return _events_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-hosteventset" aoid="HostEventSet">
       <h1>HostEventSet ( _execution_ )</h1>
       <p>The abstract operation HostEventSet takes one argument, a candidate execution _execution_. It performs the following steps:</p>
@@ -38868,12 +38894,18 @@ The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operat
       <p>For a candidate execution _execution_, _execution_.[[SynchronizesWith]] is the least Relation on events that satisfies the following.</p>
       <ul>
         <li>
-          <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if all the following are true.</p>
+          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if all the following are true.
           <ul>
             <li>_R_.[[Order]] is `"SeqCst"`.</li>
             <li>_W_.[[Order]] is `"SeqCst"` or `"Init"`.</li>
             <li>If _W_.[[Order]] is `"SeqCst"`, then _R_ and _W_ have equal ranges.</li>
             <li>If _W_.[[Order]] is `"Init"`, then for each event _V_ such that (_R_, _V_) is in _execution_.[[ReadsFrom]], _V_.[[Order]] is `"Init"`.</li>
+          </ul>
+        </li>
+        <li>
+          For each element _eventsRecord_ of _execution_.[[EventsRecords]], the following is true.
+          <ul>
+            <li>For each pair (_S_, _Sw_) in _eventsRecord_.[[AgentSynchronizesWith]], (_S_, _Sw_) is in _execution_.[[SynchronizesWith]].</li>
           </ul>
         </li>
         <li>For each pair (_E_, _D_) in _execution_.[[HostSynchronizesWith]], (_E_, _D_) is in _execution_.[[SynchronizesWith]].</li>
@@ -38888,7 +38920,7 @@ The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operat
       </emu-note>
 
       <emu-note>
-        <p>For an event _R_ and an event _W_ such that _W_ synchronizes-with _R_, _R_ may reads-from other writes than _W_.</p>
+        <p>For Shared Data Block events _R_ and _W_ such that _W_ synchronizes-with _R_, _R_ may reads-from other writes than _W_.</p>
       </emu-note>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -3388,7 +3388,7 @@
           1. Assert: _size_ &ge; 0.
           1. Let _db_ be a new Shared Data Block value consisting of _size_ bytes. If it is impossible to create such a Shared Data Block, throw a *RangeError* exception.
           1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-          1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventLists]] whose [[AgentSignifier]] is AgentSignifier().
+          1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _zero_ be &laquo; 0 &raquo;.
           1. For each index _i_ of _db_, do
             1. Append WriteSharedMemory { [[Order]]: `"Init"`, [[NoTear]]: *true*, [[Block]]: _db_, [[ByteIndex]]: _i_, [[ElementSize]]: 1, [[Payload]]: _zero_ } to _eventList_.
@@ -3409,7 +3409,7 @@
           1. Repeat, while _count_ &gt; 0
             1. If _fromBlock_ is a Shared Data Block, then
               1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-              1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventLists]] whose [[AgentSignifier]] is AgentSignifier().
+              1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
               1. Let _bytes_ be a List of length 1 that contains a nondeterministically chosen byte value.
               1. NOTE: In implementations, _bytes_ is the result of a non-atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
               1. Let _readEvent_ be ReadSharedMemory { [[Order]]: `"Unordered"`, [[NoTear]]: *true*, [[Block]]: _fromBlock_, [[ByteIndex]]: _fromIndex_, [[ElementSize]]: 1 }.
@@ -6714,7 +6714,7 @@
       <p>Examples of that type of termination are: operating systems or users terminating agents that are running in separate processes; the embedding itself terminating an agent that is running in-process with the other agents when per-agent resource accounting indicates that the agent is runaway.</p>
     </emu-note>
 
-    <p>Prior to any evaluation of any ECMAScript code by any agent in a cluster, the [[CandidateExecution]] field of the Agent Record for all agents in the cluster is set to the initial candidate execution. The initial candidate execution is an empty candidate execution whose [[EventLists]] field is a List containing, for each agent, an Agent Events Record whose [[AgentSignifier]] field is that agent's signifier and whose [[EventList]] field is an empty List.</p>
+    <p>Prior to any evaluation of any ECMAScript code by any agent in a cluster, the [[CandidateExecution]] field of the Agent Record for all agents in the cluster is set to the initial candidate execution. The initial candidate execution is an empty candidate execution whose [[EventsRecords]] field is a List containing, for each agent, an Agent Events Record whose [[AgentSignifier]] field is that agent's signifier and whose [[EventList]] field is an empty List.</p>
 
     <emu-note>
       <p>All agents in an agent cluster share the same candidate execution in its Agent Record's [[CandidateExecution]] field. The candidate execution is a specification mechanism used by the memory model.</p>
@@ -34699,7 +34699,7 @@ THH:mm:ss.sss
           1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-            1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventLists]] whose [[AgentSignifier]] is AgentSignifier().
+            1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. If _isTypedArray_ is *true* and _type_ is `"Int8"`, `"Uint8"`, `"Int16"`, `"Uint16"`, `"Int32"`, or `"Uint32"`, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
             1. Let _rawValue_ be a List of length _elementSize_ of nondeterministically chosen byte values.
             1. NOTE: In implementations, _rawValue_ is the result of a non-atomic or atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
@@ -34746,7 +34746,7 @@ THH:mm:ss.sss
           1. Let _rawBytes_ be NumberToRawBytes(_type_, _value_, _isLittleEndian_).
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-            1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventLists]] whose [[AgentSignifier]] is AgentSignifier().
+            1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. If _isTypedArray_ is *true* and _type_ is `"Int8"`, `"Uint8"`, `"Int16"`, `"Uint16"`, `"Int32"`, or `"Uint32"`, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
             1. Append WriteSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_ } to _eventList_.
           1. Else, store the individual bytes of _rawBytes_ into _block_, in order, starting at _block_[_byteIndex_].
@@ -34767,7 +34767,7 @@ THH:mm:ss.sss
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
           1. Let _rawBytes_ be NumberToRawBytes(_type_, _value_, _isLittleEndian_).
           1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-          1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventLists]] whose [[AgentSignifier]] is AgentSignifier().
+          1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _rawBytesRead_ be a List of length _elementSize_ of nondeterministically chosen byte values.
           1. NOTE: In implementations, _rawBytesRead_ is the result of a load-link, of a load-exclusive, or of an operand of a read-modify-write instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
           1. Let _rmwEvent_ be ReadModifyWriteSharedMemory { [[Order]]: `"SeqCst"`, [[NoTear]]: *true*, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_, [[ModifyOp]]: _op_ }.
@@ -38689,7 +38689,7 @@ The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operat
             <th>Meaning</th>
           </tr>
           <tr>
-            <td>[[EventLists]]</td>
+            <td>[[EventsRecords]]</td>
             <td>A List of Agent Events Records.</td>
             <td>Maps an agent to Lists of events appended during the evaluation.</td>
           </tr>
@@ -38742,7 +38742,7 @@ The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operat
       <p>The abstract operation EventSet takes one argument, a candidate execution _execution_. It performs the following steps:</p>
       <emu-alg>
         1. Let _events_ be an empty Set.
-        1. For each Agent Events Record _aer_ in _execution_.[[EventLists]], do
+        1. For each Agent Events Record _aer_ in _execution_.[[EventsRecords]], do
           1. For each event _E_ in _aer_.[[EventList]], do
             1. Add _E_ to _events_.
         1. Return _events_.
@@ -38817,7 +38817,7 @@ The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operat
       <h1>agent-order</h1>
       <p>For a candidate execution _execution_, _execution_.[[AgentOrder]] is a Relation on events that satisfies the following.</p>
       <ul>
-        <li>For each pair (_E_, _D_) in EventSet(_execution_), (_E_, _D_) is in _execution_.[[AgentOrder]] if there is some Agent Events Record _aer_ in _execution_.[[EventLists]] such that _E_ and _D_ are in _aer_.[[EventList]] and _E_ is before _D_ in List order of _aer_.[[EventList]].</li>
+        <li>For each pair (_E_, _D_) in EventSet(_execution_), (_E_, _D_) is in _execution_.[[AgentOrder]] if there is some Agent Events Record _aer_ in _execution_.[[EventsRecords]] such that _E_ and _D_ are in _aer_.[[EventList]] and _E_ is before _D_ in List order of _aer_.[[EventList]].</li>
       </ul>
 
       <emu-note>


### PR DESCRIPTION
See issue #1119 for background on the current behaviour.

This proposal strengthens the synchronization between a waking thread and its wakees as though they were each a coinciding atomic write/read (respectively) to the same memory location, in line with some previous comments by @lars-t-hansen on the informal language of an earlier draft of the memory model proposal.

Since each waker/wakee pair is determined purely operationally, there is no need to struggle to reassociate the events from scratch in the axiomatic semantics (a la the ReadsBytesFrom relation for Shared Data Block events). Instead, each agent tracks which waking events it is responsible for in a new [[AgentSynchronizesWith]] field of its Events Record, which is then unified with the global synchronizes-with relation.

I chose to introduce a rather general new "Synchronize" action rather than abuse any of the existing ones, since this spec machinery would be useful to specify a future fork or similar thread spawning operation, or explicit barrier operations, either in ECMAScript or in WebAssembly. This also limits the potential for unfortunate interactions with other parts of the spec which deal with Shared Data Block events.

I also rename the [[EventLists]] property of candidate executions to [[EventsRecords]] since Events Records now contain more than just EventLists, with the added bonus that it makes sentences which formerly read as "Let eventList be the [[EventList]] field of the element in execution.[[EventLists]] whose [[AgentSignifier]] is AgentSignifier()." easier to parse, considering the element of [[EventLists]] in question is actually an Events Record.

**Some initial discussion points**
1 -
Is "Synchronize" the right name for the new action? I mulled over "Scheduling" or something similar, but as I mentioned earlier these actions could potentially also be used to specify barriers in the future.

2 -
This change should not invalidate any user code - it is a strict subsetting of the previously allowed observable behaviour.

3 -
A scattering of informative notes throughout the PR may still be required.

4 -
**On second thoughts I don't believe this is true**
~~This new specification is still slightly weak. It doesn't incorporate all of the guarantees you might get from an OS barrier in Atomics.wait. For example, an execution for the following program is still allowed where x = 1, y = 1, z = 0.~~

| Line |Thread 1                      | Thread 2 |
|--|------------------------------|-------------- |
| 1 |   tA[2] = 1 | Atomics.store(tA, 0, 1)   |
| 2 |    tA[1] = 1 |  var x = Atomics.wake(tA, 0, 1)    |
| 3 |    Atomics.wait(tA, 0, 0)  | var y = tA[1] |
| 4 |      -                               | var z = tA[2] |

~~In a real implementation using OS calls for wake/wait, if x = 1 I'd expect to only observe y = z = 1. However this certainly isn't a property I'd expect as many people to care about or try to rely on. In particular, the execution where x = 0, y = 1, z = 0 must be allowed by the model, so it seems that the only programs that could benefit from a further strengthened model would be rather pathological.~~

5 -
On x86, this specification is satisfied by implementing Atomics.wake as a regular ECMAScript atomic load followed by a bare Linux wait, and Atomics.wake as a bare Linux wake, but (I believe) it is stronger than the same on ARM/Power, which will necessitate an extra read barrier at least (see below). I'm also not familiar enough with the barrier behaviour of other OS's to know what extra barriers are required, although I would be surprised if they do not at least issue a write barrier upon waking, as Linux does. It should be noted that this is not new - ECMAScript atomic writes are stronger than the (relaxed) atomic writes of ARM/Power, and this is reasonably well-known.

6 -
**Implementation schemes** - a "defensive" implementation scheme to ensure conformance after this change, assuming nothing about the underlying architecture/OS, is simply to do a full barrier immediately before any call to Atomics.wake and immediately after any call to Atomics.wait - this will always produce the correct behaviour, and is analogous to the "naive code generation scheme" suggested in the ECMAScript standard for atomic loads/stores.

An implementation wishing to do better than this (although I hope there are no benchmarks that depend on a very fast Atomics.wake!) must make use of knowledge about its particular architecture/OS combination. Below is my to-the-best-of-my-knowledge opinion on possible improvements.

**Atomics.wait**
On x86, a read barrier after Atomics.wait is all that is required for correctness. On ARM/Power, a full barrier is required.

On Linux a full barrier is carried out by the OS call to sleep, so no additional barrier is required by the ECMAScript implementation no matter the architecture. I don't know the behaviour of other OS's off the top of my head, but I imagine similar guarantees could be determined about their barrier behaviour.

**Atomics.wake**
No barrier at all is required at Atomics.wake if the call to Atomics.wake does not wake any waiting threads, so the cases afterwards will assume it wakes at least one.

On x86, a write barrier is sufficient for correctness, and therefore on an OS where the underlying syscall already performs this (Linux, at least, when at least one thread is woken) no additional barrier is required in the ECMAScript implementation.

On ARM/Power, a full barrier is required overall, but if the OS performs a write barrier already, the ECMAScript implementation need only perform an additional read barrier.

@lars-t-hansen, @syg, and @rossberg PTAL.