### PR TITLE
 Editorial: Built-ins needn't initialize [[Extensible]] to true

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25147,7 +25147,6 @@
         <li>is the intrinsic object <dfn>%ObjectPrototype%</dfn>.</li>
         <li>is an immutable prototype exotic object.</li>
         <li>has a [[Prototype]] internal slot whose value is *null*.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
       </ul>
 
       <!-- es6num="19.1.3.1" -->
@@ -25394,7 +25393,6 @@
       <ul>
         <li>is itself a built-in function object.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
-        <li>has an [[Extensible]] internal slot whose value is *true*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -25422,7 +25420,6 @@
         <li>accepts any arguments and returns *undefined* when invoked.</li>
         <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
         <li>does not have a `prototype` property.</li>
         <li>has a `length` property whose value is 0.</li>
         <li>has a `name` property whose value is the empty String.</li>
@@ -37222,7 +37219,6 @@ THH:mm:ss.sss
       <li>is an ordinary object.</li>
       <li>contains two functions, `parse` and `stringify`, that are used to parse and construct JSON texts.</li>
       <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
-      <li>has an [[Extensible]] internal slot whose value is *true*.</li>
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
       <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     </ul>
@@ -37893,7 +37889,6 @@ THH:mm:ss.sss
       <ul>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
         <li>is an ordinary object.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
       </ul>
       <emu-note>
         <p>All objects defined in this specification that implement the Iterator interface also inherit from %IteratorPrototype%. ECMAScript code may also define objects that inherit from %IteratorPrototype%.The %IteratorPrototype% object provides a place where additional methods that are applicable to all iterator objects may be added.</p>
@@ -37918,7 +37913,6 @@ THH:mm:ss.sss
       <ul>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
         <li>is an ordinary object.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
       </ul>
       <emu-note>
         <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%.The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
@@ -38146,7 +38140,6 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
-        <li>has an [[Extensible]] internal slot whose value is *true*.</li>
         <li>has a `name` property whose value is `"GeneratorFunction"`.</li>
         <li>has the following properties:</li>
       </ul>
@@ -38175,7 +38168,6 @@ THH:mm:ss.sss
         <li>is the value of the `prototype` property of the intrinsic object %GeneratorFunction%.</li>
         <li>is the intrinsic object <dfn>%Generator%</dfn> (see Figure 2).</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
       </ul>
 
       <!-- es6num="25.2.3.1" -->
@@ -38264,7 +38256,6 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
-        <li>has an [[Extensible]] internal slot whose value is *true*.</li>
         <li>has a `name` property whose value is `"AsyncGeneratorFunction"`.</li>
         <li>has the following properties:</li>
       </ul>
@@ -38290,7 +38281,6 @@ THH:mm:ss.sss
         <li>is the value of the `prototype` property of the intrinsic object %AsyncGeneratorFunction%.</li>
         <li>is the intrinsic object %AsyncGenerator%.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
       </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype-constructor">
@@ -38355,7 +38345,6 @@ THH:mm:ss.sss
         <li>is an ordinary object.</li>
         <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
         <li>has properties that are indirectly inherited by all Generator instances.</li>
       </ul>
 
@@ -38579,7 +38568,6 @@ THH:mm:ss.sss
         <li>is an ordinary object.</li>
         <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %AsyncIteratorPrototype%.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
         <li>has properties that are indirectly inherited by all AsyncGenerator instances.</li>
       </ul>
 
@@ -39713,7 +39701,6 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
-        <li>has an [[Extensible]] internal slot whose value is *true*.</li>
         <li>has a `name` property whose value is `"AsyncFunction"`.</li>
         <li>has the following properties:</li>
       </ul>
@@ -39739,7 +39726,6 @@ THH:mm:ss.sss
         <li>is the value of the `prototype` property of the intrinsic object %AsyncFunction%.</li>
         <li>is the intrinsic object <dfn>%AsyncFunctionPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
-        <li>has an [[Extensible]] internal slot whose initial value is *true*.</li>
       </ul>
 
       <emu-clause id="sec-async-function-prototype-properties-constructor">

--- a/spec.html
+++ b/spec.html
@@ -7325,6 +7325,7 @@
         1. Let _obj_ be a newly created object with an internal slot for each name in _internalSlotsList_.
         1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
         1. Set _obj_.[[Prototype]] to _proto_.
+        1. Set _obj_.[[Extensible]] to *true*.
         1. Return _obj_.
       </emu-alg>
     </emu-clause>
@@ -7618,6 +7619,7 @@
         1. Set _F_.[[Strict]] to _strict_.
         1. Set _F_.[[FunctionKind]] to _functionKind_.
         1. Set _F_.[[Prototype]] to _functionPrototype_.
+        1. Set _F_.[[Extensible]] to *true*.
         1. Set _F_.[[Realm]] to the current Realm Record.
         1. Return _F_.
       </emu-alg>
@@ -7961,6 +7963,7 @@
         1. Let _func_ be a new built-in function object that when called performs the action described by _steps_. The new function object has internal slots whose names are the elements of _internalSlotsList_. The initial value of each of those internal slots is *undefined*.
         1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[Prototype]] to _prototype_.
+        1. Set _func_.[[Extensible]] to *true*.
         1. Set _func_.[[ScriptOrModule]] to *null*.
         1. Return _func_.
       </emu-alg>
@@ -8070,6 +8073,7 @@
           1. If IsConstructor(_targetFunction_) is *true*, then
             1. Set _obj_.[[Construct]] as described in <emu-xref href="#sec-bound-function-exotic-objects-construct-argumentslist-newtarget"></emu-xref>.
           1. Set _obj_.[[Prototype]] to _proto_.
+          1. Set _obj_.[[Extensible]] to *true*.
           1. Set _obj_.[[BoundTargetFunction]] to _targetFunction_.
           1. Set _obj_.[[BoundThis]] to _boundThis_.
           1. Set _obj_.[[BoundArguments]] to _boundArgs_.
@@ -8126,6 +8130,7 @@
           1. Set _A_'s essential internal methods except for [[DefineOwnProperty]] to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _A_.[[Prototype]] to _proto_.
+          1. Set _A_.[[Extensible]] to *true*.
           1. Perform ! OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor{[[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
           1. Return _A_.
         </emu-alg>
@@ -8266,6 +8271,7 @@
           1. Set _S_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-string-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _S_.[[OwnPropertyKeys]] as specified in <emu-xref href="#sec-string-exotic-objects-ownpropertykeys"></emu-xref>.
           1. Set _S_.[[Prototype]] to _prototype_.
+          1. Set _S_.[[Extensible]] to *true*.
           1. Let _length_ be the number of code unit elements in _value_.
           1. Perform ! DefinePropertyOrThrow(_S_, `"length"`, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _S_.
@@ -8438,6 +8444,7 @@
           1. Set _obj_.[[Delete]] as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
           1. Set the remainder of _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _obj_.[[Prototype]] to %ObjectPrototype%.
+          1. Set _obj_.[[Extensible]] to *true*.
           1. Let _map_ be ObjectCreate(*null*).
           1. Set _obj_.[[ParameterMap]] to _map_.
           1. Let _parameterNames_ be the BoundNames of _formals_.
@@ -8643,6 +8650,7 @@
           1. Set _A_.[[Set]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-set-p-v-receiver"></emu-xref>.
           1. Set _A_.[[OwnPropertyKeys]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-ownpropertykeys"></emu-xref>.
           1. Set _A_.[[Prototype]] to _prototype_.
+          1. Set _A_.[[Extensible]] to *true*.
           1. Return _A_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Reverts #1212 and addresses #1201 properly.

[§17](https://tc39.github.io/ecma262/#sec-ecmascript-standard-built-in-objects) gives `[[Extensible]]` a default value of `true` for built-ins. This has no impact on §9 but rather implies that we should remove the superfluous initializations in §18-25.