### PR TITLE
Editorial: clarify that [[Construct]] implies [[Call]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1514,7 +1514,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. A constructor must be a function object, and so is also referred to as a <em>constructor function</em>.</p>
+        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that additionally supports the [[Construct]] internal method. A constructor must be a function object, and so is also referred to as a <em>constructor function</em>.</p>
         <emu-table id="table-6" caption="Additional Essential Internal Methods of Function Objects">
           <table>
             <tbody>

--- a/spec.html
+++ b/spec.html
@@ -1514,7 +1514,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> (also referred to as a <em>constructor function</em>) is a function object that supports the [[Construct]] internal method.</p>
+        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. A constructor must be a function object, and so is also referred to as a <em>constructor function</em>.</p>
         <emu-table id="table-6" caption="Additional Essential Internal Methods of Function Objects">
           <table>
             <tbody>


### PR DESCRIPTION
That is, an object with a [[Construct]] internal method must have a [[Call]] internal method.
Previously, this was assumed but not explicitly stated.

See https://stackoverflow.com/questions/50109554/