### PR TITLE
Editorial: create a ThrowCompletion abstract operation to reduce boilerplate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -812,7 +812,7 @@
         </emu-alg>
         <p>mean the same things as:</p>
         <emu-alg>
-          1. Return Completion{[[Type]]: ~throw~, [[Value]]: a newly created *TypeError* object, [[Target]]: ~empty~}.
+          1. Return ThrowCompletion(a newly created *TypeError* object).
         </emu-alg>
       </emu-clause>
 
@@ -3116,7 +3116,7 @@
             1. Let _prevContext_ be the running execution context.
             1. Suspend _prevContext_.
             1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. Resume the suspended evaluation of _asyncContext_ using Completion{[[Type]]: ~throw~, [[Value]]: _reason_, [[Target]]: ~empty~} as the result of the operation that suspended it.
+            1. Resume the suspended evaluation of _asyncContext_ using ThrowCompletion(_reason_) as the result of the operation that suspended it.
             1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
             1. Return *undefined*.
           </emu-alg>
@@ -3135,6 +3135,18 @@
         <p>Is a shorthand that is defined as follows:</p>
         <emu-alg>
           1. Return Completion{[[Type]]: ~normal~, [[Value]]: _argument_, [[Target]]: ~empty~}.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-throwcompletion" aoid="ThrowCompletion">
+        <h1>ThrowCompletion</h1>
+        <p>The abstract operation ThrowCompletion with a single _argument_, such as:</p>
+        <emu-alg>
+          1. Return ThrowCompletion(_argument_).
+        </emu-alg>
+        <p>Is a shorthand that is defined as follows:</p>
+        <emu-alg>
+          1. Return Completion{[[Type]]: ~throw~, [[Value]]: _argument_, [[Target]]: ~empty~}.
         </emu-alg>
       </emu-clause>
 
@@ -18265,7 +18277,7 @@
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
-        1. Return Completion{[[Type]]: ~throw~, [[Value]]: _exprValue_, [[Target]]: ~empty~}.
+        1. Return ThrowCompletion(_exprValue_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -32160,7 +32172,7 @@ THH:mm:ss.sss
             1. Let _k_ be 0.
             1. Repeat,
               1. If _k_ &ge; 2<sup>53</sup>-1, then
-                1. Let _error_ be Completion{[[Type]]: ~throw~, [[Value]]: a newly created *TypeError* object, [[Target]]: ~empty~}.
+                1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
                 1. Return ? IteratorClose(_iteratorRecord_, _error_).
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _next_ be ? IteratorStep(_iteratorRecord_).
@@ -34710,7 +34722,7 @@ THH:mm:ss.sss
             1. If _next_ is *false*, return _map_.
             1. Let _nextItem_ be ? IteratorValue(_next_).
             1. If Type(_nextItem_) is not Object, then
-              1. Let _error_ be Completion{[[Type]]: ~throw~, [[Value]]: a newly created *TypeError* object, [[Target]]: ~empty~}.
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iteratorRecord_, _error_).
             1. Let _k_ be Get(_nextItem_, `"0"`).
             1. If _k_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _k_).
@@ -35434,7 +35446,7 @@ THH:mm:ss.sss
             1. If _next_ is *false*, return _map_.
             1. Let _nextItem_ be ? IteratorValue(_next_).
             1. If Type(_nextItem_) is not Object, then
-              1. Let _error_ be Completion{[[Type]]: ~throw~, [[Value]]: a newly created *TypeError* object, [[Target]]: ~empty~}.
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iteratorRecord_, _error_).
             1. Let _k_ be Get(_nextItem_, `"0"`).
             1. If _k_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _k_).
@@ -37919,7 +37931,7 @@ THH:mm:ss.sss
         <p>The `throw` method performs the following steps:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
-          1. Let _C_ be Completion{[[Type]]: ~throw~, [[Value]]: _exception_, [[Target]]: ~empty~}.
+          1. Let _C_ be ThrowCompletion(_exception_).
           1. Return ? GeneratorResumeAbrupt(_g_, _C_).
         </emu-alg>
       </emu-clause>
@@ -38131,7 +38143,7 @@ THH:mm:ss.sss
         <h1>AsyncGenerator.prototype.throw ( _exception_ )</h1>
         <emu-alg>
           1. Let _generator_ be the *this* value.
-          1. Let _completion_ be Completion{[[Type]]: ~throw~, [[Value]]: _exception_, [[Target]]: ~empty~}.
+          1. Let _completion_ be ThrowCompletion(_exception_).
           1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_).
         </emu-alg>
       </emu-clause>
@@ -38725,7 +38737,7 @@ THH:mm:ss.sss
             1. If _type_ is `"Fulfill"`, let _handlerResult_ be NormalCompletion(_argument_).
             1. Else,
               1. Assert: _type_ is `"Reject"`.
-              1. Let _handlerResult_ be Completion {[[Type]]: ~throw~, [[Value]]: _argument_, [[Target]]: ~empty~}.
+              1. Let _handlerResult_ be ThrowCompletion(_argument_).
           1. Else, let _handlerResult_ be Call(_handler_, *undefined*, &laquo; _argument_ &raquo;).
           1. If _handlerResult_ is an abrupt completion, then
             1. Let _status_ be Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).


### PR DESCRIPTION
Using the record notation for creating a thrown TypeError completion is super awkward; this new abstract operation makes it read much more clearly for me.

Thoughts?