### PR TITLE
Editorial: move Section 25.6 Promise Objects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38466,794 +38466,6 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-generatorfunction-objects">
-    <h1>GeneratorFunction Objects</h1>
-    <p>GeneratorFunction objects are functions that are usually created by evaluating |GeneratorDeclaration|s, |GeneratorExpression|s, and |GeneratorMethod|s. They may also be created by calling the %GeneratorFunction% intrinsic.</p>
-    <emu-figure id="figure-2" caption="Generator Objects Relationships" informative>
-      <img alt="A staggering variety of boxes and arrows." src="img/figure-2.png">
-    </emu-figure>
-
-    <emu-clause id="sec-generatorfunction-constructor">
-      <h1>The GeneratorFunction Constructor</h1>
-      <p>The GeneratorFunction constructor:</p>
-      <ul>
-        <li>is <dfn>%GeneratorFunction%</dfn>.</li>
-        <li>is a subclass of `Function`.</li>
-        <li>creates and initializes a new GeneratorFunction object when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.</li>
-      </ul>
-
-      <emu-clause id="sec-generatorfunction">
-        <h1>GeneratorFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
-        <p>The last argument specifies the body (executable code) of a generator function; any preceding arguments specify formal parameters.</p>
-        <p>When the `GeneratorFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no &ldquo;_p_&rdquo; arguments, and where _body_ might also not be provided), the following steps are taken:</p>
-        <emu-alg>
-          1. Let _C_ be the active function object.
-          1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~generator~, _args_).
-        </emu-alg>
-        <emu-note>
-          <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
-        </emu-note>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-properties-of-the-generatorfunction-constructor">
-      <h1>Properties of the GeneratorFunction Constructor</h1>
-      <p>The GeneratorFunction constructor:</p>
-      <ul>
-        <li>is a standard built-in function object that inherits from the Function constructor.</li>
-        <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
-        <li>has a *"name"* property whose value is *"GeneratorFunction"*.</li>
-        <li>has the following properties:</li>
-      </ul>
-
-      <emu-clause id="sec-generatorfunction.length">
-        <h1>GeneratorFunction.length</h1>
-        <p>This is a data property with a value of 1. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-generatorfunction.prototype">
-        <h1>GeneratorFunction.prototype</h1>
-        <p>The initial value of `GeneratorFunction.prototype` is the GeneratorFunction prototype object.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-properties-of-the-generatorfunction-prototype-object">
-      <h1>Properties of the GeneratorFunction Prototype Object</h1>
-      <p>The <dfn>GeneratorFunction prototype object</dfn>:</p>
-      <ul>
-        <li>is <dfn>%GeneratorFunction.prototype%</dfn> (see <emu-xref href="#figure-2"></emu-xref>).</li>
-        <li>is an ordinary object.</li>
-        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref> or <emu-xref href="#table-internal-slots-of-generator-instances"></emu-xref>.</li>
-        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-      </ul>
-
-      <emu-clause id="sec-generatorfunction.prototype.constructor">
-        <h1>GeneratorFunction.prototype.constructor</h1>
-        <p>The initial value of `GeneratorFunction.prototype.constructor` is %GeneratorFunction%.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-generatorfunction.prototype.prototype">
-        <h1>GeneratorFunction.prototype.prototype</h1>
-        <p>The initial value of `GeneratorFunction.prototype.prototype` is the Generator prototype object.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-generatorfunction.prototype-@@tostringtag">
-        <h1>GeneratorFunction.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"GeneratorFunction"*.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-generatorfunction-instances">
-      <h1>GeneratorFunction Instances</h1>
-      <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
-      <p>Each GeneratorFunction instance has the following own properties:</p>
-
-      <emu-clause id="sec-generatorfunction-instances-length">
-        <h1>length</h1>
-        <p>The specification for the *"length"* property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to GeneratorFunction instances.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-generatorfunction-instances-name">
-        <h1>name</h1>
-        <p>The specification for the *"name"* property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to GeneratorFunction instances.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-generatorfunction-instances-prototype">
-        <h1>prototype</h1>
-        <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
-        <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-        <emu-note>
-          <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's *"prototype"* property does not have a *"constructor"* property whose value is the GeneratorFunction instance.</p>
-        </emu-note>
-      </emu-clause>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-asyncgeneratorfunction-objects">
-    <h1>AsyncGeneratorFunction Objects</h1>
-    <p>AsyncGeneratorFunction objects are functions that are usually created by evaluating |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, and |AsyncGeneratorMethod| syntactic productions. They may also be created by calling the %AsyncGeneratorFunction% intrinsic.</p>
-
-    <emu-clause id="sec-asyncgeneratorfunction-constructor">
-      <h1>The AsyncGeneratorFunction Constructor</h1>
-      <p>The AsyncGeneratorFunction constructor:</p>
-      <ul>
-        <li>is <dfn>%AsyncGeneratorFunction%</dfn>.</li>
-        <li>is a subclass of `Function`.</li>
-        <li>creates and initializes a new AsyncGeneratorFunction object when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncGeneratorFunction behaviour must include a `super` call to the AsyncGeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of AsyncGeneratorFunction. There is no syntactic means to create instances of AsyncGeneratorFunction subclasses.</li>
-      </ul>
-
-      <emu-clause id="sec-asyncgeneratorfunction">
-        <h1>AsyncGeneratorFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
-        <p>The last argument specifies the body (executable code) of an async generator function; any preceding arguments specify formal parameters.</p>
-        <p>When the `AsyncGeneratorFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no "_p_" arguments, and where _body_ might also not be provided), the following steps are taken:</p>
-        <emu-alg>
-          1. Let _C_ be the active function object.
-          1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~asyncGenerator~, _args_).
-        </emu-alg>
-        <emu-note>
-          <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
-        </emu-note>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-properties-of-asyncgeneratorfunction">
-      <h1>Properties of the AsyncGeneratorFunction Constructor</h1>
-      <p>The AsyncGeneratorFunction constructor:</p>
-      <ul>
-        <li>is a standard built-in function object that inherits from the Function constructor.</li>
-        <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
-        <li>has a *"name"* property whose value is *"AsyncGeneratorFunction"*.</li>
-        <li>has the following properties:</li>
-      </ul>
-
-      <emu-clause id="sec-asyncgeneratorfunction-length">
-        <h1>AsyncGeneratorFunction.length</h1>
-        <p>This is a data property with a value of 1. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorfunction-prototype">
-        <h1>AsyncGeneratorFunction.prototype</h1>
-        <p>The initial value of `AsyncGeneratorFunction.prototype` is the AsyncGeneratorFunction prototype object.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-properties-of-asyncgeneratorfunction-prototype">
-      <h1>Properties of the AsyncGeneratorFunction Prototype Object</h1>
-      <p>The <dfn>AsyncGeneratorFunction prototype object</dfn>:</p>
-      <ul>
-        <li>is <dfn>%AsyncGeneratorFunction.prototype%</dfn>.</li>
-        <li>is an ordinary object.</li>
-        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
-        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-      </ul>
-
-      <emu-clause id="sec-asyncgeneratorfunction-prototype-constructor">
-        <h1>AsyncGeneratorFunction.prototype.constructor</h1>
-        <p>The initial value of `AsyncGeneratorFunction.prototype.constructor` is %AsyncGeneratorFunction%.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorfunction-prototype-prototype">
-        <h1>AsyncGeneratorFunction.prototype.prototype</h1>
-        <p>The initial value of `AsyncGeneratorFunction.prototype.prototype` is the AsyncGenerator prototype object.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorfunction-prototype-tostringtag">
-        <h1>AsyncGeneratorFunction.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"AsyncGeneratorFunction"*.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-asyncgeneratorfunction-instances">
-      <h1>AsyncGeneratorFunction Instances</h1>
-      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
-      <p>Each AsyncGeneratorFunction instance has the following own properties:</p>
-
-      <emu-clause id="sec-asyncgeneratorfunction-instance-length">
-        <h1>length</h1>
-        <p>The value of the *"length"* property is an integral Number that indicates the typical number of arguments expected by the AsyncGeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of an AsyncGeneratorFunction when invoked on a number of arguments other than the number specified by its *"length"* property depends on the function.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorfunction-instance-name">
-        <h1>name</h1>
-        <p>The specification for the *"name"* property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncGeneratorFunction instances.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorfunction-instance-prototype">
-        <h1>prototype</h1>
-        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator object when the generator function object is invoked using [[Call]].</p>
-        <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-        <emu-note>
-          <p>Unlike function instances, the object that is the value of the an AsyncGeneratorFunction's *"prototype"* property does not have a *"constructor"* property whose value is the AsyncGeneratorFunction instance.</p>
-        </emu-note>
-      </emu-clause>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-generator-objects">
-    <h1>Generator Objects</h1>
-    <p>A Generator object is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
-    <p>Generator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %GeneratorFunction.prototype.prototype%.</p>
-
-    <emu-clause id="sec-properties-of-generator-prototype">
-      <h1>Properties of the Generator Prototype Object</h1>
-      <p>The <dfn>Generator prototype object</dfn>:</p>
-      <ul>
-        <li>is <dfn>%GeneratorFunction.prototype.prototype%</dfn>.</li>
-        <li>is an ordinary object.</li>
-        <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
-        <li>has properties that are indirectly inherited by all Generator instances.</li>
-      </ul>
-
-      <emu-clause id="sec-generator.prototype.constructor">
-        <h1>Generator.prototype.constructor</h1>
-        <p>The initial value of `Generator.prototype.constructor` is %GeneratorFunction.prototype%.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-generator.prototype.next">
-        <h1>Generator.prototype.next ( _value_ )</h1>
-        <p>The `next` method performs the following steps:</p>
-        <emu-alg>
-          1. Let _g_ be the *this* value.
-          1. Return ? GeneratorResume(_g_, _value_, ~empty~).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-generator.prototype.return">
-        <h1>Generator.prototype.return ( _value_ )</h1>
-        <p>The `return` method performs the following steps:</p>
-        <emu-alg>
-          1. Let _g_ be the *this* value.
-          1. Let _C_ be Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
-          1. Return ? GeneratorResumeAbrupt(_g_, _C_, ~empty~).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-generator.prototype.throw">
-        <h1>Generator.prototype.throw ( _exception_ )</h1>
-        <p>The `throw` method performs the following steps:</p>
-        <emu-alg>
-          1. Let _g_ be the *this* value.
-          1. Let _C_ be ThrowCompletion(_exception_).
-          1. Return ? GeneratorResumeAbrupt(_g_, _C_, ~empty~).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-generator.prototype-@@tostringtag">
-        <h1>Generator.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"Generator"*.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-properties-of-generator-instances">
-      <h1>Properties of Generator Instances</h1>
-      <p>Generator instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-generator-instances"></emu-xref>.</p>
-      <emu-table id="table-internal-slots-of-generator-instances" caption="Internal Slots of Generator Instances" oldids="table-56">
-        <table>
-          <tbody>
-          <tr>
-            <th>
-              Internal Slot
-            </th>
-            <th>
-              Description
-            </th>
-          </tr>
-          <tr>
-            <td>
-              [[GeneratorState]]
-            </td>
-            <td>
-              The current execution state of the generator. The possible values are: *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, and ~completed~.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              [[GeneratorContext]]
-            </td>
-            <td>
-              The execution context that is used when executing the code of this generator.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              [[GeneratorBrand]]
-            </td>
-            <td>
-              A brand used to distinguish different kinds of generators. The [[GeneratorBrand]] of generators declared by ECMAScript source text is always ~empty~.
-            </td>
-          </tr>
-          </tbody>
-        </table>
-      </emu-table>
-    </emu-clause>
-
-    <emu-clause id="sec-generator-abstract-operations">
-      <h1>Generator Abstract Operations</h1>
-
-      <emu-clause id="sec-generatorstart" aoid="GeneratorStart">
-        <h1>GeneratorStart ( _generator_, _generatorBody_ )</h1>
-        <p>The abstract operation GeneratorStart takes arguments _generator_ and _generatorBody_ (a Parse Node or an Abstract Closure with no parameters). It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
-          1. Let _genContext_ be the running execution context.
-          1. Set the Generator component of _genContext_ to _generator_.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
-            1. If _generatorBody_ is a Parse Node, then
-              1. Let _result_ be the result of evaluating _generatorBody_.
-            1. Else,
-              1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
-              1. Let _result_ be _generatorBody_().
-            1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set _generator_.[[GeneratorState]] to ~completed~.
-            1. Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
-            1. If _result_.[[Type]] is ~normal~, let _resultValue_ be *undefined*.
-            1. Else if _result_.[[Type]] is ~return~, let _resultValue_ be _result_.[[Value]].
-            1. Else,
-              1. Assert: _result_.[[Type]] is ~throw~.
-              1. Return Completion(_result_).
-            1. Return CreateIterResultObject(_resultValue_, *true*).
-          1. Set _generator_.[[GeneratorContext]] to _genContext_.
-          1. Set _generator_.[[GeneratorState]] to ~suspendedStart~.
-          1. Return NormalCompletion(*undefined*).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-generatorvalidate" aoid="GeneratorValidate">
-        <h1>GeneratorValidate ( _generator_, _generatorBrand_ )</h1>
-        <p>The abstract operation GeneratorValidate takes arguments _generator_ and _generatorBrand_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Perform ? RequireInternalSlot(_generator_, [[GeneratorState]]).
-          1. Perform ? RequireInternalSlot(_generator_, [[GeneratorBrand]]).
-          1. If _generator_.[[GeneratorBrand]] is not the same value as _generatorBrand_, throw a *TypeError* exception.
-          1. Assert: _generator_ also has a [[GeneratorContext]] internal slot.
-          1. Let _state_ be _generator_.[[GeneratorState]].
-          1. If _state_ is ~executing~, throw a *TypeError* exception.
-          1. Return _state_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-generatorresume" aoid="GeneratorResume">
-        <h1>GeneratorResume ( _generator_, _value_, _generatorBrand_ )</h1>
-        <p>The abstract operation GeneratorResume takes arguments _generator_, _value_, and _generatorBrand_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _state_ be ? GeneratorValidate(_generator_, _generatorBrand_).
-          1. If _state_ is ~completed~, return CreateIterResultObject(*undefined*, *true*).
-          1. Assert: _state_ is either ~suspendedStart~ or ~suspendedYield~.
-          1. Let _genContext_ be _generator_.[[GeneratorContext]].
-          1. Let _methodContext_ be the running execution context.
-          1. Suspend _methodContext_.
-          1. Set _generator_.[[GeneratorState]] to ~executing~.
-          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _genContext_ using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
-          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
-          1. Return Completion(_result_).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-generatorresumeabrupt" aoid="GeneratorResumeAbrupt">
-        <h1>GeneratorResumeAbrupt ( _generator_, _abruptCompletion_, _generatorBrand_ )</h1>
-        <p>The abstract operation GeneratorResumeAbrupt takes arguments _generator_, _abruptCompletion_ (a Completion Record whose [[Type]] is ~return~ or ~throw~), and _generatorBrand_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _state_ be ? GeneratorValidate(_generator_, _generatorBrand_).
-          1. If _state_ is ~suspendedStart~, then
-            1. Set _generator_.[[GeneratorState]] to ~completed~.
-            1. Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
-            1. Set _state_ to ~completed~.
-          1. If _state_ is ~completed~, then
-            1. If _abruptCompletion_.[[Type]] is ~return~, then
-              1. Return CreateIterResultObject(_abruptCompletion_.[[Value]], *true*).
-            1. Return Completion(_abruptCompletion_).
-          1. Assert: _state_ is ~suspendedYield~.
-          1. Let _genContext_ be _generator_.[[GeneratorContext]].
-          1. Let _methodContext_ be the running execution context.
-          1. Suspend _methodContext_.
-          1. Set _generator_.[[GeneratorState]] to ~executing~.
-          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _genContext_ using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
-          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
-          1. Return Completion(_result_).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-getgeneratorkind" aoid="GetGeneratorKind">
-        <h1>GetGeneratorKind ( )</h1>
-        <p>The abstract operation GetGeneratorKind takes no arguments. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _genContext_ be the running execution context.
-          1. If _genContext_ does not have a Generator component, return ~non-generator~.
-          1. Let _generator_ be the Generator component of _genContext_.
-          1. If _generator_ has an [[AsyncGeneratorState]] internal slot, return ~async~.
-          1. Else, return ~sync~.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-generatoryield" aoid="GeneratorYield">
-        <h1>GeneratorYield ( _iterNextObj_ )</h1>
-        <p>The abstract operation GeneratorYield takes argument _iterNextObj_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: _iterNextObj_ is an Object that implements the <i>IteratorResult</i> interface.
-          1. Let _genContext_ be the running execution context.
-          1. Assert: _genContext_ is the execution context of a generator.
-          1. Let _generator_ be the value of the Generator component of _genContext_.
-          1. Assert: GetGeneratorKind() is ~sync~.
-          1. Set _generator_.[[GeneratorState]] to ~suspendedYield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
-            1. Return _resumptionValue_.
-            1. NOTE: This returns to the evaluation of the |YieldExpression| that originally called this abstract operation.
-          1. Return NormalCompletion(_iterNextObj_).
-          1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-yield" aoid="Yield">
-        <h1>Yield ( _value_ )</h1>
-        <p>The abstract operation Yield takes argument _value_ (an ECMAScript language value). It performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _generatorKind_ be ! GetGeneratorKind().
-          1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(_value_).
-          1. Otherwise, return ? GeneratorYield(! CreateIterResultObject(_value_, *false*)).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-createiteratorfromclosure" aoid="CreateIteratorFromClosure">
-        <h1>CreateIteratorFromClosure ( _closure_, _generatorBrand_, _generatorPrototype_ )</h1>
-        <p>The abstract operation CreateIteratorFromClosure takes arguments _closure_ (an Abstract Closure with no parameters), _generatorBrand_, and _generatorPrototype_ (an Object). It performs the following steps when called:</p>
-        <emu-alg>
-          1. NOTE: _closure_ can contain uses of the Yield shorthand to yield an IteratorResult object.
-          1. Let _internalSlotsList_ be &laquo; [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] &raquo;.
-          1. Let _generator_ be ! OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
-          1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
-          1. Set _generator_.[[GeneratorState]] to *undefined*.
-          1. Perform ! GeneratorStart(_generator_, _closure_).
-          1. Return _generator_.
-        </emu-alg>
-      </emu-clause>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-asyncgenerator-objects">
-    <h1>AsyncGenerator Objects</h1>
-    <p>An AsyncGenerator object is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
-
-    <p>AsyncGenerator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGeneratorFunction.prototype.prototype%.</p>
-
-    <emu-clause id="sec-properties-of-asyncgenerator-prototype">
-      <h1>Properties of the AsyncGenerator Prototype Object</h1>
-      <p>The <dfn>AsyncGenerator prototype object</dfn>:</p>
-      <ul>
-        <li>is <dfn>%AsyncGeneratorFunction.prototype.prototype%</dfn>.</li>
-        <li>is an ordinary object.</li>
-        <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is %AsyncIteratorPrototype%.</li>
-        <li>has properties that are indirectly inherited by all AsyncGenerator instances.</li>
-      </ul>
-
-      <emu-clause id="sec-asyncgenerator-prototype-constructor">
-        <h1>AsyncGenerator.prototype.constructor</h1>
-        <p>The initial value of `AsyncGenerator.prototype.constructor` is %AsyncGeneratorFunction.prototype%.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgenerator-prototype-next">
-        <h1>AsyncGenerator.prototype.next ( _value_ )</h1>
-        <emu-alg>
-          1. Let _generator_ be the *this* value.
-          1. Let _completion_ be NormalCompletion(_value_).
-          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_, ~empty~).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgenerator-prototype-return">
-        <h1>AsyncGenerator.prototype.return ( _value_ )</h1>
-        <emu-alg>
-          1. Let _generator_ be the *this* value.
-          1. Let _completion_ be Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
-          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_, ~empty~).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgenerator-prototype-throw">
-        <h1>AsyncGenerator.prototype.throw ( _exception_ )</h1>
-        <emu-alg>
-          1. Let _generator_ be the *this* value.
-          1. Let _completion_ be ThrowCompletion(_exception_).
-          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_, ~empty~).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgenerator-prototype-tostringtag">
-        <h1>AsyncGenerator.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"AsyncGenerator"*.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-properties-of-asyncgenerator-intances">
-      <h1>Properties of AsyncGenerator Instances</h1>
-      <p>AsyncGenerator instances are initially created with the internal slots described below:</p>
-      <emu-table id="table-internal-slots-of-asyncgenerator-instances" caption="Internal Slots of AsyncGenerator Instances">
-        <table>
-          <tbody>
-          <tr>
-            <th>Internal Slot</th>
-            <th>Description</th>
-          </tr>
-          <tr>
-            <td>[[AsyncGeneratorState]]</td>
-            <td>The current execution state of the async generator. The possible values are: *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, ~awaiting-return~, and ~completed~.</td>
-          </tr>
-          <tr>
-            <td>[[AsyncGeneratorContext]]</td>
-            <td>The execution context that is used when executing the code of this async generator.</td>
-          </tr>
-          <tr>
-            <td>[[AsyncGeneratorQueue]]</td>
-            <td>A List of AsyncGeneratorRequest records which represent requests to resume the async generator.</td>
-          </tr>
-          <tr>
-            <td>[[GeneratorBrand]]</td>
-            <td>A brand used to distinguish different kinds of async generators. The [[GeneratorBrand]] of async generators declared by ECMAScript source text is always ~empty~.</td>
-          </tr>
-          </tbody>
-        </table>
-      </emu-table>
-    </emu-clause>
-
-    <emu-clause id="sec-asyncgenerator-abstract-operations">
-      <h1>AsyncGenerator Abstract Operations</h1>
-      <emu-clause id="sec-asyncgeneratorrequest-records">
-        <h1>AsyncGeneratorRequest Records</h1>
-        <p>The AsyncGeneratorRequest is a Record value used to store information about how an async generator should be resumed and contains capabilities for fulfilling or rejecting the corresponding promise.</p>
-        <p>They have the following fields:</p>
-        <emu-table caption="AsyncGeneratorRequest Record Fields">
-          <table>
-            <tbody>
-            <tr>
-              <th>Field Name</th>
-              <th>Value</th>
-              <th>Meaning</th>
-            </tr>
-            <tr>
-              <td>[[Completion]]</td>
-              <td>A Completion record</td>
-              <td>The completion which should be used to resume the async generator.</td>
-            </tr>
-            <tr>
-              <td>[[Capability]]</td>
-              <td>A PromiseCapability Record</td>
-              <td>The promise capabilities associated with this request.</td>
-            </tr>
-            </tbody>
-          </table>
-        </emu-table>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorstart" aoid="AsyncGeneratorStart">
-        <h1>AsyncGeneratorStart ( _generator_, _generatorBody_ )</h1>
-        <p>The abstract operation AsyncGeneratorStart takes arguments _generator_ and _generatorBody_ (a Parse Node or an Abstract Closure with no parameters). It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: _generator_ is an AsyncGenerator instance.
-          1. Assert: _generator_.[[AsyncGeneratorState]] is *undefined*.
-          1. Let _genContext_ be the running execution context.
-          1. Set the Generator component of _genContext_ to _generator_.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
-            1. If _generatorBody_ is a Parse Node, then
-              1. Let _result_ be the result of evaluating _generatorBody_.
-            1. Else,
-              1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
-              1. Let _result_ be _generatorBody_().
-            1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
-            1. If _result_ is a normal completion, let _resultValue_ be *undefined*.
-            1. Else,
-              1. Let _resultValue_ be _result_.[[Value]].
-              1. If _result_.[[Type]] is not ~return~, then
-                1. Return ! AsyncGeneratorReject(_generator_, _resultValue_).
-            1. Return ! AsyncGeneratorResolve(_generator_, _resultValue_, *true*).
-          1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
-          1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedStart~.
-          1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
-          1. Return *undefined*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorvalidate" aoid="AsyncGeneratorValidate">
-        <h1>AsyncGeneratorValidate ( _generator_, _generatorBrand_ )</h1>
-        <p>The abstract operation AsyncGeneratorValidate takes arguments _generator_ and _generatorBrand_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorContext]]).
-          1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorState]]).
-          1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorQueue]]).
-          1. If _generator_.[[GeneratorBrand]] is not the same value as _generatorBrand_, throw a *TypeError* exception.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorresolve" aoid="AsyncGeneratorResolve">
-        <h1>AsyncGeneratorResolve ( _generator_, _value_, _done_ )</h1>
-        <p>The abstract operation AsyncGeneratorResolve takes arguments _generator_, _value_, and _done_ (a Boolean). It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: _generator_ is an AsyncGenerator instance.
-          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
-          1. Assert: _queue_ is not an empty List.
-          1. Let _next_ be the first element of _queue_.
-          1. Remove the first element from _queue_.
-          1. Let _promiseCapability_ be _next_.[[Capability]].
-          1. Let _iteratorResult_ be ! CreateIterResultObject(_value_, _done_).
-          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iteratorResult_ &raquo;).
-          1. Perform ! AsyncGeneratorResumeNext(_generator_).
-          1. Return *undefined*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorreject" aoid="AsyncGeneratorReject">
-        <h1>AsyncGeneratorReject ( _generator_, _exception_ )</h1>
-        <p>The abstract operation AsyncGeneratorReject takes arguments _generator_ and _exception_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: _generator_ is an AsyncGenerator instance.
-          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
-          1. Assert: _queue_ is not an empty List.
-          1. Let _next_ be the first element of _queue_.
-          1. Remove the first element from _queue_.
-          1. Let _promiseCapability_ be _next_.[[Capability]].
-          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _exception_ &raquo;).
-          1. Perform ! AsyncGeneratorResumeNext(_generator_).
-          1. Return *undefined*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorresumenext" aoid="AsyncGeneratorResumeNext">
-        <h1>AsyncGeneratorResumeNext ( _generator_ )</h1>
-        <p>The abstract operation AsyncGeneratorResumeNext takes argument _generator_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: _generator_ is an AsyncGenerator instance.
-          1. Let _state_ be _generator_.[[AsyncGeneratorState]].
-          1. Assert: _state_ is not ~executing~.
-          1. If _state_ is ~awaiting-return~, return *undefined*.
-          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
-          1. If _queue_ is an empty List, return *undefined*.
-          1. Let _next_ be the value of the first element of _queue_.
-          1. Assert: _next_ is an AsyncGeneratorRequest record.
-          1. Let _completion_ be _next_.[[Completion]].
-          1. If _completion_ is an abrupt completion, then
-            1. If _state_ is ~suspendedStart~, then
-              1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
-              1. Set _state_ to ~completed~.
-            1. If _state_ is ~completed~, then
-              1. If _completion_.[[Type]] is ~return~, then
-                1. Set _generator_.[[AsyncGeneratorState]] to ~awaiting-return~.
-                1. Let _promise_ be ? PromiseResolve(%Promise%, _completion_.[[Value]]).
-                1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
-                1. Let _onFulfilled_ be ! CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Generator]] &raquo;).
-                1. Set _onFulfilled_.[[Generator]] to _generator_.
-                1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
-                1. Let _onRejected_ be ! CreateBuiltinFunction(_stepsRejected_, &laquo; [[Generator]] &raquo;).
-                1. Set _onRejected_.[[Generator]] to _generator_.
-                1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-                1. Return *undefined*.
-              1. Else,
-                1. Assert: _completion_.[[Type]] is ~throw~.
-                1. Perform ! AsyncGeneratorReject(_generator_, _completion_.[[Value]]).
-                1. Return *undefined*.
-          1. Else if _state_ is ~completed~, return ! AsyncGeneratorResolve(_generator_, *undefined*, *true*).
-          1. Assert: _state_ is either ~suspendedStart~ or ~suspendedYield~.
-          1. Let _genContext_ be _generator_.[[AsyncGeneratorContext]].
-          1. Let _callerContext_ be the running execution context.
-          1. Suspend _callerContext_.
-          1. Set _generator_.[[AsyncGeneratorState]] to ~executing~.
-          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _genContext_ using _completion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
-          1. Assert: _result_ is never an abrupt completion.
-          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _callerContext_ is the currently running execution context.
-          1. Return *undefined*.
-        </emu-alg>
-
-        <emu-clause id="async-generator-resume-next-return-processor-fulfilled">
-          <h1>AsyncGeneratorResumeNext Return Processor Fulfilled Functions</h1>
-          <p>An AsyncGeneratorResumeNext return processor fulfilled function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor fulfilled function has a [[Generator]] internal slot.</p>
-          <p>When an AsyncGeneratorResumeNext return processor fulfilled function is called with argument _value_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to ~completed~.
-            1. Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
-          </emu-alg>
-
-          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor fulfilled function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
-
-        <emu-clause id="async-generator-resume-next-return-processor-rejected">
-          <h1>AsyncGeneratorResumeNext Return Processor Rejected Functions</h1>
-          <p>An AsyncGeneratorResumeNext return processor rejected function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor rejected function has a [[Generator]] internal slot.</p>
-          <p>When an AsyncGeneratorResumeNext return processor rejected function is called with argument _reason_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to ~completed~.
-            1. Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
-          </emu-alg>
-
-          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor rejected function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratorenqueue" aoid="AsyncGeneratorEnqueue">
-        <h1>AsyncGeneratorEnqueue ( _generator_, _completion_, _generatorBrand_ )</h1>
-        <p>The abstract operation AsyncGeneratorEnqueue takes arguments _generator_, _completion_ (a Completion Record), and _generatorBrand_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Let _check_ be AsyncGeneratorValidate(_generator_, _generatorBrand_).
-          1. If _check_ is an abrupt completion, then
-            1. Let _badGeneratorError_ be a newly created *TypeError* object.
-            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badGeneratorError_ &raquo;).
-            1. Return _promiseCapability_.[[Promise]].
-          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
-          1. Let _request_ be AsyncGeneratorRequest { [[Completion]]: _completion_, [[Capability]]: _promiseCapability_ }.
-          1. Append _request_ to the end of _queue_.
-          1. Let _state_ be _generator_.[[AsyncGeneratorState]].
-          1. If _state_ is not ~executing~, then
-            1. Perform ! AsyncGeneratorResumeNext(_generator_).
-          1. Return _promiseCapability_.[[Promise]].
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asyncgeneratoryield" aoid="AsyncGeneratorYield">
-        <h1>AsyncGeneratorYield ( _value_ )</h1>
-        <p>The abstract operation AsyncGeneratorYield takes argument _value_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _genContext_ be the running execution context.
-          1. Assert: _genContext_ is the execution context of a generator.
-          1. Let _generator_ be the value of the Generator component of _genContext_.
-          1. Assert: GetGeneratorKind() is ~async~.
-          1. Set _value_ to ? Await(_value_).
-          1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedYield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
-            1. If _resumptionValue_.[[Type]] is not ~return~, return Completion(_resumptionValue_).
-            1. Let _awaited_ be Await(_resumptionValue_.[[Value]]).
-            1. If _awaited_.[[Type]] is ~throw~, return Completion(_awaited_).
-            1. Assert: _awaited_.[[Type]] is ~normal~.
-            1. Return Completion { [[Type]]: ~return~, [[Value]]: _awaited_.[[Value]], [[Target]]: ~empty~ }.
-            1. NOTE: When one of the above steps returns, it returns to the evaluation of the |YieldExpression| production that originally called this abstract operation.
-          1. Return ! AsyncGeneratorResolve(_generator_, _value_, *false*).
-          1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-createasynciteratorfromclosure" aoid="CreateAsyncIteratorFromClosure">
-        <h1>CreateAsyncIteratorFromClosure ( _closure_, _generatorBrand_, _generatorPrototype_ )</h1>
-        <p>The abstract operation CreateAsyncIteratorFromClosure takes arguments _closure_ (an Abstract Closure with no parameters), _generatorBrand_, and _generatorPrototype_ (an Object). It performs the following steps when called:</p>
-        <emu-alg>
-          1. NOTE: _closure_ can contain uses of the Await shorthand and uses of the Yield shorthand to yield an IteratorResult object.
-          1. Let _internalSlotsList_ be &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] &raquo;.
-          1. Let _generator_ be ! OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
-          1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
-          1. Set _generator_.[[AsyncGeneratorState]] to *undefined*.
-          1. Perform ! AsyncGeneratorStart(_generator_, _closure_).
-          1. Return _generator_.
-        </emu-alg>
-      </emu-clause>
-    </emu-clause>
-  </emu-clause>
-
   <emu-clause id="sec-promise-objects">
     <h1>Promise Objects</h1>
     <p>A Promise is an object that is used as a placeholder for the eventual results of a deferred (and possibly asynchronous) computation.</p>
@@ -40277,6 +39489,794 @@ THH:mm:ss.sss
           </tbody>
         </table>
       </emu-table>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-generatorfunction-objects">
+    <h1>GeneratorFunction Objects</h1>
+    <p>GeneratorFunction objects are functions that are usually created by evaluating |GeneratorDeclaration|s, |GeneratorExpression|s, and |GeneratorMethod|s. They may also be created by calling the %GeneratorFunction% intrinsic.</p>
+    <emu-figure id="figure-2" caption="Generator Objects Relationships" informative>
+      <img alt="A staggering variety of boxes and arrows." src="img/figure-2.png">
+    </emu-figure>
+
+    <emu-clause id="sec-generatorfunction-constructor">
+      <h1>The GeneratorFunction Constructor</h1>
+      <p>The GeneratorFunction constructor:</p>
+      <ul>
+        <li>is <dfn>%GeneratorFunction%</dfn>.</li>
+        <li>is a subclass of `Function`.</li>
+        <li>creates and initializes a new GeneratorFunction object when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.</li>
+      </ul>
+
+      <emu-clause id="sec-generatorfunction">
+        <h1>GeneratorFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
+        <p>The last argument specifies the body (executable code) of a generator function; any preceding arguments specify formal parameters.</p>
+        <p>When the `GeneratorFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no &ldquo;_p_&rdquo; arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+        <emu-alg>
+          1. Let _C_ be the active function object.
+          1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~generator~, _args_).
+        </emu-alg>
+        <emu-note>
+          <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-the-generatorfunction-constructor">
+      <h1>Properties of the GeneratorFunction Constructor</h1>
+      <p>The GeneratorFunction constructor:</p>
+      <ul>
+        <li>is a standard built-in function object that inherits from the Function constructor.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
+        <li>has a *"name"* property whose value is *"GeneratorFunction"*.</li>
+        <li>has the following properties:</li>
+      </ul>
+
+      <emu-clause id="sec-generatorfunction.length">
+        <h1>GeneratorFunction.length</h1>
+        <p>This is a data property with a value of 1. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-generatorfunction.prototype">
+        <h1>GeneratorFunction.prototype</h1>
+        <p>The initial value of `GeneratorFunction.prototype` is the GeneratorFunction prototype object.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-the-generatorfunction-prototype-object">
+      <h1>Properties of the GeneratorFunction Prototype Object</h1>
+      <p>The <dfn>GeneratorFunction prototype object</dfn>:</p>
+      <ul>
+        <li>is <dfn>%GeneratorFunction.prototype%</dfn> (see <emu-xref href="#figure-2"></emu-xref>).</li>
+        <li>is an ordinary object.</li>
+        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref> or <emu-xref href="#table-internal-slots-of-generator-instances"></emu-xref>.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      </ul>
+
+      <emu-clause id="sec-generatorfunction.prototype.constructor">
+        <h1>GeneratorFunction.prototype.constructor</h1>
+        <p>The initial value of `GeneratorFunction.prototype.constructor` is %GeneratorFunction%.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-generatorfunction.prototype.prototype">
+        <h1>GeneratorFunction.prototype.prototype</h1>
+        <p>The initial value of `GeneratorFunction.prototype.prototype` is the Generator prototype object.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-generatorfunction.prototype-@@tostringtag">
+        <h1>GeneratorFunction.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value *"GeneratorFunction"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-generatorfunction-instances">
+      <h1>GeneratorFunction Instances</h1>
+      <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
+      <p>Each GeneratorFunction instance has the following own properties:</p>
+
+      <emu-clause id="sec-generatorfunction-instances-length">
+        <h1>length</h1>
+        <p>The specification for the *"length"* property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to GeneratorFunction instances.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-generatorfunction-instances-name">
+        <h1>name</h1>
+        <p>The specification for the *"name"* property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to GeneratorFunction instances.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-generatorfunction-instances-prototype">
+        <h1>prototype</h1>
+        <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
+        <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <emu-note>
+          <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's *"prototype"* property does not have a *"constructor"* property whose value is the GeneratorFunction instance.</p>
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-asyncgeneratorfunction-objects">
+    <h1>AsyncGeneratorFunction Objects</h1>
+    <p>AsyncGeneratorFunction objects are functions that are usually created by evaluating |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, and |AsyncGeneratorMethod| syntactic productions. They may also be created by calling the %AsyncGeneratorFunction% intrinsic.</p>
+
+    <emu-clause id="sec-asyncgeneratorfunction-constructor">
+      <h1>The AsyncGeneratorFunction Constructor</h1>
+      <p>The AsyncGeneratorFunction constructor:</p>
+      <ul>
+        <li>is <dfn>%AsyncGeneratorFunction%</dfn>.</li>
+        <li>is a subclass of `Function`.</li>
+        <li>creates and initializes a new AsyncGeneratorFunction object when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncGeneratorFunction behaviour must include a `super` call to the AsyncGeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of AsyncGeneratorFunction. There is no syntactic means to create instances of AsyncGeneratorFunction subclasses.</li>
+      </ul>
+
+      <emu-clause id="sec-asyncgeneratorfunction">
+        <h1>AsyncGeneratorFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
+        <p>The last argument specifies the body (executable code) of an async generator function; any preceding arguments specify formal parameters.</p>
+        <p>When the `AsyncGeneratorFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no "_p_" arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+        <emu-alg>
+          1. Let _C_ be the active function object.
+          1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~asyncGenerator~, _args_).
+        </emu-alg>
+        <emu-note>
+          <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-asyncgeneratorfunction">
+      <h1>Properties of the AsyncGeneratorFunction Constructor</h1>
+      <p>The AsyncGeneratorFunction constructor:</p>
+      <ul>
+        <li>is a standard built-in function object that inherits from the Function constructor.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
+        <li>has a *"name"* property whose value is *"AsyncGeneratorFunction"*.</li>
+        <li>has the following properties:</li>
+      </ul>
+
+      <emu-clause id="sec-asyncgeneratorfunction-length">
+        <h1>AsyncGeneratorFunction.length</h1>
+        <p>This is a data property with a value of 1. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-prototype">
+        <h1>AsyncGeneratorFunction.prototype</h1>
+        <p>The initial value of `AsyncGeneratorFunction.prototype` is the AsyncGeneratorFunction prototype object.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-asyncgeneratorfunction-prototype">
+      <h1>Properties of the AsyncGeneratorFunction Prototype Object</h1>
+      <p>The <dfn>AsyncGeneratorFunction prototype object</dfn>:</p>
+      <ul>
+        <li>is <dfn>%AsyncGeneratorFunction.prototype%</dfn>.</li>
+        <li>is an ordinary object.</li>
+        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      </ul>
+
+      <emu-clause id="sec-asyncgeneratorfunction-prototype-constructor">
+        <h1>AsyncGeneratorFunction.prototype.constructor</h1>
+        <p>The initial value of `AsyncGeneratorFunction.prototype.constructor` is %AsyncGeneratorFunction%.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-prototype-prototype">
+        <h1>AsyncGeneratorFunction.prototype.prototype</h1>
+        <p>The initial value of `AsyncGeneratorFunction.prototype.prototype` is the AsyncGenerator prototype object.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-prototype-tostringtag">
+        <h1>AsyncGeneratorFunction.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value *"AsyncGeneratorFunction"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgeneratorfunction-instances">
+      <h1>AsyncGeneratorFunction Instances</h1>
+      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
+      <p>Each AsyncGeneratorFunction instance has the following own properties:</p>
+
+      <emu-clause id="sec-asyncgeneratorfunction-instance-length">
+        <h1>length</h1>
+        <p>The value of the *"length"* property is an integral Number that indicates the typical number of arguments expected by the AsyncGeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of an AsyncGeneratorFunction when invoked on a number of arguments other than the number specified by its *"length"* property depends on the function.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-instance-name">
+        <h1>name</h1>
+        <p>The specification for the *"name"* property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncGeneratorFunction instances.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorfunction-instance-prototype">
+        <h1>prototype</h1>
+        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator object when the generator function object is invoked using [[Call]].</p>
+        <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <emu-note>
+          <p>Unlike function instances, the object that is the value of the an AsyncGeneratorFunction's *"prototype"* property does not have a *"constructor"* property whose value is the AsyncGeneratorFunction instance.</p>
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-generator-objects">
+    <h1>Generator Objects</h1>
+    <p>A Generator object is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
+    <p>Generator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %GeneratorFunction.prototype.prototype%.</p>
+
+    <emu-clause id="sec-properties-of-generator-prototype">
+      <h1>Properties of the Generator Prototype Object</h1>
+      <p>The <dfn>Generator prototype object</dfn>:</p>
+      <ul>
+        <li>is <dfn>%GeneratorFunction.prototype.prototype%</dfn>.</li>
+        <li>is an ordinary object.</li>
+        <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
+        <li>has properties that are indirectly inherited by all Generator instances.</li>
+      </ul>
+
+      <emu-clause id="sec-generator.prototype.constructor">
+        <h1>Generator.prototype.constructor</h1>
+        <p>The initial value of `Generator.prototype.constructor` is %GeneratorFunction.prototype%.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-generator.prototype.next">
+        <h1>Generator.prototype.next ( _value_ )</h1>
+        <p>The `next` method performs the following steps:</p>
+        <emu-alg>
+          1. Let _g_ be the *this* value.
+          1. Return ? GeneratorResume(_g_, _value_, ~empty~).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-generator.prototype.return">
+        <h1>Generator.prototype.return ( _value_ )</h1>
+        <p>The `return` method performs the following steps:</p>
+        <emu-alg>
+          1. Let _g_ be the *this* value.
+          1. Let _C_ be Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Return ? GeneratorResumeAbrupt(_g_, _C_, ~empty~).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-generator.prototype.throw">
+        <h1>Generator.prototype.throw ( _exception_ )</h1>
+        <p>The `throw` method performs the following steps:</p>
+        <emu-alg>
+          1. Let _g_ be the *this* value.
+          1. Let _C_ be ThrowCompletion(_exception_).
+          1. Return ? GeneratorResumeAbrupt(_g_, _C_, ~empty~).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-generator.prototype-@@tostringtag">
+        <h1>Generator.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value *"Generator"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-generator-instances">
+      <h1>Properties of Generator Instances</h1>
+      <p>Generator instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-generator-instances"></emu-xref>.</p>
+      <emu-table id="table-internal-slots-of-generator-instances" caption="Internal Slots of Generator Instances" oldids="table-56">
+        <table>
+          <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[GeneratorState]]
+            </td>
+            <td>
+              The current execution state of the generator. The possible values are: *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, and ~completed~.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[GeneratorContext]]
+            </td>
+            <td>
+              The execution context that is used when executing the code of this generator.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[GeneratorBrand]]
+            </td>
+            <td>
+              A brand used to distinguish different kinds of generators. The [[GeneratorBrand]] of generators declared by ECMAScript source text is always ~empty~.
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-abstract-operations">
+      <h1>Generator Abstract Operations</h1>
+
+      <emu-clause id="sec-generatorstart" aoid="GeneratorStart">
+        <h1>GeneratorStart ( _generator_, _generatorBody_ )</h1>
+        <p>The abstract operation GeneratorStart takes arguments _generator_ and _generatorBody_ (a Parse Node or an Abstract Closure with no parameters). It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
+          1. Let _genContext_ be the running execution context.
+          1. Set the Generator component of _genContext_ to _generator_.
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+            1. If _generatorBody_ is a Parse Node, then
+              1. Let _result_ be the result of evaluating _generatorBody_.
+            1. Else,
+              1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
+              1. Let _result_ be _generatorBody_().
+            1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
+            1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Set _generator_.[[GeneratorState]] to ~completed~.
+            1. Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
+            1. If _result_.[[Type]] is ~normal~, let _resultValue_ be *undefined*.
+            1. Else if _result_.[[Type]] is ~return~, let _resultValue_ be _result_.[[Value]].
+            1. Else,
+              1. Assert: _result_.[[Type]] is ~throw~.
+              1. Return Completion(_result_).
+            1. Return CreateIterResultObject(_resultValue_, *true*).
+          1. Set _generator_.[[GeneratorContext]] to _genContext_.
+          1. Set _generator_.[[GeneratorState]] to ~suspendedStart~.
+          1. Return NormalCompletion(*undefined*).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-generatorvalidate" aoid="GeneratorValidate">
+        <h1>GeneratorValidate ( _generator_, _generatorBrand_ )</h1>
+        <p>The abstract operation GeneratorValidate takes arguments _generator_ and _generatorBrand_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Perform ? RequireInternalSlot(_generator_, [[GeneratorState]]).
+          1. Perform ? RequireInternalSlot(_generator_, [[GeneratorBrand]]).
+          1. If _generator_.[[GeneratorBrand]] is not the same value as _generatorBrand_, throw a *TypeError* exception.
+          1. Assert: _generator_ also has a [[GeneratorContext]] internal slot.
+          1. Let _state_ be _generator_.[[GeneratorState]].
+          1. If _state_ is ~executing~, throw a *TypeError* exception.
+          1. Return _state_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-generatorresume" aoid="GeneratorResume">
+        <h1>GeneratorResume ( _generator_, _value_, _generatorBrand_ )</h1>
+        <p>The abstract operation GeneratorResume takes arguments _generator_, _value_, and _generatorBrand_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _state_ be ? GeneratorValidate(_generator_, _generatorBrand_).
+          1. If _state_ is ~completed~, return CreateIterResultObject(*undefined*, *true*).
+          1. Assert: _state_ is either ~suspendedStart~ or ~suspendedYield~.
+          1. Let _genContext_ be _generator_.[[GeneratorContext]].
+          1. Let _methodContext_ be the running execution context.
+          1. Suspend _methodContext_.
+          1. Set _generator_.[[GeneratorState]] to ~executing~.
+          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
+          1. Resume the suspended evaluation of _genContext_ using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
+          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
+          1. Return Completion(_result_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-generatorresumeabrupt" aoid="GeneratorResumeAbrupt">
+        <h1>GeneratorResumeAbrupt ( _generator_, _abruptCompletion_, _generatorBrand_ )</h1>
+        <p>The abstract operation GeneratorResumeAbrupt takes arguments _generator_, _abruptCompletion_ (a Completion Record whose [[Type]] is ~return~ or ~throw~), and _generatorBrand_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _state_ be ? GeneratorValidate(_generator_, _generatorBrand_).
+          1. If _state_ is ~suspendedStart~, then
+            1. Set _generator_.[[GeneratorState]] to ~completed~.
+            1. Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
+            1. Set _state_ to ~completed~.
+          1. If _state_ is ~completed~, then
+            1. If _abruptCompletion_.[[Type]] is ~return~, then
+              1. Return CreateIterResultObject(_abruptCompletion_.[[Value]], *true*).
+            1. Return Completion(_abruptCompletion_).
+          1. Assert: _state_ is ~suspendedYield~.
+          1. Let _genContext_ be _generator_.[[GeneratorContext]].
+          1. Let _methodContext_ be the running execution context.
+          1. Suspend _methodContext_.
+          1. Set _generator_.[[GeneratorState]] to ~executing~.
+          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
+          1. Resume the suspended evaluation of _genContext_ using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
+          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
+          1. Return Completion(_result_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-getgeneratorkind" aoid="GetGeneratorKind">
+        <h1>GetGeneratorKind ( )</h1>
+        <p>The abstract operation GetGeneratorKind takes no arguments. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _genContext_ be the running execution context.
+          1. If _genContext_ does not have a Generator component, return ~non-generator~.
+          1. Let _generator_ be the Generator component of _genContext_.
+          1. If _generator_ has an [[AsyncGeneratorState]] internal slot, return ~async~.
+          1. Else, return ~sync~.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-generatoryield" aoid="GeneratorYield">
+        <h1>GeneratorYield ( _iterNextObj_ )</h1>
+        <p>The abstract operation GeneratorYield takes argument _iterNextObj_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: _iterNextObj_ is an Object that implements the <i>IteratorResult</i> interface.
+          1. Let _genContext_ be the running execution context.
+          1. Assert: _genContext_ is the execution context of a generator.
+          1. Let _generator_ be the value of the Generator component of _genContext_.
+          1. Assert: GetGeneratorKind() is ~sync~.
+          1. Set _generator_.[[GeneratorState]] to ~suspendedYield~.
+          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
+            1. Return _resumptionValue_.
+            1. NOTE: This returns to the evaluation of the |YieldExpression| that originally called this abstract operation.
+          1. Return NormalCompletion(_iterNextObj_).
+          1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-yield" aoid="Yield">
+        <h1>Yield ( _value_ )</h1>
+        <p>The abstract operation Yield takes argument _value_ (an ECMAScript language value). It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _generatorKind_ be ! GetGeneratorKind().
+          1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(_value_).
+          1. Otherwise, return ? GeneratorYield(! CreateIterResultObject(_value_, *false*)).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-createiteratorfromclosure" aoid="CreateIteratorFromClosure">
+        <h1>CreateIteratorFromClosure ( _closure_, _generatorBrand_, _generatorPrototype_ )</h1>
+        <p>The abstract operation CreateIteratorFromClosure takes arguments _closure_ (an Abstract Closure with no parameters), _generatorBrand_, and _generatorPrototype_ (an Object). It performs the following steps when called:</p>
+        <emu-alg>
+          1. NOTE: _closure_ can contain uses of the Yield shorthand to yield an IteratorResult object.
+          1. Let _internalSlotsList_ be &laquo; [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] &raquo;.
+          1. Let _generator_ be ! OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
+          1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
+          1. Set _generator_.[[GeneratorState]] to *undefined*.
+          1. Perform ! GeneratorStart(_generator_, _closure_).
+          1. Return _generator_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-asyncgenerator-objects">
+    <h1>AsyncGenerator Objects</h1>
+    <p>An AsyncGenerator object is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
+
+    <p>AsyncGenerator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGeneratorFunction.prototype.prototype%.</p>
+
+    <emu-clause id="sec-properties-of-asyncgenerator-prototype">
+      <h1>Properties of the AsyncGenerator Prototype Object</h1>
+      <p>The <dfn>AsyncGenerator prototype object</dfn>:</p>
+      <ul>
+        <li>is <dfn>%AsyncGeneratorFunction.prototype.prototype%</dfn>.</li>
+        <li>is an ordinary object.</li>
+        <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is %AsyncIteratorPrototype%.</li>
+        <li>has properties that are indirectly inherited by all AsyncGenerator instances.</li>
+      </ul>
+
+      <emu-clause id="sec-asyncgenerator-prototype-constructor">
+        <h1>AsyncGenerator.prototype.constructor</h1>
+        <p>The initial value of `AsyncGenerator.prototype.constructor` is %AsyncGeneratorFunction.prototype%.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgenerator-prototype-next">
+        <h1>AsyncGenerator.prototype.next ( _value_ )</h1>
+        <emu-alg>
+          1. Let _generator_ be the *this* value.
+          1. Let _completion_ be NormalCompletion(_value_).
+          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_, ~empty~).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgenerator-prototype-return">
+        <h1>AsyncGenerator.prototype.return ( _value_ )</h1>
+        <emu-alg>
+          1. Let _generator_ be the *this* value.
+          1. Let _completion_ be Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_, ~empty~).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgenerator-prototype-throw">
+        <h1>AsyncGenerator.prototype.throw ( _exception_ )</h1>
+        <emu-alg>
+          1. Let _generator_ be the *this* value.
+          1. Let _completion_ be ThrowCompletion(_exception_).
+          1. Return ! AsyncGeneratorEnqueue(_generator_, _completion_, ~empty~).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgenerator-prototype-tostringtag">
+        <h1>AsyncGenerator.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value *"AsyncGenerator"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-asyncgenerator-intances">
+      <h1>Properties of AsyncGenerator Instances</h1>
+      <p>AsyncGenerator instances are initially created with the internal slots described below:</p>
+      <emu-table id="table-internal-slots-of-asyncgenerator-instances" caption="Internal Slots of AsyncGenerator Instances">
+        <table>
+          <tbody>
+          <tr>
+            <th>Internal Slot</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>[[AsyncGeneratorState]]</td>
+            <td>The current execution state of the async generator. The possible values are: *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, ~awaiting-return~, and ~completed~.</td>
+          </tr>
+          <tr>
+            <td>[[AsyncGeneratorContext]]</td>
+            <td>The execution context that is used when executing the code of this async generator.</td>
+          </tr>
+          <tr>
+            <td>[[AsyncGeneratorQueue]]</td>
+            <td>A List of AsyncGeneratorRequest records which represent requests to resume the async generator.</td>
+          </tr>
+          <tr>
+            <td>[[GeneratorBrand]]</td>
+            <td>A brand used to distinguish different kinds of async generators. The [[GeneratorBrand]] of async generators declared by ECMAScript source text is always ~empty~.</td>
+          </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-abstract-operations">
+      <h1>AsyncGenerator Abstract Operations</h1>
+      <emu-clause id="sec-asyncgeneratorrequest-records">
+        <h1>AsyncGeneratorRequest Records</h1>
+        <p>The AsyncGeneratorRequest is a Record value used to store information about how an async generator should be resumed and contains capabilities for fulfilling or rejecting the corresponding promise.</p>
+        <p>They have the following fields:</p>
+        <emu-table caption="AsyncGeneratorRequest Record Fields">
+          <table>
+            <tbody>
+            <tr>
+              <th>Field Name</th>
+              <th>Value</th>
+              <th>Meaning</th>
+            </tr>
+            <tr>
+              <td>[[Completion]]</td>
+              <td>A Completion record</td>
+              <td>The completion which should be used to resume the async generator.</td>
+            </tr>
+            <tr>
+              <td>[[Capability]]</td>
+              <td>A PromiseCapability Record</td>
+              <td>The promise capabilities associated with this request.</td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorstart" aoid="AsyncGeneratorStart">
+        <h1>AsyncGeneratorStart ( _generator_, _generatorBody_ )</h1>
+        <p>The abstract operation AsyncGeneratorStart takes arguments _generator_ and _generatorBody_ (a Parse Node or an Abstract Closure with no parameters). It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: _generator_ is an AsyncGenerator instance.
+          1. Assert: _generator_.[[AsyncGeneratorState]] is *undefined*.
+          1. Let _genContext_ be the running execution context.
+          1. Set the Generator component of _genContext_ to _generator_.
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+            1. If _generatorBody_ is a Parse Node, then
+              1. Let _result_ be the result of evaluating _generatorBody_.
+            1. Else,
+              1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
+              1. Let _result_ be _generatorBody_().
+            1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
+            1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
+            1. If _result_ is a normal completion, let _resultValue_ be *undefined*.
+            1. Else,
+              1. Let _resultValue_ be _result_.[[Value]].
+              1. If _result_.[[Type]] is not ~return~, then
+                1. Return ! AsyncGeneratorReject(_generator_, _resultValue_).
+            1. Return ! AsyncGeneratorResolve(_generator_, _resultValue_, *true*).
+          1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
+          1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedStart~.
+          1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
+          1. Return *undefined*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorvalidate" aoid="AsyncGeneratorValidate">
+        <h1>AsyncGeneratorValidate ( _generator_, _generatorBrand_ )</h1>
+        <p>The abstract operation AsyncGeneratorValidate takes arguments _generator_ and _generatorBrand_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorContext]]).
+          1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorState]]).
+          1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorQueue]]).
+          1. If _generator_.[[GeneratorBrand]] is not the same value as _generatorBrand_, throw a *TypeError* exception.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorresolve" aoid="AsyncGeneratorResolve">
+        <h1>AsyncGeneratorResolve ( _generator_, _value_, _done_ )</h1>
+        <p>The abstract operation AsyncGeneratorResolve takes arguments _generator_, _value_, and _done_ (a Boolean). It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: _generator_ is an AsyncGenerator instance.
+          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
+          1. Assert: _queue_ is not an empty List.
+          1. Let _next_ be the first element of _queue_.
+          1. Remove the first element from _queue_.
+          1. Let _promiseCapability_ be _next_.[[Capability]].
+          1. Let _iteratorResult_ be ! CreateIterResultObject(_value_, _done_).
+          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iteratorResult_ &raquo;).
+          1. Perform ! AsyncGeneratorResumeNext(_generator_).
+          1. Return *undefined*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorreject" aoid="AsyncGeneratorReject">
+        <h1>AsyncGeneratorReject ( _generator_, _exception_ )</h1>
+        <p>The abstract operation AsyncGeneratorReject takes arguments _generator_ and _exception_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: _generator_ is an AsyncGenerator instance.
+          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
+          1. Assert: _queue_ is not an empty List.
+          1. Let _next_ be the first element of _queue_.
+          1. Remove the first element from _queue_.
+          1. Let _promiseCapability_ be _next_.[[Capability]].
+          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _exception_ &raquo;).
+          1. Perform ! AsyncGeneratorResumeNext(_generator_).
+          1. Return *undefined*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorresumenext" aoid="AsyncGeneratorResumeNext">
+        <h1>AsyncGeneratorResumeNext ( _generator_ )</h1>
+        <p>The abstract operation AsyncGeneratorResumeNext takes argument _generator_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: _generator_ is an AsyncGenerator instance.
+          1. Let _state_ be _generator_.[[AsyncGeneratorState]].
+          1. Assert: _state_ is not ~executing~.
+          1. If _state_ is ~awaiting-return~, return *undefined*.
+          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
+          1. If _queue_ is an empty List, return *undefined*.
+          1. Let _next_ be the value of the first element of _queue_.
+          1. Assert: _next_ is an AsyncGeneratorRequest record.
+          1. Let _completion_ be _next_.[[Completion]].
+          1. If _completion_ is an abrupt completion, then
+            1. If _state_ is ~suspendedStart~, then
+              1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
+              1. Set _state_ to ~completed~.
+            1. If _state_ is ~completed~, then
+              1. If _completion_.[[Type]] is ~return~, then
+                1. Set _generator_.[[AsyncGeneratorState]] to ~awaiting-return~.
+                1. Let _promise_ be ? PromiseResolve(%Promise%, _completion_.[[Value]]).
+                1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
+                1. Let _onFulfilled_ be ! CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Generator]] &raquo;).
+                1. Set _onFulfilled_.[[Generator]] to _generator_.
+                1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
+                1. Let _onRejected_ be ! CreateBuiltinFunction(_stepsRejected_, &laquo; [[Generator]] &raquo;).
+                1. Set _onRejected_.[[Generator]] to _generator_.
+                1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
+                1. Return *undefined*.
+              1. Else,
+                1. Assert: _completion_.[[Type]] is ~throw~.
+                1. Perform ! AsyncGeneratorReject(_generator_, _completion_.[[Value]]).
+                1. Return *undefined*.
+          1. Else if _state_ is ~completed~, return ! AsyncGeneratorResolve(_generator_, *undefined*, *true*).
+          1. Assert: _state_ is either ~suspendedStart~ or ~suspendedYield~.
+          1. Let _genContext_ be _generator_.[[AsyncGeneratorContext]].
+          1. Let _callerContext_ be the running execution context.
+          1. Suspend _callerContext_.
+          1. Set _generator_.[[AsyncGeneratorState]] to ~executing~.
+          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
+          1. Resume the suspended evaluation of _genContext_ using _completion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
+          1. Assert: _result_ is never an abrupt completion.
+          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _callerContext_ is the currently running execution context.
+          1. Return *undefined*.
+        </emu-alg>
+
+        <emu-clause id="async-generator-resume-next-return-processor-fulfilled">
+          <h1>AsyncGeneratorResumeNext Return Processor Fulfilled Functions</h1>
+          <p>An AsyncGeneratorResumeNext return processor fulfilled function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor fulfilled function has a [[Generator]] internal slot.</p>
+          <p>When an AsyncGeneratorResumeNext return processor fulfilled function is called with argument _value_, the following steps are taken:</p>
+
+          <emu-alg>
+            1. Let _F_ be the active function object.
+            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to ~completed~.
+            1. Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
+          </emu-alg>
+
+          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor fulfilled function is *1*<sub>𝔽</sub>.</p>
+        </emu-clause>
+
+        <emu-clause id="async-generator-resume-next-return-processor-rejected">
+          <h1>AsyncGeneratorResumeNext Return Processor Rejected Functions</h1>
+          <p>An AsyncGeneratorResumeNext return processor rejected function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor rejected function has a [[Generator]] internal slot.</p>
+          <p>When an AsyncGeneratorResumeNext return processor rejected function is called with argument _reason_, the following steps are taken:</p>
+
+          <emu-alg>
+            1. Let _F_ be the active function object.
+            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to ~completed~.
+            1. Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
+          </emu-alg>
+
+          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor rejected function is *1*<sub>𝔽</sub>.</p>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratorenqueue" aoid="AsyncGeneratorEnqueue">
+        <h1>AsyncGeneratorEnqueue ( _generator_, _completion_, _generatorBrand_ )</h1>
+        <p>The abstract operation AsyncGeneratorEnqueue takes arguments _generator_, _completion_ (a Completion Record), and _generatorBrand_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. Let _check_ be AsyncGeneratorValidate(_generator_, _generatorBrand_).
+          1. If _check_ is an abrupt completion, then
+            1. Let _badGeneratorError_ be a newly created *TypeError* object.
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _badGeneratorError_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
+          1. Let _request_ be AsyncGeneratorRequest { [[Completion]]: _completion_, [[Capability]]: _promiseCapability_ }.
+          1. Append _request_ to the end of _queue_.
+          1. Let _state_ be _generator_.[[AsyncGeneratorState]].
+          1. If _state_ is not ~executing~, then
+            1. Perform ! AsyncGeneratorResumeNext(_generator_).
+          1. Return _promiseCapability_.[[Promise]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncgeneratoryield" aoid="AsyncGeneratorYield">
+        <h1>AsyncGeneratorYield ( _value_ )</h1>
+        <p>The abstract operation AsyncGeneratorYield takes argument _value_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _genContext_ be the running execution context.
+          1. Assert: _genContext_ is the execution context of a generator.
+          1. Let _generator_ be the value of the Generator component of _genContext_.
+          1. Assert: GetGeneratorKind() is ~async~.
+          1. Set _value_ to ? Await(_value_).
+          1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedYield~.
+          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
+            1. If _resumptionValue_.[[Type]] is not ~return~, return Completion(_resumptionValue_).
+            1. Let _awaited_ be Await(_resumptionValue_.[[Value]]).
+            1. If _awaited_.[[Type]] is ~throw~, return Completion(_awaited_).
+            1. Assert: _awaited_.[[Type]] is ~normal~.
+            1. Return Completion { [[Type]]: ~return~, [[Value]]: _awaited_.[[Value]], [[Target]]: ~empty~ }.
+            1. NOTE: When one of the above steps returns, it returns to the evaluation of the |YieldExpression| production that originally called this abstract operation.
+          1. Return ! AsyncGeneratorResolve(_generator_, _value_, *false*).
+          1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-createasynciteratorfromclosure" aoid="CreateAsyncIteratorFromClosure">
+        <h1>CreateAsyncIteratorFromClosure ( _closure_, _generatorBrand_, _generatorPrototype_ )</h1>
+        <p>The abstract operation CreateAsyncIteratorFromClosure takes arguments _closure_ (an Abstract Closure with no parameters), _generatorBrand_, and _generatorPrototype_ (an Object). It performs the following steps when called:</p>
+        <emu-alg>
+          1. NOTE: _closure_ can contain uses of the Await shorthand and uses of the Yield shorthand to yield an IteratorResult object.
+          1. Let _internalSlotsList_ be &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] &raquo;.
+          1. Let _generator_ be ! OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
+          1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
+          1. Set _generator_.[[AsyncGeneratorState]] to *undefined*.
+          1. Perform ! AsyncGeneratorStart(_generator_, _closure_).
+          1. Return _generator_.
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
Move Section 25.6 Promise Objects up to become Section 25.2, below
Section 25.1 Iteration and Section 25.3 GeneratorFunction Objects,
thus also moving Sections 25.5 AsyncGenerator Objects and 25.7
AsyncFunction Objects together.

Fixes: https://github.com/tc39/ecma262/issues/1170