### PR TITLE
Editorial: Refactor QuoteJSONString (and propagate improvements)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37419,7 +37419,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
           1. For each code unit _C_ in _value_, do
-            1. If _C_ matches any entry in <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
+            1. If the numeric value of _C_ is listed in the Code Unit Value column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
               1. Set _product_ to the string-concatenation of _product_ and the Escape Sequence for _C_ as specified in <emu-xref href="#table-json-single-character-escapes"></emu-xref>.
             1. Else if _C_ has a numeric value less than 0x0020 (SPACE), then
               1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_C_).
@@ -37529,6 +37529,7 @@ THH:mm:ss.sss
         <p>The abstract operation UnicodeEscape takes a code unit argument _C_ and represents it as a Unicode escape sequence.</p>
         <emu-alg>
           1. Let _n_ be the numeric value of _C_.
+          1. Assert: _n_ &le; 0xFFFF.
           1. Return the string-concatenation of:
             * the code unit 0x005C (REVERSE SOLIDUS)
             * `"u"`

--- a/spec.html
+++ b/spec.html
@@ -37419,57 +37419,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
           1. For each code unit _C_ in _value_, do
-            1. If _C_ is the code unit 0x0022 (QUOTATION MARK) or the code unit 0x005C (REVERSE SOLIDUS), then
-              1. Set _product_ to the string-concatenation of _product_ and the code unit 0x005C (REVERSE SOLIDUS).
-              1. Set _product_ to the string-concatenation of _product_ and _C_.
-            1. Else if _C_ is the code unit 0x0008 (BACKSPACE), the code unit 0x000C (FORM FEED), the code unit 0x000A (LINE FEED), the code unit 0x000D (CARRIAGE RETURN), or the code unit 0x0009 (CHARACTER TABULATION), then
-              1. Set _product_ to the string-concatenation of _product_ and the code unit 0x005C (REVERSE SOLIDUS).
-              1. Let _abbrev_ be the String value corresponding to the value of _C_ as follows:
-                <table class="lightweight">
-                  <tbody>
-                  <tr>
-                    <td>
-                      BACKSPACE
-                    </td>
-                    <td>
-                      `"b"`
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      FORM FEED (FF)
-                    </td>
-                    <td>
-                      `"f"`
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      LINE FEED (LF)
-                    </td>
-                    <td>
-                      `"n"`
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      CARRIAGE RETURN (CR)
-                    </td>
-                    <td>
-                      `"r"`
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      CHARACTER TABULATION
-                    </td>
-                    <td>
-                      `"t"`
-                    </td>
-                  </tr>
-                  </tbody>
-                </table>
-              1. Set _product_ to the string-concatenation of _product_ and _abbrev_.
+            1. If _C_ matches any entry in <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
+              1. Set _product_ to the string-concatenation of _product_ and the Escape Sequence for _C_ as specified in <emu-xref href="#table-json-single-character-escapes"></emu-xref>.
             1. Else if _C_ has a numeric value less than 0x0020 (SPACE), then
               1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_C_).
             1. Else,
@@ -37477,6 +37428,100 @@ THH:mm:ss.sss
           1. Set _product_ to the string-concatenation of _product_ and the code unit 0x0022 (QUOTATION MARK).
           1. Return _product_.
         </emu-alg>
+        <emu-table id="table-json-single-character-escapes" caption="JSON Single Character Escape Sequences">
+          <table>
+            <tbody>
+            <tr>
+              <th>
+                Code Unit Value
+              </th>
+              <th>
+                Unicode Character Name
+              </th>
+              <th>
+                Escape Sequence
+              </th>
+            </tr>
+            <tr>
+              <td>
+                `0x0008`
+              </td>
+              <td>
+                BACKSPACE
+              </td>
+              <td>
+                `\\b`
+              </td>
+            </tr>
+            <tr>
+              <td>
+                `0x0009`
+              </td>
+              <td>
+                CHARACTER TABULATION
+              </td>
+              <td>
+                `\\t`
+              </td>
+            </tr>
+            <tr>
+              <td>
+                `0x000A`
+              </td>
+              <td>
+                LINE FEED (LF)
+              </td>
+              <td>
+                `\\n`
+              </td>
+            </tr>
+            <tr>
+              <td>
+                `0x000C`
+              </td>
+              <td>
+                FORM FEED (FF)
+              </td>
+              <td>
+                `\\f`
+              </td>
+            </tr>
+            <tr>
+              <td>
+                `0x000D`
+              </td>
+              <td>
+                CARRIAGE RETURN (CR)
+              </td>
+              <td>
+                `\\r`
+              </td>
+            </tr>
+            <tr>
+              <td>
+                `0x0022`
+              </td>
+              <td>
+                QUOTATION MARK
+              </td>
+              <td>
+                `\\"`
+              </td>
+            </tr>
+            <tr>
+              <td>
+                `0x005C`
+              </td>
+              <td>
+                REVERSE SOLIDUS
+              </td>
+              <td>
+                `\\\\`
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
       </emu-clause>
 
       <emu-clause id="sec-unicodeescape" aoid="UnicodeEscape">

--- a/spec.html
+++ b/spec.html
@@ -37469,13 +37469,22 @@ THH:mm:ss.sss
                 </table>
               1. Set _product_ to the string-concatenation of _product_ and _abbrev_.
             1. Else if _C_ has a numeric value less than 0x0020 (SPACE), then
-              1. Set _product_ to the string-concatenation of _product_ and the code unit 0x005C (REVERSE SOLIDUS).
-              1. Set _product_ to the string-concatenation of _product_ and `"u"`.
-              1. Let _hex_ be the string result of converting the numeric value of _C_ to a String of four lowercase hexadecimal digits.
-              1. Set _product_ to the string-concatenation of _product_ and _hex_.
+              1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_C_).
             1. Else,
               1. Set _product_ to the string-concatenation of _product_ and _C_.
           1. Set _product_ to the string-concatenation of _product_ and the code unit 0x0022 (QUOTATION MARK).
+          1. Return _product_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-unicodeescape" aoid="UnicodeEscape">
+        <h1>Runtime Semantics: UnicodeEscape ( _C_ )</h1>
+        <p>The abstract operation UnicodeEscape takes a code unit argument _C_ and represents it as a Unicode escape sequence.</p>
+        <emu-alg>
+          1. Let _product_ be the String value consisting solely of the code unit 0x005C (REVERSE SOLIDUS).
+          1. Set _product_ to the string-concatenation of _product_ and `"u"`.
+          1. Let _hex_ be the string result of converting the numeric value of _C_ to a String of four lowercase hexadecimal digits.
+          1. Set _product_ to the string-concatenation of _product_ and _hex_.
           1. Return _product_.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -37481,12 +37481,11 @@ THH:mm:ss.sss
         <h1>Runtime Semantics: UnicodeEscape ( _C_ )</h1>
         <p>The abstract operation UnicodeEscape takes a code unit argument _C_ and represents it as a Unicode escape sequence.</p>
         <emu-alg>
-          1. Let _escaped_ be the String value consisting solely of the code unit 0x005C (REVERSE SOLIDUS).
-          1. Set _escaped_ to the string-concatenation of _escaped_ and `"u"`.
           1. Let _n_ be the numeric value of _C_.
-          1. Let _hex_ be the String representation of _n_, formatted as a four-digit lowercase hexadecimal number, padded to the left with zeroes if necessary.
-          1. Set _escaped_ to the string-concatenation of _escaped_ and _hex_.
-          1. Return _escaped_.
+          1. Return the string-concatenation of:
+            * the code unit 0x005C (REVERSE SOLIDUS)
+            * `"u"`
+            * the String representation of _n_, formatted as a four-digit lowercase hexadecimal number, padded to the left with zeroes if necessary
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -37481,11 +37481,11 @@ THH:mm:ss.sss
         <h1>Runtime Semantics: UnicodeEscape ( _C_ )</h1>
         <p>The abstract operation UnicodeEscape takes a code unit argument _C_ and represents it as a Unicode escape sequence.</p>
         <emu-alg>
-          1. Let _product_ be the String value consisting solely of the code unit 0x005C (REVERSE SOLIDUS).
-          1. Set _product_ to the string-concatenation of _product_ and `"u"`.
+          1. Let _escaped_ be the String value consisting solely of the code unit 0x005C (REVERSE SOLIDUS).
+          1. Set _escaped_ to the string-concatenation of _escaped_ and `"u"`.
           1. Let _hex_ be the string result of converting the numeric value of _C_ to a String of four lowercase hexadecimal digits.
-          1. Set _product_ to the string-concatenation of _product_ and _hex_.
-          1. Return _product_.
+          1. Set _escaped_ to the string-concatenation of _escaped_ and _hex_.
+          1. Return _escaped_.
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -28626,9 +28626,9 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
-            1. Let _hour_ be the String representation of HourFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
-            1. Let _minute_ be the String representation of MinFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
-            1. Let _second_ be the String representation of SecFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. Let _hour_ be the String representation of HourFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+            1. Let _minute_ be the String representation of MinFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+            1. Let _second_ be the String representation of SecFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Return the string-concatenation of _hour_, `":"`, _minute_, `":"`, _second_, the code unit 0x0020 (SPACE), and `"GMT"`.
           </emu-alg>
         </emu-clause>
@@ -28641,8 +28641,8 @@ THH:mm:ss.sss
             1. Assert: _tv_ is not *NaN*.
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
-            1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
-            1. Let _year_ be the String representation of YearFromTime(_tv_), formatted as a number of at least four digits, padded to the left with zeroes if necessary.
+            1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+            1. Let _year_ be the String representation of YearFromTime(_tv_), formatted as a decimal number of at least four digits, padded to the left with zeroes if necessary.
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), and _year_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
@@ -28835,8 +28835,8 @@ THH:mm:ss.sss
             1. Assert: _tv_ is not *NaN*.
             1. Let _offset_ be LocalTZA(_tv_, *true*).
             1. If _offset_ &ge; 0, let _offsetSign_ be `"+"`; otherwise, let _offsetSign_ be `"-"`.
-            1. Let _offsetMin_ be the String representation of MinFromTime(abs(_offset_)), formatted as a two-digit number, padded to the left with a zero if necessary.
-            1. Let _offsetHour_ be the String representation of HourFromTime(abs(_offset_)), formatted as a two-digit number, padded to the left with a zero if necessary.
+            1. Let _offsetMin_ be the String representation of MinFromTime(abs(_offset_)), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+            1. Let _offsetHour_ be the String representation of HourFromTime(abs(_offset_)), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _tzName_ be an implementation-defined string that is either the empty string or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-dependent timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>
@@ -28878,8 +28878,8 @@ THH:mm:ss.sss
           1. If _tv_ is *NaN*, return `"Invalid Date"`.
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
-          1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit number, padded to the left with a zero if necessary.
-          1. Let _year_ be the String representation of YearFromTime(_tv_), formatted as a number of at least four digits, padded to the left with zeroes if necessary.
+          1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+          1. Let _year_ be the String representation of YearFromTime(_tv_), formatted as a decimal number of at least four digits, padded to the left with zeroes if necessary.
           1. Return the string-concatenation of _weekday_, `","`, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _year_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -37483,7 +37483,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _escaped_ be the String value consisting solely of the code unit 0x005C (REVERSE SOLIDUS).
           1. Set _escaped_ to the string-concatenation of _escaped_ and `"u"`.
-          1. Let _hex_ be the string result of converting the numeric value of _C_ to a String of four lowercase hexadecimal digits.
+          1. Let _n_ be the numeric value of _C_.
+          1. Let _hex_ be the String representation of _n_, formatted as a four-digit lowercase hexadecimal number, padded to the left with zeroes if necessary.
           1. Set _escaped_ to the string-concatenation of _escaped_ and _hex_.
           1. Return _escaped_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -24282,7 +24282,9 @@
                   1. Let _V_ be UTF16Decode(_C_, _kChar_).
                 1. Let _Octets_ be the List of octets resulting by applying the UTF-8 transformation to _V_.
                 1. For each element _octet_ of _Octets_ in List order, do
-                  1. Let _S_ be the string-concatenation of `"%"` and the two uppercase hexadecimal digits encoding _octet_.
+                  1. Let _S_ be the string-concatenation of:
+                    * `"%"`
+                    * the String representation of _octet_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
                   1. Set _R_ to the string-concatenation of the previous value of _R_ and _S_.
               1. Increase _k_ by 1.
           </emu-alg>
@@ -41513,9 +41515,15 @@ THH:mm:ss.sss
             1. If _char_ is one of the code units in `"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@*_+-./"`, then
               1. Let _S_ be the String value containing the single code unit _char_.
             1. Else if _char_ &ge; 256, then
-              1. Let _S_ be the string-concatenation of `"%u"` and the four uppercase hexadecimal digits encoding _char_.
+              1. Let _n_ be the numeric value of _char_.
+              1. Let _S_ be the string-concatenation of:
+                * `"%u"`
+                * the String representation of _n_, formatted as a four-digit uppercase hexadecimal number, padded to the left with zeroes if necessary
             1. Else _char_ &lt; 256,
-              1. Let _S_ be the string-concatenation of `"%"` and the two uppercase hexadecimal digits encoding _char_.
+              1. Let _n_ be the numeric value of _char_.
+              1. Let _S_ be the string-concatenation of:
+                * `"%"`
+                * the String representation of _n_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
             1. Set _R_ to the string-concatenation of the previous value of _R_ and _S_.
             1. Increase _k_ by 1.
           1. Return _R_.


### PR DESCRIPTION
As requested by @ljharb: https://github.com/tc39/proposal-well-formed-stringify/issues/6#issuecomment-394888970

* Introduce UnicodeEscape for QuoteJSONString.
* Use similar language for all fixed-length (hexa)decimal conversions.
* Specify all JSON single-character escapes via table.