### PR TITLE
Editorial: fix section IDs for some async generator sections.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19942,7 +19942,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-boundnames">
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
       <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
@@ -19958,7 +19958,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-computedpropertycontains">
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-computedpropertycontains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
@@ -19968,7 +19968,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-contains">
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
@@ -19987,7 +19987,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-hasdirectsuper">
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
       <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
@@ -19997,7 +19997,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-hasname">
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
       <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
@@ -20010,7 +20010,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-isconstantdeclaration">
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
       <emu-grammar>
@@ -20023,7 +20023,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-isfunctiondefinition">
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
       <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
@@ -20032,7 +20032,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-propname">
+    <emu-clause id="sec-async-generator-function-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
       <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>


### PR DESCRIPTION
Fixes #1140.

This appears to have been a copy-paste artifact from adding async generators.

Most of the existing ones have "async-generator", very few have "asyncgenerator", so I went with the (nicer) hyphenated variant.