### PR TITLE
Added 'yield' example for line terminator grammar restrictions.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10975,6 +10975,7 @@
             ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=&gt;` ConciseBody[?In]
 
           YieldExpression[In, Await] :
+            `yield`
             `yield` [no LineTerminator here] AssignmentExpression[?In, +Yield, ?Await]
             `yield` [no LineTerminator here] `*` AssignmentExpression[?In, +Yield, ?Await]
         </emu-grammar>


### PR DESCRIPTION
Fixes #1192.