### PR TITLE
Normative: specify RequireObjectCoercible as first step in destructuring assignment semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14192,12 +14192,14 @@
         </emu-alg>
         <emu-grammar>ObjectAssignmentPattern : `{` AssignmentRestProperty `}`</emu-grammar>
         <emu-alg>
+          1. Perform ? RequireObjectCoercible(_value_).
           1. Let _excludedNames_ be a new empty List.
           1. Return the result of performing RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with _value_ and _excludedNames_ as the arguments.
         </emu-alg>
 
         <emu-grammar>ObjectAssignmentPattern : `{` AssignmentPropertyList `,` AssignmentRestProperty `}`</emu-grammar>
         <emu-alg>
+          1. Perform ? RequireObjectCoercible(_value_).
           1. Let _excludedNames_ be the result of performing ? PropertyDestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
           1. Return the result of performing RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with _value_ and _excludedNames_ as the arguments.
         </emu-alg>


### PR DESCRIPTION
Issue tracked here:  https://github.com/tc39/ecma262/issues/1130

This PR attempts to specify that the runtime semantics for **DestructuringAssignmentEvaluation (12.14.5.2)** should perform `RequireObjectCoercible(value)` as the first step, since assignment to `null` throws a TypeError as specified in [this test assertion](https://github.com/tc39/test262/blob/master/test/language/expressions/assignment/dstr-obj-rest-val-null.js).

Thank you.