### PR TITLE
Editorial: Default littleEndian to false in DataView.p.getInt32

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36699,7 +36699,7 @@ THH:mm:ss.sss
         <p>When the `getInt32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
-          1. If _littleEndian_ is not present, let _littleEndian_ be *undefined*.
+          1. If _littleEndian_ is not present, let _littleEndian_ be *false*.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int32"`).
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
All the other getter/setter methods default `littleEndian` to `false`
when it is not present.

This doesn't affect the overall algorithm.