### PR TITLE
Evaluate this binding first in SuperProperty

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12501,17 +12501,21 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>SuperProperty : `super` `[` Expression `]`</emu-grammar>
         <emu-alg>
+          1. Let _env_ be GetThisEnvironment( ).
+          1. Let _actualThis_ be ? _env_.GetThisBinding().
           1. Let _propertyNameReference_ be the result of evaluating |Expression|.
           1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
           1. Let _propertyKey_ be ? ToPropertyKey(_propertyNameValue_).
           1. If the code matched by this |SuperProperty| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
-          1. Return ? MakeSuperPropertyReference(_propertyKey_, _strict_).
+          1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
         </emu-alg>
         <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
         <emu-alg>
+          1. Let _env_ be GetThisEnvironment( ).
+          1. Let _actualThis_ be ? _env_.GetThisBinding().
           1. Let _propertyKey_ be StringValue of |IdentifierName|.
           1. If the code matched by this |SuperProperty| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
-          1. Return ? MakeSuperPropertyReference(_propertyKey_, _strict_).
+          1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
         </emu-alg>
         <emu-grammar>SuperCall : `super` Arguments</emu-grammar>
         <emu-alg>
@@ -12541,12 +12545,11 @@
       </emu-clause>
 
       <emu-clause id="sec-makesuperpropertyreference" aoid="MakeSuperPropertyReference">
-        <h1>Runtime Semantics: MakeSuperPropertyReference ( _propertyKey_, _strict_ )</h1>
-        <p>The abstract operation MakeSuperPropertyReference with arguments _propertyKey_ and _strict_ performs the following steps:</p>
+        <h1>Runtime Semantics: MakeSuperPropertyReference ( _actualThis_, _propertyKey_, _strict_ )</h1>
+        <p>The abstract operation MakeSuperPropertyReference with arguments _actualThis_, _propertyKey_, and _strict_ performs the following steps:</p>
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
           1. Assert: _env_.HasSuperBinding() is *true*.
-          1. Let _actualThis_ be ? _env_.GetThisBinding().
           1. Let _baseValue_ be ? _env_.GetSuperBase().
           1. Let _bv_ be ? RequireObjectCoercible(_baseValue_).
           1. Return a value of type Reference that is a Super Reference whose base value component is _bv_, whose referenced name component is _propertyKey_, whose thisValue component is _actualThis_, and whose strict reference flag is _strict_.


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/1175 by moving the `getThisBinding()` before evaluating the computed property expression.