### PR TITLE
Editorial: clarify that [[Construct]] implies [[Call]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1514,7 +1514,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that additionally supports the [[Construct]] internal method. A constructor must be a function object, and so is also referred to as a <em>constructor function</em>.</p>
+        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em>.
         <emu-table id="table-6" caption="Additional Essential Internal Methods of Function Objects">
           <table>
             <tbody>

--- a/spec.html
+++ b/spec.html
@@ -1514,7 +1514,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em>.
+        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.
         <emu-table id="table-6" caption="Additional Essential Internal Methods of Function Objects">
           <table>
             <tbody>


### PR DESCRIPTION
This is a continuation/fix of PR #1187 (which I can't add to, because it's already been merged).