### PR TITLE
Normative: Extend definition of "function code"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9383,7 +9383,15 @@
         <em>Eval code</em> is the source text supplied to the built-in `eval` function. More precisely, if the parameter to the built-in `eval` function is a String, it is treated as an ECMAScript |Script|. The eval code for a particular invocation of `eval` is the global code portion of that |Script|.
       </li>
       <li>
-        <em>Function code</em> is source text that is parsed to supply the value of the [[ECMAScriptCode]] and [[FormalParameters]] internal slots (see <emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) of an ECMAScript function object. The function code of a particular ECMAScript function does not include any source text that is parsed as the function code of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
+        <p><em>Function code</em> is source text that is parsed to supply the value of the [[ECMAScriptCode]] and [[FormalParameters]] internal slots (see <emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) of an ECMAScript function object. The function code of a particular ECMAScript function does not include any source text that is parsed as the function code of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.</p>
+        <p>In addition, if the source text referred to above is parsed as:</p>
+        <ul>
+          <li>the |FormalParameters| and |FunctionBody| of a |FunctionDeclaration| or |FunctionExpression|,</li>
+          <li>the |FormalParameters| and |GeneratorBody| of a |GeneratorDeclaration| or |GeneratorExpression|,</li>
+          <li>the |FormalParameters| and |AsyncFunctionBody| of an |AsyncFunctionDeclaration| or |AsyncFunctionExpression|, or</li>
+          <li>the |FormalParameters| and |AsyncGeneratorBody| of an |AsyncGeneratorDeclaration| or |AsyncGeneratorExpression|,</li>
+        </ul>
+        <p>then the source text matching the |BindingIdentifier| (if any) of that declaration or expression is also included in the function code of the corresponding function.</p>
       </li>
       <li>
         <em>Module code</em> is source text that is code that is provided as a |ModuleBody|. It is the code that is directly evaluated when a module is initialized. The module code of a particular module does not include any source text that is parsed as part of a nested |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |MethodDefinition|, |ArrowFunction|, |AsyncArrowFunction|, |ClassDeclaration|, or |ClassExpression|.
@@ -9391,6 +9399,9 @@
     </ul>
     <emu-note>
       <p>Function code is generally provided as the bodies of Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>), Arrow Function Definitions (<emu-xref href="#sec-arrow-function-definitions"></emu-xref>), Method Definitions (<emu-xref href="#sec-method-definitions"></emu-xref>), Generator Function Definitions (<emu-xref href="#sec-generator-function-definitions"></emu-xref>), Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>), Async Generator Function Definitions (<emu-xref href="#sec-async-generator-function-definitions"></emu-xref>), and Async Arrow Functions (<emu-xref href="#sec-async-arrow-function-definitions"></emu-xref>). Function code is also derived from the arguments to the `Function` constructor (<emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>), the `GeneratorFunction` constructor (<emu-xref href="#sec-generatorfunction"></emu-xref>), and the `AsyncFunction` constructor (<emu-xref href="#sec-async-function-constructor-arguments"></emu-xref>).</p>
+    </emu-note>
+    <emu-note>
+      <p>The practical effect of including the |BindingIdentifier| in function code is that the Early Errors for strict mode code are applied to a |BindingIdentifier| that is the name of a function whose body contains a "use strict" directive, even if the surrounding code is not strict mode code.</p>
     </emu-note>
 
     <emu-clause id="sec-strict-mode-code">


### PR DESCRIPTION
Commit message:

> In the March 2018 meeting of TC39, the committee elected to extend the
> definition of "function code" to include the BindingIdentifier of the
> productions where a BindingIdentifier is present. This decision was motivated
> by a desire to match implementation reality.
>
> This alteration does not require a change to Test262 because like the
> majority of modern implementations, Test262 already enforces the new
> behavior [1].
>
> [1] tc39/test262#1404

I don't know the best way to specify this, though I have a feeling that what I'm proposing here isn't it. The phrase "any BindingIdentifier present in the grammar production" is somewhat vague, but including a specific list of productions would be pretty verbose, especially considering the existing list of productions in this paragraph.

We could formalize it a bit by using an abstract operation. It's tempting to use HasName, but that's only valid for expressions. We'd need to either extend HasName (maybe refactor as "FunctionName" which may return null) or define a new operation (and then write something like, "If HasName returns true for the production, the BindingIdentifier is also included.").

But that's a lot of change for such a minor detail, especially considering that most implementers have taken it for granted.

I think @bterlson and @bakkot are the most likely people to care about this, but I'm happy to take input from anyone!

