### PR TITLE
Restore early SyntaxError for strict mode assignment to eval/arguments

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11103,21 +11103,21 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-identifiers-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-identifiers-static-semantics-isvalidsimpleassignmenttarget" id="sec-identifiers-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
-        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is `"eval"` or `"arguments"`, return *false*.
-        1. Return *true*.
+        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is `"eval"` or `"arguments"`, return ~strict~.
+        1. Return ~simple~.
       </emu-alg>
       <emu-grammar>IdentifierReference : `yield`</emu-grammar>
       <emu-alg>
-        1. Return *true*.
+        1. Return ~simple~.
       </emu-alg>
       <emu-grammar>IdentifierReference : `await`</emu-grammar>
       <emu-alg>
-        1. Return *true*.
+        1. Return ~simple~.
       </emu-alg>
     </emu-clause>
 
@@ -11320,9 +11320,9 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-semantics-static-semantics-isvalidsimpleassignmenttarget">
-        <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-        <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+      <emu-clause oldids="sec-semantics-static-semantics-isvalidsimpleassignmenttarget" id="sec-semantics-static-semantics-assignmenttargettype">
+        <h1>Static Semantics: AssignmentTargetType</h1>
+        <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
         <emu-grammar>
           PrimaryExpression :
             `this`
@@ -11338,12 +11338,12 @@
             TemplateLiteral
         </emu-grammar>
         <emu-alg>
-          1. Return *false*.
+          1. Return ~invalid~.
         </emu-alg>
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. Return IsValidSimpleAssignmentTarget of _expr_.
+          1. Return AssignmentTargetType of _expr_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -12097,12 +12097,12 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget">
-        <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-        <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+      <emu-clause oldids="sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget" id="sec-grouping-operator-static-semantics-assignmenttargettype">
+        <h1>Static Semantics: AssignmentTargetType</h1>
+        <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
         <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
-          1. Return IsValidSimpleAssignmentTarget of |Expression|.
+          1. Return AssignmentTargetType of |Expression|.
         </emu-alg>
       </emu-clause>
 
@@ -12298,9 +12298,9 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget">
-        <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-        <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+      <emu-clause oldids="sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget" id="sec-static-semantics-static-semantics-assignmenttargettype">
+        <h1>Static Semantics: AssignmentTargetType</h1>
+        <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
         <emu-grammar>
           CallExpression :
             CallExpression `[` Expression `]`
@@ -12312,7 +12312,7 @@
             SuperProperty
         </emu-grammar>
         <emu-alg>
-          1. Return *true*.
+          1. Return ~simple~.
         </emu-alg>
         <emu-grammar>
           CallExpression :
@@ -12332,7 +12332,7 @@
             `new` `.` `target`
         </emu-grammar>
         <emu-alg>
-          1. Return *false*.
+          1. Return ~invalid~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -12673,7 +12673,10 @@
       </emu-grammar>
       <ul>
         <li>
-          It is an early Reference Error if IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
+          It is an early Reference Error if AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
+        </li>
+        <li>
+          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is ~strict~.
         </li>
       </ul>
 
@@ -12684,7 +12687,10 @@
       </emu-grammar>
       <ul>
         <li>
-          It is an early Reference Error if IsValidSimpleAssignmentTarget of |UnaryExpression| is *false*.
+          It is an early Reference Error if AssignmentTargetType of |UnaryExpression| is ~invalid~.
+        </li>
+        <li>
+          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is ~strict~.
         </li>
       </ul>
     </emu-clause>
@@ -12704,9 +12710,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget" id="sec-update-expressions-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         UpdateExpression :
           LeftHandSideExpression `++`
@@ -12715,7 +12721,7 @@
           `--` UnaryExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -12819,9 +12825,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-unary-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         UnaryExpression :
           `delete` UnaryExpression
@@ -12834,7 +12840,7 @@
           AwaitExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13104,15 +13110,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget" id="sec-exp-operator-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         ExponentiationExpression :
           UpdateExpression `**` ExponentiationExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13189,12 +13195,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-multiplicative-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13326,16 +13332,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-additive-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         AdditiveExpression :
           AdditiveExpression `+` MultiplicativeExpression
           AdditiveExpression `-` MultiplicativeExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13452,9 +13458,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-bitwise-shift-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         ShiftExpression :
           ShiftExpression `&lt;&lt;` AdditiveExpression
@@ -13462,7 +13468,7 @@
           ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13570,9 +13576,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-relational-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         RelationalExpression :
           RelationalExpression `&lt;` ShiftExpression
@@ -13583,7 +13589,7 @@
           RelationalExpression `in` ShiftExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13695,9 +13701,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-equality-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         EqualityExpression :
           EqualityExpression `==` RelationalExpression
@@ -13706,7 +13712,7 @@
           EqualityExpression `!==` RelationalExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13820,9 +13826,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-binary-bitwise-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
 
@@ -13831,7 +13837,7 @@
         BitwiseORExpression : BitwiseORExpression `|` BitwiseXORExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13879,16 +13885,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-binary-logical-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression
 
         LogicalORExpression : LogicalORExpression `||` LogicalANDExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13936,12 +13942,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget" id="sec-conditional-operator-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -13985,13 +13991,19 @@
           It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and |LeftHandSideExpression| is not covering an |AssignmentPattern|.
         </li>
         <li>
-          It is an early Reference Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
+          It is an early Reference Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
+        </li>
+        <li>
+          It is an early Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType of |LeftHandSideExpression| is ~strict~.
         </li>
       </ul>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <ul>
         <li>
-          It is an early Reference Error if IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
+          It is an early Reference Error if AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
+        </li>
+        <li>
+          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is ~strict~.
         </li>
       </ul>
     </emu-clause>
@@ -14018,9 +14030,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-assignment-operators-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>
         AssignmentExpression :
           YieldExpression
@@ -14030,7 +14042,7 @@
           LeftHandSideExpression AssignmentOperator AssignmentExpression
       </emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -14123,7 +14135,7 @@
         <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if IsValidSimpleAssignmentTarget of |IdentifierReference| is *false*.
+            It is a Syntax Error if AssignmentTargetType of |IdentifierReference| is not ~simple~.
           </li>
         </ul>
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
@@ -14138,7 +14150,7 @@
             It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
           </li>
           <li>
-            It is a Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and IsValidSimpleAssignmentTarget(|LeftHandSideExpression|) is *false*.
+            It is a Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType(|LeftHandSideExpression|) is not ~simple~.
           </li>
         </ul>
       </emu-clause>
@@ -14416,12 +14428,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget">
-      <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-      <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
+    <emu-clause oldids="sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget" id="sec-comma-operator-static-semantics-assignmenttargettype">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Return *false*.
+        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -16303,7 +16315,7 @@
         <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and if |LeftHandSideExpression| is covering an |AssignmentPattern| then the following rules are not applied. Instead, the Early Error rules for |AssignmentPattern| are used.</p>
         <ul>
           <li>
-            It is a Syntax Error if IsValidSimpleAssignmentTarget of |LeftHandSideExpression| is *false*.
+            It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
           <li>
             It is a Syntax Error if the |LeftHandSideExpression| is <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar> and |Expression| derives a phrase that would produce a Syntax Error according to these rules if that phrase were substituted for |LeftHandSideExpression|. This rule is recursively applied.


### PR DESCRIPTION
Fixes https://bugs.ecmascript.org/show_bug.cgi?id=4375

Closes #1267.