### PR TITLE
Editorial: fix typo in Section 6.4.2

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3170,7 +3170,7 @@
         <p>The Reference type is used to explain the behaviour of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a reference.</p>
       </emu-note>
       <p>A <dfn>Reference</dfn> is a resolved name or property binding. A Reference consists of three components, the base value component, the referenced name component, and the Boolean-valued strict reference flag. The base value component is either *undefined*, an Object, a Boolean, a String, a Symbol, a Number, or an Environment Record. A base value component of *undefined* indicates that the Reference could not be resolved to a binding. The referenced name component is a String or Symbol value.</p>
-      <p>A <dfn id="super-reference">Super Reference</dfn> is a Reference that is used to represents a name binding that was expressed using the super keyword. A Super Reference has an additional thisValue component, and its base value component will never be an Environment Record.</p>
+      <p>A <dfn id="super-reference">Super Reference</dfn> is a Reference that is used to represent a name binding that was expressed using the super keyword. A Super Reference has an additional thisValue component, and its base value component will never be an Environment Record.</p>
       <p>The following abstract operations are used in this specification to operate on references:</p>
 
       <emu-clause id="sec-getbase" aoid="GetBase" oldids="ao-getbase">


### PR DESCRIPTION
Fix a typo in Section 6.4.2, which concerns the Reference Specification
Type in the definition for a "Super Reference".

represents => represent

Fixes: https://github.com/tc39/ecma262/issues/1229