### PR TITLE
Normative: Cleanup Time Values and Time Range

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26482,10 +26482,15 @@
 
       <emu-clause id="sec-time-values-and-time-range">
         <h1>Time Values and Time Range</h1>
-        <p>A Date object contains a Number indicating a particular instant in time to within a millisecond. Such a Number is called a <dfn>time value</dfn>. A time value may also be *NaN*, indicating that the Date object does not represent a specific instant of time.</p>
-        <p>Time is measured in ECMAScript in milliseconds since 01 January, 1970 UTC. In time values leap seconds are ignored. It is assumed that there are exactly 86,400,000 milliseconds per day. ECMAScript Number values can represent all integers from -9,007,199,254,740,992 to 9,007,199,254,740,992; this range suffices to measure times to millisecond precision for any instant that is within approximately 285,616 years, either forward or backward, from 01 January, 1970 UTC.</p>
-        <p>The actual range of times supported by ECMAScript Date objects is slightly smaller: exactly -100,000,000 days to 100,000,000 days measured relative to midnight at the beginning of 01 January, 1970 UTC. This gives a range of 8,640,000,000,000,000 milliseconds to either side of 01 January, 1970 UTC.</p>
-        <p>The exact moment of midnight at the beginning of 01 January, 1970 UTC is represented by the value *+0*.</p>
+        <p>A Date object contains a Number representing an instant in time with millisecond precision. Such a Number is called a <dfn>time value</dfn>. A time value may also be *NaN*, indicating that the Date object does not represent a specific instant in time.</p>
+        <p>Time is measured in ECMAScript as milliseconds since midnight at the beginning of 01 January, 1970 UTC. Time in ECMAScript does not observe leap seconds; they are ignored. Time calculations assume each and every day contains exactly <emu-eqn>60 &times; 60 &times; 24 &times; 1000 = 86,400,000</emu-eqn> milliseconds, to align with the POSIX specification of each and every day containing exactly 86,400 seconds.</p>
+        <p>A Number can exactly represent all integers from -9,007,199,254,740,992 to 9,007,199,254,740,992 (<emu-xref href="#sec-number.min_safe_integer"></emu-xref> and <emu-xref href="#sec-number.max_safe_integer"></emu-xref>). A time value supports a slightly smaller range of exactly -100,000,000 days to 100,000,000 days measured relative to midnight at the beginning of 01 January, 1970 UTC. This yields an exact supported time value range of -8,640,000,000,000,000 to 8,640,000,000,000,000 milliseconds relative to midnight at the beginning of 01 January, 1970 UTC.</p>
+        <p>The exact moment of midnight at the beginning of 01 January, 1970 UTC is represented by the time value *+0*.</p>
+        <emu-note>
+          <p>The 400 year cycle of the Gregorian calendar contains 97 leap years. This yields an average of 365.2425 days per year, or an average of 31,556,952,000 milliseconds per year under the Gregorian calendar. ECMAScript applies a proleptic Gregorian calendar for all time computations.</p>
+          <p>As specified by this section, the maximum year range a Number can represent exactly with millisecond precision is approximately -285,426 to 285,426 years relative to midnight at the beginning of 01 January, 1970 UTC.</p>
+          <p>As specified by this section, the maximum year range a time value can represent is approximately -273,790 to 273,790 years relative to midnight at the beginning of 01 January, 1970 UTC.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-day-number-and-time-within-day">
@@ -26802,15 +26807,15 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-extended-years">
           <h1>Extended Years</h1>
-          <p>ECMAScript requires the ability to specify 6 digit years (extended years); approximately 285,426 years, either forward or backward, from 01 January, 1970 UTC. To represent years before 0 or after 9999, ISO 8601 permits the expansion of the year representation, but only by prior agreement between the sender and the receiver. In the simplified ECMAScript format such an expanded year representation shall have 2 extra year digits and is always prefixed with a + or - sign. The year 0 is considered positive and hence prefixed with a + sign.</p>
+          <p>ECMAScript requires the ability to specify 6 digit years, or <dfn>extended years</dfn>, to render the full range of a time value; -100,000,000 days to 100,000,000 days, or approximately -273,790 to 273,790 years, relative to midnight at the beginning of 01 January, 1970 UTC (<emu-xref href="#sec-time-values-and-time-range"></emu-xref>). To represent years before 0 or after 9999, ISO 8601 permits the expansion of the year representation, but only by prior agreement between the sender and the receiver. In the simplified ECMAScript format such an expanded year representation shall have 2 extra year digits and is always prefixed with a + or - sign. The year 0 is considered positive and hence prefixed with a + sign. ISO 8601 formatted strings with extended years representing points in time outside the range of a time value are represented as the Number *NaN* when parsed by `Date.parse()` and do not fall back to implementation-specific behavior or heuristics.</p>
           <emu-note>
             <p>Examples of extended years:</p>
             <figure>
               <table class="lightweight-table">
                 <tbody>
                   <tr>
-                    <td>-283457-03-21T15:00:59.008Z</td>
-                    <td>283458 B.C.</td>
+                    <td>-271821-04-20T00:00:00Z</td>
+                    <td>271822 B.C.</td>
                   </tr>
                   <tr>
                     <td>-000001-01-01T00:00:00Z</td>
@@ -26833,8 +26838,8 @@ THH:mm:ss.sss
                     <td>2009 A.D.</td>
                   </tr>
                   <tr>
-                    <td>+287396-10-12T08:59:00.992Z</td>
-                    <td>287396 A.D.</td>
+                    <td>+275760-09-13T00:00:00Z</td>
+                    <td>275760 A.D.</td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
Implementations are not currently consistently limiting *time values* to the spec defined ranges of both *time value* and *extended years*.

This change is editorial cleanup that more clearly states the allowed *time value* range and the supported range of *extended years* that fit within the allowed *time value* range.

Implementations will need to be updated to conform with the spec (SM currently adheres) and pass the accompanying test in tc39/test262#1501.

**Concrete examples of what will be fixed are detailed in #1145.**

Time Values and Time Range:

- Language about `Number` range in hundreds-of-thousands of years plus/minus UTC epoch is not immediately relevant; move it to an `emu-note`
- New `emu-note` text fixes inconsistency in spec where this section was not properly accounting for leap years when computing the approximate number of years in the maximum range but 20.3.1.15.1 *extended years* was stating it correctly
- Add `emu-xref` for Number integer range
- Add comment referring to POSIX day for the source of 86,400 seconds
- Simplify remaining spec in section into clear, consistent language

Extended Years:

- Add `dfn` to *extended years* so it is linked from format section
- Add `emu-xref` for *time value* range
- Explicitly state *extended years* relation to *time value* range
- Explicitly state ISO 8601 strings outside *time value* range are not accepted
- Modify *extended years* example table to reflect the proper minimum/maximum values allowed by the *time value* range