### PR TITLE
Editorial: Explicitly note mathematical values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta charset="ascii">
+<meta charset="utf-8">
 <link rel="icon" href="img/favicon.ico">
 <link href="ecmarkup.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">

--- a/spec.html
+++ b/spec.html
@@ -865,13 +865,27 @@
     </emu-clause>
     <emu-clause id=sec-mathematical-operations>
       <h1>Mathematical Operations</h1>
-      <p>Mathematical operations such as addition, subtraction, negation, multiplication, division, and the mathematical functions defined later in this clause should always be understood as computing exact mathematical results on mathematical real numbers, which unless otherwise noted do not include infinities and do not include a negative zero that is distinguished from positive zero. Algorithms in this standard that model floating-point arithmetic include explicit steps, where necessary, to handle infinities and signed zero and to perform rounding. If a mathematical operation or function is applied to a floating-point number, it should be understood as being applied to the exact mathematical value represented by that floating-point number; such a floating-point number must be finite, and if it is *+0* or *-0* then the corresponding mathematical value is simply 0.</p>
-      <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs">abs(_x_)</emu-eqn> produces the absolute value of _x_, which is <emu-eqn>-_x_</emu-eqn> if _x_ is negative (less than zero) and otherwise is _x_ itself.</p>
-      <p>The mathematical function <emu-eqn id="eqn-min" aoid="min">min(_x1_, _x2_, &hellip; , _xN_)</emu-eqn> produces the mathematically smallest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max">max(_x1_, _x2_, &hellip; , _xN_)</emu-eqn> produces the mathematically largest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The domain and range of these mathematical functions include *+&infin;* and *-&infin;*.</p>
-      <p>The notation &ldquo;<emu-eqn id="eqn-modulo" aoid="modulo">_x_ modulo _y_</emu-eqn>&rdquo; (_y_ must be finite and nonzero) computes a value _k_ of the same sign as _y_ (or zero) such that <emu-eqn>abs(_k_) &lt; abs(_y_) and _x_ - _k_ = _q_ &times; _y_</emu-eqn> for some integer _q_.</p>
-      <p>The mathematical function <emu-eqn id="eqn-floor" aoid="floor">floor(_x_)</emu-eqn> produces the largest integer (closest to positive infinity) that is not larger than _x_.</p>
+      <p>This specification makes reference to two kinds of numeric values:</p>
+      <ul>
+        <li><em>Number</em>: IEEE 754-2008 double-precision floating point values, used as the default numeric type.</li>
+        <li><em>Mathematical value</em>: Arbitrary real numbers, used for specific situations.</li>
+      </ul>
+
+      <p>In the language of this specification, numerical values and operations (including addition, subtraction, negation, multiplication, division, and comparison) are distinguished among different numeric kinds using subscripts. The subscript <sub><dfn id="𝔽">𝔽</dfn></sub> refers to Numbers, and the subscript <sub><dfn id="ℝ">ℝ</dfn></sub> refers to mathematical values. A subscript is used following each numeric value and operation.</p>
+      <p>For brevity, the <sub>𝔽</sub> subscript can be omitted on Number values--a numeric value with no subscript is interpreted to be a Number. An operation with no subscript is interpreted to be a Number operation, unless one of the parameters has a particular subscript, in which case the operation adopts that subscript. For example, 1<sub>ℝ</sub> + 2<sub>ℝ</sub> = 3<sub>ℝ</sub> is a statement about mathematical values, and 1 + 2 = 3 is a statement about Numbers.</p>
+      <p>In general, when this specification refers to a numerical value, such as in the phrase, "the length of _y_" or "the integer represented by the four hexadecimal digits ...", without explicitly specifying a numeric kind, the phrase refers to a Number. Phrases which refer to a mathematical value are explicitly annotated as such; for example, "the mathematical value of the number of code points in ...".</p>
+      <p>It is not defined to mix Numbers and mathematical values in either arithmetic or comparison operations, and any such undefined operation would be an editorial error in this specification text.</p>
+      <p>The Number value 0, alternatively written 0<sub>𝔽</sub>, is defined as the double-precision floating point positive zero value. In certain contexts, it may also be written as +0 for clarity.</p>
+      <p>This specification denotes most numeric values in base 10; it also uses numeric values of the form 0x followed by digits 0-9 or A-F as base-16 values.</p>
+      <p>In certain contexts, an operation is specified which is generic between Numbers and mathematical values. In these cases, the subscript can be a variable; _t_ is often used for this purpose, for example 5<sub>_t_</sub> &times; 10<sub>_t_</sub> = 50<sub>_t_</sub> for any _t_ ranging over ℝ and 𝔽, since the values involved are within the range where the semantics coincide.</p>
+      <p>Conversions between mathematical values and numbers are never implicit, and always explicit in this document. A conversion from a mathematical value to a Number is denoted as "the Number value for _x_", and is defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>. A conversion from a Number to a mathematical value is denoted as "the <dfn id="mathematical-value">mathematical value</dfn> of _x_", or ℝ(_x_). Note that the mathematical value of non-finite values is not defined, and the mathematical value of *+0* and *-0* is the mathematical value 0<sub>ℝ</sub>.</p>
+      <p>When the term <dfn id="integer">integer</dfn> is used in this specification, it refers to a Number value whose mathematical value is in the set of integers, unless otherwise stated: when the term <dfn id="mathematical integer">mathematical integer</dfn> is used in this specification, it refers to a mathematical value which is in the set of integers. As shorthand, integer<sub>_t_</sub> can be used to refer to either of the two, as determined by _t_.</p>
+      <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs">abs<sub>_t_</sub>(_x_)</emu-eqn> produces the absolute value of _x_, which is <emu-eqn>-<sub>_t_</sub>_x_</emu-eqn> if _x_ &lt;<sub>_t_</sub> 0<sub>_t_</sub> and otherwise is _x_ itself.</p>
+      <p>The mathematical function <emu-eqn id="eqn-min" aoid="min">min<sub>_t_</sub>(_x1_, _x2_, &hellip; , _xN_)</emu-eqn> produces the mathematically smallest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max">max<sub>_t_</sub>(_x1_, _x2_, ..., _xN_)</emu-eqn> produces the mathematically largest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The domain and range of these mathematical functions include *+&infin;* and *-&infin;*.</p>
+      <p>The notation &ldquo;<emu-eqn id="eqn-modulo" aoid="modulo">_x_ modulo<sub>_t_</sub> _y_</emu-eqn>&rdquo; (_y_ must be finite and nonzero) computes a value _k_ of the same sign as _y_ (or zero) such that <emu-eqn>abs<sub>_t_</sub>(_k_) &lt;<sub>_t_</sub> abs<sub>_t_</sub>(_y_) and _x_-<sub>_t_</sub>_k_ = _q_ &times;<sub>_t_</sub> _y_</emu-eqn> for some integer<sub>_t_</sub> _q_.</p>
+      <p>The mathematical function <emu-eqn id="eqn-floor" aoid="floor">floor<sub>_t_</sub>(_x_)</emu-eqn> produces the largest integer<sub>_t_</sub> (closest to positive infinity) that is not larger than _x_.</p>
       <emu-note>
-        <p><emu-eqn>floor(_x_) = _x_ - (_x_ modulo 1)</emu-eqn>.</p>
+        <p><emu-eqn>floor<sub>_t_</sub>(_x_) = _x_ -<sub>_t_</sub> (_x_ modulo<sub>_t_</sub> 1<sub>_t_</sub>)</emu-eqn>.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -1098,27 +1112,27 @@
 
     <emu-clause id="sec-ecmascript-language-types-number-type">
       <h1>The Number Type</h1>
-      <p>The Number type has exactly 18437736874454810627 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> + 3</emu-eqn>) values, representing the double-precision 64-bit binary format IEEE 754-2008 values as specified in the IEEE Standard for Floating-Point Arithmetic, except that the 9007199254740990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+      <p>The Number type has exactly 18437736874454810627<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> + 3<sub>ℝ</sub></emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2008 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
       <emu-note>
         <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
       </emu-note>
       <p>There are two other special values, called *positive Infinity* and *negative Infinity*. For brevity, these values are also referred to for expository purposes by the symbols *+&infin;* and *-&infin;*, respectively. (Note that these two infinite Number values are produced by the program expressions `+Infinity` (or simply `Infinity`) and `-Infinity`.)</p>
-      <p>The other 18437736874454810624 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
+      <p>The other 18437736874454810624<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
       <p>Note that there is both a *positive zero* and a *negative zero*. For brevity, these values are also referred to for expository purposes by the symbols *+0* and *-0*, respectively. (Note that these two different zero Number values are produced by the program expressions `+0` (or simply `0`) and `-0`.)</p>
-      <p>The 18437736874454810622 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> - 2</emu-eqn>) finite nonzero values are of two kinds:</p>
-      <p>18428729675200069632 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>54</sup></emu-eqn>) of them are normalized, having the form</p>
+      <p>The 18437736874454810622<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) finite nonzero values are of two kinds:</p>
+      <p>18428729675200069632<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>54<sub>ℝ</sub></sup></emu-eqn>) of them are normalized, having the form</p>
       <div class="math-display">
         _s_ &times; _m_ &times; 2<sup>_e_</sup>
       </div>
-      <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>53</sup> but not less than 2<sup>52</sup>, and _e_ is an integer ranging from -1074 to 971, inclusive.</p>
-      <p>The remaining 9007199254740990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) values are denormalized, having the form</p>
+      <p>where _s_ is +1<sub>ℝ</sub> or -1<sub>ℝ</sub>, _m_ is a positive mathematical integer less than 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> but not less than 2<sub>ℝ</sub><sup>52<sub>ℝ</sub></sup>, and _e_ is a mathematical integer ranging from -1074<sub>ℝ</sub> to 971<sub>ℝ</sub>, inclusive.</p>
+      <p>The remaining 9007199254740990<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) values are denormalized, having the form</p>
       <div class="math-display">
         _s_ &times; _m_ &times; 2<sup>_e_</sup>
       </div>
-      <p>where _s_ is +1 or -1, _m_ is a positive integer less than 2<sup>52</sup>, and _e_ is -1074.</p>
-      <p>Note that all the positive and negative integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the integer 0 has two representations, *+0* and *-0*).</p>
-      <p>A finite number has an <em>odd significand</em> if it is nonzero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
-      <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 roundTiesToEven mode.)</p>
+      <p>where _s_ is +1<sub>ℝ</sub> or -1<sub>ℝ</sub>, _m_ is a positive mathematical integer less than 2<sub>ℝ</sub><sup>52<sub>ℝ</sub></sup>, and _e_ is -1074<sub>ℝ</sub>.</p>
+      <p>Note that all the positive and negative mathematical integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the mathematical integer 0 has two representations, *+0* and *-0*).</p>
+      <p>A finite number has an <em>odd significand</em> if it is nonzero and the mathematical integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
+      <p>In this specification, the phrase &ldquo;the <dfn id="number-value">Number value</dfn> for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> (which is <emu-eqn>+1<sub>ℝ</sub> &times; 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> &times; 2<sub>ℝ</sub><sup>971<sub>ℝ</sub></sup></emu-eqn>) and <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> (which is <emu-eqn>-1<sub>ℝ</sub> &times; 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> &times; 2<sub>ℝ</sub><sup>971<sub>ℝ</sub></sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> and <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> are considered to have even significands. Finally, if 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 roundTiesToEven mode.)</p>
       <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
     </emu-clause>
 
@@ -3727,10 +3741,10 @@
           <p>The conversion of a String to a Number value is similar overall to the determination of the Number value for a numeric literal (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different, so the process for converting a String numeric literal to a value of Number type is given here. This value is determined in two steps: first, a mathematical value (MV) is derived from the String numeric literal; second, this mathematical value is rounded as described below. The MV on any grammar symbol, not provided below, is the MV for that symbol defined in <emu-xref href="#sec-static-semantics-mv"></emu-xref>.</p>
           <ul>
             <li>
-              The MV of <emu-grammar>StringNumericLiteral ::: [empty]</emu-grammar> is 0.
+              The MV of <emu-grammar>StringNumericLiteral ::: [empty]</emu-grammar> is 0<sub>ℝ</sub>.
             </li>
             <li>
-              The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace</emu-grammar> is 0.
+              The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace</emu-grammar> is 0<sub>ℝ</sub>.
             </li>
             <li>
               The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar> is the MV of |StrNumericLiteral|, no matter whether white space is present or not.
@@ -3757,31 +3771,31 @@
               The MV of <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar> is the negative of the MV of |StrUnsignedDecimalLiteral|. (Note that if the MV of |StrUnsignedDecimalLiteral| is 0, the negative of this MV is also 0. The rounding rule described below handles the conversion of this signless mathematical zero to a floating-point *+0* or *-0* as appropriate.)
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sup>10000</sup> (a value so large that it will round to *+&infin;*).
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sub>ℝ</sub><sup>10000<sub>ℝ</sub></sup> (a value so large that it will round to *+&infin;*).
             </li>
             <li>
               The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.`</emu-grammar> is the MV of |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>), where _n_ is the number of code points in the second |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>), where _n_ is the mathematical value of the number of code points in the second |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>)) times 10<sup>_e_</sup>, where _n_ is the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>)) times 10<sub>ℝ</sub><sup>_e_</sup>, where _n_ is the mathematical value of the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>, where _n_ is the mathematical value of the number of code points in |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_ - _n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_ -<sub>ℝ</sub> _n_</sup>, where _n_ is the mathematical value of the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
               The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits</emu-grammar> is the MV of |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
           </ul>
           <p>Once the exact MV for a String numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0* unless the first non white space code point in the String numeric literal is `"-"`, in which case the rounded value is *-0*. Otherwise, the rounded value must be the Number value for the MV (in the sense defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal includes a |StrUnsignedDecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit and then incrementing the literal at the 20th digit position. A digit is significant if it is not part of an |ExponentPart| and</p>
@@ -3804,7 +3818,7 @@
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, return *+0*.
         1. If _number_ is *+0*, *-0*, *+&infin;*, or *-&infin;*, return _number_.
-        1. Return the number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Return the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
       </emu-alg>
     </emu-clause>
 
@@ -3814,7 +3828,7 @@
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
         1. If _int32bit_ &ge; 2<sup>31</sup>, return _int32bit_ - 2<sup>32</sup>; otherwise return _int32bit_.
       </emu-alg>
@@ -3840,7 +3854,7 @@
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
         1. Return _int32bit_.
       </emu-alg>
@@ -3869,7 +3883,7 @@
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
         1. If _int16bit_ &ge; 2<sup>15</sup>, return _int16bit_ - 2<sup>16</sup>; otherwise return _int16bit_.
       </emu-alg>
@@ -3881,7 +3895,7 @@
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
         1. Return _int16bit_.
       </emu-alg>
@@ -3904,7 +3918,7 @@
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
         1. If _int8bit_ &ge; 2<sup>7</sup>, return _int8bit_ - 2<sup>8</sup>; otherwise return _int8bit_.
       </emu-alg>
@@ -3916,7 +3930,7 @@
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
         1. Return _int8bit_.
       </emu-alg>
@@ -4028,7 +4042,7 @@
           1. If _m_ is *+0* or *-0*, return the String `"0"`.
           1. If _m_ is less than zero, return the string-concatenation of `"-"` and ! NumberToString(-_m_).
           1. If _m_ is *+&infin;*, return the String `"Infinity"`.
-          1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for _s_ &times; 10<sup>_n_ - _k_</sup> is _m_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
+          1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _m_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10<sub>ℝ</sub>, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
           1. If _k_ &le; _n_ &le; 21, return the string-concatenation of:
             * the code units of the _k_ digits of the decimal representation of _s_ (in order, with no leading zeroes)
             * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
@@ -4068,7 +4082,7 @@
         <emu-note>
           <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 5 be used as a guideline:</p>
           <emu-alg>
-            5. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for _s_ &times; 10<sup>_n_ - _k_</sup> is _m_, and _k_ is as small as possible. If there are multiple possibilities for _s_, choose the value of _s_ for which _s_ &times; 10<sup>_n_ - _k_</sup> is closest in value to _m_. If there are two such possible values of _s_, choose the one that is even. Note that _k_ is the number of digits in the decimal representation of _s_ and that _s_ is not divisible by 10.
+            5. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _m_, and _k_ is as small as possible. If there are multiple possibilities for _s_, choose the value of _s_ for which ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is closest in value to ℝ(_m_). If there are two such possible values of _s_, choose the one that is even. Note that _k_ is the number of digits in the decimal representation of _s_ and that _s_ is not divisible by 10<sub>ℝ</sub>.
           </emu-alg>
         </emu-note>
         <emu-note>
@@ -4195,7 +4209,7 @@
 
     <emu-clause id="sec-toindex" aoid="ToIndex">
       <h1>ToIndex ( _value_ )</h1>
-      <p>The abstract operation ToIndex returns _value_ argument converted to a numeric value if it is a valid integer index value. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToIndex returns _value_ argument converted to a non-negative integer if it is a valid integer index value. This abstract operation functions as follows:</p>
       <emu-alg>
         1. If _value_ is *undefined*, then
           1. Let _index_ be 0.
@@ -8437,7 +8451,7 @@
           1. If _index_ &lt; 0 or _index_ &ge; _length_, return *undefined*.
           1. Let _offset_ be _O_.[[ByteOffset]].
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, `"Unordered"`).
@@ -8459,7 +8473,7 @@
           1. If _index_ &lt; 0 or _index_ &ge; _length_, return *false*.
           1. Let _offset_ be _O_.[[ByteOffset]].
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _numValue_, *true*, `"Unordered"`).
@@ -10124,40 +10138,40 @@
             The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.`</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>), where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>), where _n_ is the mathematical value of the number of code points in |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>)) &times; 10<sup>_e_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>)) &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>_e_ - _n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>_e_ -<sub>ℝ</sub> _n_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalIntegerLiteral :: `0`</emu-grammar> is 0.
+            The MV of <emu-grammar>DecimalIntegerLiteral :: `0`</emu-grammar> is 0<sub>ℝ</sub>.
           </li>
           <li>
             The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit</emu-grammar> is the MV of |NonZeroDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sub>ℝ</sub><sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the mathematical integer number of code points in |DecimalDigits|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalDigits :: DecimalDigit</emu-grammar> is the MV of |DecimalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10) plus the MV of |DecimalDigit|.
+            The MV of <emu-grammar>DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub>) plus the MV of |DecimalDigit|.
           </li>
           <li>
             The MV of <emu-grammar>ExponentPart :: ExponentIndicator SignedInteger</emu-grammar> is the MV of |SignedInteger|.
@@ -10172,52 +10186,52 @@
             The MV of <emu-grammar>SignedInteger :: `-` DecimalDigits</emu-grammar> is the negative of the MV of |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `0`</emu-grammar> or of <emu-grammar>HexDigit :: `0`</emu-grammar> or of <emu-grammar>OctalDigit :: `0`</emu-grammar> or of <emu-grammar>BinaryDigit :: `0`</emu-grammar> is 0.
+            The MV of <emu-grammar>DecimalDigit :: `0`</emu-grammar> or of <emu-grammar>HexDigit :: `0`</emu-grammar> or of <emu-grammar>OctalDigit :: `0`</emu-grammar> or of <emu-grammar>BinaryDigit :: `0`</emu-grammar> is 0<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `1`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `1`</emu-grammar> or of <emu-grammar>HexDigit :: `1`</emu-grammar> or of <emu-grammar>OctalDigit :: `1`</emu-grammar> or of <emu-grammar>BinaryDigit :: `1`</emu-grammar> is 1.
+            The MV of <emu-grammar>DecimalDigit :: `1`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `1`</emu-grammar> or of <emu-grammar>HexDigit :: `1`</emu-grammar> or of <emu-grammar>OctalDigit :: `1`</emu-grammar> or of <emu-grammar>BinaryDigit :: `1`</emu-grammar> is 1<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `2`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `2`</emu-grammar> or of <emu-grammar>HexDigit :: `2`</emu-grammar> or of <emu-grammar>OctalDigit :: `2`</emu-grammar> is 2.
+            The MV of <emu-grammar>DecimalDigit :: `2`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `2`</emu-grammar> or of <emu-grammar>HexDigit :: `2`</emu-grammar> or of <emu-grammar>OctalDigit :: `2`</emu-grammar> is 2<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `3`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `3`</emu-grammar> or of <emu-grammar>HexDigit :: `3`</emu-grammar> or of <emu-grammar>OctalDigit :: `3`</emu-grammar> is 3.
+            The MV of <emu-grammar>DecimalDigit :: `3`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `3`</emu-grammar> or of <emu-grammar>HexDigit :: `3`</emu-grammar> or of <emu-grammar>OctalDigit :: `3`</emu-grammar> is 3<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `4`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `4`</emu-grammar> or of <emu-grammar>HexDigit :: `4`</emu-grammar> or of <emu-grammar>OctalDigit :: `4`</emu-grammar> is 4.
+            The MV of <emu-grammar>DecimalDigit :: `4`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `4`</emu-grammar> or of <emu-grammar>HexDigit :: `4`</emu-grammar> or of <emu-grammar>OctalDigit :: `4`</emu-grammar> is 4<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `5`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `5`</emu-grammar> or of <emu-grammar>HexDigit :: `5`</emu-grammar> or of <emu-grammar>OctalDigit :: `5`</emu-grammar> is 5.
+            The MV of <emu-grammar>DecimalDigit :: `5`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `5`</emu-grammar> or of <emu-grammar>HexDigit :: `5`</emu-grammar> or of <emu-grammar>OctalDigit :: `5`</emu-grammar> is 5<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `6`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `6`</emu-grammar> or of <emu-grammar>HexDigit :: `6`</emu-grammar> or of <emu-grammar>OctalDigit :: `6`</emu-grammar> is 6.
+            The MV of <emu-grammar>DecimalDigit :: `6`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `6`</emu-grammar> or of <emu-grammar>HexDigit :: `6`</emu-grammar> or of <emu-grammar>OctalDigit :: `6`</emu-grammar> is 6<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `7`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `7`</emu-grammar> or of <emu-grammar>HexDigit :: `7`</emu-grammar> or of <emu-grammar>OctalDigit :: `7`</emu-grammar> is 7.
+            The MV of <emu-grammar>DecimalDigit :: `7`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `7`</emu-grammar> or of <emu-grammar>HexDigit :: `7`</emu-grammar> or of <emu-grammar>OctalDigit :: `7`</emu-grammar> is 7<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `8`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `8`</emu-grammar> or of <emu-grammar>HexDigit :: `8`</emu-grammar> is 8.
+            The MV of <emu-grammar>DecimalDigit :: `8`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `8`</emu-grammar> or of <emu-grammar>HexDigit :: `8`</emu-grammar> is 8<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `9`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `9`</emu-grammar> or of <emu-grammar>HexDigit :: `9`</emu-grammar> is 9.
+            The MV of <emu-grammar>DecimalDigit :: `9`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `9`</emu-grammar> or of <emu-grammar>HexDigit :: `9`</emu-grammar> is 9<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `a`</emu-grammar> or of <emu-grammar>HexDigit :: `A`</emu-grammar> is 10.
+            The MV of <emu-grammar>HexDigit :: `a`</emu-grammar> or of <emu-grammar>HexDigit :: `A`</emu-grammar> is 10<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `b`</emu-grammar> or of <emu-grammar>HexDigit :: `B`</emu-grammar> is 11.
+            The MV of <emu-grammar>HexDigit :: `b`</emu-grammar> or of <emu-grammar>HexDigit :: `B`</emu-grammar> is 11<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `c`</emu-grammar> or of <emu-grammar>HexDigit :: `C`</emu-grammar> is 12.
+            The MV of <emu-grammar>HexDigit :: `c`</emu-grammar> or of <emu-grammar>HexDigit :: `C`</emu-grammar> is 12<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `d`</emu-grammar> or of <emu-grammar>HexDigit :: `D`</emu-grammar> is 13.
+            The MV of <emu-grammar>HexDigit :: `d`</emu-grammar> or of <emu-grammar>HexDigit :: `D`</emu-grammar> is 13<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `e`</emu-grammar> or of <emu-grammar>HexDigit :: `E`</emu-grammar> is 14.
+            The MV of <emu-grammar>HexDigit :: `e`</emu-grammar> or of <emu-grammar>HexDigit :: `E`</emu-grammar> is 14<sub>ℝ</sub>.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `f`</emu-grammar> or of <emu-grammar>HexDigit :: `F`</emu-grammar> is 15.
+            The MV of <emu-grammar>HexDigit :: `f`</emu-grammar> or of <emu-grammar>HexDigit :: `F`</emu-grammar> is 15<sub>ℝ</sub>.
           </li>
           <li>
             The MV of <emu-grammar>BinaryIntegerLiteral :: `0b` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
@@ -10229,7 +10243,7 @@
             The MV of <emu-grammar>BinaryDigits :: BinaryDigit</emu-grammar> is the MV of |BinaryDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2) plus the MV of |BinaryDigit|.
+            The MV of <emu-grammar>BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2<sub>ℝ</sub>) plus the MV of |BinaryDigit|.
           </li>
           <li>
             The MV of <emu-grammar>OctalIntegerLiteral :: `0o` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
@@ -10241,7 +10255,7 @@
             The MV of <emu-grammar>OctalDigits :: OctalDigit</emu-grammar> is the MV of |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8) plus the MV of |OctalDigit|.
+            The MV of <emu-grammar>OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8<sub>ℝ</sub>) plus the MV of |OctalDigit|.
           </li>
           <li>
             The MV of <emu-grammar>HexIntegerLiteral :: `0x` HexDigits</emu-grammar> is the MV of |HexDigits|.
@@ -10253,10 +10267,10 @@
             The MV of <emu-grammar>HexDigits :: HexDigit</emu-grammar> is the MV of |HexDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16) plus the MV of |HexDigit|.
+            The MV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16<sub>ℝ</sub>) plus the MV of |HexDigit|.
           </li>
         </ul>
-        <p>Once the exact MV for a numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0*; otherwise, the rounded value must be the Number value for the MV (as specified in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal is a |DecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit and then incrementing the literal at the 20th significant digit position. A digit is <em>significant</em> if it is not part of an |ExponentPart| and</p>
+        <p>Once the exact MV for a numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0<sub>ℝ</sub>, then the rounded value is *+0*; otherwise, the rounded value must be the Number value for the MV (as specified in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal is a |DecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit and then incrementing the literal at the 20th significant digit position. A digit is <em>significant</em> if it is not part of an |ExponentPart| and</p>
         <ul>
           <li>
             it is not `0`; or
@@ -10582,13 +10596,13 @@
             The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit whose value is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
+            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit whose value is (16<sub>ℝ</sub> times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
           </li>
           <li>
             The SV of <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the SV of |Hex4Digits|.
           </li>
           <li>
-            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit whose value is (0x1000 times the MV of the first |HexDigit|) plus (0x100 times the MV of the second |HexDigit|) plus (0x10 times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
+            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit whose value is (0x1000<sub>ℝ</sub> times the MV of the first |HexDigit|) plus (0x100<sub>ℝ</sub> times the MV of the second |HexDigit|) plus (0x10<sub>ℝ</sub> times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
           </li>
           <li>
             The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar> is the UTF16Encoding of the MV of |CodePoint|.
@@ -11496,7 +11510,7 @@
         </emu-alg>
         <emu-grammar>Literal : NumericLiteral</emu-grammar>
         <emu-alg>
-          1. Return the number whose value is MV of |NumericLiteral| as defined in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.
+          1. Return the Number value represented by |NumericLiteral| as defined in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.
         </emu-alg>
         <emu-grammar>Literal : StringLiteral</emu-grammar>
         <emu-alg>
@@ -13363,7 +13377,7 @@
             Multiplication of an infinity by a finite nonzero value results in a signed infinity. The sign is determined by the rule already stated above.
           </li>
           <li>
-            In the remaining cases, where neither an infinity nor *NaN* is involved, the product is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the result is then a zero of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
+            In the remaining cases, where neither an infinity nor *NaN* is involved, the product of the mathematical values of the operands is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the result is then a zero of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
           </li>
         </ul>
       </emu-clause>
@@ -13397,7 +13411,7 @@
             Division of a nonzero finite value by a zero results in a signed infinity. The sign is determined by the rule already stated above.
           </li>
           <li>
-            In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the quotient is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows; the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the operation underflows and the result is a zero of the appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
+            In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the quotient of the mathematical values of the operands is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven. If the magnitude is too large to represent, the operation overflows; the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the operation underflows and the result is a zero of the appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
           </li>
         </ul>
       </emu-clause>
@@ -13427,7 +13441,7 @@
             If the dividend is a zero and the divisor is nonzero and finite, the result is the same as the dividend.
           </li>
           <li>
-            In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the floating-point remainder r from a dividend n and a divisor d is defined by the mathematical relation r = n - (d &times; q) where q is an integer that is negative only if n/d is negative and positive only if n/d is positive, and whose magnitude is as large as possible without exceeding the magnitude of the true mathematical quotient of n and d. r is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode.
+            In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the floating-point remainder _r_ from a dividend _n_ and a divisor _d_ is defined by the mathematical relation _r_ = ℝ(_n_) - (ℝ(_d_) &times; _q_) where _q_ is a mathematical integer that is negative only if ℝ(_n_) &divide;<sub>ℝ</sub> ℝ(_d_) is negative and positive only if ℝ(_n_) &divide;<sub>ℝ</sub> ℝ(_d_) is positive, and whose magnitude is as large as possible without exceeding ℝ(_n_) &divide;<sub>ℝ</sub> ℝ(_d_). The result of the operation is the Number value for _r_.
           </li>
         </ul>
       </emu-clause>
@@ -13549,7 +13563,7 @@
           The sum of two nonzero finite values of the same magnitude and opposite sign is *+0*.
         </li>
         <li>
-          In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, and the operands have the same sign or have different magnitudes, the sum is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows and the result is then an infinity of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
+          In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, and the operands have the same sign or have different magnitudes, the sum of the mathematical values of the operands is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows and the result is then an infinity of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
         </li>
       </ul>
       <emu-note>
@@ -23685,7 +23699,7 @@
         1. If neither _trimmedString_ nor any prefix of _trimmedString_ satisfies the syntax of a |StrDecimalLiteral| (see <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>), return *NaN*.
         1. Let _numberString_ be the longest prefix of _trimmedString_, which might be _trimmedString_ itself, that satisfies the syntax of a |StrDecimalLiteral|.
         1. Let _mathFloat_ be MV of _numberString_.
-        1. If _mathFloat_ = 0, then
+        1. If _mathFloat_ = 0<sub>ℝ</sub>, then
           1. If the first code unit of _trimmedString_ is the code unit 0x002D (HYPHEN-MINUS), return *-0*.
           1. Return *+0*.
         1. Return the Number value for _mathFloat_.
@@ -23719,7 +23733,7 @@
         1. If _S_ contains a code unit that is not a radix-_R_ digit, let _Z_ be the substring of _S_ consisting of all code units before the first such code unit; otherwise, let _Z_ be _S_.
         1. If _Z_ is empty, return *NaN*.
         1. Let _mathInt_ be the mathematical integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b>-<b>Z</b> and <b>a</b>-<b>z</b> for digits with values 10 through 35. (However, if _R_ is 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-dependent approximation to the mathematical integer value that is represented by _Z_ in radix-_R_ notation.)
-        1. If _mathInt_ = 0, then
+        1. If _mathInt_ = 0<sub>ℝ</sub>, then
           1. If _sign_ = -1, return *-0*.
           1. Return *+0*.
         1. Let _number_ be the Number value for _mathInt_.
@@ -25813,9 +25827,9 @@
             1. Let _e_ be 0.
           1. Else,
             1. If _fractionDigits_ is not *undefined*, then
-              1. Let _e_ and _n_ be integers such that 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup> and for which the exact mathematical value of _n_ &times; 10<sup>_e_ - _f_</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ &times; 10<sup>_e_ - _f_</sup> is larger.
+              1. Let _e_ and _n_ be integers such that 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup> and for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_n_)</sup> - ℝ(_x_) is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is larger.
             1. Else,
-              1. Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for _n_ &times; 10<sup>_e_ - _f_</sup> is _x_, and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1 digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
+              1. Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is _x_, and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1<sub>ℝ</sub> digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
             1. Let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. If _f_ &ne; 0, then
             1. Let _a_ be the first code unit of _m_, and let _b_ be the remaining _f_ code units of _m_.
@@ -25836,7 +25850,7 @@
         <emu-note>
           <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 10.b.i be used as a guideline:</p>
           <emu-alg type="i">
-            1. Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for _n_ &times; 10<sup>_e_ - _f_</sup> is _x_, and _f_ is as small as possible. If there are multiple possibilities for _n_, choose the value of _n_ for which _n_ &times; 10<sup>_e_ - _f_</sup> is closest in value to _x_. If there are two such possible values of _n_, choose the one that is even.
+            1. Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is _x_, and _f_ is as small as possible. If there are multiple possibilities for _n_, choose the value of _n_ for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is closest in value to _x_. If there are two such possible values of _n_, choose the one that is even.
           </emu-alg>
         </emu-note>
       </emu-clause>
@@ -25860,7 +25874,7 @@
           1. If _x_ &ge; 10<sup>21</sup>, then
             1. Let _m_ be ! ToString(_x_).
           1. Else,
-            1. Let _n_ be an integer for which the exact mathematical value of _n_ &divide; 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
+            1. Let _n_ be an integer for which ℝ(_n_) &divide; 10<sub>ℝ</sub><sup>ℝ(_f_)</sup> - ℝ(_x_) is as close to zero as possible. If there are two such _n_, pick the larger _n_.
             1. If _n_ = 0, let _m_ be the String `"0"`. Otherwise, let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _f_ &ne; 0, then
               1. Let _k_ be the length of _m_.
@@ -25906,7 +25920,7 @@
             1. Let _m_ be the String value consisting of _p_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.
           1. Else,
-            1. Let _e_ and _n_ be integers such that 10<sup>_p_ - 1</sup> &le; _n_ &lt; 10<sup>_p_</sup> and for which the exact mathematical value of _n_ &times; 10<sup>_e_ - _p_ + 1</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> is larger.
+            1. Let _e_ and _n_ be integers such that 10<sup>_p_ - 1</sup> &le; _n_ &lt; 10<sup>_p_</sup> and for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_p_) + 1<sub>ℝ</sub></sup> - ℝ(_x_) is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_p_) + 1<sub>ℝ</sub></sup> is larger.
             1. Let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _e_ &lt; -6 or _e_ &ge; _p_, then
               1. Assert: _e_ &ne; 0.
@@ -25984,25 +25998,25 @@
 
       <emu-clause id="sec-math.e">
         <h1>Math.E</h1>
-        <p>The Number value for _e_, the base of the natural logarithms, which is approximately 2.7182818284590452354.</p>
+        <p>The Number value for _e_<sub>ℝ</sub>, the base of the natural logarithms, which is approximately 2.7182818284590452354.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.ln10">
         <h1>Math.LN10</h1>
-        <p>The Number value for the natural logarithm of 10, which is approximately 2.302585092994046.</p>
+        <p>The Number value for the natural logarithm of 10<sub>ℝ</sub>, which is approximately 2.302585092994046.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.ln2">
         <h1>Math.LN2</h1>
-        <p>The Number value for the natural logarithm of 2, which is approximately 0.6931471805599453.</p>
+        <p>The Number value for the natural logarithm of 2<sub>ℝ</sub>, which is approximately 0.6931471805599453.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.log10e">
         <h1>Math.LOG10E</h1>
-        <p>The Number value for the base-10 logarithm of _e_, the base of the natural logarithms; this value is approximately 0.4342944819032518.</p>
+        <p>The Number value for the base-10 logarithm of _e_<sub>ℝ</sub>, the base of the natural logarithms; this value is approximately 0.4342944819032518.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>The value of `Math.LOG10E` is approximately the reciprocal of the value of `Math.LN10`.</p>
@@ -26011,7 +26025,7 @@
 
       <emu-clause id="sec-math.log2e">
         <h1>Math.LOG2E</h1>
-        <p>The Number value for the base-2 logarithm of _e_, the base of the natural logarithms; this value is approximately 1.4426950408889634.</p>
+        <p>The Number value for the base-2 logarithm of _e_<sub>ℝ</sub>, the base of the natural logarithms; this value is approximately 1.4426950408889634.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>The value of `Math.LOG2E` is approximately the reciprocal of the value of `Math.LN2`.</p>
@@ -26020,13 +26034,13 @@
 
       <emu-clause id="sec-math.pi">
         <h1>Math.PI</h1>
-        <p>The Number value for &pi;, the ratio of the circumference of a circle to its diameter, which is approximately 3.1415926535897932.</p>
+        <p>The Number value for &pi;<sub>ℝ</sub>, the ratio of the circumference of a circle to its diameter, which is approximately 3.1415926535897932.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.sqrt1_2">
         <h1>Math.SQRT1_2</h1>
-        <p>The Number value for the square root of &frac12;, which is approximately 0.7071067811865476.</p>
+        <p>The Number value for the square root of &frac12;<sub>ℝ</sub>, which is approximately 0.7071067811865476.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>The value of `Math.SQRT1_2` is approximately the reciprocal of the value of `Math.SQRT2`.</p>
@@ -26035,7 +26049,7 @@
 
       <emu-clause id="sec-math.sqrt2">
         <h1>Math.SQRT2</h1>
-        <p>The Number value for the square root of 2, which is approximately 1.4142135623730951.</p>
+        <p>The Number value for the square root of 2<sub>ℝ</sub>, which is approximately 1.4142135623730951.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26303,7 +26317,7 @@
 
       <emu-clause id="sec-math.ceil">
         <h1>Math.ceil ( _x_ )</h1>
-        <p>Returns the smallest (closest to *-&infin;*) Number value that is not less than _x_ and is equal to a mathematical integer. If _x_ is already an integer, the result is _x_.</p>
+        <p>Returns the smallest (closest to *-&infin;*) Number value that is not less than _x_ and is an integer. If _x_ is already an integer, the result is _x_.</p>
         <ul>
           <li>
             If _x_ is *NaN*, the result is *NaN*.
@@ -26433,7 +26447,7 @@
 
       <emu-clause id="sec-math.floor">
         <h1>Math.floor ( _x_ )</h1>
-        <p>Returns the greatest (closest to *+&infin;*) Number value that is not greater than _x_ and is equal to a mathematical integer. If _x_ is already an integer, the result is _x_.</p>
+        <p>Returns the greatest (closest to *+&infin;*) Number value that is not greater than _x_ and is an integer. If _x_ is already an integer, the result is _x_.</p>
         <ul>
           <li>
             If _x_ is *NaN*, the result is *NaN*.
@@ -26651,7 +26665,7 @@
 
       <emu-clause id="sec-math.round">
         <h1>Math.round ( _x_ )</h1>
-        <p>Returns the Number value that is closest to _x_ and is equal to a mathematical integer. If two integer Number values are equally close to _x_, then the result is the Number value that is closer to *+&infin;*. If _x_ is already an integer, the result is _x_.</p>
+        <p>Returns the Number value that is closest to _x_ and is an integer. If two integers are equally close to _x_, then the result is the Number value that is closer to *+&infin;*. If _x_ is already an integer, the result is _x_.</p>
         <ul>
           <li>
             If _x_ is *NaN*, the result is *NaN*.
@@ -29533,12 +29547,12 @@ THH:mm:ss.sss
         <h1>Static Semantics: CapturingGroupNumber</h1>
         <emu-grammar>DecimalEscape :: NonZeroDigit</emu-grammar>
         <emu-alg>
-          1. Return the MV of |NonZeroDigit|.
+          1. Return the Number value for the MV of |NonZeroDigit|.
         </emu-alg>
         <emu-grammar>DecimalEscape :: NonZeroDigit DecimalDigits</emu-grammar>
         <emu-alg>
-          1. Let _n_ be the number of code points in |DecimalDigits|.
-          1. Return (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|.
+          1. Let _n_ be the mathematical integer number of code points in |DecimalDigits|.
+          1. Return the Number value for (the MV of |NonZeroDigit| &times;<sub>ℝ</sub> 10<sub>ℝ</sub><sup>_n_</sup> plus the MV of |DecimalDigits|).
         </emu-alg>
         <p>The definitions of &ldquo;the MV of |NonZeroDigit|&rdquo; and &ldquo;the MV of |DecimalDigits|&rdquo; are in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
       </emu-clause>
@@ -29742,11 +29756,11 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar>
         <emu-alg>
-          1. Return the MV of |Hex4Digits|.
+          1. Return the Number value for the MV of |Hex4Digits|.
         </emu-alg>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar>
         <emu-alg>
-          1. Return the MV of |CodePoint|.
+          1. Return the Number value for the MV of |CodePoint|.
         </emu-alg>
         <emu-grammar>
           LeadSurrogate :: Hex4Digits
@@ -29756,7 +29770,7 @@ THH:mm:ss.sss
           NonSurrogate :: Hex4Digits
         </emu-grammar>
         <emu-alg>
-          1. Return the MV of |HexDigits|.
+          1. Return the Number value for the MV of |HexDigits|.
         </emu-alg>
         <emu-grammar>CharacterEscape :: IdentityEscape</emu-grammar>
         <emu-alg>
@@ -33457,7 +33471,7 @@ THH:mm:ss.sss
             1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. Let _typedArrayName_ be the String value of _O_.[[TypedArrayName]].
-            1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _typedArrayName_.
+            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _typedArrayName_.
             1. Let _byteOffset_ be _O_.[[ByteOffset]].
             1. Let _toByteIndex_ be _to_ &times; _elementSize_ + _byteOffset_.
             1. Let _fromByteIndex_ be _from_ &times; _elementSize_ + _byteOffset_.
@@ -33686,7 +33700,7 @@ THH:mm:ss.sss
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetLength_ be _target_.[[ArrayLength]].
             1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
-            1. Let _targetElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
+            1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _src_ be ? ToObject(_array_).
@@ -33723,11 +33737,11 @@ THH:mm:ss.sss
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
             1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
-            1. Let _targetElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
+            1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _srcName_ be the String value of _typedArray_.[[TypedArrayName]].
             1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
-            1. Let _srcElementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcName_.
+            1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcName_.
             1. Let _srcLength_ be _typedArray_.[[ArrayLength]].
             1. Let _srcByteOffset_ be _typedArray_.[[ByteOffset]].
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
@@ -33789,7 +33803,7 @@ THH:mm:ss.sss
             1. Let _srcBuffer_ be _O_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetBuffer_ be _A_.[[ViewedArrayBuffer]].
-            1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcType_.
+            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcType_.
             1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
             1. Let _srcByteOffet_ be _O_.[[ByteOffset]].
             1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
@@ -33861,7 +33875,7 @@ THH:mm:ss.sss
           1. If _relativeEnd_ &lt; 0, let _endIndex_ be max((_srcLength_ + _relativeEnd_), 0); else let _endIndex_ be min(_relativeEnd_, _srcLength_).
           1. Let _newLength_ be max(_endIndex_ - _beginIndex_, 0).
           1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
           1. Let _beginByteOffset_ be _srcByteOffset_ + _beginIndex_ &times; _elementSize_.
           1. Let _argumentsList_ be &laquo; _buffer_, _beginByteOffset_, _newLength_ &raquo;.
@@ -34077,7 +34091,7 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
           1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
-          1. Let _elementSize_ be the Number value of the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
+          1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
           1. If _length_ is present and _length_ is not *undefined*, then
@@ -34134,7 +34148,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-typedarray.bytes_per_element">
         <h1>_TypedArray_.BYTES_PER_ELEMENT</h1>
-        <p>The value of _TypedArray_.BYTES_PER_ELEMENT is the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
+        <p>The value of _TypedArray_.BYTES_PER_ELEMENT is the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -34156,7 +34170,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-typedarray.prototype.bytes_per_element">
         <h1>_TypedArray_.prototype.BYTES_PER_ELEMENT</h1>
-        <p>The value of <code><var>TypedArray</var>.prototype.BYTES_PER_ELEMENT</code> is the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
+        <p>The value of <code><var>TypedArray</var>.prototype.BYTES_PER_ELEMENT</code> is the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -35230,7 +35244,7 @@ THH:mm:ss.sss
         <h1>RawBytesToNumber ( _type_, _rawBytes_, _isLittleEndian_ )</h1>
         <p>The abstract operation RawBytesToNumber takes three parameters, a String _type_, a List _rawBytes_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is *false*, reverse the order of the elements of _rawBytes_.
           1. If _type_ is `"Float32"`, then
             1. Let _value_ be the byte elements of _rawBytes_ concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2008 binary32 value.
@@ -35256,7 +35270,7 @@ THH:mm:ss.sss
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
           1. Assert: _byteIndex_ is an integer value &ge; 0.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
             1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
@@ -35281,7 +35295,7 @@ THH:mm:ss.sss
           1. Else if _type_ is `"Float64"`, then
             1. Let _rawBytes_ be a List containing the 8 bytes that are the IEEE 754-2008 binary64 format encoding of _value_. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2008 binary64 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
           1. Else,
-            1. Let _n_ be the Number value of the Element Size specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
+            1. Let _n_ be the Element Size specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
             1. Let _convOp_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
             1. Let _intValue_ be _convOp_(_value_).
             1. If _intValue_ &ge; 0, then
@@ -35301,7 +35315,7 @@ THH:mm:ss.sss
           1. Assert: _byteIndex_ is an integer value &ge; 0.
           1. Assert: Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
           1. Let _rawBytes_ be NumberToRawBytes(_type_, _value_, _isLittleEndian_).
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
@@ -35323,7 +35337,7 @@ THH:mm:ss.sss
           1. Assert: _byteIndex_ is an integer value &ge; 0.
           1. Assert: Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
           1. Let _rawBytes_ be NumberToRawBytes(_type_, _value_, _isLittleEndian_).
           1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
@@ -35641,7 +35655,7 @@ THH:mm:ss.sss
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
           1. Let _viewSize_ be _view_.[[ByteLength]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
           1. Return GetValueFromBuffer(_buffer_, _bufferIndex_, _type_, *false*, `"Unordered"`, _isLittleEndian_).
@@ -35661,7 +35675,7 @@ THH:mm:ss.sss
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
           1. Let _viewSize_ be _view_.[[ByteLength]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
           1. Return SetValueInBuffer(_buffer_, _bufferIndex_, _type_, _numberValue_, *false*, `"Unordered"`, _isLittleEndian_).
@@ -36110,7 +36124,7 @@ THH:mm:ss.sss
           1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
           1. Let _v_ be ? ToInteger(_value_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _offset_ be _typedArray_.[[ByteOffset]].
           1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
@@ -36125,7 +36139,7 @@ THH:mm:ss.sss
           1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
           1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _offset_ be _typedArray_.[[ByteOffset]].
           1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
@@ -36164,7 +36178,7 @@ THH:mm:ss.sss
         1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _expectedBytes_ be NumberToRawBytes(_elementType_, _expected_, _isLittleEndian_).
-        1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _offset_ be _typedArray_.[[ByteOffset]].
         1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Let `compareExchange` denote a semantic function of two List of byte values arguments that returns the second argument if the first argument is element-wise equal to _expectedBytes_.
@@ -36222,7 +36236,7 @@ THH:mm:ss.sss
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _v_ be ? ToInteger(_value_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. Let _elementSize_ be the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _offset_ be _typedArray_.[[ByteOffset]].
         1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.


### PR DESCRIPTION
This patch changes math in the ECMAScript specification to be based on
a concrete division into mathematical values and Numbers. All
numeric values and operations are explicitly either one or the other
with this patch. Previously, math took place in mathematical values,
based on a system of implicit conversions between these values and
Numbers.

This patch makes a big change in the idea of how most math operations
are evaluated internally, from mathematical values to Numbers, but the
goal is to make no observable change in semantics. The notation here
is intended to be relatively unintrusive and terse but unambiguous and
readable; I'd appreciate any feedback and suggestions. The hope is that
this notation will extend cleanly to BigInt as well as specifications for
embedders such as the Web Platform if they choose.

Thanks for your patience in this patch; as @bterlson pointed out, I promised
to make this change almost three years ago as part of the SIMD.js effort :)
The change here ended up touching much less of the specification than
I expected.

Closes https://github.com/tc39/proposal-bigint/issues/10

If interested, I'd really appreciate reviews from @anba @jmdyck @claudepache @domenic @annevk