### PR TITLE
Editorial: refactor PerformPromiseThen to allow no capability

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3005,9 +3005,7 @@
           1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#await-rejected" title></emu-xref>.
           1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[AsyncContext]] &raquo;).
           1. Set _onRejected_.[[AsyncContext]] to _asyncContext_.
-          1. Let _throwawayCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
-          1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
+          1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_).
           1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _completion_, the following steps of the algorithm that invoked Await will be performed, with _completion_ available.
         </emu-alg>
@@ -37232,9 +37230,7 @@ THH:mm:ss.sss
                 1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
                 1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Generator]] &raquo;).
                 1. Set _onRejected_.[[Generator]] to _generator_.
-                1. Let _throwawayCapability_ be ! NewPromiseCapability(%Promise%).
-                1. Set _throwawayCapability_.[[Promise]].[[PromiseIsHandled]] to *true*.
-                1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_, _throwawayCapability_).
+                1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_).
                 1. Return *undefined*.
               1. Else,
                 1. Assert: _completion_.[[Type]] is ~throw~.
@@ -37443,7 +37439,7 @@ THH:mm:ss.sss
                 [[Capability]]
               </td>
               <td>
-                A PromiseCapability Record
+                A PromiseCapability Record, or *undefined*
               </td>
               <td>
                 The capabilities of the promise for which this record provides a reaction handler.
@@ -37662,6 +37658,9 @@ THH:mm:ss.sss
               1. Assert: _type_ is `"Reject"`.
               1. Let _handlerResult_ be ThrowCompletion(_argument_).
           1. Else, let _handlerResult_ be Call(_handler_, *undefined*, &laquo; _argument_ &raquo;).
+          1. If _promiseCapability_ is *undefined*, then
+            1. Assert: _handlerResult_ is not an abrupt completion.
+            1. Return NormalCompletion(~empty~);
           1. If _handlerResult_ is an abrupt completion, then
             1. Let _status_ be Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
           1. Else,
@@ -38015,11 +38014,14 @@ THH:mm:ss.sss
         <p>This function is the <dfn>%PromiseProto_then%</dfn> intrinsic object.</p>
 
         <emu-clause id="sec-performpromisethen" aoid="PerformPromiseThen">
-          <h1>PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_, _resultCapability_ )</h1>
-          <p>The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. The result is _resultCapability_'s promise.</p>
+          <h1>PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_ [ , _resultCapability_ ] )</h1>
+The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. If _resultCapability_ is passed, the result is stored by updating _resultCapability_’s promise. (If it is not passed, then PerformPromiseThen is being called by a specification-internal operation where the result does not matter.)</p>
           <emu-alg>
             1. Assert: IsPromise(_promise_) is *true*.
-            1. Assert: _resultCapability_ is a PromiseCapability Record.
+            1. If _resultCapability_ is present, then
+              1. Assert: _resultCapability_ is a PromiseCapability Record.
+            1. Else,
+              1. Set _resultCapability_ to *undefined*.
             1. If IsCallable(_onFulfilled_) is *false*, then
               1. Set _onFulfilled_ to *undefined*.
             1. If IsCallable(_onRejected_) is *false*, then


### PR DESCRIPTION
Fixes #694.

I followed @domenic's steps in the linked issue here; I'm not sure if other changes are needed.

Specifically, which `PerformPromiseThen` calls should now be able to omit a capability?