### PR TITLE
Meta: add package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 out/
 test*.js
 
+# Only apps should have lockfiles
+npm-shrinkwrap.json
+package-lock.json
+yarn.lock


### PR DESCRIPTION
Add package-lock.json to the gitignore file because we do not commit it
anyway.