### PR TITLE
Editorial: Don't explicitly set [[Extensible]] to true

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7324,7 +7324,6 @@
         1. Let _obj_ be a newly created object with an internal slot for each name in _internalSlotsList_.
         1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
         1. Set _obj_.[[Prototype]] to _proto_.
-        1. Set _obj_.[[Extensible]] to *true*.
         1. Return _obj_.
       </emu-alg>
     </emu-clause>
@@ -7618,7 +7617,6 @@
         1. Set _F_.[[Strict]] to _strict_.
         1. Set _F_.[[FunctionKind]] to _functionKind_.
         1. Set _F_.[[Prototype]] to _functionPrototype_.
-        1. Set _F_.[[Extensible]] to *true*.
         1. Set _F_.[[Realm]] to the current Realm Record.
         1. Return _F_.
       </emu-alg>
@@ -7962,7 +7960,6 @@
         1. Let _func_ be a new built-in function object that when called performs the action described by _steps_. The new function object has internal slots whose names are the elements of _internalSlotsList_. The initial value of each of those internal slots is *undefined*.
         1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[Prototype]] to _prototype_.
-        1. Set _func_.[[Extensible]] to *true*.
         1. Set _func_.[[ScriptOrModule]] to *null*.
         1. Return _func_.
       </emu-alg>
@@ -8072,7 +8069,6 @@
           1. If IsConstructor(_targetFunction_) is *true*, then
             1. Set _obj_.[[Construct]] as described in <emu-xref href="#sec-bound-function-exotic-objects-construct-argumentslist-newtarget"></emu-xref>.
           1. Set _obj_.[[Prototype]] to _proto_.
-          1. Set _obj_.[[Extensible]] to *true*.
           1. Set _obj_.[[BoundTargetFunction]] to _targetFunction_.
           1. Set _obj_.[[BoundThis]] to _boundThis_.
           1. Set _obj_.[[BoundArguments]] to _boundArgs_.
@@ -8129,7 +8125,6 @@
           1. Set _A_'s essential internal methods except for [[DefineOwnProperty]] to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _A_.[[Prototype]] to _proto_.
-          1. Set _A_.[[Extensible]] to *true*.
           1. Perform ! OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor{[[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
           1. Return _A_.
         </emu-alg>
@@ -8270,7 +8265,6 @@
           1. Set _S_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-string-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _S_.[[OwnPropertyKeys]] as specified in <emu-xref href="#sec-string-exotic-objects-ownpropertykeys"></emu-xref>.
           1. Set _S_.[[Prototype]] to _prototype_.
-          1. Set _S_.[[Extensible]] to *true*.
           1. Let _length_ be the number of code unit elements in _value_.
           1. Perform ! DefinePropertyOrThrow(_S_, `"length"`, PropertyDescriptor{[[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _S_.
@@ -8443,7 +8437,6 @@
           1. Set _obj_.[[Delete]] as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
           1. Set the remainder of _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _obj_.[[Prototype]] to %ObjectPrototype%.
-          1. Set _obj_.[[Extensible]] to *true*.
           1. Let _map_ be ObjectCreate(*null*).
           1. Set _obj_.[[ParameterMap]] to _map_.
           1. Let _parameterNames_ be the BoundNames of _formals_.
@@ -8649,7 +8642,6 @@
           1. Set _A_.[[Set]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-set-p-v-receiver"></emu-xref>.
           1. Set _A_.[[OwnPropertyKeys]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-ownpropertykeys"></emu-xref>.
           1. Set _A_.[[Prototype]] to _prototype_.
-          1. Set _A_.[[Extensible]] to *true*.
           1. Return _A_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Resolves #1201.

Follows from:

[§17](https://tc39.github.io/ecma262/#sec-ecmascript-standard-built-in-objects):
> Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value **true**.

[§9.1](https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots):
> Once the value of an object's [[Extensible]] internal slot has been set to **false** it may not be subsequently changed to **true**.