### PR TITLE
Editorial: clarify when early errors for functions apply

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18057,10 +18057,10 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
+          If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
         </li>
         <li>
           It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -19002,10 +19002,10 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
+          If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
         </li>
         <li>
           It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -19347,8 +19347,8 @@
         AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <ul>
-        <li>If the source code matching this production is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If the source code matching this production is strict mode code, it is a Syntax Error if |BindingIdentifier| is the |IdentifierName| `eval` or the |IdentifierName| `arguments`.</li>
+        <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
         <li>It is a Syntax Error if ContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |YieldExpression| is *true*.</li>
@@ -20010,8 +20010,8 @@
       <ul>
         <li>It is a Syntax Error if ContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
-        <li>If the source code matching this production is strict code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If the source code matching this production is strict code, it is a Syntax Error if |BindingIdentifier| is present and the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
+        <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperProperty| is *true*.</li>


### PR DESCRIPTION
Fixes #632.

This is _arguably_ normative, in that it changes the interpretation of a strict reading of the spec (which, I argue in the above issue, implies that `function f(a, a) { 'use strict'; }` would be legal, contrary to the intent of the author of the relevant text, implementations, and common sense).

In practice I think we're regarding this as either fixing a spec bug or merely a clarification, depending on whether you buy my above reading. So I've marked it as editorial.

Note that I've also changed the rule for names to be based on the strictness of `BindingIdentifier` rather than the strictness of the entire `FunctionDeclaration` (or similar) production. I don't think that actually changes anything, since the full production can't be strict unless all of its parts are. I'm mainly making this change to minimize ambiguity and to better match #1091.

cc @jugglinmike.