### PR TITLE
Editorial: reduce indirection in NumberToString

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4088,7 +4088,7 @@
         <emu-alg>
           1. If _m_ is *NaN*, return the String `"NaN"`.
           1. If _m_ is *+0* or *-0*, return the String `"0"`.
-          1. If _m_ is less than zero, return the string-concatenation of `"-"` and ! ToString(-_m_).
+          1. If _m_ is less than zero, return the string-concatenation of `"-"` and ! NumberToString(-_m_).
           1. If _m_ is *+&infin;*, return the String `"Infinity"`.
           1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_-1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for _s_ &times; 10<sup>_n_-_k_</sup> is _m_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
           1. If _k_ &le; _n_ &le; 21, return the string-concatenation of:


### PR DESCRIPTION
`ToString` on a guaranteed Number just calls into `NumberToString`, so let's remove a conceptual stack frame from this recursion.