### PR TITLE
Editorial: replace obj.[[Get]](j) with Get(obj, j)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33724,11 +33724,11 @@ THH:mm:ss.sss
         </ul>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Perform an implementation-dependent sequence of calls to the [[Get]] and [[Set]] internal methods of _obj_, to the DeletePropertyOrThrow and HasOwnProperty abstract operation with _obj_ as the first argument, and to SortCompare (described below), such that:
-            * The property key argument for each call to [[Get]], [[Set]], HasOwnProperty, or DeletePropertyOrThrow is the string representation of a nonnegative integer less than _len_.
-            * The arguments for calls to SortCompare are values returned by a previous call to the [[Get]] internal method, unless the properties accessed by those previous calls did not exist according to HasOwnProperty. If both prospective arguments to SortCompare correspond to non-existent properties, use *+0* instead of calling SortCompare. If only the first prospective argument is non-existent use +1. If only the second prospective argument is non-existent use -1.
+          1. Perform an implementation-dependent sequence of calls to the Get, <emu-xref href="#sec-set-o-p-v-throw">Set</emu-xref>, DeletePropertyOrThrow, and HasOwnProperty abstract operation with _obj_ as the first argument, and to SortCompare (described below), such that:
+            * The property key argument for each call to Get, <emu-xref href="#sec-set-o-p-v-throw">Set</emu-xref>, HasOwnProperty, or DeletePropertyOrThrow is the string representation of a nonnegative integer less than _len_.
+            * The `Throw` argument for every call to <emu-xref href="#sec-set-o-p-v-throw">Set</emu-xref> is *true*.
+            * The arguments for calls to SortCompare are values returned by a previous call to the Get abstract operation, unless the properties accessed by those previous calls did not exist according to HasOwnProperty. If both prospective arguments to SortCompare correspond to non-existent properties, use *+0* instead of calling SortCompare. If only the first prospective argument is non-existent use +1. If only the second prospective argument is non-existent use -1.
             * If _obj_ is not sparse then DeletePropertyOrThrow must not be called.
-            * If any [[Set]] call returns *false* a *TypeError* exception is thrown.
             * If an abrupt completion is returned from any of these operations, it is immediately returned as the value of this function.
           1. Return _obj_.
         </emu-alg>
@@ -33741,7 +33741,7 @@ THH:mm:ss.sss
             Then for all nonnegative integers _j_ and _k_, each less than _len_, if <emu-eqn>SortCompare(old[_j_], old[_k_]) &lt; 0</emu-eqn> (see SortCompare below), then <emu-eqn>new[&pi;(_j_)] &lt; new[&pi;(_k_)]</emu-eqn>.
           </li>
         </ul>
-        <p>Here the notation <emu-eqn>old[_j_]</emu-eqn> is used to refer to the hypothetical result of calling _obj_.[[Get]](_j_) before this function is executed, and the notation <emu-eqn>new[_j_]</emu-eqn> to refer to the hypothetical result of calling _obj_.[[Get]](_j_) after this function has been executed.</p>
+        <p>Here the notation <emu-eqn>old[_j_]</emu-eqn> is used to refer to the hypothetical result of calling <emu-eqn>Get(_obj_, _j_)</emu-eqn> before this function is executed, and the notation <emu-eqn>new[_j_]</emu-eqn> to refer to the hypothetical result of calling <emu-eqn>Get(_obj_, _j_)</emu-eqn> after this function has been executed.</p>
         <p>A function _comparefn_ is a consistent comparison function for a set of values _S_ if all of the requirements below are met for all values _a_, _b_, and _c_ (possibly the same value) in the set _S_: The notation <emu-eqn>_a_ &lt;<sub>CF</sub> _b_</emu-eqn> means <emu-eqn>_comparefn_(_a_, _b_) &lt; 0</emu-eqn>; <emu-eqn>_a_ =<sub>CF</sub> _b_</emu-eqn> means <emu-eqn>_comparefn_(_a_, _b_) = 0</emu-eqn> (of either sign); and <emu-eqn>_a_ &gt;<sub>CF</sub> _b_</emu-eqn> means <emu-eqn>_comparefn_(_a_, _b_) &gt; 0</emu-eqn>.</p>
         <ul>
           <li>


### PR DESCRIPTION
Fixes #1180.

This PR replaces those `obj.[[Get]](j)`s by the abstract operation `Get(obj, j)` since those lacked the 2nd argument `Receiver`.