### PR TITLE
Restore original definition of DataView.length

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36211,7 +36211,7 @@ THH:mm:ss.sss
 
       <!-- es6num="24.2.2.1" -->
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
-        <h1>DataView ( _buffer_ [ , _byteOffset_ [ , _byteLength_  ] ] )</h1>
+        <h1>DataView ( _buffer_, _byteOffset_, _byteLength_ )</h1>
         <p>When the `DataView` is called with at least one argument _buffer_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
@@ -36221,7 +36221,7 @@ THH:mm:ss.sss
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
           1. If _offset_ &gt; _bufferByteLength_, throw a *RangeError* exception.
-          1. If _byteLength_ is either not present or *undefined*, then
+          1. If _byteLength_ is *undefined*, then
             1. Let _viewByteLength_ be _bufferByteLength_ - _offset_.
           1. Else,
             1. Let _viewByteLength_ be ? ToIndex(_byteLength_).


### PR DESCRIPTION
Chakra, JSC, V8, and SpiderMonkey all agree that `DataView.length` is 3. test262 also tests that `DataView.length` is 3.


Fixes #787