### PR TITLE
Editorial: remove unused variables in ArraySetLength

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8194,7 +8194,7 @@
             1. If _deleteSucceeded_ is *false*, then
               1. Set _newLenDesc_.[[Value]] to _oldLen_ + 1.
               1. If _newWritable_ is *false*, set _newLenDesc_.[[Writable]] to *false*.
-              1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, `"length"`, _newLenDesc_).
+              1. Perform ! OrdinaryDefineOwnProperty(_A_, `"length"`, _newLenDesc_).
               1. Return *false*.
           1. If _newWritable_ is *false*, then
             1. Return OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor { [[Writable]]: *false* }). This call will always return *true*.


### PR DESCRIPTION
Remove the unused variable (named `succeeded`) in Steps 16.c.iii-iv. in
Section 9.4.2.4, which describes the abstract operation ArraySetLength.

Fixes: https://github.com/tc39/ecma262/issues/1230