### PR TITLE
Editorial: remove useless es6num comments

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -88,13 +88,11 @@
   </p>
 </emu-intro>
 
-<!-- es6num="1" -->
 <emu-clause id="sec-scope">
   <h1>Scope</h1>
   <p>This Standard defines the ECMAScript 2019 general-purpose programming language.</p>
 </emu-clause>
 
-<!-- es6num="2" -->
 <emu-clause id="sec-conformance">
   <h1>Conformance</h1>
   <p>A conforming implementation of ECMAScript must provide and support all the types, values, objects, properties, functions, and program syntax and semantics described in this specification.</p>
@@ -105,7 +103,6 @@
   <p>A conforming implementation of ECMAScript must not implement any extension that is listed as a Forbidden Extension in subclause <emu-xref href="#sec-forbidden-extensions"></emu-xref>.</p>
 </emu-clause>
 
-<!-- es6num="3" -->
 <emu-clause id="sec-normative-references">
   <h1>Normative References</h1>
   <p>The following referenced documents are indispensable for the application of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
@@ -118,7 +115,6 @@
     <a href="https://ecma-international.org/publications/standards/Ecma-404.htm">https://ecma-international.org/publications/standards/Ecma-404.htm</a></p>
 </emu-clause>
 
-<!-- es6num="4" -->
 <emu-clause id="sec-overview">
   <h1>Overview</h1>
   <p>This section contains a non-normative overview of the ECMAScript language.</p>
@@ -132,7 +128,6 @@
   <p>Ungar, David, and Smith, Randall B. Self: The Power of Simplicity. <i>OOPSLA '87 Conference Proceedings</i>, pp. 227-241, Orlando, FL, October 1987.</p>
   <p><i>IEEE Standard for the Scheme Programming Language</i>. IEEE Std 1178-1990.</p>
 
-  <!-- es6num="4.1" -->
   <emu-clause id="sec-web-scripting">
     <h1>Web Scripting</h1>
     <p>A web browser provides an ECMAScript host environment for client-side computation including, for instance, objects that represent windows, menus, pop-ups, dialog boxes, text areas, anchors, frames, history, cookies, and input/output. Further, the host environment provides a means to attach scripting code to events such as change of focus, page and image loading, unloading, error and abort, selection, form submission, and mouse actions. Scripting code appears within the HTML and the displayed page is a combination of user interface elements and fixed and computed text and images. The scripting code is reactive to user interaction, and there is no need for a main program.</p>
@@ -140,7 +135,6 @@
     <p>Each Web browser and server that supports ECMAScript supplies its own host environment, completing the ECMAScript execution environment.</p>
   </emu-clause>
 
-  <!-- es6num="4.2" -->
   <emu-clause id="sec-ecmascript-overview">
     <h1>ECMAScript Overview</h1>
     <p>The following is an informal overview of ECMAScript&mdash;not all parts of the language are described. This overview is not part of the standard proper.</p>
@@ -150,7 +144,6 @@
     <p>Large ECMAScript programs are supported by <em>modules</em> which allow a program to be divided into multiple sequences of statements and declarations. Each module explicitly identifies declarations it uses that need to be provided by other modules and which of its declarations are available for use by other modules.</p>
     <p>ECMAScript syntax intentionally resembles Java syntax. ECMAScript syntax is relaxed to enable it to serve as an easy-to-use scripting language. For example, a variable is not required to have its type declared nor are types associated with properties, and defined functions are not required to have their declarations appear textually before calls to them.</p>
 
-    <!-- es6num="4.2.1" -->
     <emu-clause id="sec-objects">
       <h1>Objects</h1>
       <p>Even though ECMAScript includes syntax for class definitions, ECMAScript objects are not fundamentally class-based such as those in C++, Smalltalk, or Java. Instead objects may be created in various ways including via a literal notation or via <em>constructors</em> which create objects and then execute code that initializes all or part of them by assigning initial values to their properties. Each constructor is a function that has a property named `"prototype"` that is used to implement <em>prototype-based inheritance</em> and <em>shared properties</em>. Objects are created by using constructors in <b>new</b> expressions; for example, `new Date(2009, 11)` creates a new Date object. Invoking a constructor without using <b>new</b> has consequences that depend on the constructor. For example, `Date()` produces a string representation of the current date and time rather than an object.</p>
@@ -165,7 +158,6 @@
       <p>Although ECMAScript objects are not inherently class-based, it is often convenient to define class-like abstractions based upon a common pattern of constructor functions, prototype objects, and methods. The ECMAScript built-in objects themselves follow such a class-like pattern. Beginning with ECMAScript 2015, the ECMAScript language includes syntactic class definitions that permit programmers to concisely define objects that conform to the same class-like abstraction pattern used by the built-in objects.</p>
     </emu-clause>
 
-    <!-- es6num="4.2.2" -->
     <emu-clause id="sec-strict-variant-of-ecmascript">
       <h1>The Strict Variant of ECMAScript</h1>
       <p>The ECMAScript Language recognizes the possibility that some users of the language may wish to restrict their usage of some features available in the language. They might do so in the interests of security, to avoid what they consider to be error-prone features, to get enhanced error checking, or for other reasons of their choosing. In support of this possibility, ECMAScript defines a strict variant of the language. The strict variant of the language excludes some specific syntactic and semantic features of the regular ECMAScript language and modifies the detailed semantics of some features. The strict variant also specifies additional error conditions that must be reported by throwing error exceptions in situations that are not specified as errors by the non-strict form of the language.</p>
@@ -174,18 +166,15 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="4.3" -->
   <emu-clause id="sec-terms-and-definitions">
     <h1>Terms and Definitions</h1>
     <p>For the purposes of this document, the following terms and definitions apply.</p>
 
-    <!-- es6num="4.3.1" -->
     <emu-clause id="sec-type">
       <h1>type</h1>
       <p>set of data values as defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> of this specification</p>
     </emu-clause>
 
-    <!-- es6num="4.3.2" -->
     <emu-clause id="sec-primitive-value">
       <h1>primitive value</h1>
       <p>member of one of the types Undefined, Null, Boolean, Number, Symbol, or String as defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref></p>
@@ -194,7 +183,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.3" -->
     <emu-clause id="sec-terms-and-definitions-object">
       <h1>object</h1>
       <p>member of the type Object</p>
@@ -203,7 +191,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.4" -->
     <emu-clause id="sec-constructor">
       <h1>constructor</h1>
       <p>function object that creates and initializes objects</p>
@@ -212,7 +199,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.5" -->
     <emu-clause id="sec-terms-and-definitions-prototype">
       <h1>prototype</h1>
       <p>object that provides shared properties for other objects</p>
@@ -221,13 +207,11 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.6" -->
     <emu-clause id="sec-ordinary-object">
       <h1>ordinary object</h1>
       <p>object that has the default behaviour for the essential internal methods that must be supported by all objects</p>
     </emu-clause>
 
-    <!-- es6num="4.3.7" -->
     <emu-clause id="sec-exotic-object">
       <h1>exotic object</h1>
       <p>object that does not have the default behaviour for one or more of the essential internal methods</p>
@@ -236,13 +220,11 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.8" -->
     <emu-clause id="sec-standard-object">
       <h1>standard object</h1>
       <p>object whose semantics are defined by this specification</p>
     </emu-clause>
 
-    <!-- es6num="4.3.9" -->
     <emu-clause id="sec-built-in-object">
       <h1>built-in object</h1>
       <p>object specified and supplied by an ECMAScript implementation</p>
@@ -251,31 +233,26 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.10" -->
     <emu-clause id="sec-undefined-value">
       <h1>undefined value</h1>
       <p>primitive value used when a variable has not been assigned a value</p>
     </emu-clause>
 
-    <!-- es6num="4.3.11" -->
     <emu-clause id="sec-terms-and-definitions-undefined-type">
       <h1>Undefined type</h1>
       <p>type whose sole value is the *undefined* value</p>
     </emu-clause>
 
-    <!-- es6num="4.3.12" -->
     <emu-clause id="sec-null-value">
       <h1>null value</h1>
       <p>primitive value that represents the intentional absence of any object value</p>
     </emu-clause>
 
-    <!-- es6num="4.3.13" -->
     <emu-clause id="sec-terms-and-definitions-null-type">
       <h1>Null type</h1>
       <p>type whose sole value is the *null* value</p>
     </emu-clause>
 
-    <!-- es6num="4.3.14" -->
     <emu-clause id="sec-terms-and-definitions-boolean-value">
       <h1>Boolean value</h1>
       <p>member of the Boolean type</p>
@@ -284,13 +261,11 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.15" -->
     <emu-clause id="sec-terms-and-definitions-boolean-type">
       <h1>Boolean type</h1>
       <p>type consisting of the primitive values *true* and *false*</p>
     </emu-clause>
 
-    <!-- es6num="4.3.16" -->
     <emu-clause id="sec-boolean-object">
       <h1>Boolean object</h1>
       <p>member of the Object type that is an instance of the standard built-in `Boolean` constructor</p>
@@ -299,7 +274,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.17" -->
     <emu-clause id="sec-terms-and-definitions-string-value">
       <h1>String value</h1>
       <p>primitive value that is a finite ordered sequence of zero or more 16-bit unsigned integer values</p>
@@ -308,13 +282,11 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.18" -->
     <emu-clause id="sec-terms-and-definitions-string-type">
       <h1>String type</h1>
       <p>set of all possible String values</p>
     </emu-clause>
 
-    <!-- es6num="4.3.19" -->
     <emu-clause id="sec-string-object">
       <h1>String object</h1>
       <p>member of the Object type that is an instance of the standard built-in `String` constructor</p>
@@ -323,7 +295,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.20" -->
     <emu-clause id="sec-terms-and-definitions-number-value">
       <h1>Number value</h1>
       <p>primitive value corresponding to a double-precision 64-bit binary format IEEE 754-2008 value</p>
@@ -332,13 +303,11 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.21" -->
     <emu-clause id="sec-terms-and-definitions-number-type">
       <h1>Number type</h1>
       <p>set of all possible Number values including the special &ldquo;Not-a-Number&rdquo; (NaN) value, positive infinity, and negative infinity</p>
     </emu-clause>
 
-    <!-- es6num="4.3.22" -->
     <emu-clause id="sec-number-object">
       <h1>Number object</h1>
       <p>member of the Object type that is an instance of the standard built-in `Number` constructor</p>
@@ -347,37 +316,31 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.23" -->
     <emu-clause id="sec-terms-and-definitions-infinity">
       <h1>Infinity</h1>
       <p>number value that is the positive infinite number value</p>
     </emu-clause>
 
-    <!-- es6num="4.3.24" -->
     <emu-clause id="sec-terms-and-definitions-nan">
       <h1>NaN</h1>
       <p>number value that is an IEEE 754-2008 &ldquo;Not-a-Number&rdquo; value</p>
     </emu-clause>
 
-    <!-- es6num="4.3.25" -->
     <emu-clause id="sec-symbol-value">
       <h1>Symbol value</h1>
       <p>primitive value that represents a unique, non-String Object property key</p>
     </emu-clause>
 
-    <!-- es6num="4.3.26" -->
     <emu-clause id="sec-terms-and-definitions-symbol-type">
       <h1>Symbol type</h1>
       <p>set of all possible Symbol values</p>
     </emu-clause>
 
-    <!-- es6num="4.3.27" -->
     <emu-clause id="sec-symbol-object">
       <h1>Symbol object</h1>
       <p>member of the Object type that is an instance of the standard built-in `Symbol` constructor</p>
     </emu-clause>
 
-    <!-- es6num="4.3.28" -->
     <emu-clause id="sec-terms-and-definitions-function">
       <h1>function</h1>
       <p>member of the Object type that may be invoked as a subroutine</p>
@@ -386,7 +349,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.29" -->
     <emu-clause id="sec-built-in-function">
       <h1>built-in function</h1>
       <p>built-in object that is a function</p>
@@ -395,7 +357,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.30" -->
     <emu-clause id="sec-property">
       <h1>property</h1>
       <p>part of an object that associates a key (either a String value or a Symbol value) and a value</p>
@@ -404,7 +365,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.31" -->
     <emu-clause id="sec-method">
       <h1>method</h1>
       <p>function that is the value of a property</p>
@@ -413,7 +373,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.32" -->
     <emu-clause id="sec-built-in-method">
       <h1>built-in method</h1>
       <p>method that is a built-in function</p>
@@ -422,26 +381,22 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="4.3.33" -->
     <emu-clause id="sec-attribute">
       <h1>attribute</h1>
       <p>internal value that defines some characteristic of a property</p>
     </emu-clause>
 
-    <!-- es6num="4.3.34" -->
     <emu-clause id="sec-own-property">
       <h1>own property</h1>
       <p>property that is directly contained by its object</p>
     </emu-clause>
 
-    <!-- es6num="4.3.35" -->
     <emu-clause id="sec-inherited-property">
       <h1>inherited property</h1>
       <p>property of an object that is not an own property but is a property (either own or inherited) of the object's prototype</p>
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="4.4" -->
   <emu-clause id="sec-organization-of-this-specification">
     <h1>Organization of This Specification</h1>
     <p>The remainder of this specification is organized as follows:</p>
@@ -453,15 +408,12 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="5" -->
 <emu-clause id="sec-notational-conventions">
   <h1>Notational Conventions</h1>
 
-  <!-- es6num="5.1" -->
   <emu-clause id="sec-syntactic-and-lexical-grammars">
     <h1>Syntactic and Lexical Grammars</h1>
 
-    <!-- es6num="5.1.1" -->
     <emu-clause id="sec-context-free-grammars">
       <h1>Context-Free Grammars</h1>
       <p>A <em>context-free grammar</em> consists of a number of <em>productions</em>. Each production has an abstract symbol called a <em>nonterminal</em> as its <em>left-hand side</em>, and a sequence of zero or more nonterminal and <em>terminal</em> symbols as its <em>right-hand side</em>. For each grammar, the terminal symbols are drawn from a specified alphabet.</p>
@@ -469,7 +421,6 @@
       <p>Starting from a sentence consisting of a single distinguished nonterminal, called the <dfn>goal symbol</dfn>, a given context-free grammar specifies a <em>language</em>, namely, the (perhaps infinite) set of possible sequences of terminal symbols that can result from repeatedly replacing any nonterminal in the sequence with a right-hand side of a production for which the nonterminal is the left-hand side.</p>
     </emu-clause>
 
-    <!-- es6num="5.1.2" -->
     <emu-clause id="sec-lexical-and-regexp-grammars">
       <h1>The Lexical and RegExp Grammars</h1>
       <p>A <em>lexical grammar</em> for ECMAScript is given in clause <emu-xref href="#sec-ecmascript-language-lexical-grammar"></emu-xref>. This grammar has as its terminal symbols Unicode code points that conform to the rules for |SourceCharacter| defined in <emu-xref href="#sec-source-text"></emu-xref>. It defines a set of productions, starting from the goal symbol |InputElementDiv|, |InputElementTemplateTail|, or |InputElementRegExp|, or |InputElementRegExpOrTemplateTail|, that describe how sequences of such code points are translated into a sequence of input elements.</p>
@@ -478,14 +429,12 @@
       <p>Productions of the lexical and RegExp grammars are distinguished by having two colons &ldquo;<b>::</b>&rdquo; as separating punctuation. The lexical and RegExp grammars share some productions.</p>
     </emu-clause>
 
-    <!-- es6num="5.1.3" -->
     <emu-clause id="sec-numeric-string-grammar">
       <h1>The Numeric String Grammar</h1>
       <p>Another grammar is used for translating Strings into numeric values. This grammar is similar to the part of the lexical grammar having to do with numeric literals and has as its terminal symbols |SourceCharacter|. This grammar appears in <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>.</p>
       <p>Productions of the numeric string grammar are distinguished by having three colons &ldquo;<b>:::</b>&rdquo; as punctuation.</p>
     </emu-clause>
 
-    <!-- es6num="5.1.4" -->
     <emu-clause id="sec-syntactic-grammar">
       <h1>The Syntactic Grammar</h1>
       <p>The <em>syntactic grammar</em> for ECMAScript is given in clauses 11, 12, 13, 14, and 15. This grammar has ECMAScript tokens defined by the lexical grammar as its terminal symbols (<emu-xref href="#sec-lexical-and-regexp-grammars"></emu-xref>). It defines a set of productions, starting from two alternative goal symbols |Script| and |Module|, that describe how sequences of tokens form syntactically correct independent components of ECMAScript programs.</p>
@@ -502,7 +451,6 @@
       <p>In certain cases, in order to avoid ambiguities, the syntactic grammar uses generalized productions that permit token sequences that do not form a valid ECMAScript |Script| or |Module|. For example, this technique is used for object literals and object destructuring patterns. In such cases a more restrictive <em>supplemental grammar</em> is provided that further restricts the acceptable token sequences. Typically, an early error rule will then define an error condition if "_P_ is not <dfn>covering</dfn> an _N_", where _P_ is a Parse Node (an instance of the generalized production) and _N_ is a nonterminal from the supplemental grammar. Here, the sequence of tokens originally matched by _P_ is parsed again using _N_ as the goal symbol. (If _N_ takes grammatical parameters, then they are set to the same values used when _P_ was originally parsed.) An error occurs if the sequence of tokens cannot be parsed as a single instance of _N_, with no tokens left over. Subsequently, algorithms access the result of the parse using a phrase of the form "the _N_ that is <dfn>covered</dfn> by _P_". This will always be a Parse Node (an instance of _N_, unique for a given _P_), since any parsing failure would have been detected by an early error rule.</p>
     </emu-clause>
 
-    <!-- es6num="5.1.5" -->
     <emu-clause id="sec-grammar-notation" namespace=grammar-notation>
       <h1>Grammar Notation</h1>
       <p>Terminal symbols of the lexical, RegExp, and numeric string grammars are shown in `fixed width` font, both in the productions of the grammars and throughout this specification whenever the text directly refers to such a terminal symbol. These are to appear in a script exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin range, as opposed to any similar-looking code points from other Unicode ranges.</p>
@@ -727,7 +675,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="5.2" -->
   <emu-clause id="sec-algorithm-conventions">
     <h1>Algorithm Conventions</h1>
     <p>The specification often uses a numbered list to specify steps in an algorithm. These algorithms are used to precisely specify the required semantics of ECMAScript language constructs. The algorithms are not intended to imply the use of any specific implementation technique. In practice, there may be more efficient algorithms available to implement a given feature.</p>
@@ -777,7 +724,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="6.2.2.2" -->
     <emu-clause id="sec-runtime-semantics">
       <h1>Runtime Semantics</h1>
       <p>Algorithms which specify semantics that must be called at runtime are called <dfn>runtime semantics</dfn>. Runtime semantics are defined by abstract operations or syntax-directed operations. Such algorithms always return a completion record.</p>
@@ -804,7 +750,6 @@
         <p>Any reference to a Completion Record value that is in a context that does not explicitly require a complete Completion Record value is equivalent to an explicit reference to the [[Value]] field of the Completion Record value unless the Completion Record is an abrupt completion.</p>
       </emu-clause>
 
-      <!-- es6num="6.2.2.3" -->
       <emu-clause id="sec-throw-an-exception">
         <h1>Throw an Exception</h1>
         <p>Algorithms steps that say to throw an exception, such as</p>
@@ -817,7 +762,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.2.4" -->
       <emu-clause id="sec-returnifabrupt" aoid="ReturnIfAbrupt">
         <h1>ReturnIfAbrupt</h1>
         <p>Algorithms steps that say or are otherwise equivalent to:</p>
@@ -885,7 +829,6 @@
         </emu-alg>
       </emu-clause>
     </emu-clause>
-    <!-- es6num="5.3" -->
     <emu-clause id="sec-static-semantic-rules">
       <h1>Static Semantics</h1>
       <p>Context-free grammars are not sufficiently powerful to express all the rules that define whether a stream of input elements form a valid ECMAScript |Script| or |Module| that may be evaluated. In some situations additional rules are needed that may be expressed using either ECMAScript algorithm conventions or prose requirements. Such rules are always associated with a production of a grammar and are called the <dfn>static semantics</dfn> of the production.</p>
@@ -916,36 +859,30 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="6" -->
 <emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
   <h1>ECMAScript Data Types and Values</h1>
   <p>Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further subclassified into ECMAScript language types and specification types.</p>
   <p>Within this specification, the notation &ldquo;Type(_x_)&rdquo; is used as shorthand for &ldquo;the <dfn id="type">type</dfn> of _x_&rdquo; where &ldquo;type&rdquo; refers to the ECMAScript language and specification types defined in this clause. When the term &ldquo;empty&rdquo; is used as if it was naming a value, it is equivalent to saying &ldquo;no value of any type&rdquo;.</p>
 
-  <!-- es6num="6.1" -->
   <emu-clause id="sec-ecmascript-language-types">
     <h1>ECMAScript Language Types</h1>
     <p>An <dfn>ECMAScript language type</dfn> corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, and Object. An <dfn>ECMAScript language value</dfn> is a value that is characterized by an ECMAScript language type.</p>
 
-    <!-- es6num="6.1.1" -->
     <emu-clause id="sec-ecmascript-language-types-undefined-type">
       <h1>The Undefined Type</h1>
       <p>The Undefined type has exactly one value, called *undefined*. Any variable that has not been assigned a value has the value *undefined*.</p>
     </emu-clause>
 
-    <!-- es6num="6.1.2" -->
     <emu-clause id="sec-ecmascript-language-types-null-type">
       <h1>The Null Type</h1>
       <p>The Null type has exactly one value, called *null*.</p>
     </emu-clause>
 
-    <!-- es6num="6.1.3" -->
     <emu-clause id="sec-ecmascript-language-types-boolean-type">
       <h1>The Boolean Type</h1>
       <p>The Boolean type represents a logical entity having two values, called *true* and *false*.</p>
     </emu-clause>
 
-    <!-- es6num="6.1.4" -->
     <emu-clause id="sec-ecmascript-language-types-string-type">
       <h1>The String Type</h1>
       <p>The String type is the set of all ordered sequences of zero or more 16-bit unsigned integer values (&ldquo;elements&rdquo;) up to a maximum length of 2<sup>53</sup>-1 elements. The String type is generally used to represent textual data in a running ECMAScript program, in which case each element in the String is treated as a UTF-16 code unit value. Each element is regarded as occupying a position within the sequence. These positions are indexed with nonnegative integers. The first element (if any) is at index 0, the next element (if any) at index 1, and so on. The length of a String is the number of elements (i.e., 16-bit values) within it. The empty String has length zero and therefore contains no elements.</p>
@@ -968,14 +905,12 @@
       <p>In this specification, the phrase "the <dfn>string-concatenation</dfn> of _A_, _B_, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
     </emu-clause>
 
-    <!-- es6num="6.1.5" -->
     <emu-clause id="sec-ecmascript-language-types-symbol-type">
       <h1>The Symbol Type</h1>
       <p>The Symbol type is the set of all non-String values that may be used as the key of an Object property (<emu-xref href="#sec-object-type"></emu-xref>).</p>
       <p>Each possible Symbol value is unique and immutable.</p>
       <p>Each Symbol value immutably holds an associated value called [[Description]] that is either *undefined* or a String value.</p>
 
-      <!-- es6num="6.1.5.1" -->
       <emu-clause id="sec-well-known-symbols">
         <h1>Well-Known Symbols</h1>
         <p>Well-known symbols are built-in Symbol values that are explicitly referenced by algorithms of this specification. They are typically used as the keys of properties whose values serve as extension points of a specification algorithm. Unless otherwise specified, well-known symbols values are shared by all realms (<emu-xref href="#sec-code-realms"></emu-xref>).</p>
@@ -1132,7 +1067,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="6.1.6" -->
     <emu-clause id="sec-ecmascript-language-types-number-type">
       <h1>The Number Type</h1>
       <p>The Number type has exactly 18437736874454810627 (that is, <emu-eqn>2<sup>64</sup>-2<sup>53</sup>+3</emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2008 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990 (that is, <emu-eqn>2<sup>53</sup>-2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
@@ -1159,7 +1093,6 @@
       <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup>-1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup>-1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="6.1.7" -->
     <emu-clause id="sec-object-type">
       <h1>The Object Type</h1>
       <p>An Object is logically a collection of properties. Each property is either a data property, or an accessor property:</p>
@@ -1176,7 +1109,6 @@
       <p>Property keys are used to access properties and their values. There are two kinds of access for properties: <em>get</em> and <em>set</em>, corresponding to value retrieval and assignment, respectively. The properties accessible via get and set access includes both <em>own properties</em> that are a direct part of an object and <em>inherited properties</em> which are provided by another associated object via a property inheritance relationship. Inherited properties may be either own or inherited properties of the associated object. Each own property of an object must each have a key value that is distinct from the key values of the other own properties of that object.</p>
       <p>All objects are logically collections of properties, but there are multiple forms of objects that differ in their semantics for accessing and manipulating their properties. <dfn id="ordinary-objects">Ordinary objects</dfn> are the most common form of objects and have the default object semantics. An <dfn id="exotic-object">exotic object</dfn> is any form of object whose property semantics differ in any way from the default semantics.</p>
 
-      <!-- es6num="6.1.7.1" -->
       <emu-clause id="sec-property-attributes">
         <h1>Property Attributes</h1>
         <p>Attributes are used in this specification to define and explain the state of Object properties. A data property associates a key value with the attributes listed in <emu-xref href="#table-2"></emu-xref>.</p>
@@ -1368,7 +1300,6 @@
         </emu-table>
       </emu-clause>
 
-      <!-- es6num="6.1.7.2" -->
       <emu-clause id="sec-object-internal-methods-and-internal-slots">
         <h1>Object Internal Methods and Internal Slots</h1>
         <p>The actual semantics of objects, in ECMAScript, are specified via algorithms called <em>internal methods</em>. Each object in an ECMAScript engine is associated with a set of internal methods that defines its runtime behaviour. These internal methods are not part of the ECMAScript language. They are defined by this specification purely for expository purposes. However, each object within an implementation of ECMAScript must behave as specified by the internal methods associated with it. The exact manner in which this is accomplished is determined by the implementation.</p>
@@ -1558,7 +1489,6 @@
         <p>The semantics of the essential internal methods for ordinary objects and standard exotic objects are specified in clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>. If any specified use of an internal method of an exotic object is not supported by an implementation, that usage must throw a *TypeError* exception when attempted.</p>
       </emu-clause>
 
-      <!-- es6num="6.1.7.3" -->
       <emu-clause id="sec-invariants-of-the-essential-internal-methods">
         <h1>Invariants of the Essential Internal Methods</h1>
         <p>The Internal Methods of Objects of an ECMAScript engine must conform to the list of invariants specified below. Ordinary ECMAScript Objects as well as all standard exotic objects in this specification maintain these invariants. ECMAScript Proxy objects maintain these invariants by means of runtime checks on the result of traps invoked on the [[ProxyHandler]] object.</p>
@@ -1727,7 +1657,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="6.1.7.4" -->
       <emu-clause id="sec-well-known-intrinsic-objects">
         <h1>Well-Known Intrinsic Objects</h1>
         <p>Well-known intrinsics are built-in objects that are explicitly referenced by the algorithms of this specification and which usually have realm-specific identities. Unless otherwise specified each intrinsic object actually corresponds to a set of similar objects, one per realm.</p>
@@ -2934,12 +2863,10 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="6.2" -->
   <emu-clause id="sec-ecmascript-specification-types">
     <h1>ECMAScript Specification Types</h1>
     <p>A specification type corresponds to meta-values that are used within algorithms to describe the semantics of ECMAScript language constructs and ECMAScript language types. The specification types include Reference, List, Completion, Property Descriptor, Lexical Environment, Environment Record, and Data Block. Specification type values are specification artefacts that do not necessarily correspond to any specific entity within an ECMAScript implementation. Specification type values may be used to describe intermediate results of ECMAScript expression evaluation but such values cannot be stored as properties of objects or values of ECMAScript language variables.</p>
 
-    <!-- es6num="6.2.1" -->
     <emu-clause id="sec-list-and-record-specification-type">
       <h1>The List and Record Specification Types</h1>
       <p>The <dfn>List</dfn> type is used to explain the evaluation of argument lists (see <emu-xref href="#sec-argument-lists"></emu-xref>) in `new` expressions, in function calls, and in other algorithms where a simple ordered list of values is needed. Values of the List type are simply ordered sequences of list elements containing the individual values. These sequences may be of any length. The elements of a list may be randomly accessed using 0-origin indices. For notational convenience an array-like syntax can be used to access List elements. For example, _arguments_[2] is shorthand for saying the 3<sup>rd</sup> element of the List _arguments_.</p>
@@ -2983,7 +2910,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="6.2.2" -->
     <emu-clause id="sec-completion-record-specification-type" aoid="Completion">
       <h1>The Completion Record Specification Type</h1>
       <p>The Completion type is a Record used to explain the runtime propagation of values and control flow such as the behaviour of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
@@ -3126,7 +3052,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="6.2.2.1" -->
       <emu-clause id="sec-normalcompletion" aoid="NormalCompletion">
         <h1>NormalCompletion</h1>
         <p>The abstract operation NormalCompletion with a single _argument_, such as:</p>
@@ -3151,7 +3076,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.2.5" -->
       <emu-clause id="sec-updateempty" aoid="UpdateEmpty">
         <h1>UpdateEmpty ( _completionRecord_, _value_ )</h1>
         <p>The abstract operation UpdateEmpty with arguments _completionRecord_ and _value_ performs the following steps:</p>
@@ -3163,7 +3087,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="6.2.3" -->
     <emu-clause id="sec-reference-specification-type">
       <h1>The Reference Specification Type</h1>
       <emu-note>
@@ -3229,7 +3152,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.3.1" -->
       <emu-clause id="sec-getvalue" aoid="GetValue">
         <h1>GetValue ( _V_ )</h1>
         <emu-alg>
@@ -3250,7 +3172,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="6.2.3.2" -->
       <emu-clause id="sec-putvalue" aoid="PutValue">
         <h1>PutValue ( _V_, _W_ )</h1>
         <emu-alg>
@@ -3278,7 +3199,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="6.2.3.3" -->
       <emu-clause id="sec-getthisvalue" aoid="GetThisValue">
         <h1>GetThisValue ( _V_ )</h1>
         <emu-alg>
@@ -3289,7 +3209,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.3.4" -->
       <emu-clause id="sec-initializereferencedbinding" aoid="InitializeReferencedBinding">
         <h1>InitializeReferencedBinding ( _V_, _W_ )</h1>
         <emu-alg>
@@ -3304,14 +3223,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="6.2.4" -->
     <emu-clause id="sec-property-descriptor-specification-type">
       <h1>The Property Descriptor Specification Type</h1>
       <p>The <dfn>Property Descriptor</dfn> type is used to explain the manipulation and reification of Object property attributes. Values of the Property Descriptor type are Records. Each field's name is an attribute name and its value is a corresponding attribute value as specified in <emu-xref href="#sec-property-attributes"></emu-xref>. In addition, any field may be present or absent. The schema name used within this specification to tag literal descriptions of Property Descriptor records is &ldquo;PropertyDescriptor&rdquo;.</p>
       <p>Property Descriptor values may be further classified as data Property Descriptors and accessor Property Descriptors based upon the existence or use of certain fields. A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]]. An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]]. Any Property Descriptor may have fields named [[Enumerable]] and [[Configurable]]. A Property Descriptor value may not be both a data Property Descriptor and an accessor Property Descriptor; however, it may be neither. A generic Property Descriptor is a Property Descriptor value that is neither a data Property Descriptor nor an accessor Property Descriptor. A fully populated Property Descriptor is one that is either an accessor Property Descriptor or a data Property Descriptor and that has all of the fields that correspond to the property attributes defined in either <emu-xref href="#table-2"></emu-xref> or <emu-xref href="#table-3"></emu-xref>.</p>
       <p>The following abstract operations are used in this specification to operate upon Property Descriptor values:</p>
 
-      <!-- es6num="6.2.4.1" -->
       <emu-clause id="sec-isaccessordescriptor" aoid="IsAccessorDescriptor">
         <h1>IsAccessorDescriptor ( _Desc_ )</h1>
         <p>When the abstract operation IsAccessorDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
@@ -3322,7 +3239,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.4.2" -->
       <emu-clause id="sec-isdatadescriptor" aoid="IsDataDescriptor">
         <h1>IsDataDescriptor ( _Desc_ )</h1>
         <p>When the abstract operation IsDataDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
@@ -3333,7 +3249,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.4.3" -->
       <emu-clause id="sec-isgenericdescriptor" aoid="IsGenericDescriptor">
         <h1>IsGenericDescriptor ( _Desc_ )</h1>
         <p>When the abstract operation IsGenericDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
@@ -3344,7 +3259,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.4.4" -->
       <emu-clause id="sec-frompropertydescriptor" aoid="FromPropertyDescriptor">
         <h1>FromPropertyDescriptor ( _Desc_ )</h1>
         <p>When the abstract operation FromPropertyDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
@@ -3369,7 +3283,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.4.5" -->
       <emu-clause id="sec-topropertydescriptor" aoid="ToPropertyDescriptor">
         <h1>ToPropertyDescriptor ( _Obj_ )</h1>
         <p>When the abstract operation ToPropertyDescriptor is called with object _Obj_, the following steps are taken:</p>
@@ -3408,7 +3321,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.4.6" -->
       <emu-clause id="sec-completepropertydescriptor" aoid="CompletePropertyDescriptor">
         <h1>CompletePropertyDescriptor ( _Desc_ )</h1>
         <p>When the abstract operation CompletePropertyDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
@@ -3428,13 +3340,11 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="6.2.5" -->
     <emu-clause id="sec-lexical-environment-and-environment-record-specification-types">
       <h1>The Lexical Environment and Environment Record Specification Types</h1>
       <p>The Lexical Environment and Environment Record types are used to explain the behaviour of name resolution in nested functions and blocks. These types and the operations upon them are defined in <emu-xref href="#sec-lexical-environments"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="6.2.6" -->
     <emu-clause id="sec-data-blocks">
       <h1>Data Blocks</h1>
       <p>The <dfn>Data Block</dfn> specification type is used to describe a distinct and mutable sequence of byte-sized (8 bit) numeric values. A Data Block value is created with a fixed number of bytes that each have the initial value 0.</p>
@@ -3444,7 +3354,6 @@
       <p>Shared Data Block events are modeled by Records, defined in the memory model.</p>
       <p>The following abstract operations are used in this specification to operate upon Data Block values:</p>
 
-      <!-- es6num="6.2.6.1" -->
       <emu-clause id="sec-createbytedatablock" aoid="CreateByteDataBlock">
         <h1>CreateByteDataBlock ( _size_ )</h1>
         <p>When the abstract operation CreateByteDataBlock is called with integer argument _size_, the following steps are taken:</p>
@@ -3471,7 +3380,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="6.2.6.2" -->
       <emu-clause id="sec-copydatablockbytes" aoid="CopyDataBlockBytes">
         <h1>CopyDataBlockBytes ( _toBlock_, _toIndex_, _fromBlock_, _fromIndex_, _count_ )</h1>
         <p>When the abstract operation CopyDataBlockBytes is called, the following steps are taken:</p>
@@ -3507,17 +3415,14 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="7" -->
 <emu-clause id="sec-abstract-operations">
   <h1>Abstract Operations</h1>
   <p>These operations are not a part of the ECMAScript language; they are defined here to solely to aid the specification of the semantics of the ECMAScript language. Other, more specialized abstract operations are defined throughout this specification.</p>
 
-  <!-- es6num="7.1" -->
   <emu-clause id="sec-type-conversion">
     <h1>Type Conversion</h1>
     <p>The ECMAScript language implicitly performs automatic type conversion as needed. To clarify the semantics of certain constructs it is useful to define a set of conversion abstract operations. The conversion abstract operations are polymorphic; they can accept a value of any ECMAScript language type. But no other specification types are used with these operations.</p>
 
-    <!-- es6num="7.1.1" -->
     <emu-clause id="sec-toprimitive" aoid="ToPrimitive" oldids="table-9">
       <h1>ToPrimitive ( _input_ [ , _PreferredType_ ] )</h1>
       <p>The abstract operation ToPrimitive takes an _input_ argument and an optional argument _PreferredType_. The abstract operation ToPrimitive converts its _input_ argument to a non-Object type. If an object is capable of converting to more than one primitive type, it may use the optional hint _PreferredType_ to favour that type. Conversion occurs according to the following algorithm:</p>
@@ -3560,7 +3465,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="7.1.2" -->
     <emu-clause id="sec-toboolean" aoid="ToBoolean">
       <h1>ToBoolean ( _argument_ )</h1>
       <p>The abstract operation ToBoolean converts _argument_ to a value of type Boolean according to <emu-xref href="#table-10"></emu-xref>:</p>
@@ -3636,7 +3540,6 @@
       </emu-table>
     </emu-clause>
 
-    <!-- es6num="7.1.3" -->
     <emu-clause id="sec-tonumber" aoid="ToNumber">
       <h1>ToNumber ( _argument_ )</h1>
       <p>The abstract operation ToNumber converts _argument_ to a value of type Number according to <emu-xref href="#table-11"></emu-xref>:</p>
@@ -3715,7 +3618,6 @@
         </table>
       </emu-table>
 
-      <!-- es6num="7.1.3.1" -->
       <emu-clause id="sec-tonumber-applied-to-the-string-type">
         <h1>ToNumber Applied to the String Type</h1>
         <p>ToNumber applied to Strings applies the following grammar to the input String interpreted as a sequence of UTF-16 encoded code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). If the grammar cannot interpret the String as an expansion of |StringNumericLiteral|, then the result of ToNumber is *NaN*.</p>
@@ -3774,7 +3676,6 @@
           </ul>
         </emu-note>
 
-        <!-- es6num="7.1.3.1.1" -->
         <emu-clause id="sec-runtime-semantics-mv-s">
           <h1>Runtime Semantics: MV</h1>
           <p>The conversion of a String to a Number value is similar overall to the determination of the Number value for a numeric literal (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different, so the process for converting a String numeric literal to a value of Number type is given here. This value is determined in two steps: first, a mathematical value (MV) is derived from the String numeric literal; second, this mathematical value is rounded as described below. The MV on any grammar symbol, not provided below, is the MV for that symbol defined in <emu-xref href="#sec-static-semantics-mv"></emu-xref>.</p>
@@ -3850,7 +3751,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="7.1.4" -->
     <emu-clause id="sec-tointeger" aoid="ToInteger">
       <h1>ToInteger ( _argument_ )</h1>
       <p>The abstract operation ToInteger converts _argument_ to an integral numeric value. This abstract operation functions as follows:</p>
@@ -3862,7 +3762,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.1.5" -->
     <emu-clause id="sec-toint32" aoid="ToInt32">
       <h1>ToInt32 ( _argument_ )</h1>
       <p>The abstract operation ToInt32 converts _argument_ to one of 2<sup>32</sup> integer values in the range <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup>-1</emu-eqn>, inclusive. This abstract operation functions as follows:</p>
@@ -3889,7 +3788,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.1.6" -->
     <emu-clause id="sec-touint32" aoid="ToUint32">
       <h1>ToUint32 ( _argument_ )</h1>
       <p>The abstract operation ToUint32 converts _argument_ to one of 2<sup>32</sup> integer values in the range 0 through <emu-eqn>2<sup>32</sup>-1</emu-eqn>, inclusive. This abstract operation functions as follows:</p>
@@ -3919,7 +3817,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.1.7" -->
     <emu-clause id="sec-toint16" aoid="ToInt16">
       <h1>ToInt16 ( _argument_ )</h1>
       <p>The abstract operation ToInt16 converts _argument_ to one of 2<sup>16</sup> integer values in the range -32768 through 32767, inclusive. This abstract operation functions as follows:</p>
@@ -3932,7 +3829,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.1.8" -->
     <emu-clause id="sec-touint16" aoid="ToUint16">
       <h1>ToUint16 ( _argument_ )</h1>
       <p>The abstract operation ToUint16 converts _argument_ to one of 2<sup>16</sup> integer values in the range 0 through <emu-eqn>2<sup>16</sup>-1</emu-eqn>, inclusive. This abstract operation functions as follows:</p>
@@ -3956,7 +3852,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.1.9" -->
     <emu-clause id="sec-toint8" aoid="ToInt8">
       <h1>ToInt8 ( _argument_ )</h1>
       <p>The abstract operation ToInt8 converts _argument_ to one of 2<sup>8</sup> integer values in the range -128 through 127, inclusive. This abstract operation functions as follows:</p>
@@ -3969,7 +3864,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.1.10" -->
     <emu-clause id="sec-touint8" aoid="ToUint8">
       <h1>ToUint8 ( _argument_ )</h1>
       <p>The abstract operation ToUint8 converts _argument_ to one of 2<sup>8</sup> integer values in the range 0 through 255, inclusive. This abstract operation functions as follows:</p>
@@ -3982,7 +3876,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.1.11" -->
     <emu-clause id="sec-touint8clamp" aoid="ToUint8Clamp">
       <h1>ToUint8Clamp ( _argument_ )</h1>
       <p>The abstract operation ToUint8Clamp converts _argument_ to one of 2<sup>8</sup> integer values in the range 0 through 255, inclusive. This abstract operation functions as follows:</p>
@@ -4002,7 +3895,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.1.12" -->
     <emu-clause id="sec-tostring" aoid="ToString">
       <h1>ToString ( _argument_ )</h1>
       <p>The abstract operation ToString converts _argument_ to a value of type String according to <emu-xref href="#table-12"></emu-xref>:</p>
@@ -4082,7 +3974,6 @@
         </table>
       </emu-table>
 
-      <!-- es6num="7.1.12.1" -->
       <emu-clause id="sec-tostring-applied-to-the-number-type" aoid="NumberToString">
         <h1>NumberToString ( _m_ )</h1>
         <p>The abstract operation NumberToString converts a Number _m_ to String format as follows:</p>
@@ -4147,7 +4038,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="7.1.13" -->
     <emu-clause id="sec-toobject" aoid="ToObject">
       <h1>ToObject ( _argument_ )</h1>
       <p>The abstract operation ToObject converts _argument_ to a value of type Object according to <emu-xref href="#table-13"></emu-xref>:</p>
@@ -4223,7 +4113,6 @@
       </emu-table>
     </emu-clause>
 
-    <!-- es6num="7.1.14" -->
     <emu-clause id="sec-topropertykey" aoid="ToPropertyKey">
       <h1>ToPropertyKey ( _argument_ )</h1>
       <p>The abstract operation ToPropertyKey converts _argument_ to a value that can be used as a property key by performing the following steps:</p>
@@ -4235,7 +4124,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.1.15" -->
     <emu-clause id="sec-tolength" aoid="ToLength">
       <h1>ToLength ( _argument_ )</h1>
       <p>The abstract operation ToLength converts _argument_ to an integer suitable for use as the length of an array-like object. It performs the following steps:</p>
@@ -4246,7 +4134,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.1.16" -->
     <emu-clause id="sec-canonicalnumericindexstring" aoid="CanonicalNumericIndexString">
       <h1>CanonicalNumericIndexString ( _argument_ )</h1>
       <p>The abstract operation CanonicalNumericIndexString returns _argument_ converted to a numeric value if it is a String representation of a Number that would be produced by ToString, or the string `"-0"`. Otherwise, it returns *undefined*. This abstract operation functions as follows:</p>
@@ -4276,11 +4163,9 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="7.2" -->
   <emu-clause id="sec-testing-and-comparison-operations">
     <h1>Testing and Comparison Operations</h1>
 
-    <!-- es6num="7.2.1" -->
     <emu-clause id="sec-requireobjectcoercible" aoid="RequireObjectCoercible">
       <h1>RequireObjectCoercible ( _argument_ )</h1>
       <p>The abstract operation RequireObjectCoercible throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-14"></emu-xref>:</p>
@@ -4356,7 +4241,6 @@
       </emu-table>
     </emu-clause>
 
-    <!-- es6num="7.2.2" -->
     <emu-clause id="sec-isarray" aoid="IsArray">
       <h1>IsArray ( _argument_ )</h1>
       <p>The abstract operation IsArray takes one argument _argument_, and performs the following steps:</p>
@@ -4371,7 +4255,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.3" -->
     <emu-clause id="sec-iscallable" aoid="IsCallable">
       <h1>IsCallable ( _argument_ )</h1>
       <p>The abstract operation IsCallable determines if _argument_, which must be an ECMAScript language value, is a callable function with a [[Call]] internal method.</p>
@@ -4382,7 +4265,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.4" -->
     <emu-clause id="sec-isconstructor" aoid="IsConstructor">
       <h1>IsConstructor ( _argument_ )</h1>
       <p>The abstract operation IsConstructor determines if _argument_, which must be an ECMAScript language value, is a function object with a [[Construct]] internal method.</p>
@@ -4393,7 +4275,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.5" -->
     <emu-clause id="sec-isextensible-o" aoid="IsExtensible">
       <h1>IsExtensible ( _O_ )</h1>
       <p>The abstract operation IsExtensible is used to determine whether additional properties can be added to the object that is _O_. A Boolean value is returned. This abstract operation performs the following steps:</p>
@@ -4403,7 +4284,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.6" -->
     <emu-clause id="sec-isinteger" aoid="IsInteger">
       <h1>IsInteger ( _argument_ )</h1>
       <p>The abstract operation IsInteger determines if _argument_ is a finite integer numeric value.</p>
@@ -4415,7 +4295,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.7" -->
     <emu-clause id="sec-ispropertykey" aoid="IsPropertyKey">
       <h1>IsPropertyKey ( _argument_ )</h1>
       <p>The abstract operation IsPropertyKey determines if _argument_, which must be an ECMAScript language value, is a value that may be used as a property key.</p>
@@ -4426,7 +4305,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.8" -->
     <emu-clause id="sec-isregexp" aoid="IsRegExp">
       <h1>IsRegExp ( _argument_ )</h1>
       <p>The abstract operation IsRegExp with argument _argument_ performs the following steps:</p>
@@ -4450,7 +4328,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.9" -->
     <emu-clause id="sec-samevalue" aoid="SameValue">
       <h1>SameValue ( _x_, _y_ )</h1>
       <p>The internal comparison abstract operation SameValue(_x_, _y_), where _x_ and _y_ are ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
@@ -4469,7 +4346,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.2.10" -->
     <emu-clause id="sec-samevaluezero" aoid="SameValueZero">
       <h1>SameValueZero ( _x_, _y_ )</h1>
       <p>The internal comparison abstract operation SameValueZero(_x_, _y_), where _x_ and _y_ are ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
@@ -4506,7 +4382,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.11" -->
     <emu-clause id="sec-abstract-relational-comparison" aoid="Abstract Relational Comparison">
       <h1>Abstract Relational Comparison</h1>
       <p>The comparison _x_ &lt; _y_, where _x_ and _y_ are values, produces *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). In addition to _x_ and _y_ the algorithm takes a Boolean flag named _LeftFirst_ as a parameter. The flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. The default value of _LeftFirst_ is *true* and indicates that the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_. Such a comparison is performed as follows:</p>
@@ -4547,7 +4422,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.2.12" -->
     <emu-clause id="sec-abstract-equality-comparison" aoid="Abstract Equality Comparison">
       <h1>Abstract Equality Comparison</h1>
       <p>The comparison _x_ == _y_, where _x_ and _y_ are values, produces *true* or *false*. Such a comparison is performed as follows:</p>
@@ -4566,7 +4440,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.2.13" -->
     <emu-clause id="sec-strict-equality-comparison" aoid="Strict Equality Comparison">
       <h1>Strict Equality Comparison</h1>
       <p>The comparison _x_ === _y_, where _x_ and _y_ are values, produces *true* or *false*. Such a comparison is performed as follows:</p>
@@ -4587,11 +4460,9 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="7.3" -->
   <emu-clause id="sec-operations-on-objects">
     <h1>Operations on Objects</h1>
 
-    <!-- es6num="7.3.1" -->
     <emu-clause id="sec-get-o-p" aoid="Get">
       <h1>Get ( _O_, _P_ )</h1>
       <p>The abstract operation Get is used to retrieve the value of a specific property of an object. The operation is called with arguments _O_ and _P_ where _O_ is the object and _P_ is the property key. This abstract operation performs the following steps:</p>
@@ -4602,7 +4473,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.2" -->
     <emu-clause id="sec-getv" aoid="GetV">
       <h1>GetV ( _V_, _P_ )</h1>
       <p>The abstract operation GetV is used to retrieve the value of a specific property of an ECMAScript language value. If the value is not an object, the property lookup is performed using a wrapper object appropriate for the type of the value. The operation is called with arguments _V_ and _P_ where _V_ is the value and _P_ is the property key. This abstract operation performs the following steps:</p>
@@ -4613,7 +4483,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.3" -->
     <emu-clause id="sec-set-o-p-v-throw" aoid="Set">
       <h1>Set ( _O_, _P_, _V_, _Throw_ )</h1>
       <p>The abstract operation Set is used to set the value of a specific property of an object. The operation is called with arguments _O_, _P_, _V_, and _Throw_ where _O_ is the object, _P_ is the property key, _V_ is the new value for the property and _Throw_ is a Boolean flag. This abstract operation performs the following steps:</p>
@@ -4627,7 +4496,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.4" -->
     <emu-clause id="sec-createdataproperty" aoid="CreateDataProperty">
       <h1>CreateDataProperty ( _O_, _P_, _V_ )</h1>
       <p>The abstract operation CreateDataProperty is used to create a new own property of an object. The operation is called with arguments _O_, _P_, and _V_ where _O_ is the object, _P_ is the property key, and _V_ is the value for the property. This abstract operation performs the following steps:</p>
@@ -4642,7 +4510,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.3.5" -->
     <emu-clause id="sec-createmethodproperty" aoid="CreateMethodProperty">
       <h1>CreateMethodProperty ( _O_, _P_, _V_ )</h1>
       <p>The abstract operation CreateMethodProperty is used to create a new own property of an object. The operation is called with arguments _O_, _P_, and _V_ where _O_ is the object, _P_ is the property key, and _V_ is the value for the property. This abstract operation performs the following steps:</p>
@@ -4657,7 +4524,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.3.6" -->
     <emu-clause id="sec-createdatapropertyorthrow" aoid="CreateDataPropertyOrThrow">
       <h1>CreateDataPropertyOrThrow ( _O_, _P_, _V_ )</h1>
       <p>The abstract operation CreateDataPropertyOrThrow is used to create a new own property of an object. It throws a *TypeError* exception if the requested property update cannot be performed. The operation is called with arguments _O_, _P_, and _V_ where _O_ is the object, _P_ is the property key, and _V_ is the value for the property. This abstract operation performs the following steps:</p>
@@ -4673,7 +4539,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.3.7" -->
     <emu-clause id="sec-definepropertyorthrow" aoid="DefinePropertyOrThrow">
       <h1>DefinePropertyOrThrow ( _O_, _P_, _desc_ )</h1>
       <p>The abstract operation DefinePropertyOrThrow is used to call the [[DefineOwnProperty]] internal method of an object in a manner that will throw a *TypeError* exception if the requested property update cannot be performed. The operation is called with arguments _O_, _P_, and _desc_ where _O_ is the object, _P_ is the property key, and _desc_ is the Property Descriptor for the property. This abstract operation performs the following steps:</p>
@@ -4686,7 +4551,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.8" -->
     <emu-clause id="sec-deletepropertyorthrow" aoid="DeletePropertyOrThrow">
       <h1>DeletePropertyOrThrow ( _O_, _P_ )</h1>
       <p>The abstract operation DeletePropertyOrThrow is used to remove a specific own property of an object. It throws an exception if the property is not configurable. The operation is called with arguments _O_ and _P_ where _O_ is the object and _P_ is the property key. This abstract operation performs the following steps:</p>
@@ -4699,7 +4563,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.9" -->
     <emu-clause id="sec-getmethod" aoid="GetMethod">
       <h1>GetMethod ( _V_, _P_ )</h1>
       <p>The abstract operation GetMethod is used to get the value of a specific property of an ECMAScript language value when the value of the property is expected to be a function. The operation is called with arguments _V_ and _P_ where _V_ is the ECMAScript language value, _P_ is the property key. This abstract operation performs the following steps:</p>
@@ -4712,7 +4575,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.10" -->
     <emu-clause id="sec-hasproperty" aoid="HasProperty">
       <h1>HasProperty ( _O_, _P_ )</h1>
       <p>The abstract operation HasProperty is used to determine whether an object has a property with the specified property key. The property may be either an own or inherited. A Boolean value is returned. The operation is called with arguments _O_ and _P_ where _O_ is the object and _P_ is the property key. This abstract operation performs the following steps:</p>
@@ -4723,7 +4585,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.11" -->
     <emu-clause id="sec-hasownproperty" aoid="HasOwnProperty">
       <h1>HasOwnProperty ( _O_, _P_ )</h1>
       <p>The abstract operation HasOwnProperty is used to determine whether an object has an own property with the specified property key. A Boolean value is returned. The operation is called with arguments _O_ and _P_ where _O_ is the object and _P_ is the property key. This abstract operation performs the following steps:</p>
@@ -4736,7 +4597,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.12" -->
     <emu-clause id="sec-call" aoid="Call">
       <h1>Call ( _F_, _V_ [ , _argumentsList_ ] )</h1>
       <p>The abstract operation Call is used to call the [[Call]] internal method of a function object. The operation is called with arguments _F_, _V_, and optionally _argumentsList_ where _F_ is the function object, _V_ is an ECMAScript language value that is the *this* value of the [[Call]], and _argumentsList_ is the value passed to the corresponding argument of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. This abstract operation performs the following steps:</p>
@@ -4747,7 +4607,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.13" -->
     <emu-clause id="sec-construct" aoid="Construct">
       <h1>Construct ( _F_ [ , _argumentsList_ [ , _newTarget_ ]] )</h1>
       <p>The abstract operation Construct is used to call the [[Construct]] internal method of a function object. The operation is called with arguments _F_, and optionally _argumentsList_, and _newTarget_ where _F_ is the function object. _argumentsList_ and _newTarget_ are the values to be passed as the corresponding arguments of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. If _newTarget_ is not present, _F_ is used as its value. This abstract operation performs the following steps:</p>
@@ -4763,7 +4622,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="7.3.14" -->
     <emu-clause id="sec-setintegritylevel" aoid="SetIntegrityLevel">
       <h1>SetIntegrityLevel ( _O_, _level_ )</h1>
       <p>The abstract operation SetIntegrityLevel is used to fix the set of own properties of an object. This abstract operation performs the following steps:</p>
@@ -4789,7 +4647,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.15" -->
     <emu-clause id="sec-testintegritylevel" aoid="TestIntegrityLevel">
       <h1>TestIntegrityLevel ( _O_, _level_ )</h1>
       <p>The abstract operation TestIntegrityLevel is used to determine if the set of own properties of an object are fixed. This abstract operation performs the following steps:</p>
@@ -4810,7 +4667,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.16" -->
     <emu-clause id="sec-createarrayfromlist" aoid="CreateArrayFromList">
       <h1>CreateArrayFromList ( _elements_ )</h1>
       <p>The abstract operation CreateArrayFromList is used to create an Array object whose elements are provided by a List. This abstract operation performs the following steps:</p>
@@ -4826,7 +4682,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.17" -->
     <emu-clause id="sec-createlistfromarraylike" aoid="CreateListFromArrayLike">
       <h1>CreateListFromArrayLike ( _obj_ [ , _elementTypes_ ] )</h1>
       <p>The abstract operation CreateListFromArrayLike is used to create a List value whose elements are provided by the indexed properties of an array-like object, _obj_. The optional argument _elementTypes_ is a List containing the names of ECMAScript Language Types that are allowed for element values of the List that is created. This abstract operation performs the following steps:</p>
@@ -4846,7 +4701,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.18" -->
     <emu-clause id="sec-invoke" aoid="Invoke">
       <h1>Invoke ( _V_, _P_ [ , _argumentsList_ ] )</h1>
       <p>The abstract operation Invoke is used to call a method property of an ECMAScript language value. The operation is called with arguments _V_, _P_, and optionally _argumentsList_ where _V_ serves as both the lookup point for the property and the *this* value of the call, _P_ is the property key, and _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, a new empty List is used as its value. This abstract operation performs the following steps:</p>
@@ -4859,7 +4713,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.19" -->
     <emu-clause id="sec-ordinaryhasinstance" aoid="OrdinaryHasInstance">
       <h1>OrdinaryHasInstance ( _C_, _O_ )</h1>
       <p>The abstract operation OrdinaryHasInstance implements the default algorithm for determining if an object _O_ inherits from the instance object inheritance path provided by constructor _C_. This abstract operation performs the following steps:</p>
@@ -4878,7 +4731,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.20" -->
     <emu-clause id="sec-speciesconstructor" aoid="SpeciesConstructor">
       <h1>SpeciesConstructor ( _O_, _defaultConstructor_ )</h1>
       <p>The abstract operation SpeciesConstructor is used to retrieve the constructor that should be used to create new objects that are derived from the argument object _O_. The _defaultConstructor_ argument is the constructor to use if a constructor @@species property cannot be found starting from _O_. This abstract operation performs the following steps:</p>
@@ -4918,7 +4770,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.3.22" -->
     <emu-clause id="sec-getfunctionrealm" aoid="GetFunctionRealm">
       <h1>GetFunctionRealm ( _obj_ )</h1>
       <p>The abstract operation GetFunctionRealm with argument _obj_ performs the following steps:</p>
@@ -4968,12 +4819,10 @@
 
   </emu-clause>
 
-  <!-- es6num="7.4" -->
   <emu-clause id="sec-operations-on-iterator-objects">
     <h1>Operations on Iterator Objects</h1>
     <p>See Common Iteration Interfaces (<emu-xref href="#sec-iteration"></emu-xref>).</p>
 
-    <!-- es6num="7.4.1" -->
     <emu-clause id="sec-getiterator" aoid="GetIterator">
       <h1>GetIterator ( _obj_ [ , _hint_ [ , _method_ ] ] )</h1>
       <p>The abstract operation GetIterator with argument _obj_ and optional arguments _hint_ and _method_ performs the following steps:</p>
@@ -4996,7 +4845,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.4.2" -->
     <emu-clause id="sec-iteratornext" aoid="IteratorNext">
       <h1>IteratorNext ( _iteratorRecord_ [ , _value_ ] )</h1>
       <p>The abstract operation IteratorNext with argument _iteratorRecord_ and optional argument _value_ performs the following steps:</p>
@@ -5010,7 +4858,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.4.3" -->
     <emu-clause id="sec-iteratorcomplete" aoid="IteratorComplete">
       <h1>IteratorComplete ( _iterResult_ )</h1>
       <p>The abstract operation IteratorComplete with argument _iterResult_ performs the following steps:</p>
@@ -5020,7 +4867,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.4.4" -->
     <emu-clause id="sec-iteratorvalue" aoid="IteratorValue">
       <h1>IteratorValue ( _iterResult_ )</h1>
       <p>The abstract operation IteratorValue with argument _iterResult_ performs the following steps:</p>
@@ -5030,7 +4876,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.4.5" -->
     <emu-clause id="sec-iteratorstep" aoid="IteratorStep">
       <h1>IteratorStep ( _iteratorRecord_ )</h1>
       <p>The abstract operation IteratorStep with argument _iteratorRecord_ requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either *false* indicating that the iterator has reached its end or the IteratorResult object if a next value is available. IteratorStep performs the following steps:</p>
@@ -5042,7 +4887,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.4.6" -->
     <emu-clause id="sec-iteratorclose" aoid="IteratorClose">
       <h1>IteratorClose ( _iteratorRecord_, _completion_ )</h1>
       <p>The abstract operation IteratorClose with arguments _iteratorRecord_ and _completion_ is used to notify an iterator that it should perform any actions it would normally perform when it has reached its completed state:</p>
@@ -5078,7 +4922,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.4.7" -->
     <emu-clause id="sec-createiterresultobject" aoid="CreateIterResultObject">
       <h1>CreateIterResultObject ( _value_, _done_ )</h1>
       <p>The abstract operation CreateIterResultObject with arguments _value_ and _done_ creates an object that supports the IteratorResult interface by performing the following steps:</p>
@@ -5091,7 +4934,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="7.4.8" -->
     <emu-clause id="sec-createlistiteratorRecord" oldids="sec-createlistiterator" aoid="CreateListIteratorRecord">
       <h1>CreateListIteratorRecord ( _list_ )</h1>
       <p>The abstract operation CreateListIteratorRecord with argument _list_ creates an Iterator (<emu-xref href="#sec-iterator-interface"></emu-xref>) object record whose next method returns the successive elements of _list_. It performs the following steps:</p>
@@ -5107,7 +4949,6 @@
         <p>The list iterator object is never directly accessible to ECMAScript code.</p>
       </emu-note>
 
-      <!-- es6num="7.4.8.1" -->
       <emu-clause id="sec-listiterator-next">
         <h1>ListIterator next ( )</h1>
         <p>The ListIterator `next` method is a standard built-in function object (clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>) that performs the following steps:</p>
@@ -5128,11 +4969,9 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="8" -->
 <emu-clause id="sec-executable-code-and-execution-contexts">
   <h1>Executable Code and Execution Contexts</h1>
 
-  <!-- es6num="8.1" -->
   <emu-clause id="sec-lexical-environments">
     <h1>Lexical Environments</h1>
     <p>A <dfn>Lexical Environment</dfn> is a specification type used to define the association of |Identifier|s to specific variables and functions based upon the lexical nesting structure of ECMAScript code. A Lexical Environment consists of an Environment Record and a possibly null reference to an <em>outer</em> Lexical Environment. Usually a Lexical Environment is associated with some specific syntactic structure of ECMAScript code such as a |FunctionDeclaration|, a |BlockStatement|, or a |Catch| clause of a |TryStatement| and a new Lexical Environment is created each time such code is evaluated.</p>
@@ -5143,7 +4982,6 @@
     <p>A <dfn id="function-environment">function environment</dfn> is a Lexical Environment that corresponds to the invocation of an ECMAScript function object. A function environment may establish a new `this` binding. A function environment also captures the state necessary to support `super` method invocations.</p>
     <p>Lexical Environments and Environment Record values are purely specification mechanisms and need not correspond to any specific artefact of an ECMAScript implementation. It is impossible for an ECMAScript program to directly access or manipulate such values.</p>
 
-    <!-- es6num="8.1.1" -->
     <emu-clause id="sec-environment-records">
       <h1>Environment Records</h1>
       <p>There are two primary kinds of <dfn>Environment Record</dfn> values used in this specification: <em>declarative Environment Records</em> and <em>object Environment Records</em>. Declarative Environment Records are used to define the effect of ECMAScript language syntactic elements such as |FunctionDeclaration|s, |VariableDeclaration|s, and |Catch| clauses that directly associate identifier bindings with ECMAScript language values. Object Environment Records are used to define the effect of ECMAScript elements such as |WithStatement| that associate identifier bindings with the properties of some object. Global Environment Records and function Environment Records are specializations that are used for specifically for |Script| global declarations and for top-level declarations within functions.</p>
@@ -5243,13 +5081,11 @@
         </table>
       </emu-table>
 
-      <!-- es6num="8.1.1.1" -->
       <emu-clause id="sec-declarative-environment-records">
         <h1>Declarative Environment Records</h1>
         <p>Each declarative Environment Record is associated with an ECMAScript program scope containing variable, constant, let, class, module, import, and/or function declarations. A declarative Environment Record binds the set of identifiers defined by the declarations contained within its scope.</p>
         <p>The behaviour of the concrete specification methods for declarative Environment Records is defined by the following algorithms.</p>
 
-        <!-- es6num="8.1.1.1.1" -->
         <emu-clause id="sec-declarative-environment-records-hasbinding-n">
           <h1>HasBinding ( _N_ )</h1>
           <p>The concrete Environment Record method HasBinding for declarative Environment Records simply determines if the argument identifier is one of the identifiers bound by the record:</p>
@@ -5260,7 +5096,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.2" -->
         <emu-clause id="sec-declarative-environment-records-createmutablebinding-n-d">
           <h1>CreateMutableBinding ( _N_, _D_ )</h1>
           <p>The concrete Environment Record method CreateMutableBinding for declarative Environment Records creates a new mutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If Boolean argument _D_ has the value *true* the new binding is marked as being subject to deletion.</p>
@@ -5272,7 +5107,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.3" -->
         <emu-clause id="sec-declarative-environment-records-createimmutablebinding-n-s">
           <h1>CreateImmutableBinding ( _N_, _S_ )</h1>
           <p>The concrete Environment Record method CreateImmutableBinding for declarative Environment Records creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If the Boolean argument _S_ has the value *true* the new binding is marked as a strict binding.</p>
@@ -5284,7 +5118,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.4" -->
         <emu-clause id="sec-declarative-environment-records-initializebinding-n-v">
           <h1>InitializeBinding ( _N_, _V_ )</h1>
           <p>The concrete Environment Record method InitializeBinding for declarative Environment Records is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</p>
@@ -5297,7 +5130,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.5" -->
         <emu-clause id="sec-declarative-environment-records-setmutablebinding-n-v-s">
           <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
           <p>The concrete Environment Record method SetMutableBinding for declarative Environment Records attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. A binding for _N_ normally already exists, but in rare cases it may not. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*.</p>
@@ -5322,7 +5154,6 @@
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.6" -->
         <emu-clause id="sec-declarative-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue ( _N_, _S_ )</h1>
           <p>The concrete Environment Record method GetBindingValue for declarative Environment Records simply returns the value of its bound identifier whose name is the value of the argument _N_. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.</p>
@@ -5334,7 +5165,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.7" -->
         <emu-clause id="sec-declarative-environment-records-deletebinding-n">
           <h1>DeleteBinding ( _N_ )</h1>
           <p>The concrete Environment Record method DeleteBinding for declarative Environment Records can only delete bindings that have been explicitly designated as being subject to deletion.</p>
@@ -5347,7 +5177,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.8" -->
         <emu-clause id="sec-declarative-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
           <p>Regular declarative Environment Records do not provide a `this` binding.</p>
@@ -5356,7 +5185,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.9" -->
         <emu-clause id="sec-declarative-environment-records-hassuperbinding">
           <h1>HasSuperBinding ( )</h1>
           <p>Regular declarative Environment Records do not provide a `super` binding.</p>
@@ -5365,7 +5193,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.1.10" -->
         <emu-clause id="sec-declarative-environment-records-withbaseobject">
           <h1>WithBaseObject ( )</h1>
           <p>Declarative Environment Records always return *undefined* as their WithBaseObject.</p>
@@ -5375,14 +5202,12 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="8.1.1.2" -->
       <emu-clause id="sec-object-environment-records">
         <h1>Object Environment Records</h1>
         <p>Each object Environment Record is associated with an object called its <em>binding object</em>. An object Environment Record binds the set of string identifier names that directly correspond to the property names of its binding object. Property keys that are not strings in the form of an |IdentifierName| are not included in the set of bound identifiers. Both own and inherited properties are included in the set regardless of the setting of their [[Enumerable]] attribute. Because properties can be dynamically added and deleted from objects, the set of identifiers bound by an object Environment Record may potentially change as a side-effect of any operation that adds or deletes properties. Any bindings that are created as a result of such a side-effect are considered to be a mutable binding even if the Writable attribute of the corresponding property has the value *false*. Immutable bindings do not exist for object Environment Records.</p>
         <p>Object Environment Records created for `with` statements (<emu-xref href="#sec-with-statement"></emu-xref>) can provide their binding object as an implicit *this* value for use in function calls. The capability is controlled by a _withEnvironment_ Boolean value that is associated with each object Environment Record. By default, the value of _withEnvironment_ is *false* for any object Environment Record.</p>
         <p>The behaviour of the concrete specification methods for object Environment Records is defined by the following algorithms.</p>
 
-        <!-- es6num="8.1.1.2.1" -->
         <emu-clause id="sec-object-environment-records-hasbinding-n">
           <h1>HasBinding ( _N_ )</h1>
           <p>The concrete Environment Record method HasBinding for object Environment Records determines if its associated binding object has a property whose name is the value of the argument _N_:</p>
@@ -5400,7 +5225,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.2" -->
         <emu-clause id="sec-object-environment-records-createmutablebinding-n-d">
           <h1>CreateMutableBinding ( _N_, _D_ )</h1>
           <p>The concrete Environment Record method CreateMutableBinding for object Environment Records creates in an Environment Record's associated binding object a property whose name is the String value and initializes it to the value *undefined*. If Boolean argument _D_ has the value *true* the new property's [[Configurable]] attribute is set to *true*; otherwise it is set to *false*.</p>
@@ -5414,13 +5238,11 @@
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.3" -->
         <emu-clause id="sec-object-environment-records-createimmutablebinding-n-s">
           <h1>CreateImmutableBinding ( _N_, _S_ )</h1>
           <p>The concrete Environment Record method CreateImmutableBinding is never used within this specification in association with object Environment Records.</p>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.4" -->
         <emu-clause id="sec-object-environment-records-initializebinding-n-v">
           <h1>InitializeBinding ( _N_, _V_ )</h1>
           <p>The concrete Environment Record method InitializeBinding for object Environment Records is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</p>
@@ -5435,7 +5257,6 @@
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.5" -->
         <emu-clause id="sec-object-environment-records-setmutablebinding-n-v-s">
           <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
           <p>The concrete Environment Record method SetMutableBinding for object Environment Records attempts to set the value of the Environment Record's associated binding object's property whose name is the value of the argument _N_ to the value of argument _V_. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by the value of the Boolean argument _S_.</p>
@@ -5446,7 +5267,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.6" -->
         <emu-clause id="sec-object-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue ( _N_, _S_ )</h1>
           <p>The concrete Environment Record method GetBindingValue for object Environment Records returns the value of its associated binding object's property whose name is the String value of the argument identifier _N_. The property should already exist but if it does not the result depends upon the value of the _S_ argument:</p>
@@ -5460,7 +5280,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.7" -->
         <emu-clause id="sec-object-environment-records-deletebinding-n">
           <h1>DeleteBinding ( _N_ )</h1>
           <p>The concrete Environment Record method DeleteBinding for object Environment Records can only delete bindings that correspond to properties of the environment object whose [[Configurable]] attribute have the value *true*.</p>
@@ -5471,7 +5290,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.8" -->
         <emu-clause id="sec-object-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
           <p>Regular object Environment Records do not provide a `this` binding.</p>
@@ -5480,7 +5298,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.9" -->
         <emu-clause id="sec-object-environment-records-hassuperbinding">
           <h1>HasSuperBinding ( )</h1>
           <p>Regular object Environment Records do not provide a `super` binding.</p>
@@ -5489,7 +5306,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.2.10" -->
         <emu-clause id="sec-object-environment-records-withbaseobject">
           <h1>WithBaseObject ( )</h1>
           <p>Object Environment Records return *undefined* as their WithBaseObject unless their _withEnvironment_ flag is *true*.</p>
@@ -5501,7 +5317,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="8.1.1.3" -->
       <emu-clause id="sec-function-environment-records">
         <h1>Function Environment Records</h1>
         <p>A <dfn>function Environment Record</dfn> is a declarative Environment Record that is used to represent the top-level scope of a function and, if the function is not an |ArrowFunction|, provides a `this` binding. If a function is not an |ArrowFunction| function and references `super`, its function Environment Record also contains the state that is used to perform `super` method invocations from within the function.</p>
@@ -5619,7 +5434,6 @@
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for function Environment Records is defined by the following algorithms:</p>
 
-        <!-- es6num="8.1.1.3.1" -->
         <emu-clause id="sec-bindthisvalue">
           <h1>BindThisValue ( _V_ )</h1>
           <emu-alg>
@@ -5632,7 +5446,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.3.2" -->
         <emu-clause id="sec-function-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
           <emu-alg>
@@ -5641,7 +5454,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.3.3" -->
         <emu-clause id="sec-function-environment-records-hassuperbinding">
           <h1>HasSuperBinding ( )</h1>
           <emu-alg>
@@ -5651,7 +5463,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.3.4" -->
         <emu-clause id="sec-function-environment-records-getthisbinding">
           <h1>GetThisBinding ( )</h1>
           <emu-alg>
@@ -5662,7 +5473,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.3.5" -->
         <emu-clause id="sec-getsuperbase">
           <h1>GetSuperBase ( )</h1>
           <emu-alg>
@@ -5675,7 +5485,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="8.1.1.4" -->
       <emu-clause id="sec-global-environment-records">
         <h1>Global Environment Records</h1>
         <p>A global Environment Record is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm. A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-block-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-block-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
@@ -5823,7 +5632,6 @@
         </emu-table>
         <p>The behaviour of the concrete specification methods for global Environment Records is defined by the following algorithms.</p>
 
-        <!-- es6num="8.1.1.4.1" -->
         <emu-clause id="sec-global-environment-records-hasbinding-n">
           <h1>HasBinding ( _N_ )</h1>
           <p>The concrete Environment Record method HasBinding for global Environment Records simply determines if the argument identifier is one of the identifiers bound by the record:</p>
@@ -5836,7 +5644,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.2" -->
         <emu-clause id="sec-global-environment-records-createmutablebinding-n-d">
           <h1>CreateMutableBinding ( _N_, _D_ )</h1>
           <p>The concrete Environment Record method CreateMutableBinding for global Environment Records creates a new mutable binding for the name _N_ that is uninitialized. The binding is created in the associated DeclarativeRecord. A binding for _N_ must not already exist in the DeclarativeRecord. If Boolean argument _D_ has the value *true* the new binding is marked as being subject to deletion.</p>
@@ -5848,7 +5655,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.3" -->
         <emu-clause id="sec-global-environment-records-createimmutablebinding-n-s">
           <h1>CreateImmutableBinding ( _N_, _S_ )</h1>
           <p>The concrete Environment Record method CreateImmutableBinding for global Environment Records creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If the Boolean argument _S_ has the value *true* the new binding is marked as a strict binding.</p>
@@ -5860,7 +5666,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.4" -->
         <emu-clause id="sec-global-environment-records-initializebinding-n-v">
           <h1>InitializeBinding ( _N_, _V_ )</h1>
           <p>The concrete Environment Record method InitializeBinding for global Environment Records is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</p>
@@ -5875,7 +5680,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.5" -->
         <emu-clause id="sec-global-environment-records-setmutablebinding-n-v-s">
           <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
           <p>The concrete Environment Record method SetMutableBinding for global Environment Records attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by the value of the Boolean argument _S_.</p>
@@ -5889,7 +5693,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.6" -->
         <emu-clause id="sec-global-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue ( _N_, _S_ )</h1>
           <p>The concrete Environment Record method GetBindingValue for global Environment Records returns the value of its bound identifier whose name is the value of the argument _N_. If the binding is an uninitialized binding throw a *ReferenceError* exception. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by the value of the Boolean argument _S_.</p>
@@ -5903,7 +5706,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.7" -->
         <emu-clause id="sec-global-environment-records-deletebinding-n">
           <h1>DeleteBinding ( _N_ )</h1>
           <p>The concrete Environment Record method DeleteBinding for global Environment Records can only delete bindings that have been explicitly designated as being subject to deletion.</p>
@@ -5925,7 +5727,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.8" -->
         <emu-clause id="sec-global-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
           <emu-alg>
@@ -5933,7 +5734,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.9" -->
         <emu-clause id="sec-global-environment-records-hassuperbinding">
           <h1>HasSuperBinding ( )</h1>
           <emu-alg>
@@ -5941,7 +5741,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.10" -->
         <emu-clause id="sec-global-environment-records-withbaseobject">
           <h1>WithBaseObject ( )</h1>
           <p>Global Environment Records always return *undefined* as their WithBaseObject.</p>
@@ -5950,7 +5749,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.11" -->
         <emu-clause id="sec-global-environment-records-getthisbinding">
           <h1>GetThisBinding ( )</h1>
           <emu-alg>
@@ -5959,7 +5757,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.12" -->
         <emu-clause id="sec-hasvardeclaration">
           <h1>HasVarDeclaration ( _N_ )</h1>
           <p>The concrete Environment Record method HasVarDeclaration for global Environment Records determines if the argument identifier has a binding in this record that was created using a |VariableStatement| or a |FunctionDeclaration|:</p>
@@ -5971,7 +5768,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.13" -->
         <emu-clause id="sec-haslexicaldeclaration">
           <h1>HasLexicalDeclaration ( _N_ )</h1>
           <p>The concrete Environment Record method HasLexicalDeclaration for global Environment Records determines if the argument identifier has a binding in this record that was created using a lexical declaration such as a |LexicalDeclaration| or a |ClassDeclaration|:</p>
@@ -5982,7 +5778,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.14" -->
         <emu-clause id="sec-hasrestrictedglobalproperty">
           <h1>HasRestrictedGlobalProperty ( _N_ )</h1>
           <p>The concrete Environment Record method HasRestrictedGlobalProperty for global Environment Records determines if the argument identifier is the name of a property of the global object that must not be shadowed by a global lexical binding:</p>
@@ -6000,7 +5795,6 @@
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.15" -->
         <emu-clause id="sec-candeclareglobalvar">
           <h1>CanDeclareGlobalVar ( _N_ )</h1>
           <p>The concrete Environment Record method CanDeclareGlobalVar for global Environment Records determines if a corresponding CreateGlobalVarBinding call would succeed if called for the same argument _N_. Redundant var declarations and var declarations for pre-existing global object properties are allowed.</p>
@@ -6014,7 +5808,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.16" -->
         <emu-clause id="sec-candeclareglobalfunction">
           <h1>CanDeclareGlobalFunction ( _N_ )</h1>
           <p>The concrete Environment Record method CanDeclareGlobalFunction for global Environment Records determines if a corresponding CreateGlobalFunctionBinding call would succeed if called for the same argument _N_.</p>
@@ -6030,7 +5823,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.17" -->
         <emu-clause id="sec-createglobalvarbinding">
           <h1>CreateGlobalVarBinding ( _N_, _D_ )</h1>
           <p>The concrete Environment Record method CreateGlobalVarBinding for global Environment Records creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is reused and assumed to be initialized.</p>
@@ -6050,7 +5842,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.4.18" -->
         <emu-clause id="sec-createglobalfunctionbinding">
           <h1>CreateGlobalFunctionBinding ( _N_, _V_, _D_ )</h1>
           <p>The concrete Environment Record method CreateGlobalFunctionBinding for global Environment Records creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is replaced.</p>
@@ -6077,7 +5868,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="8.1.1.5" -->
       <emu-clause id="sec-module-environment-records">
         <h1>Module Environment Records</h1>
         <p>A module Environment Record is a declarative Environment Record that is used to represent the outer scope of an ECMAScript |Module|. In additional to normal mutable and immutable bindings, module Environment Records also provide immutable import bindings which are bindings that provide indirect access to a target binding that exists in another Environment Record.</p>
@@ -6114,7 +5904,6 @@
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
 
-        <!-- es6num="8.1.1.5.1" -->
         <emu-clause id="sec-module-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue ( _N_, _S_ )</h1>
           <p>The concrete Environment Record method GetBindingValue for module Environment Records returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown.</p>
@@ -6136,7 +5925,6 @@
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="8.1.1.5.2" -->
         <emu-clause id="sec-module-environment-records-deletebinding-n">
           <h1>DeleteBinding ( _N_ )</h1>
           <p>The concrete Environment Record method DeleteBinding for module Environment Records refuses to delete bindings.</p>
@@ -6148,7 +5936,6 @@
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="8.1.1.5.3" -->
         <emu-clause id="sec-module-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
           <p>Module Environment Records provide a `this` binding.</p>
@@ -6157,7 +5944,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.5.4" -->
         <emu-clause id="sec-module-environment-records-getthisbinding">
           <h1>GetThisBinding ( )</h1>
           <emu-alg>
@@ -6165,7 +5951,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="8.1.1.5.5" -->
         <emu-clause id="sec-createimportbinding">
           <h1>CreateImportBinding ( _N_, _M_, _N2_ )</h1>
           <p>The concrete Environment Record method CreateImportBinding for module Environment Records creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _M_ is a Module Record, and _N2_ is the name of a binding that exists in M's module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding.</p>
@@ -6181,12 +5966,10 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="8.1.2" -->
     <emu-clause id="sec-lexical-environment-operations">
       <h1>Lexical Environment Operations</h1>
       <p>The following abstract operations are used in this specification to operate upon lexical environments:</p>
 
-      <!-- es6num="8.1.2.1" -->
       <emu-clause id="sec-getidentifierreference" aoid="GetIdentifierReference">
         <h1>GetIdentifierReference ( _lex_, _name_, _strict_ )</h1>
         <p>The abstract operation GetIdentifierReference is called with a Lexical Environment _lex_, a String _name_, and a Boolean flag _strict_. The value of _lex_ may be *null*. When called, the following steps are performed:</p>
@@ -6203,7 +5986,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="8.1.2.2" -->
       <emu-clause id="sec-newdeclarativeenvironment" aoid="NewDeclarativeEnvironment">
         <h1>NewDeclarativeEnvironment ( _E_ )</h1>
         <p>When the abstract operation NewDeclarativeEnvironment is called with a Lexical Environment as argument _E_ the following steps are performed:</p>
@@ -6216,7 +5998,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="8.1.2.3" -->
       <emu-clause id="sec-newobjectenvironment" aoid="NewObjectEnvironment">
         <h1>NewObjectEnvironment ( _O_, _E_ )</h1>
         <p>When the abstract operation NewObjectEnvironment is called with an Object _O_ and a Lexical Environment _E_ as arguments, the following steps are performed:</p>
@@ -6229,7 +6010,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="8.1.2.4" -->
       <emu-clause id="sec-newfunctionenvironment" aoid="NewFunctionEnvironment">
         <h1>NewFunctionEnvironment ( _F_, _newTarget_ )</h1>
         <p>When the abstract operation NewFunctionEnvironment is called with arguments _F_ and _newTarget_ the following steps are performed:</p>
@@ -6250,7 +6030,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="8.1.2.5" -->
       <emu-clause id="sec-newglobalenvironment" aoid="NewGlobalEnvironment">
         <h1>NewGlobalEnvironment ( _G_, _thisValue_ )</h1>
         <p>When the abstract operation NewGlobalEnvironment is called with arguments _G_ and _thisValue_, the following steps are performed:</p>
@@ -6269,7 +6048,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="8.1.2.6" -->
       <emu-clause id="sec-newmoduleenvironment" aoid="NewModuleEnvironment">
         <h1>NewModuleEnvironment ( _E_ )</h1>
         <p>When the abstract operation NewModuleEnvironment is called with a Lexical Environment argument _E_ the following steps are performed:</p>
@@ -6284,7 +6062,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="8.2" -->
   <emu-clause id="sec-code-realms">
     <h1>Realms</h1>
     <p>Before it is evaluated, all ECMAScript code must be associated with a <dfn id="realm">realm</dfn>. Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript global environment, all of the ECMAScript code that is loaded within the scope of that global environment, and other associated state and resources.</p>
@@ -6363,7 +6140,6 @@
       </table>
     </emu-table>
 
-    <!-- es6num="8.2.1" -->
     <emu-clause id="sec-createrealm" aoid="CreateRealm">
       <h1>CreateRealm ( )</h1>
       <p>The abstract operation CreateRealm with no arguments performs the following steps:</p>
@@ -6377,7 +6153,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="8.2.2" -->
     <emu-clause id="sec-createintrinsics" aoid="CreateIntrinsics">
       <h1>CreateIntrinsics ( _realmRec_ )</h1>
       <p>The abstract operation CreateIntrinsics with argument _realmRec_ performs the following steps:</p>
@@ -6399,7 +6174,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="8.2.3" -->
     <emu-clause id="sec-setrealmglobalobject" aoid="SetRealmGlobalObject">
       <h1>SetRealmGlobalObject ( _realmRec_, _globalObj_, _thisValue_ )</h1>
       <p>The abstract operation SetRealmGlobalObject with arguments _realmRec_, _globalObj_, and _thisValue_ performs the following steps:</p>
@@ -6416,7 +6190,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="8.2.4" -->
     <emu-clause id="sec-setdefaultglobalbindings" aoid="SetDefaultGlobalBindings">
       <h1>SetDefaultGlobalBindings ( _realmRec_ )</h1>
       <p>The abstract operation SetDefaultGlobalBindings with argument _realmRec_ performs the following steps:</p>
@@ -6431,7 +6204,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="8.3" -->
   <emu-clause id="sec-execution-contexts">
     <h1>Execution Contexts</h1>
     <p>An <dfn>execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context">running execution context</dfn>.  All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
@@ -6554,7 +6326,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="8.3.1" -->
     <emu-clause id="sec-resolvebinding" aoid="ResolveBinding">
       <h1>ResolveBinding ( _name_ [ , _env_ ] )</h1>
       <p>The ResolveBinding abstract operation is used to determine the binding of _name_ passed as a String value. The optional argument _env_ can be used to explicitly provide the Lexical Environment that is to be searched for the binding. During execution of ECMAScript code, ResolveBinding is performed using the following algorithm:</p>
@@ -6570,7 +6341,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="8.3.2" -->
     <emu-clause id="sec-getthisenvironment" aoid="GetThisEnvironment">
       <h1>GetThisEnvironment ( )</h1>
       <p>The abstract operation GetThisEnvironment finds the Environment Record that currently supplies the binding of the keyword `this`. GetThisEnvironment performs the following steps:</p>
@@ -6589,7 +6359,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="8.3.3" -->
     <emu-clause id="sec-resolvethisbinding" aoid="ResolveThisBinding">
       <h1>ResolveThisBinding ( )</h1>
       <p>The abstract operation ResolveThisBinding determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context. ResolveThisBinding performs the following steps:</p>
@@ -6599,7 +6368,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="8.3.4" -->
     <emu-clause id="sec-getnewtarget" aoid="GetNewTarget">
       <h1>GetNewTarget ( )</h1>
       <p>The abstract operation GetNewTarget determines the NewTarget value using the LexicalEnvironment of the running execution context. GetNewTarget performs the following steps:</p>
@@ -6610,7 +6378,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="8.3.5" -->
     <emu-clause id="sec-getglobalobject" aoid="GetGlobalObject">
       <h1>GetGlobalObject ( )</h1>
       <p>The abstract operation GetGlobalObject returns the global object used by the currently running execution context. GetGlobalObject performs the following steps:</p>
@@ -6622,7 +6389,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="8.4" -->
   <emu-clause id="sec-jobs-and-job-queues">
     <h1>Jobs and Job Queues</h1>
     <p>A Job is an abstract operation that initiates an ECMAScript computation when no other ECMAScript computation is currently in progress. A Job abstract operation may be defined to accept an arbitrary set of job parameters.</p>
@@ -6738,7 +6504,6 @@
     </emu-note>
     <p>The following abstract operations are used to create and manage Jobs and Job Queues:</p>
 
-    <!-- es6num="8.4.1" -->
     <emu-clause id="sec-enqueuejob" aoid="EnqueueJob">
       <h1>EnqueueJob ( _queueName_, _job_, _arguments_ )</h1>
       <p>The EnqueueJob abstract operation requires three arguments: _queueName_, _job_, and _arguments_. It performs the following steps:</p>
@@ -6963,11 +6728,9 @@
 
 </emu-clause>
 
-<!-- es6num="9" -->
 <emu-clause id="sec-ordinary-and-exotic-objects-behaviours">
   <h1>Ordinary and Exotic Objects Behaviours</h1>
 
-  <!-- es6num="9.1" -->
   <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots">
     <h1>Ordinary Object Internal Methods and Internal Slots</h1>
     <p>All ordinary objects have an internal slot called [[Prototype]]. The value of this internal slot is either *null* or an object and is used for implementing inheritance. Data properties of the [[Prototype]] object are inherited (and visible as properties of the child object) for the purposes of get access, but not for set access. Accessor properties are inherited for both get access and set access.</p>
@@ -6975,7 +6738,6 @@
     <p>In the following algorithm descriptions, assume _O_ is an ordinary object, _P_ is a property key value, _V_ is any ECMAScript language value, and _Desc_ is a Property Descriptor record.</p>
     <p>Each ordinary object internal method delegates to a similarly-named abstract operation. If such an abstract operation depends on another internal method, then the internal method is invoked on _O_ rather than calling the similarly-named abstract operation directly. These semantics ensure that exotic objects have their overridden internal methods invoked when ordinary object internal methods are applied to them.</p>
 
-    <!-- es6num="9.1.1" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof">
       <h1>[[GetPrototypeOf]] ( )</h1>
       <p>When the [[GetPrototypeOf]] internal method of _O_ is called, the following steps are taken:</p>
@@ -6992,7 +6754,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.2" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v">
       <h1>[[SetPrototypeOf]] ( _V_ )</h1>
       <p>When the [[SetPrototypeOf]] internal method of _O_ is called with argument _V_, the following steps are taken:</p>
@@ -7026,7 +6787,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.3" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-isextensible">
       <h1>[[IsExtensible]] ( )</h1>
       <p>When the [[IsExtensible]] internal method of _O_ is called, the following steps are taken:</p>
@@ -7043,7 +6803,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.4" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-preventextensions">
       <h1>[[PreventExtensions]] ( )</h1>
       <p>When the [[PreventExtensions]] internal method of _O_ is called, the following steps are taken:</p>
@@ -7061,7 +6820,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.5" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">
       <h1>[[GetOwnProperty]] ( _P_ )</h1>
       <p>When the [[GetOwnProperty]] internal method of _O_ is called with property key _P_, the following steps are taken:</p>
@@ -7069,7 +6827,6 @@
         1. Return ! OrdinaryGetOwnProperty(_O_, _P_).
       </emu-alg>
 
-      <!-- es6num="9.1.5.1" -->
       <emu-clause id="sec-ordinarygetownproperty" aoid="OrdinaryGetOwnProperty">
         <h1>OrdinaryGetOwnProperty ( _O_, _P_ )</h1>
         <p>When the abstract operation OrdinaryGetOwnProperty is called with Object _O_ and with property key _P_, the following steps are taken:</p>
@@ -7091,7 +6848,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.6" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">
       <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
       <p>When the [[DefineOwnProperty]] internal method of _O_ is called with property key _P_ and Property Descriptor _Desc_, the following steps are taken:</p>
@@ -7099,7 +6855,6 @@
         1. Return ? OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
       </emu-alg>
 
-      <!-- es6num="9.1.6.1" -->
       <emu-clause id="sec-ordinarydefineownproperty" aoid="OrdinaryDefineOwnProperty">
         <h1>OrdinaryDefineOwnProperty ( _O_, _P_, _Desc_ )</h1>
         <p>When the abstract operation OrdinaryDefineOwnProperty is called with Object _O_, property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
@@ -7110,7 +6865,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.1.6.2" -->
       <emu-clause id="sec-iscompatiblepropertydescriptor" aoid="IsCompatiblePropertyDescriptor">
         <h1>IsCompatiblePropertyDescriptor ( _Extensible_, _Desc_, _Current_ )</h1>
         <p>When the abstract operation IsCompatiblePropertyDescriptor is called with Boolean value _Extensible_, and Property Descriptors _Desc_, and _Current_, the following steps are taken:</p>
@@ -7119,7 +6873,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.1.6.3" -->
       <emu-clause id="sec-validateandapplypropertydescriptor" aoid="ValidateAndApplyPropertyDescriptor">
         <h1>ValidateAndApplyPropertyDescriptor ( _O_, _P_, _extensible_, _Desc_, _current_ )</h1>
         <p>When the abstract operation ValidateAndApplyPropertyDescriptor is called with Object _O_, property key _P_, Boolean value _extensible_, and Property Descriptors _Desc_, and _current_, the following steps are taken:</p>
@@ -7164,7 +6917,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.7" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p">
       <h1>[[HasProperty]] ( _P_ )</h1>
       <p>When the [[HasProperty]] internal method of _O_ is called with property key _P_, the following steps are taken:</p>
@@ -7172,7 +6924,6 @@
         1. Return ? OrdinaryHasProperty(_O_, _P_).
       </emu-alg>
 
-      <!-- es6num="9.1.7.1" -->
       <emu-clause id="sec-ordinaryhasproperty" aoid="OrdinaryHasProperty">
         <h1>OrdinaryHasProperty ( _O_, _P_ )</h1>
         <p>When the abstract operation OrdinaryHasProperty is called with Object _O_ and with property key _P_, the following steps are taken:</p>
@@ -7188,7 +6939,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.8" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">
       <h1>[[Get]] ( _P_, _Receiver_ )</h1>
       <p>When the [[Get]] internal method of _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -7217,7 +6967,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.9" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">
       <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
       <p>When the [[Set]] internal method of _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -7268,7 +7017,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.10" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-delete-p">
       <h1>[[Delete]] ( _P_ )</h1>
       <p>When the [[Delete]] internal method of _O_ is called with property key _P_, the following steps are taken:</p>
@@ -7291,7 +7039,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.12" -->
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">
       <h1>[[OwnPropertyKeys]] ( )</h1>
       <p>When the [[OwnPropertyKeys]] internal method of _O_ is called, the following steps are taken:</p>
@@ -7316,7 +7063,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.1.13" -->
     <emu-clause id="sec-objectcreate" aoid="ObjectCreate">
       <h1>ObjectCreate ( _proto_ [ , _internalSlotsList_ ] )</h1>
       <p>The abstract operation ObjectCreate with argument _proto_ (an object or null) is used to specify the runtime creation of new ordinary objects. The optional argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
@@ -7330,7 +7076,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.1.14" -->
     <emu-clause id="sec-ordinarycreatefromconstructor" aoid="OrdinaryCreateFromConstructor">
       <h1>OrdinaryCreateFromConstructor ( _constructor_, _intrinsicDefaultProto_ [ , _internalSlotsList_ ] )</h1>
       <p>The abstract operation OrdinaryCreateFromConstructor creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's `prototype` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. The optional _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
@@ -7341,7 +7086,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.1.15" -->
     <emu-clause id="sec-getprototypefromconstructor" aoid="GetPrototypeFromConstructor">
       <h1>GetPrototypeFromConstructor ( _constructor_, _intrinsicDefaultProto_ )</h1>
       <p>The abstract operation GetPrototypeFromConstructor determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's `prototype` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. This abstract operation performs the following steps:</p>
@@ -7360,7 +7104,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="9.2" -->
   <emu-clause id="sec-ecmascript-function-objects">
     <h1>ECMAScript Function Objects</h1>
     <p>ECMAScript function objects encapsulate parameterized ECMAScript code closed over a lexical environment and support the dynamic evaluation of that code. An ECMAScript function object is an ordinary object and has the same internal slots and the same internal methods as other ordinary objects. The code of an ECMAScript function object may be either strict mode code (<emu-xref href="#sec-strict-mode-code"></emu-xref>) or non-strict code. An ECMAScript function object whose code is strict mode code is called a <dfn id="strict-function">strict function</dfn>. One whose code is not strict mode code is called a <dfn id="non-strict-function">non-strict function</dfn>.</p>
@@ -7494,7 +7237,6 @@
     </emu-table>
     <p>All ECMAScript function objects have the [[Call]] internal method defined here. ECMAScript functions that are also constructors in addition have the [[Construct]] internal method.</p>
 
-    <!-- es6num="9.2.1" -->
     <emu-clause id="sec-ecmascript-function-objects-call-thisargument-argumentslist">
       <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
       <p>The [[Call]] internal method for an ECMAScript function object _F_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
@@ -7515,7 +7257,6 @@
         <p>When _calleeContext_ is removed from the execution context stack in step 8 it must not be destroyed if it is suspended and retained for later resumption by an accessible generator object.</p>
       </emu-note>
 
-      <!-- es6num="9.2.1.1" -->
       <emu-clause id="sec-prepareforordinarycall" aoid="PrepareForOrdinaryCall">
         <h1>PrepareForOrdinaryCall ( _F_, _newTarget_ )</h1>
         <p>When the abstract operation PrepareForOrdinaryCall is called with function object _F_ and ECMAScript language value _newTarget_, the following steps are taken:</p>
@@ -7537,7 +7278,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.2.1.2" -->
       <emu-clause id="sec-ordinarycallbindthis" aoid="OrdinaryCallBindThis">
         <h1>OrdinaryCallBindThis ( _F_, _calleeContext_, _thisArgument_ )</h1>
         <p>When the abstract operation OrdinaryCallBindThis is called with function object _F_, execution context _calleeContext_, and ECMAScript value _thisArgument_, the following steps are taken:</p>
@@ -7563,7 +7303,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.2.1.3" -->
       <emu-clause id="sec-ordinarycallevaluatebody" aoid="OrdinaryCallEvaluateBody">
         <h1>OrdinaryCallEvaluateBody ( _F_, _argumentsList_ )</h1>
         <p>When the abstract operation OrdinaryCallEvaluateBody is called with function object _F_ and List _argumentsList_, the following steps are taken:</p>
@@ -7573,7 +7312,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.2.2" -->
     <emu-clause id="sec-ecmascript-function-objects-construct-argumentslist-newtarget">
       <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
       <p>The [[Construct]] internal method for an ECMAScript function object _F_ is called with parameters _argumentsList_ and _newTarget_. _argumentsList_ is a possibly empty List of ECMAScript language values. The following steps are taken:</p>
@@ -7600,7 +7338,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.3" -->
     <emu-clause id="sec-functionallocate" aoid="FunctionAllocate">
       <h1>FunctionAllocate ( _functionPrototype_, _strict_, _functionKind_ )</h1>
       <p>The abstract operation FunctionAllocate requires the three arguments _functionPrototype_, _strict_ and _functionKind_. FunctionAllocate performs the following steps:</p>
@@ -7625,7 +7362,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.4" -->
     <emu-clause id="sec-functioninitialize" aoid="FunctionInitialize">
       <h1>FunctionInitialize ( _F_, _kind_, _ParameterList_, _Body_, _Scope_ )</h1>
       <p>The abstract operation FunctionInitialize requires the arguments: a function object _F_, _kind_ which is one of (Normal, Method, Arrow), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. FunctionInitialize performs the following steps:</p>
@@ -7644,7 +7380,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.5" -->
     <emu-clause id="sec-functioncreate" aoid="FunctionCreate">
       <h1>FunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_, _Strict_ [ , _prototype_ ] )</h1>
       <p>The abstract operation FunctionCreate requires the arguments: _kind_ which is one of (Normal, Method, Arrow), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, a Boolean flag _Strict_, and optionally, an object _prototype_. FunctionCreate performs the following steps:</p>
@@ -7658,7 +7393,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.6" -->
     <emu-clause id="sec-generatorfunctioncreate" aoid="GeneratorFunctionCreate">
       <h1>GeneratorFunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_, _Strict_ )</h1>
       <p>The abstract operation GeneratorFunctionCreate requires the arguments: _kind_ which is one of (Normal, Method), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. GeneratorFunctionCreate performs the following steps:</p>
@@ -7689,7 +7423,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.7" -->
     <emu-clause id="sec-addrestrictedfunctionproperties" aoid="AddRestrictedFunctionProperties">
       <h1>AddRestrictedFunctionProperties ( _F_, _realm_ )</h1>
       <p>The abstract operation AddRestrictedFunctionProperties is called with a function object _F_ and Realm Record _realm_ as its argument. It performs the following steps:</p>
@@ -7700,7 +7433,6 @@
         1. Return ! DefinePropertyOrThrow(_F_, `"arguments"`, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
       </emu-alg>
 
-      <!-- es6num="9.2.7.1" -->
       <emu-clause id="sec-%throwtypeerror%">
         <h1>%ThrowTypeError% ( )</h1>
         <p>The <dfn>%ThrowTypeError%</dfn> intrinsic is an anonymous built-in function object that is defined once for each realm. When %ThrowTypeError% is called it performs the following steps:</p>
@@ -7712,7 +7444,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.2.8" -->
     <emu-clause id="sec-makeconstructor" aoid="MakeConstructor">
       <h1>MakeConstructor ( _F_ [ , _writablePrototype_ [ , _prototype_ ] ] )</h1>
       <p>The abstract operation MakeConstructor requires a Function argument _F_ and optionally, a Boolean _writablePrototype_ and an object _prototype_. If _prototype_ is provided it is assumed to already contain, if needed, a `"constructor"` property whose value is _F_. This operation converts _F_ into a constructor by performing the following steps:</p>
@@ -7729,7 +7460,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.9" -->
     <emu-clause id="sec-makeclassconstructor" aoid="MakeClassConstructor">
       <h1>MakeClassConstructor ( _F_ )</h1>
       <p>The abstract operation MakeClassConstructor with argument _F_ performs the following steps:</p>
@@ -7741,7 +7471,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.10" -->
     <emu-clause id="sec-makemethod" aoid="MakeMethod">
       <h1>MakeMethod ( _F_, _homeObject_ )</h1>
       <p>The abstract operation MakeMethod with arguments _F_ and _homeObject_ configures _F_ as a method by performing the following steps:</p>
@@ -7753,7 +7482,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.11" -->
     <emu-clause id="sec-setfunctionname" aoid="SetFunctionName">
       <h1>SetFunctionName ( _F_, _name_ [ , _prefix_ ] )</h1>
       <p>The abstract operation SetFunctionName requires a Function argument _F_, a String or Symbol argument _name_ and optionally a String argument _prefix_. This operation adds a `name` property to _F_ by performing the following steps:</p>
@@ -7782,7 +7510,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.2.12" -->
     <emu-clause id="sec-functiondeclarationinstantiation" aoid="FunctionDeclarationInstantiation">
       <h1>FunctionDeclarationInstantiation ( _func_, _argumentsList_ )</h1>
       <emu-note>
@@ -7908,7 +7635,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="9.3" -->
   <emu-clause id="sec-built-in-function-objects">
     <h1>Built-in Function Objects</h1>
     <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided function exotic objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
@@ -7919,7 +7645,6 @@
     <p>Built-in functions that are not constructors do not have a `prototype` property unless otherwise specified in the description of a particular function.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
 
-    <!-- es6num="9.3.1" -->
     <emu-clause id="sec-built-in-function-objects-call-thisargument-argumentslist">
       <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
       <p>The [[Call]] internal method for a built-in function object _F_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
@@ -7942,7 +7667,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.3.2" -->
     <emu-clause id="sec-built-in-function-objects-construct-argumentslist-newtarget">
       <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
       <p>The [[Construct]] internal method for built-in function object _F_ is called with parameters _argumentsList_ and _newTarget_. The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step 10 is replaced by:</p>
@@ -7951,7 +7675,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="9.3.3" -->
     <emu-clause id="sec-createbuiltinfunction" aoid="CreateBuiltinFunction">
       <h1>CreateBuiltinFunction ( _steps_, _internalSlotsList_ [ , _realm_ [ , _prototype_ ] ] )</h1>
       <p>The abstract operation CreateBuiltinFunction takes arguments _steps_, _internalSlotsList_, _realm_, and _prototype_. The argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. CreateBuiltinFunction returns a built-in function object created by the following steps:</p>
@@ -7971,12 +7694,10 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="9.4" -->
   <emu-clause id="sec-built-in-exotic-object-internal-methods-and-slots">
     <h1>Built-in Exotic Object Internal Methods and Slots</h1>
     <p>This specification defines several kinds of built-in exotic objects. These objects generally behave similar to ordinary objects except for a few specific situations. The following exotic objects use the ordinary object internal methods except where it is explicitly specified otherwise below:</p>
 
-    <!-- es6num="9.4.1" -->
     <emu-clause id="sec-bound-function-exotic-objects">
       <h1>Bound Function Exotic Objects</h1>
       <p>A <dfn>bound function</dfn> is an exotic object that wraps another function object. A bound function is callable (it has a [[Call]] internal method and may have a [[Construct]] internal method). Calling a bound function generally results in a call of its wrapped function.</p>
@@ -8033,7 +7754,6 @@
       </emu-table>
       <p>Bound function objects provide all of the essential internal methods as specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. However, they use the following definitions for the essential internal methods of function objects.</p>
 
-      <!-- es6num="9.4.1.1" -->
       <emu-clause id="sec-bound-function-exotic-objects-call-thisargument-argumentslist">
         <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
         <p>When the [[Call]] internal method of a bound function exotic object, _F_, which was created using the bind function is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values, the following steps are taken:</p>
@@ -8046,7 +7766,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.1.2" -->
       <emu-clause id="sec-bound-function-exotic-objects-construct-argumentslist-newtarget">
         <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
         <p>When the [[Construct]] internal method of a bound function exotic object, _F_ that was created using the bind function is called with a list of arguments _argumentsList_ and _newTarget_, the following steps are taken:</p>
@@ -8060,7 +7779,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.1.3" -->
       <emu-clause id="sec-boundfunctioncreate" aoid="BoundFunctionCreate">
         <h1>BoundFunctionCreate ( _targetFunction_, _boundThis_, _boundArgs_ )</h1>
         <p>The abstract operation BoundFunctionCreate with arguments _targetFunction_, _boundThis_ and _boundArgs_ is used to specify the creation of new Bound Function exotic objects. It performs the following steps:</p>
@@ -8082,7 +7800,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.4.2" -->
     <emu-clause id="sec-array-exotic-objects">
       <h1>Array Exotic Objects</h1>
       <p>An <em>Array object</em> is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array object has a `length` property whose value is always a nonnegative integer less than 2<sup>32</sup>. The value of the `length` property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array object is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the `length` property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the `length` property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array object and is unaffected by `length` or array index properties that may be inherited from its prototypes.</p>
@@ -8092,7 +7809,6 @@
       <p>Array exotic objects always have a non-configurable property named `"length"`.</p>
       <p>Array exotic objects provide an alternative definition for the [[DefineOwnProperty]] internal method. Except for that internal method, Array exotic objects provide all of the other essential internal methods as specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</p>
 
-      <!-- es6num="9.4.2.1" -->
       <emu-clause id="sec-array-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
         <p>When the [[DefineOwnProperty]] internal method of an Array exotic object _A_ is called with property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
@@ -8117,7 +7833,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.2.2" -->
       <emu-clause id="sec-arraycreate" aoid="ArrayCreate">
         <h1>ArrayCreate ( _length_ [ , _proto_ ] )</h1>
         <p>The abstract operation ArrayCreate with argument _length_ (either 0 or a positive integer) and optional argument _proto_ is used to specify the creation of new Array exotic objects. It performs the following steps:</p>
@@ -8136,7 +7851,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.2.3" -->
       <emu-clause id="sec-arrayspeciescreate" aoid="ArraySpeciesCreate">
         <h1>ArraySpeciesCreate ( _originalArray_, _length_ )</h1>
         <p>The abstract operation ArraySpeciesCreate with arguments _originalArray_ and _length_ is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_. It performs the following steps:</p>
@@ -8163,7 +7877,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="9.4.2.4" -->
       <emu-clause id="sec-arraysetlength" aoid="ArraySetLength">
         <h1>ArraySetLength ( _A_, _Desc_ )</h1>
         <p>When the abstract operation ArraySetLength is called with an Array exotic object _A_, and Property Descriptor _Desc_, the following steps are taken:</p>
@@ -8206,14 +7919,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.4.3" -->
     <emu-clause id="sec-string-exotic-objects">
       <h1>String Exotic Objects</h1>
       <p>A <em>String object</em> is an exotic object that encapsulates a String value and exposes virtual integer-indexed data properties corresponding to the individual code unit elements of the String value. String exotic objects always have a data property named `"length"` whose value is the number of code unit elements in the encapsulated String value. Both the code unit data properties and the `"length"` property are non-writable and non-configurable.</p>
       <p>String exotic objects have the same internal slots as ordinary objects. They also have a [[StringData]] internal slot.</p>
       <p>String exotic objects provide alternative definitions for the following internal methods. All of the other String exotic object essential internal methods that are not defined below are as specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</p>
 
-      <!-- es6num="9.4.3.1" -->
       <emu-clause id="sec-string-exotic-objects-getownproperty-p">
         <h1>[[GetOwnProperty]] ( _P_ )</h1>
         <p>When the [[GetOwnProperty]] internal method of a String exotic object _S_ is called with property key _P_, the following steps are taken:</p>
@@ -8238,7 +7949,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.3.3" -->
       <emu-clause id="sec-string-exotic-objects-ownpropertykeys">
         <h1>[[OwnPropertyKeys]] ( )</h1>
         <p>When the [[OwnPropertyKeys]] internal method of a String exotic object _O_ is called, the following steps are taken:</p>
@@ -8258,7 +7968,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.3.4" -->
       <emu-clause id="sec-stringcreate" aoid="StringCreate">
         <h1>StringCreate ( _value_, _prototype_ )</h1>
         <p>The abstract operation StringCreate with arguments _value_ and _prototype_ is used to specify the creation of new String exotic objects. It performs the following steps:</p>
@@ -8298,7 +8007,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.4.4" -->
     <emu-clause id="sec-arguments-exotic-objects">
       <h1>Arguments Exotic Objects</h1>
       <p>Most ECMAScript functions make an arguments object available to their code. Depending upon the characteristics of the function definition, its arguments object is either an ordinary object or an <em>arguments exotic object</em>. An arguments exotic object is an exotic object whose array index properties map to the formal parameters bindings of an invocation of its associated ECMAScript function.</p>
@@ -8317,7 +8025,6 @@
         <p>ECMAScript implementations of arguments exotic objects have historically contained an accessor property named `"caller"`. Prior to ECMAScript 2017, this specification included the definition of a throwing `"caller"` property on ordinary arguments objects. Since implementations do not contain this extension any longer, ECMAScript 2017 dropped the requirement for a throwing `"caller"` accessor.</p>
       </emu-note>
 
-      <!-- es6num="9.4.4.1" -->
       <emu-clause id="sec-arguments-exotic-objects-getownproperty-p">
         <h1>[[GetOwnProperty]] ( _P_ )</h1>
         <p>The [[GetOwnProperty]] internal method of an arguments exotic object when called with a property key _P_ performs the following steps:</p>
@@ -8333,7 +8040,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.4.2" -->
       <emu-clause id="sec-arguments-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
         <p>The [[DefineOwnProperty]] internal method of an arguments exotic object when called with a property key _P_ and Property Descriptor _Desc_ performs the following steps:</p>
@@ -8361,7 +8067,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.4.3" -->
       <emu-clause id="sec-arguments-exotic-objects-get-p-receiver">
         <h1>[[Get]] ( _P_, _Receiver_ )</h1>
         <p>The [[Get]] internal method of an arguments exotic object when called with a property key _P_ and ECMAScript language value _Receiver_ performs the following steps:</p>
@@ -8376,7 +8081,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.4.4" -->
       <emu-clause id="sec-arguments-exotic-objects-set-p-v-receiver">
         <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
         <p>The [[Set]] internal method of an arguments exotic object when called with property key _P_, value _V_, and ECMAScript language value _Receiver_ performs the following steps:</p>
@@ -8394,7 +8098,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.4.5" -->
       <emu-clause id="sec-arguments-exotic-objects-delete-p">
         <h1>[[Delete]] ( _P_ )</h1>
         <p>The [[Delete]] internal method of an arguments exotic object when called with a property key _P_ performs the following steps:</p>
@@ -8409,7 +8112,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.4.6" -->
       <emu-clause id="sec-createunmappedargumentsobject" aoid="CreateUnmappedArgumentsObject">
         <h1>CreateUnmappedArgumentsObject ( _argumentsList_ )</h1>
         <p>The abstract operation CreateUnmappedArgumentsObject called with an argument _argumentsList_ performs the following steps:</p>
@@ -8429,7 +8131,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.4.7" -->
       <emu-clause id="sec-createmappedargumentsobject" aoid="CreateMappedArgumentsObject">
         <h1>CreateMappedArgumentsObject ( _func_, _formals_, _argumentsList_, _env_ )</h1>
         <p>The abstract operation CreateMappedArgumentsObject is called with object _func_, Parse Node _formals_, List _argumentsList_, and Environment Record _env_. The following steps are performed:</p>
@@ -8471,7 +8172,6 @@
           1. Return _obj_.
         </emu-alg>
 
-        <!-- es6num="9.4.4.7.1" -->
         <emu-clause id="sec-makearggetter" aoid="MakeArgGetter">
           <h1>MakeArgGetter ( _name_, _env_ )</h1>
           <p>The abstract operation MakeArgGetter called with String _name_ and Environment Record _env_ creates a built-in function object that when executed returns the value bound for _name_ in _env_. It performs the following steps:</p>
@@ -8493,7 +8193,6 @@
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="9.4.4.7.2" -->
         <emu-clause id="sec-makeargsetter" aoid="MakeArgSetter">
           <h1>MakeArgSetter ( _name_, _env_ )</h1>
           <p>The abstract operation MakeArgSetter called with String _name_ and Environment Record _env_ creates a built-in function object that when executed sets the value bound for _name_ in _env_. It performs the following steps:</p>
@@ -8517,14 +8216,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.4.5" -->
     <emu-clause id="sec-integer-indexed-exotic-objects">
       <h1>Integer-Indexed Exotic Objects</h1>
       <p>An <dfn id="integer-indexed-exotic-object">Integer-Indexed exotic object</dfn> is an exotic object that performs special handling of integer index property keys.</p>
       <p><emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref> have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.</p>
       <p><emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref> provide alternative definitions for the following internal methods. All of the other Integer-Indexed exotic object essential internal methods that are not defined below are as specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</p>
 
-      <!-- es6num="9.4.5.1" -->
       <emu-clause id="sec-integer-indexed-exotic-objects-getownproperty-p">
         <h1>[[GetOwnProperty]] ( _P_ )</h1>
         <p>When the [[GetOwnProperty]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, the following steps are taken:</p>
@@ -8541,7 +8238,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.5.2" -->
       <emu-clause id="sec-integer-indexed-exotic-objects-hasproperty-p">
         <h1>[[HasProperty]] ( _P_ )</h1>
         <p>When the [[HasProperty]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, the following steps are taken:</p>
@@ -8562,7 +8258,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.5.3" -->
       <emu-clause id="sec-integer-indexed-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
         <p>When the [[DefineOwnProperty]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
@@ -8589,7 +8284,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.5.4" -->
       <emu-clause id="sec-integer-indexed-exotic-objects-get-p-receiver">
         <h1>[[Get]] ( _P_, _Receiver_ )</h1>
         <p>When the [[Get]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -8603,7 +8297,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.5.5" -->
       <emu-clause id="sec-integer-indexed-exotic-objects-set-p-v-receiver">
         <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
         <p>When the [[Set]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -8617,7 +8310,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.5.6" -->
       <emu-clause id="sec-integer-indexed-exotic-objects-ownpropertykeys">
         <h1>[[OwnPropertyKeys]] ( )</h1>
         <p>When the [[OwnPropertyKeys]] internal method of an Integer-Indexed exotic object _O_ is called, the following steps are taken:</p>
@@ -8635,7 +8327,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.5.7" -->
       <emu-clause id="sec-integerindexedobjectcreate" aoid="IntegerIndexedObjectCreate">
         <h1>IntegerIndexedObjectCreate ( _prototype_, _internalSlotsList_ )</h1>
         <p>The abstract operation IntegerIndexedObjectCreate with arguments _prototype_ and _internalSlotsList_ is used to specify the creation of new <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>. The argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. IntegerIndexedObjectCreate performs the following steps:</p>
@@ -8655,7 +8346,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.5.8" -->
       <emu-clause id="sec-integerindexedelementget" aoid="IntegerIndexedElementGet">
         <h1>IntegerIndexedElementGet ( _O_, _index_ )</h1>
         <p>The abstract operation IntegerIndexedElementGet with arguments _O_ and _index_ performs the following steps:</p>
@@ -8677,7 +8367,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.5.9" -->
       <emu-clause id="sec-integerindexedelementset" aoid="IntegerIndexedElementSet">
         <h1>IntegerIndexedElementSet ( _O_, _index_, _value_ )</h1>
         <p>The abstract operation IntegerIndexedElementSet with arguments _O_, _index_, and _value_ performs the following steps:</p>
@@ -8702,7 +8391,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="9.4.6" -->
     <emu-clause id="sec-module-namespace-exotic-objects">
       <h1>Module Namespace Exotic Objects</h1>
       <p>A <em>module namespace object</em> is an exotic object that exposes the bindings exported from an ECMAScript |Module| (See <emu-xref href="#sec-exports"></emu-xref>). There is a one-to-one correspondence between the String-keyed own properties of a module namespace exotic object and the binding names exported by the |Module|. The exported bindings include any bindings that are indirectly exported using `export *` export items. Each String-valued own property key is the StringValue of the corresponding exported binding name. These are the only String-keyed properties of a module namespace exotic object. Each such property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }. Module namespace objects are not extensible.</p>
@@ -8759,7 +8447,6 @@
       </emu-table>
       <p>Module namespace exotic objects provide alternative definitions for all of the internal methods except [[GetPrototypeOf]], which behaves as defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>.</p>
 
-      <!-- es6num="9.4.6.2" -->
       <emu-clause id="sec-module-namespace-exotic-objects-setprototypeof-v">
         <h1>[[SetPrototypeOf]] ( _V_ )</h1>
         <p>When the [[SetPrototypeOf]] internal method of a module namespace exotic object _O_ is called with argument _V_, the following steps are taken:</p>
@@ -8768,7 +8455,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.3" -->
       <emu-clause id="sec-module-namespace-exotic-objects-isextensible">
         <h1>[[IsExtensible]] ( )</h1>
         <p>When the [[IsExtensible]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
@@ -8777,7 +8463,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.4" -->
       <emu-clause id="sec-module-namespace-exotic-objects-preventextensions">
         <h1>[[PreventExtensions]] ( )</h1>
         <p>When the [[PreventExtensions]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
@@ -8786,7 +8471,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.5" -->
       <emu-clause id="sec-module-namespace-exotic-objects-getownproperty-p">
         <h1>[[GetOwnProperty]] ( _P_ )</h1>
         <p>When the [[GetOwnProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
@@ -8799,7 +8483,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.6" -->
       <emu-clause id="sec-module-namespace-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
         <p>When the [[DefineOwnProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_ and Property Descriptor _Desc_, the following steps are taken:</p>
@@ -8808,7 +8491,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.7" -->
       <emu-clause id="sec-module-namespace-exotic-objects-hasproperty-p">
         <h1>[[HasProperty]] ( _P_ )</h1>
         <p>When the [[HasProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
@@ -8820,7 +8502,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.8" -->
       <emu-clause id="sec-module-namespace-exotic-objects-get-p-receiver">
         <h1>[[Get]] ( _P_, _Receiver_ )</h1>
         <p>When the [[Get]] internal method of a module namespace exotic object _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -8845,7 +8526,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="9.4.6.9" -->
       <emu-clause id="sec-module-namespace-exotic-objects-set-p-v-receiver">
         <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
         <p>When the [[Set]] internal method of a module namespace exotic object _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -8854,7 +8534,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.10" -->
       <emu-clause id="sec-module-namespace-exotic-objects-delete-p">
         <h1>[[Delete]] ( _P_ )</h1>
         <p>When the [[Delete]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
@@ -8868,7 +8547,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.12" -->
       <emu-clause id="sec-module-namespace-exotic-objects-ownpropertykeys">
         <h1>[[OwnPropertyKeys]] ( )</h1>
         <p>When the [[OwnPropertyKeys]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
@@ -8880,7 +8558,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.4.6.13" -->
       <emu-clause id="sec-modulenamespacecreate" aoid="ModuleNamespaceCreate">
         <h1>ModuleNamespaceCreate ( _module_, _exports_ )</h1>
         <p>The abstract operation ModuleNamespaceCreate with arguments _module_, and _exports_ is used to specify the creation of new module namespace exotic objects. It performs the following steps:</p>
@@ -8927,7 +8604,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="9.5" -->
   <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots">
     <h1>Proxy Object Internal Methods and Internal Slots</h1>
     <p>A proxy object is an exotic object whose essential internal methods are partially implemented using ECMAScript code. Every proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's <em>handler object</em>, or *null*. Methods (see <emu-xref href="#table-30"></emu-xref>) of a handler object may be used to augment the implementation for one or more of the proxy object's internal methods. Every proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the *null* value. This object is called the proxy's <em>target object</em>.</p>
@@ -9054,7 +8730,6 @@
     <p>Because proxy objects permit the implementation of internal methods to be provided by arbitrary ECMAScript code, it is possible to define a proxy object whose handler methods violates the invariants defined in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref>. Some of the internal method invariants defined in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref> are essential integrity invariants. These invariants are explicitly enforced by the proxy object internal methods specified in this section. An ECMAScript implementation must be robust in the presence of all possible invariant violations.</p>
     <p>In the following algorithm descriptions, assume _O_ is an ECMAScript proxy object, _P_ is a property key value, _V_ is any ECMAScript language value and _Desc_ is a Property Descriptor record.</p>
 
-    <!-- es6num="9.5.1" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getprototypeof">
       <h1>[[GetPrototypeOf]] ( )</h1>
       <p>When the [[GetPrototypeOf]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
@@ -9087,7 +8762,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.2" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v">
       <h1>[[SetPrototypeOf]] ( _V_ )</h1>
       <p>When the [[SetPrototypeOf]] internal method of a Proxy exotic object _O_ is called with argument _V_, the following steps are taken:</p>
@@ -9121,7 +8795,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.3" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-isextensible">
       <h1>[[IsExtensible]] ( )</h1>
       <p>When the [[IsExtensible]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
@@ -9151,7 +8824,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.4" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-preventextensions">
       <h1>[[PreventExtensions]] ( )</h1>
       <p>When the [[PreventExtensions]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
@@ -9182,7 +8854,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.5" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p">
       <h1>[[GetOwnProperty]] ( _P_ )</h1>
       <p>When the [[GetOwnProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
@@ -9237,7 +8908,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.6" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc">
       <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
       <p>When the [[DefineOwnProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_ and Property Descriptor _Desc_, the following steps are taken:</p>
@@ -9285,7 +8955,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.7" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p">
       <h1>[[HasProperty]] ( _P_ )</h1>
       <p>When the [[HasProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
@@ -9323,7 +8992,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.8" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver">
       <h1>[[Get]] ( _P_, _Receiver_ )</h1>
       <p>When the [[Get]] internal method of a Proxy exotic object _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -9358,7 +9026,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.9" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver">
       <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
       <p>When the [[Set]] internal method of a Proxy exotic object _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -9397,7 +9064,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.10" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-delete-p">
       <h1>[[Delete]] ( _P_ )</h1>
       <p>When the [[Delete]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
@@ -9430,7 +9096,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.12" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">
       <h1>[[OwnPropertyKeys]] ( )</h1>
       <p>When the [[OwnPropertyKeys]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
@@ -9492,7 +9157,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.13" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist">
       <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
       <p>The [[Call]] internal method of a Proxy exotic object _O_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
@@ -9512,7 +9176,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.14" -->
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget">
       <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
       <p>The [[Construct]] internal method of a Proxy exotic object _O_ is called with parameters _argumentsList_ which is a possibly empty List of ECMAScript language values and _newTarget_. The following steps are taken:</p>
@@ -9543,7 +9206,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="9.5.15" -->
     <emu-clause id="sec-proxycreate" aoid="ProxyCreate">
       <h1>ProxyCreate ( _target_, _handler_ )</h1>
       <p>The abstract operation ProxyCreate with arguments _target_ and _handler_ is used to specify the creation of new Proxy exotic objects. It performs the following steps:</p>
@@ -9566,11 +9228,9 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="10" -->
 <emu-clause id="sec-ecmascript-language-source-code">
   <h1>ECMAScript Language: Source Code</h1>
 
-  <!-- es6num="10.1" -->
   <emu-clause id="sec-source-text">
     <h1>Source Text</h1>
     <h2>Syntax</h2>
@@ -9585,7 +9245,6 @@
       <p>ECMAScript differs from the Java programming language in the behaviour of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a string literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a string literal&mdash;one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the String value of a string literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a string literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the string literal.</p>
     </emu-note>
 
-    <!-- es6num="10.1.1" -->
     <emu-clause id="sec-utf16encoding" aoid="UTF16Encoding">
       <h1>Static Semantics: UTF16Encoding ( _cp_ )</h1>
       <p>The UTF16Encoding of a numeric code point value, _cp_, is determined as follows:</p>
@@ -9598,7 +9257,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="10.1.2" -->
     <emu-clause id="sec-utf16decode" aoid="UTF16Decode">
       <h1>Static Semantics: UTF16Decode ( _lead_, _trail_ )</h1>
       <p>Two code units, _lead_ and _trail_, that form a UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> are converted to a code point by performing the following steps:</p>
@@ -9610,7 +9268,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="10.2" -->
   <emu-clause id="sec-types-of-source-code">
     <h1>Types of Source Code</h1>
     <p>There are four types of ECMAScript code:</p>
@@ -9632,7 +9289,6 @@
       <p>Function code is generally provided as the bodies of Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>), Arrow Function Definitions (<emu-xref href="#sec-arrow-function-definitions"></emu-xref>), Method Definitions (<emu-xref href="#sec-method-definitions"></emu-xref>), Generator Function Definitions (<emu-xref href="#sec-generator-function-definitions"></emu-xref>), Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>), Async Generator Function Definitions (<emu-xref href="#sec-async-generator-function-definitions"></emu-xref>), and Async Arrow Functions (<emu-xref href="#sec-async-arrow-function-definitions"></emu-xref>). Function code is also derived from the arguments to the `Function` constructor (<emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>), the `GeneratorFunction` constructor (<emu-xref href="#sec-generatorfunction"></emu-xref>), and the `AsyncFunction` constructor (<emu-xref href="#sec-async-function-constructor-arguments"></emu-xref>).</p>
     </emu-note>
 
-    <!-- es6num="10.2.1" -->
     <emu-clause id="sec-strict-mode-code">
       <h1>Strict Mode Code</h1>
       <p>An ECMAScript |Script| syntactic unit may be processed using either unrestricted or strict mode syntax and semantics. Code is interpreted as <dfn>strict mode code</dfn> in the following situations:</p>
@@ -9659,7 +9315,6 @@
       <p>ECMAScript code that is not strict mode code is called <dfn id="non-strict-code">non-strict code</dfn>.</p>
     </emu-clause>
 
-    <!-- es6num="10.2.2" -->
     <emu-clause id="sec-non-ecmascript-functions">
       <h1>Non-ECMAScript Functions</h1>
       <p>An ECMAScript implementation may support the evaluation of function exotic objects whose evaluative behaviour is expressed in some implementation-defined form of executable code other than via ECMAScript code. Whether a function object is an ECMAScript code function or a non-ECMAScript function is not semantically observable from the perspective of an ECMAScript code function that calls or is called by such a non-ECMAScript function.</p>
@@ -9667,7 +9322,6 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="11" -->
 <emu-clause id="sec-ecmascript-language-lexical-grammar">
   <h1>ECMAScript Language: Lexical Grammar</h1>
   <p>The source text of an ECMAScript |Script| or |Module| is first converted into a sequence of input elements, which are tokens, line terminators, comments, or white space. The source text is scanned from left to right, repeatedly taking the longest possible sequence of code points as the next input element.</p>
@@ -9718,7 +9372,6 @@
       TemplateSubstitutionTail
   </emu-grammar>
 
-  <!-- es6num="11.1" -->
   <emu-clause id="sec-unicode-format-control-characters">
     <h1>Unicode Format-Control Characters</h1>
     <p>The Unicode format-control characters (i.e., the characters in category &ldquo;Cf&rdquo; in the Unicode Character Database such as LEFT-TO-RIGHT MARK or RIGHT-TO-LEFT MARK) are control codes used to control the formatting of a range of text in the absence of higher-level protocols for this (such as mark-up languages).</p>
@@ -9790,7 +9443,6 @@
     </emu-table>
   </emu-clause>
 
-  <!-- es6num="11.2" -->
   <emu-clause id="sec-white-space">
     <h1>White Space</h1>
     <p>White space code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other, but are otherwise insignificant. White space code points may occur between any two tokens and at the start or end of input. White space code points may occur within a |StringLiteral|, a |RegularExpressionLiteral|, a |Template|, or a |TemplateSubstitutionTail| where they are considered significant code points forming part of a literal value. They may also occur within a |Comment|, but cannot appear within any other kind of token.</p>
@@ -9906,7 +9558,6 @@
     </emu-grammar>
   </emu-clause>
 
-  <!-- es6num="11.3" -->
   <emu-clause id="sec-line-terminators">
     <h1>Line Terminators</h1>
     <p>Like white space code points, line terminator code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other. However, unlike white space code points, line terminators have some influence over the behaviour of the syntactic grammar. In general, line terminators may occur between any two tokens, but there are a few places where they are forbidden by the syntactic grammar. Line terminators also affect the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A line terminator cannot occur within any token except a |StringLiteral|, |Template|, or |TemplateSubstitutionTail|. Line terminators may only occur within a |StringLiteral| token as part of a |LineContinuation|.</p>
@@ -9992,7 +9643,6 @@
     </emu-grammar>
   </emu-clause>
 
-  <!-- es6num="11.4" -->
   <emu-clause id="sec-comments">
     <h1>Comments</h1>
     <p>Comments can be either single or multi-line. Multi-line comments cannot nest.</p>
@@ -10032,7 +9682,6 @@
     </emu-grammar>
   </emu-clause>
 
-  <!-- es6num="11.5" -->
   <emu-clause id="sec-tokens">
     <h1>Tokens</h1>
     <h2>Syntax</h2>
@@ -10049,7 +9698,6 @@
     </emu-note>
   </emu-clause>
 
-  <!-- es6num="11.6" -->
   <emu-clause id="sec-names-and-keywords">
     <h1>Names and Keywords</h1>
     <p>|IdentifierName| and |ReservedWord| are tokens that are interpreted according to the Default Identifier Syntax given in Unicode Standard Annex #31, Identifier and Pattern Syntax, with some small modifications. |ReservedWord| is an enumerated subset of |IdentifierName|. The syntactic grammar defines |Identifier| as an |IdentifierName| that is not a |ReservedWord|. The Unicode identifier grammar is based on character properties specified by the Unicode Standard. The Unicode code points in the specified categories in the latest version of the Unicode standard must be treated as in those categories by all conforming ECMAScript implementations. ECMAScript implementations may recognize identifier code points defined in later editions of the Unicode Standard.</p>
@@ -10091,11 +9739,9 @@
       <p>The sets of code points with Unicode properties &ldquo;ID_Start&rdquo; and &ldquo;ID_Continue&rdquo; include, respectively, the code points with Unicode properties &ldquo;Other_ID_Start&rdquo; and &ldquo;Other_ID_Continue&rdquo;.</p>
     </emu-note>
 
-    <!-- es6num="11.6.1" -->
     <emu-clause id="sec-identifier-names">
       <h1>Identifier Names</h1>
 
-      <!-- es6num="11.6.1.1" -->
       <emu-clause id="sec-identifier-names-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
@@ -10112,7 +9758,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="11.6.1.2" -->
       <emu-clause id="sec-identifier-names-static-semantics-stringvalue">
         <h1>Static Semantics: StringValue</h1>
         <emu-see-also-para op="StringValue"></emu-see-also-para>
@@ -10127,7 +9772,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="11.6.2" -->
     <emu-clause id="sec-reserved-words">
       <h1>Reserved Words</h1>
       <p>A reserved word is an |IdentifierName| that cannot be used as an |Identifier|.</p>
@@ -10143,7 +9787,6 @@
         <p>The |ReservedWord| definitions are specified as literal sequences of specific |SourceCharacter| elements. A code point in a |ReservedWord| cannot be expressed by a `\\` |UnicodeEscapeSequence|.</p>
       </emu-note>
 
-      <!-- es6num="11.6.2.1" -->
       <emu-clause id="sec-keywords">
         <h1>Keywords</h1>
         <p>The following tokens are ECMAScript keywords and may not be used as |Identifier|s in ECMAScript programs.</p>
@@ -10170,7 +9813,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="11.6.2.2" -->
       <emu-clause id="sec-future-reserved-words">
         <h1>Future Reserved Words</h1>
         <p>The following tokens are reserved for use as keywords in future language extensions.</p>
@@ -10218,7 +9860,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="11.7" -->
   <emu-clause id="sec-punctuators">
     <h1>Punctuators</h1>
     <h2>Syntax</h2>
@@ -10247,11 +9888,9 @@
     </emu-grammar>
   </emu-clause>
 
-  <!-- es6num="11.8" -->
   <emu-clause id="sec-ecmascript-language-lexical-grammar-literals">
     <h1>Literals</h1>
 
-    <!-- es6num="11.8.1" -->
     <emu-clause id="sec-null-literals">
       <h1>Null Literals</h1>
       <h2>Syntax</h2>
@@ -10261,7 +9900,6 @@
       </emu-grammar>
     </emu-clause>
 
-    <!-- es6num="11.8.2" -->
     <emu-clause id="sec-boolean-literals">
       <h1>Boolean Literals</h1>
       <h2>Syntax</h2>
@@ -10272,7 +9910,6 @@
       </emu-grammar>
     </emu-clause>
 
-    <!-- es6num="11.8.3" -->
     <emu-clause id="sec-literals-numeric-literals">
       <h1>Numeric Literals</h1>
       <h2>Syntax</h2>
@@ -10352,7 +9989,6 @@
       </emu-note>
       <p>A conforming implementation, when processing strict mode code, must not extend, as described in <emu-xref href="#sec-additional-syntax-numeric-literals"></emu-xref>, the syntax of |NumericLiteral| to include <emu-xref href="#prod-annexB-LegacyOctalIntegerLiteral"></emu-xref>, nor extend the syntax of |DecimalIntegerLiteral| to include <emu-xref href="#prod-annexB-NonOctalDecimalIntegerLiteral"></emu-xref>.</p>
 
-      <!-- es6num="11.8.3.1" -->
       <emu-clause id="sec-static-semantics-mv">
         <h1>Static Semantics: MV</h1>
         <p>A numeric literal stands for a value of the Number type. This value is determined in two steps: first, a mathematical value (MV) is derived from the literal; second, this mathematical value is rounded as described below.</p>
@@ -10517,7 +10153,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="11.8.4" -->
     <emu-clause id="sec-literals-string-literals">
       <h1>String Literals</h1>
       <emu-note>
@@ -10587,7 +10222,6 @@
         <p>A line terminator code point cannot appear in a string literal, except as part of a |LineContinuation| to produce the empty code points sequence. The proper way to cause a line terminator code point to be part of the String value of a string literal is to use an escape sequence such as `\\n` or `\\u000A`.</p>
       </emu-note>
 
-      <!-- es6num="11.8.4.2" -->
       <emu-clause id="sec-string-literals-static-semantics-stringvalue">
         <h1>Static Semantics: StringValue</h1>
         <emu-see-also-para op="StringValue"></emu-see-also-para>
@@ -10601,7 +10235,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="11.8.4.3" -->
       <emu-clause id="sec-static-semantics-sv">
         <h1>Static Semantics: SV</h1>
         <p>A string literal stands for a value of the String type. The String value (SV) of the literal is described in terms of code unit values contributed by the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value (MV), as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
@@ -10833,7 +10466,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="11.8.5" -->
     <emu-clause id="sec-literals-regular-expression-literals">
       <h1>Regular Expression Literals</h1>
       <emu-note>
@@ -10888,7 +10520,6 @@
         <p>Regular expression literals may not be empty; instead of representing an empty regular expression literal, the code unit sequence `//` starts a single-line comment. To specify an empty regular expression, use: `/(?:)/`.</p>
       </emu-note>
 
-      <!-- es6num="11.8.5.1" -->
       <emu-clause id="sec-literals-regular-expression-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>RegularExpressionFlags :: RegularExpressionFlags IdentifierPart</emu-grammar>
@@ -10899,7 +10530,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="11.8.5.2" -->
       <emu-clause id="sec-static-semantics-bodytext">
         <h1>Static Semantics: BodyText</h1>
         <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
@@ -10908,7 +10538,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="11.8.5.3" -->
       <emu-clause id="sec-static-semantics-flagtext">
         <h1>Static Semantics: FlagText</h1>
         <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
@@ -10918,7 +10547,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="11.8.6" -->
     <emu-clause id="sec-template-literal-lexical-components">
       <h1>Template Literal Lexical Components</h1>
       <h2>Syntax</h2>
@@ -10978,7 +10606,6 @@
         <p>|TemplateSubstitutionTail| is used by the |InputElementTemplateTail| alternative lexical goal.</p>
       </emu-note>
 
-      <!-- es6num="11.8.6.1" -->
       <emu-clause id="sec-static-semantics-tv-and-trv">
         <h1>Static Semantics: TV and TRV</h1>
         <p>A template literal component is interpreted as a sequence of Unicode code points. The Template Value (TV) of a literal component is described in terms of code unit values (SV, <emu-xref href="#sec-literals-string-literals"></emu-xref>) contributed by the various parts of the template literal component. As part of this process, some Unicode code points within the template component are interpreted as having a mathematical value (MV, <emu-xref href="#sec-literals-numeric-literals"></emu-xref>). In determining a TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence. The Template Raw Value (TRV) is similar to a Template Value with the difference that in TRVs escape sequences are interpreted literally.</p>
@@ -11171,12 +10798,10 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="11.9" -->
   <emu-clause id="sec-automatic-semicolon-insertion">
     <h1>Automatic Semicolon Insertion</h1>
     <p>Most ECMAScript statements and declarations must be terminated with a semicolon. Such semicolons may always appear explicitly in the source text. For convenience, however, such semicolons may be omitted from the source text in certain situations. These situations are described by saying that semicolons are automatically inserted into the source code token stream in those situations.</p>
 
-    <!-- es6num="11.9.1" -->
     <emu-clause id="sec-rules-of-automatic-semicolon-insertion" namespace=asi-rules>
       <h1>Rules of Automatic Semicolon Insertion</h1>
       <p>In the following rules, &ldquo;token&rdquo; means the actual recognized lexical token determined using the current lexical goal symbol as described in clause <emu-xref href="#sec-ecmascript-language-lexical-grammar"></emu-xref>.</p>
@@ -11257,7 +10882,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="11.9.2" -->
     <emu-clause id="sec-examples-of-automatic-semicolon-insertion">
       <h1>Examples of Automatic Semicolon Insertion</h1>
       <p>The source</p>
@@ -11323,11 +10947,9 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="12" -->
 <emu-clause id="sec-ecmascript-language-expressions">
   <h1>ECMAScript Language: Expressions</h1>
 
-  <!-- es6num="12.1" -->
   <emu-clause id="sec-identifiers">
     <h1>Identifiers</h1>
     <h2>Syntax</h2>
@@ -11359,7 +10981,6 @@
       </code></pre>
     </emu-note>
 
-    <!-- es6num="12.1.1" -->
     <emu-clause id="sec-identifiers-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
@@ -11440,7 +11061,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="12.1.2" -->
     <emu-clause id="sec-identifiers-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -11458,7 +11078,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.1.3" -->
     <emu-clause id="sec-identifiers-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -11477,7 +11096,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.1.4" -->
     <emu-clause id="sec-identifiers-static-semantics-stringvalue">
       <h1>Static Semantics: StringValue</h1>
       <emu-see-also-para op="StringValue"></emu-see-also-para>
@@ -11507,7 +11125,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.1.5" -->
     <emu-clause id="sec-identifiers-runtime-semantics-bindinginitialization">
       <h1>Runtime Semantics: BindingInitialization</h1>
       <p>With parameters _value_ and _environment_.</p>
@@ -11529,7 +11146,6 @@
         1. Return ? InitializeBoundName(`"await"`, _value_, _environment_).
       </emu-alg>
 
-      <!-- es6num="12.1.5.1" -->
       <emu-clause id="sec-initializeboundname" aoid="InitializeBoundName">
         <h1>Runtime Semantics: InitializeBoundName ( _name_, _value_, _environment_ )</h1>
         <emu-alg>
@@ -11545,7 +11161,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.1.6" -->
     <emu-clause id="sec-identifiers-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
@@ -11569,7 +11184,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.2" -->
   <emu-clause id="sec-primary-expression">
     <h1>Primary Expression</h1>
     <h2>Syntax</h2>
@@ -11609,11 +11223,9 @@
         `(` Expression[+In, ?Yield, ?Await] `)`
     </emu-grammar>
 
-    <!-- es6num="12.2.1" -->
     <emu-clause id="sec-primary-expression-semantics">
       <h1>Semantics</h1>
 
-      <!-- es6num="12.2.1.1" -->
       <emu-clause id="sec-static-semantics-coveredparenthesizedexpression">
         <h1>Static Semantics: CoveredParenthesizedExpression</h1>
         <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar>
@@ -11622,7 +11234,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.1.2" -->
       <emu-clause id="sec-semantics-static-semantics-hasname">
         <h1>Static Semantics: HasName</h1>
         <emu-see-also-para op="HasName"></emu-see-also-para>
@@ -11634,7 +11245,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.1.3" -->
       <emu-clause id="sec-semantics-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -11658,7 +11268,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.1.4" -->
       <emu-clause id="sec-semantics-static-semantics-isidentifierref">
         <h1>Static Semantics: IsIdentifierRef</h1>
         <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
@@ -11686,7 +11295,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.1.5" -->
       <emu-clause id="sec-semantics-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -11715,11 +11323,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.2.2" -->
     <emu-clause id="sec-this-keyword">
       <h1>The `this` Keyword</h1>
 
-      <!-- es6num="12.2.2.1" -->
       <emu-clause id="sec-this-keyword-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : `this`</emu-grammar>
@@ -11729,13 +11335,11 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.2.3" -->
     <emu-clause id="sec-identifier-reference">
       <h1>Identifier Reference</h1>
       <p>See <emu-xref href="#sec-identifiers"></emu-xref> for |IdentifierReference|.</p>
     </emu-clause>
 
-    <!-- es6num="12.2.4" -->
     <emu-clause id="sec-primary-expression-literals">
       <h1>Literals</h1>
       <h2>Syntax</h2>
@@ -11747,7 +11351,6 @@
           StringLiteral
       </emu-grammar>
 
-      <!-- es6num="12.2.4.1" -->
       <emu-clause id="sec-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>Literal : NullLiteral</emu-grammar>
@@ -11770,7 +11373,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.2.5" -->
     <emu-clause id="sec-array-initializer">
       <h1>Array Initializer</h1>
       <emu-note>
@@ -11798,7 +11400,6 @@
           `...` AssignmentExpression[+In, ?Yield, ?Await]
       </emu-grammar>
 
-      <!-- es6num="12.2.5.1" -->
       <emu-clause id="sec-static-semantics-elisionwidth">
         <h1>Static Semantics: ElisionWidth</h1>
         <emu-grammar>Elision : `,`</emu-grammar>
@@ -11812,7 +11413,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.5.2" -->
       <emu-clause id="sec-runtime-semantics-arrayaccumulation">
         <h1>Runtime Semantics: ArrayAccumulation</h1>
         <p>With parameters _array_ and _nextIndex_.</p>
@@ -11866,7 +11466,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="12.2.5.3" -->
       <emu-clause id="sec-array-initializer-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ArrayLiteral : `[` Elision? `]`</emu-grammar>
@@ -11899,7 +11498,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.2.6" -->
     <emu-clause id="sec-object-initializer">
       <h1>Object Initializer</h1>
       <emu-note>
@@ -11948,7 +11546,6 @@
         <p>In certain contexts, |ObjectLiteral| is used as a cover grammar for a more restricted secondary grammar. The |CoverInitializedName| production is necessary to fully cover these secondary grammars. However, use of this production results in an early Syntax Error in normal contexts where an actual |ObjectLiteral| is expected.</p>
       </emu-note>
 
-      <!-- es6num="12.2.6.1" -->
       <emu-clause id="sec-object-initializer-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
@@ -11969,7 +11566,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="12.2.6.2" -->
       <emu-clause id="sec-object-initializer-static-semantics-computedpropertycontains">
         <h1>Static Semantics: ComputedPropertyContains</h1>
         <p>With parameter _symbol_.</p>
@@ -11984,7 +11580,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.6.3" -->
       <emu-clause id="sec-object-initializer-static-semantics-contains">
         <h1>Static Semantics: Contains</h1>
         <p>With parameter _symbol_.</p>
@@ -12005,7 +11600,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.6.5" -->
       <emu-clause id="sec-static-semantics-iscomputedpropertykey">
         <h1>Static Semantics: IsComputedPropertyKey</h1>
         <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
@@ -12018,7 +11612,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.6.6" -->
       <emu-clause id="sec-object-initializer-static-semantics-propname">
         <h1>Static Semantics: PropName</h1>
         <emu-see-also-para op="PropName"></emu-see-also-para>
@@ -12053,7 +11646,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.6.7" -->
       <emu-clause id="sec-static-semantics-propertynamelist">
         <h1>Static Semantics: PropertyNameList</h1>
         <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
@@ -12070,7 +11662,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.6.8" -->
       <emu-clause id="sec-object-initializer-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ObjectLiteral : `{` `}`</emu-grammar>
@@ -12108,7 +11699,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.6.9" -->
       <emu-clause id="sec-object-initializer-runtime-semantics-propertydefinitionevaluation">
         <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
         <p>With parameters _object_ and _enumerable_.</p>
@@ -12151,7 +11741,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.2.7" -->
     <emu-clause id="sec-function-defining-expressions">
       <h1>Function Defining Expressions</h1>
       <p>See <emu-xref href="#sec-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : FunctionExpression</emu-grammar>.</p>
@@ -12161,13 +11750,11 @@
       <p>See <emu-xref href="#sec-async-generator-function-definitions"></emu-xref> for <emu-grammar>PrimaryExpression : AsyncGeneratorExpression</emu-grammar>.</p>
     </emu-clause>
 
-    <!-- es6num="12.2.8" -->
     <emu-clause id="sec-primary-expression-regular-expression-literals">
       <h1>Regular Expression Literals</h1>
       <h2>Syntax</h2>
       <p>See <emu-xref href="#sec-literals-regular-expression-literals"></emu-xref>.</p>
 
-      <!-- es6num="12.2.8.1" -->
       <emu-clause id="sec-primary-expression-regular-expression-literals-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
@@ -12181,7 +11768,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="12.2.8.2" -->
       <emu-clause id="sec-regular-expression-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
@@ -12193,7 +11779,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.2.9" -->
     <emu-clause id="sec-template-literals">
       <h1>Template Literals</h1>
       <h2>Syntax</h2>
@@ -12258,7 +11843,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="12.2.9.1" -->
       <emu-clause id="sec-static-semantics-templatestrings">
         <h1>Static Semantics: TemplateStrings</h1>
         <p>With parameter _raw_.</p>
@@ -12316,7 +11900,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.9.2" -->
       <emu-clause id="sec-template-literals-runtime-semantics-argumentlistevaluation">
         <h1>Runtime Semantics: ArgumentListEvaluation</h1>
         <emu-see-also-para op="ArgumentListEvaluation"></emu-see-also-para>
@@ -12339,7 +11922,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.9.3" -->
       <emu-clause id="sec-gettemplateobject" aoid="GetTemplateObject">
         <h1>Runtime Semantics: GetTemplateObject ( _templateLiteral_ )</h1>
         <p>The abstract operation GetTemplateObject is called with a Parse Node, _templateLiteral_, as an argument. It performs the following steps:</p>
@@ -12380,7 +11962,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="12.2.9.4" -->
       <emu-clause id="sec-runtime-semantics-substitutionevaluation">
         <h1>Runtime Semantics: SubstitutionEvaluation</h1>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
@@ -12408,7 +11989,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.9.5" -->
       <emu-clause id="sec-template-literals-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
@@ -12467,11 +12047,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.2.10" -->
     <emu-clause id="sec-grouping-operator">
       <h1>The Grouping Operator</h1>
 
-      <!-- es6num="12.2.10.1" -->
       <emu-clause id="sec-grouping-operator-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
@@ -12485,7 +12063,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="12.2.10.2" -->
       <emu-clause id="sec-grouping-operator-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -12495,7 +12072,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.10.3" -->
       <emu-clause id="sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -12505,7 +12081,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.2.10.4" -->
       <emu-clause id="sec-grouping-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
@@ -12524,7 +12099,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.3" -->
   <emu-clause id="sec-left-hand-side-expressions">
     <h1>Left-Hand-Side Expressions</h1>
     <h2>Syntax</h2>
@@ -12585,7 +12159,6 @@
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
     </emu-grammar>
 
-    <!-- es6num="12.3.1" -->
     <emu-clause id="sec-static-semantics">
       <h1>Static Semantics</h1>
 
@@ -12599,7 +12172,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.3.1.1" -->
       <emu-clause id="sec-static-semantics-static-semantics-contains">
         <h1>Static Semantics: Contains</h1>
         <p>With parameter _symbol_.</p>
@@ -12627,7 +12199,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.3.1.2" -->
       <emu-clause id="sec-static-semantics-static-semantics-isfunctiondefinition">
         <h1>Static Semantics: IsFunctionDefinition</h1>
         <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -12651,7 +12222,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.3.1.3" -->
       <emu-clause id="sec-static-semantics-static-semantics-isdestructuring">
         <h1>Static Semantics: IsDestructuring</h1>
         <emu-see-also-para op="IsDestructuring"></emu-see-also-para>
@@ -12680,7 +12250,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.3.1.4" -->
       <emu-clause id="sec-static-semantics-static-semantics-isidentifierref">
         <h1>Static Semantics: IsIdentifierRef</h1>
         <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
@@ -12704,7 +12273,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.3.1.5" -->
       <emu-clause id="sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget">
         <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
         <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -12744,7 +12312,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.3.2" -->
     <emu-clause id="sec-property-accessors">
       <h1>Property Accessors</h1>
       <emu-note>
@@ -12779,7 +12346,6 @@
         <p>where &lt;<i>identifier-name-string</i>&gt; is the result of evaluating StringValue of |IdentifierName|.</p>
       </emu-note>
 
-      <!-- es6num="12.3.2.1" -->
       <emu-clause id="sec-property-accessors-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>MemberExpression : MemberExpression `[` Expression `]`</emu-grammar>
@@ -12809,11 +12375,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.3.3" -->
     <emu-clause id="sec-new-operator">
       <h1>The `new` Operator</h1>
 
-      <!-- es6num="12.3.3.1" -->
       <emu-clause id="sec-new-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>NewExpression : `new` NewExpression</emu-grammar>
@@ -12825,7 +12389,6 @@
           1. Return ? EvaluateNew(|MemberExpression|, |Arguments|).
         </emu-alg>
 
-        <!-- es6num="12.3.3.1.1" -->
         <emu-clause id="sec-evaluatenew" aoid="EvaluateNew">
           <h1>Runtime Semantics: EvaluateNew ( _constructExpr_, _arguments_ )</h1>
           <p>The abstract operation EvaluateNew with arguments _constructExpr_, and _arguments_ performs the following steps:</p>
@@ -12845,11 +12408,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.3.4" -->
     <emu-clause id="sec-function-calls">
       <h1>Function Calls</h1>
 
-      <!-- es6num="12.3.4.1" -->
       <emu-clause id="sec-function-calls-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
@@ -12883,7 +12444,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.3.4.2" -->
       <emu-clause id="sec-evaluatecall" aoid="EvaluateCall" oldids="sec-evaluatedirectcall">
         <h1>Runtime Semantics: EvaluateCall ( _func_, _ref_, _arguments_, _tailPosition_ )</h1>
         <p>The abstract operation EvaluateCall takes as arguments a value _func_, a value _ref_, a Parse Node _arguments_, and a Boolean argument _tailPosition_. It performs the following steps:</p>
@@ -12909,11 +12469,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.3.5" -->
     <emu-clause id="sec-super-keyword">
       <h1>The `super` Keyword</h1>
 
-      <!-- es6num="12.3.5.1" -->
       <emu-clause id="sec-super-keyword-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>SuperProperty : `super` `[` Expression `]`</emu-grammar>
@@ -12943,7 +12501,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.3.5.2" -->
       <emu-clause id="sec-getsuperconstructor" aoid="GetSuperConstructor">
         <h1>Runtime Semantics: GetSuperConstructor ( )</h1>
         <p>The abstract operation GetSuperConstructor performs the following steps:</p>
@@ -12958,7 +12515,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.3.5.3" -->
       <emu-clause id="sec-makesuperpropertyreference" aoid="MakeSuperPropertyReference">
         <h1>Runtime Semantics: MakeSuperPropertyReference ( _propertyKey_, _strict_ )</h1>
         <p>The abstract operation MakeSuperPropertyReference with arguments _propertyKey_ and _strict_ performs the following steps:</p>
@@ -12973,14 +12529,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.3.6" -->
     <emu-clause id="sec-argument-lists">
       <h1>Argument Lists</h1>
       <emu-note>
         <p>The evaluation of an argument list produces a List of values.</p>
       </emu-note>
 
-      <!-- es6num="12.3.6.1" -->
       <emu-clause id="sec-argument-lists-runtime-semantics-argumentlistevaluation">
         <h1>Runtime Semantics: ArgumentListEvaluation</h1>
         <emu-see-also-para op="ArgumentListEvaluation"></emu-see-also-para>
@@ -13030,14 +12584,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.3.7" -->
     <emu-clause id="sec-tagged-templates">
       <h1>Tagged Templates</h1>
       <emu-note>
         <p>A tagged template is a function call where the arguments of the call are derived from a |TemplateLiteral| (<emu-xref href="#sec-template-literals"></emu-xref>). The actual arguments include a template object (<emu-xref href="#sec-gettemplateobject"></emu-xref>) and the values produced by evaluating the expressions embedded within the |TemplateLiteral|.</p>
       </emu-note>
 
-      <!-- es6num="12.3.7.1" -->
       <emu-clause id="sec-tagged-templates-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
@@ -13059,11 +12611,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.3.8" -->
     <emu-clause id="sec-meta-properties">
       <h1>Meta Properties</h1>
 
-      <!-- es6num="12.3.8.1" -->
       <emu-clause id="sec-meta-properties-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>NewTarget : `new` `.` `target`</emu-grammar>
@@ -13074,7 +12624,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.4" -->
   <emu-clause id="sec-update-expressions">
     <h1>Update Expressions</h1>
     <h2>Syntax</h2>
@@ -13087,7 +12636,6 @@
         `--` UnaryExpression[?Yield, ?Await]
     </emu-grammar>
 
-    <!-- es6num="12.4.1" -->
     <emu-clause id="sec-update-expressions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
@@ -13113,7 +12661,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="12.4.2" -->
     <emu-clause id="sec-update-expressions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -13129,7 +12676,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.4.3" -->
     <emu-clause id="sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -13145,11 +12691,9 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.4.4" -->
     <emu-clause id="sec-postfix-increment-operator">
       <h1>Postfix Increment Operator</h1>
 
-      <!-- es6num="12.4.4.1" -->
       <emu-clause id="sec-postfix-increment-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
@@ -13163,11 +12707,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.4.5" -->
     <emu-clause id="sec-postfix-decrement-operator">
       <h1>Postfix Decrement Operator</h1>
 
-      <!-- es6num="12.4.5.1" -->
       <emu-clause id="sec-postfix-decrement-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
@@ -13181,11 +12723,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.5.7" -->
     <emu-clause id="sec-prefix-increment-operator">
       <h1>Prefix Increment Operator</h1>
 
-      <!-- es6num="12.5.7.1" -->
       <emu-clause id="sec-prefix-increment-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : `++` UnaryExpression</emu-grammar>
@@ -13199,11 +12739,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.5.8" -->
     <emu-clause id="sec-prefix-decrement-operator">
       <h1>Prefix Decrement Operator</h1>
 
-      <!-- es6num="12.5.8.1" -->
       <emu-clause id="sec-prefix-decrement-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : `--` UnaryExpression</emu-grammar>
@@ -13218,7 +12756,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.5" -->
   <emu-clause id="sec-unary-operators">
     <h1>Unary Operators</h1>
     <h2>Syntax</h2>
@@ -13235,7 +12772,6 @@
         [+Await] AwaitExpression[?Yield]
     </emu-grammar>
 
-    <!-- es6num="12.5.2" -->
     <emu-clause id="sec-unary-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -13255,7 +12791,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.5.3" -->
     <emu-clause id="sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -13275,11 +12810,9 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.5.4" -->
     <emu-clause id="sec-delete-operator">
       <h1>The `delete` Operator</h1>
 
-      <!-- es6num="12.5.4.1" -->
       <emu-clause id="sec-delete-operator-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
@@ -13300,7 +12833,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="12.5.4.2" -->
       <emu-clause id="sec-delete-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
@@ -13327,11 +12859,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.5.5" -->
     <emu-clause id="sec-void-operator">
       <h1>The `void` Operator</h1>
 
-      <!-- es6num="12.5.5.1" -->
       <emu-clause id="sec-void-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `void` UnaryExpression</emu-grammar>
@@ -13346,11 +12876,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.5.6" -->
     <emu-clause id="sec-typeof-operator">
       <h1>The `typeof` Operator</h1>
 
-      <!-- es6num="12.5.6.1" -->
       <emu-clause id="sec-typeof-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `typeof` UnaryExpression</emu-grammar>
@@ -13462,14 +12990,12 @@
     </emu-clause>
 
 
-    <!-- es6num="12.5.9" -->
     <emu-clause id="sec-unary-plus-operator">
       <h1>Unary `+` Operator</h1>
       <emu-note>
         <p>The unary + operator converts its operand to Number type.</p>
       </emu-note>
 
-      <!-- es6num="12.5.9.1" -->
       <emu-clause id="sec-unary-plus-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `+` UnaryExpression</emu-grammar>
@@ -13480,14 +13006,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.5.10" -->
     <emu-clause id="sec-unary-minus-operator">
       <h1>Unary `-` Operator</h1>
       <emu-note>
         <p>The unary `-` operator converts its operand to Number type and then negates it. Negating *+0* produces *-0*, and negating *-0* produces *+0*.</p>
       </emu-note>
 
-      <!-- es6num="12.5.10.1" -->
       <emu-clause id="sec-unary-minus-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
@@ -13500,11 +13024,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.5.11" -->
     <emu-clause id="sec-bitwise-not-operator">
       <h1>Bitwise NOT Operator ( `~` )</h1>
 
-      <!-- es6num="12.5.11.1" -->
       <emu-clause id="sec-bitwise-not-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `~` UnaryExpression</emu-grammar>
@@ -13516,11 +13038,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.5.12" -->
     <emu-clause id="sec-logical-not-operator">
       <h1>Logical NOT Operator ( `!` )</h1>
 
-      <!-- es6num="12.5.12.1" -->
       <emu-clause id="sec-logical-not-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `!` UnaryExpression</emu-grammar>
@@ -13620,7 +13140,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.6" -->
   <emu-clause id="sec-multiplicative-operators">
     <h1>Multiplicative Operators</h1>
     <h2>Syntax</h2>
@@ -13633,7 +13152,6 @@
         `*` `/` `%`
     </emu-grammar>
 
-    <!-- es6num="12.6.1" -->
     <emu-clause id="sec-multiplicative-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -13643,7 +13161,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.6.2" -->
     <emu-clause id="sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -13653,7 +13170,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.6.3" -->
     <emu-clause id="sec-multiplicative-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
@@ -13667,7 +13183,6 @@
         1. Return the result of applying the |MultiplicativeOperator| (`*`, `/`, or `%`) to _lnum_ and _rnum_ as specified in <emu-xref href="#sec-applying-the-mul-operator"></emu-xref>, <emu-xref href="#sec-applying-the-div-operator"></emu-xref>, or <emu-xref href="#sec-applying-the-mod-operator"></emu-xref>.
       </emu-alg>
 
-      <!-- es6num="12.6.3.1" -->
       <emu-clause id="sec-applying-the-mul-operator">
         <h1>Applying the `*` Operator</h1>
         <p>The `*` |MultiplicativeOperator| performs multiplication, producing the product of its operands. Multiplication is commutative. Multiplication is not always associative in ECMAScript, because of finite precision.</p>
@@ -13694,7 +13209,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="12.6.3.2" -->
       <emu-clause id="sec-applying-the-div-operator">
         <h1>Applying the `/` Operator</h1>
         <p>The `/` |MultiplicativeOperator| performs division, producing the quotient of its operands. The left operand is the dividend and the right operand is the divisor. ECMAScript does not perform integer division. The operands and result of all division operations are double-precision floating-point numbers. The result of division is determined by the specification of IEEE 754-2008 arithmetic:</p>
@@ -13729,7 +13243,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="12.6.3.3" -->
       <emu-clause id="sec-applying-the-mod-operator">
         <h1>Applying the `%` Operator</h1>
         <p>The `%` |MultiplicativeOperator| yields the remainder of its operands from an implied division; the left operand is the dividend and the right operand is the divisor.</p>
@@ -13762,7 +13275,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.7" -->
   <emu-clause id="sec-additive-operators">
     <h1>Additive Operators</h1>
     <h2>Syntax</h2>
@@ -13773,7 +13285,6 @@
         AdditiveExpression[?Yield, ?Await] `-` MultiplicativeExpression[?Yield, ?Await]
     </emu-grammar>
 
-    <!-- es6num="12.7.1" -->
     <emu-clause id="sec-additive-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -13787,7 +13298,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.7.2" -->
     <emu-clause id="sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -13801,14 +13311,12 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.7.3" -->
     <emu-clause id="sec-addition-operator-plus">
       <h1>The Addition Operator ( `+` )</h1>
       <emu-note>
         <p>The addition operator either performs string concatenation or numeric addition.</p>
       </emu-note>
 
-      <!-- es6num="12.7.3.1" -->
       <emu-clause id="sec-addition-operator-plus-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>AdditiveExpression : AdditiveExpression `+` MultiplicativeExpression</emu-grammar>
@@ -13836,11 +13344,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.7.4" -->
     <emu-clause id="sec-subtraction-operator-minus">
       <h1>The Subtraction Operator ( `-` )</h1>
 
-      <!-- es6num="12.7.4.1" -->
       <emu-clause id="sec-subtraction-operator-minus-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>AdditiveExpression : AdditiveExpression `-` MultiplicativeExpression</emu-grammar>
@@ -13856,7 +13362,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.7.5" -->
     <emu-clause id="sec-applying-the-additive-operators-to-numbers">
       <h1>Applying the Additive Operators to Numbers</h1>
       <p>The `+` operator performs addition when applied to two operands of numeric type, producing the sum of the operands. The `-` operator performs subtraction, producing the difference of two numeric operands.</p>
@@ -13894,7 +13399,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.8" -->
   <emu-clause id="sec-bitwise-shift-operators">
     <h1>Bitwise Shift Operators</h1>
     <h2>Syntax</h2>
@@ -13906,7 +13410,6 @@
         ShiftExpression[?Yield, ?Await] `&gt;&gt;&gt;` AdditiveExpression[?Yield, ?Await]
     </emu-grammar>
 
-    <!-- es6num="12.8.1" -->
     <emu-clause id="sec-bitwise-shift-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -13921,7 +13424,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.8.2" -->
     <emu-clause id="sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -13936,14 +13438,12 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.8.3" -->
     <emu-clause id="sec-left-shift-operator">
       <h1>The Left Shift Operator ( `&lt;&lt;` )</h1>
       <emu-note>
         <p>Performs a bitwise left shift operation on the left operand by the amount specified by the right operand.</p>
       </emu-note>
 
-      <!-- es6num="12.8.3.1" -->
       <emu-clause id="sec-left-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&lt;&lt;` AdditiveExpression</emu-grammar>
@@ -13960,14 +13460,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.8.4" -->
     <emu-clause id="sec-signed-right-shift-operator">
       <h1>The Signed Right Shift Operator ( `&gt;&gt;` )</h1>
       <emu-note>
         <p>Performs a sign-filling bitwise right shift operation on the left operand by the amount specified by the right operand.</p>
       </emu-note>
 
-      <!-- es6num="12.8.4.1" -->
       <emu-clause id="sec-signed-right-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;` AdditiveExpression</emu-grammar>
@@ -13984,14 +13482,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="12.8.5" -->
     <emu-clause id="sec-unsigned-right-shift-operator">
       <h1>The Unsigned Right Shift Operator ( `&gt;&gt;&gt;` )</h1>
       <emu-note>
         <p>Performs a zero-filling bitwise right shift operation on the left operand by the amount specified by the right operand.</p>
       </emu-note>
 
-      <!-- es6num="12.8.5.1" -->
       <emu-clause id="sec-unsigned-right-shift-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;&gt;` AdditiveExpression</emu-grammar>
@@ -14009,7 +13505,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.9" -->
   <emu-clause id="sec-relational-operators">
     <h1>Relational Operators</h1>
     <emu-note>
@@ -14030,7 +13525,6 @@
       <p>The <sub>[In]</sub> grammar parameter is needed to avoid confusing the `in` operator in a relational expression with the `in` operator in a `for` statement.</p>
     </emu-note>
 
-    <!-- es6num="12.9.1" -->
     <emu-clause id="sec-relational-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -14048,7 +13542,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.9.2" -->
     <emu-clause id="sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -14066,7 +13559,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.9.3" -->
     <emu-clause id="sec-relational-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
@@ -14128,7 +13620,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.9.4" -->
     <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
       <h1>Runtime Semantics: InstanceofOperator ( _V_, _target_ )</h1>
       <p>The abstract operation InstanceofOperator(_V_, _target_) implements the generic algorithm for determining if  ECMAScript value _V_ is an instance of object _target_ either by consulting _target_'s @@hasinstance method or, if absent, determining whether the value of _target_'s `prototype` property is present in _V_'s prototype chain. This abstract operation performs the following steps:</p>
@@ -14146,7 +13637,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.10" -->
   <emu-clause id="sec-equality-operators">
     <h1>Equality Operators</h1>
     <emu-note>
@@ -14162,7 +13652,6 @@
         EqualityExpression[?In, ?Yield, ?Await] `!==` RelationalExpression[?In, ?Yield, ?Await]
     </emu-grammar>
 
-    <!-- es6num="12.10.1" -->
     <emu-clause id="sec-equality-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -14178,7 +13667,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.10.2" -->
     <emu-clause id="sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -14194,7 +13682,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.10.3" -->
     <emu-clause id="sec-equality-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
@@ -14273,7 +13760,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.11" -->
   <emu-clause id="sec-binary-bitwise-operators">
     <h1>Binary Bitwise Operators</h1>
     <h2>Syntax</h2>
@@ -14291,7 +13777,6 @@
         BitwiseORExpression[?In, ?Yield, ?Await] `|` BitwiseXORExpression[?In, ?Yield, ?Await]
     </emu-grammar>
 
-    <!-- es6num="12.11.1" -->
     <emu-clause id="sec-binary-bitwise-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -14307,7 +13792,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.11.2" -->
     <emu-clause id="sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -14323,7 +13807,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.11.3" -->
     <emu-clause id="sec-binary-bitwise-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <p>The production <emu-grammar type="example">A : A @ B</emu-grammar>, where @ is one of the bitwise operators in the productions above, is evaluated as follows:</p>
@@ -14339,7 +13822,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.12" -->
   <emu-clause id="sec-binary-logical-operators">
     <h1>Binary Logical Operators</h1>
     <h2>Syntax</h2>
@@ -14356,7 +13838,6 @@
       <p>The value produced by a `&amp;&amp;` or `||` operator is not necessarily of type Boolean. The value produced will always be the value of one of the two operand expressions.</p>
     </emu-note>
 
-    <!-- es6num="12.12.1" -->
     <emu-clause id="sec-binary-logical-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -14370,7 +13851,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.12.2" -->
     <emu-clause id="sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -14384,7 +13864,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.12.3" -->
     <emu-clause id="sec-binary-logical-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
@@ -14408,7 +13887,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.13" -->
   <emu-clause id="sec-conditional-operator">
     <h1>Conditional Operator ( `? :` )</h1>
     <h2>Syntax</h2>
@@ -14421,7 +13899,6 @@
       <p>The grammar for a |ConditionalExpression| in ECMAScript is slightly different from that in C and Java, which each allow the second subexpression to be an |Expression| but restrict the third expression to be a |ConditionalExpression|. The motivation for this difference in ECMAScript is to allow an assignment expression to be governed by either arm of a conditional and to eliminate the confusing and fairly useless case of a comma expression as the centre expression.</p>
     </emu-note>
 
-    <!-- es6num="12.13.1" -->
     <emu-clause id="sec-conditional-operator-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -14431,7 +13908,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.13.2" -->
     <emu-clause id="sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -14441,7 +13917,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.13.3" -->
     <emu-clause id="sec-conditional-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
@@ -14458,7 +13933,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.14" -->
   <emu-clause id="sec-assignment-operators">
     <h1>Assignment Operators</h1>
     <h2>Syntax</h2>
@@ -14475,7 +13949,6 @@
         `*=` `/=` `%=` `+=` `-=` `&lt;&lt;=` `&gt;&gt;=` `&gt;&gt;&gt;=` `&amp;=` `^=` `|=` `**=`
     </emu-grammar>
 
-    <!-- es6num="12.14.1" -->
     <emu-clause id="sec-assignment-operators-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
@@ -14495,7 +13968,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="12.14.2" -->
     <emu-clause id="sec-assignment-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -14518,7 +13990,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.14.3" -->
     <emu-clause id="sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -14535,7 +14006,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.14.4" -->
     <emu-clause id="sec-assignment-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
@@ -14572,7 +14042,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="12.14.5" -->
     <emu-clause id="sec-destructuring-assignment">
       <h1>Destructuring Assignment</h1>
       <h2>Supplemental Syntax</h2>
@@ -14621,7 +14090,6 @@
           LeftHandSideExpression[?Yield, ?Await]
       </emu-grammar>
 
-      <!-- es6num="12.14.5.1" -->
       <emu-clause id="sec-destructuring-assignment-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
@@ -14647,7 +14115,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="12.14.5.2" -->
       <emu-clause id="sec-runtime-semantics-destructuringassignmentevaluation">
         <h1>Runtime Semantics: DestructuringAssignmentEvaluation</h1>
         <p>With parameter _value_.</p>
@@ -14780,7 +14247,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.14.5.3" -->
       <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation">
         <h1>Runtime Semantics: IteratorDestructuringAssignmentEvaluation</h1>
         <p>With parameter _iteratorRecord_.</p>
@@ -14877,7 +14343,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="12.14.5.4" -->
       <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation">
         <h1>Runtime Semantics: KeyedDestructuringAssignmentEvaluation</h1>
         <p>With parameters _value_ and _propertyName_.</p>
@@ -14903,7 +14368,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="12.15" -->
   <emu-clause id="sec-comma-operator">
     <h1>Comma Operator ( `,` )</h1>
     <h2>Syntax</h2>
@@ -14913,7 +14377,6 @@
         Expression[?In, ?Yield, ?Await] `,` AssignmentExpression[?In, ?Yield, ?Await]
     </emu-grammar>
 
-    <!-- es6num="12.15.1" -->
     <emu-clause id="sec-comma-operator-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -14923,7 +14386,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.15.2" -->
     <emu-clause id="sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget">
       <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
       <emu-see-also-para op="IsValidSimpleAssignmentTarget"></emu-see-also-para>
@@ -14933,7 +14395,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="12.15.3" -->
     <emu-clause id="sec-comma-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
@@ -14950,7 +14411,6 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="13" -->
 <emu-clause id="sec-ecmascript-language-statements-and-declarations">
   <h1>ECMAScript Language: Statements and Declarations</h1>
   <h2>Syntax</h2>
@@ -14987,11 +14447,9 @@
       SwitchStatement[?Yield, ?Await, ?Return]
   </emu-grammar>
 
-  <!-- es6num="13.1" -->
   <emu-clause id="sec-statement-semantics">
     <h1>Statement Semantics</h1>
 
-    <!-- es6num="13.1.1" -->
     <emu-clause id="sec-statement-semantics-static-semantics-containsduplicatelabels">
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
@@ -15012,7 +14470,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.1.2" -->
     <emu-clause id="sec-statement-semantics-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -15032,7 +14489,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.1.3" -->
     <emu-clause id="sec-statement-semantics-static-semantics-containsundefinedcontinuetarget">
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -15057,7 +14513,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.1.4" -->
     <emu-clause id="sec-static-semantics-declarationpart">
       <h1>Static Semantics: DeclarationPart</h1>
       <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar>
@@ -15086,7 +14541,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.1.5" -->
     <emu-clause id="sec-statement-semantics-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -15105,7 +14559,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.1.6" -->
     <emu-clause id="sec-statement-semantics-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -15124,7 +14577,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.1.7" -->
     <emu-clause id="sec-statement-semantics-runtime-semantics-labelledevaluation">
       <h1>Runtime Semantics: LabelledEvaluation</h1>
       <p>With parameter _labelSet_.</p>
@@ -15152,7 +14604,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.1.8" -->
     <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
@@ -15182,7 +14633,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.2" -->
   <emu-clause id="sec-block">
     <h1>Block</h1>
     <h2>Syntax</h2>
@@ -15202,7 +14652,6 @@
         Declaration[?Yield, ?Await]
     </emu-grammar>
 
-    <!-- es6num="13.2.1" -->
     <emu-clause id="sec-block-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
@@ -15216,7 +14665,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="13.2.2" -->
     <emu-clause id="sec-block-static-semantics-containsduplicatelabels">
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
@@ -15237,7 +14685,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.3" -->
     <emu-clause id="sec-block-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -15258,7 +14705,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.4" -->
     <emu-clause id="sec-block-static-semantics-containsundefinedcontinuetarget">
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -15279,7 +14725,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.5" -->
     <emu-clause id="sec-block-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
@@ -15304,7 +14749,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.6" -->
     <emu-clause id="sec-block-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
@@ -15325,7 +14769,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.7" -->
     <emu-clause id="sec-block-static-semantics-toplevellexicallydeclarednames">
       <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
       <emu-see-also-para op="TopLevelLexicallyDeclaredNames"></emu-see-also-para>
@@ -15350,7 +14793,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.2.8" -->
     <emu-clause id="sec-block-static-semantics-toplevellexicallyscopeddeclarations">
       <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelLexicallyScopedDeclarations"></emu-see-also-para>
@@ -15376,7 +14818,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.9" -->
     <emu-clause id="sec-block-static-semantics-toplevelvardeclarednames">
       <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
       <emu-see-also-para op="TopLevelVarDeclaredNames"></emu-see-also-para>
@@ -15406,7 +14847,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.2.10" -->
     <emu-clause id="sec-block-static-semantics-toplevelvarscopeddeclarations">
       <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelVarScopedDeclarations"></emu-see-also-para>
@@ -15434,7 +14874,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.11" -->
     <emu-clause id="sec-block-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -15454,7 +14893,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.12" -->
     <emu-clause id="sec-block-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -15474,7 +14912,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.2.13" -->
     <emu-clause id="sec-block-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Block : `{` `}`</emu-grammar>
@@ -15511,7 +14948,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.2.14" -->
     <emu-clause id="sec-blockdeclarationinstantiation" aoid="BlockDeclarationInstantiation">
       <h1>Runtime Semantics: BlockDeclarationInstantiation ( _code_, _env_ )</h1>
       <emu-note>
@@ -15541,11 +14977,9 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.3" -->
   <emu-clause id="sec-declarations-and-the-variable-statement">
     <h1>Declarations and the Variable Statement</h1>
 
-    <!-- es6num="13.3.1" -->
     <emu-clause id="sec-let-and-const-declarations">
       <h1>Let and Const Declarations</h1>
       <emu-note>
@@ -15569,7 +15003,6 @@
           BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]
       </emu-grammar>
 
-      <!-- es6num="13.3.1.1" -->
       <emu-clause id="sec-let-and-const-declarations-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
@@ -15589,7 +15022,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="13.3.1.2" -->
       <emu-clause id="sec-let-and-const-declarations-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -15613,7 +15045,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.1.3" -->
       <emu-clause id="sec-let-and-const-declarations-static-semantics-isconstantdeclaration">
         <h1>Static Semantics: IsConstantDeclaration</h1>
         <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
@@ -15631,7 +15062,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.1.4" -->
       <emu-clause id="sec-let-and-const-declarations-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
@@ -15675,7 +15105,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="13.3.2" -->
     <emu-clause id="sec-variable-statement">
       <h1>Variable Statement</h1>
       <emu-note>
@@ -15695,7 +15124,6 @@
           BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]
       </emu-grammar>
 
-      <!-- es6num="13.3.2.1" -->
       <emu-clause id="sec-variable-statement-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -15715,7 +15143,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.2.2" -->
       <emu-clause id="sec-variable-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -15725,7 +15152,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.2.3" -->
       <emu-clause id="sec-variable-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -15741,7 +15167,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.2.4" -->
       <emu-clause id="sec-variable-statement-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
@@ -15783,7 +15208,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="13.3.3" -->
     <emu-clause id="sec-destructuring-binding-patterns">
       <h1>Destructuring Binding Patterns</h1>
       <h2>Syntax</h2>
@@ -15833,7 +15257,6 @@
           `...` BindingPattern[?Yield, ?Await]
       </emu-grammar>
 
-      <!-- es6num="13.3.3.1" -->
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -15889,7 +15312,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.3.2" -->
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-containsexpression">
         <h1>Static Semantics: ContainsExpression</h1>
         <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
@@ -15959,7 +15381,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.3.3" -->
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-hasinitializer">
         <h1>Static Semantics: HasInitializer</h1>
         <emu-see-also-para op="HasInitializer"></emu-see-also-para>
@@ -15981,7 +15402,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.3.4" -->
       <emu-clause id="sec-destructuring-binding-patterns-static-semantics-issimpleparameterlist">
         <h1>Static Semantics: IsSimpleParameterList</h1>
         <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
@@ -16003,7 +15423,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.3.5" -->
       <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization">
         <h1>Runtime Semantics: BindingInitialization</h1>
         <p>With parameters _value_ and _environment_.</p>
@@ -16094,7 +15513,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.3.6" -->
       <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-iteratorbindinginitialization">
         <h1>Runtime Semantics: IteratorBindingInitialization</h1>
         <p>With parameters _iteratorRecord_ and _environment_.</p>
@@ -16240,7 +15658,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.3.3.7" -->
       <emu-clause id="sec-runtime-semantics-keyedbindinginitialization">
         <h1>Runtime Semantics: KeyedBindingInitialization</h1>
         <p>With parameters _value_, _environment_, and _propertyName_.</p>
@@ -16273,7 +15690,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.4" -->
   <emu-clause id="sec-empty-statement">
     <h1>Empty Statement</h1>
     <h2>Syntax</h2>
@@ -16282,7 +15698,6 @@
         `;`
     </emu-grammar>
 
-    <!-- es6num="13.4.1" -->
     <emu-clause id="sec-empty-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EmptyStatement : `;`</emu-grammar>
@@ -16292,7 +15707,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.5" -->
   <emu-clause id="sec-expression-statement">
     <h1>Expression Statement</h1>
     <h2>Syntax</h2>
@@ -16304,7 +15718,6 @@
       <p>An |ExpressionStatement| cannot start with a U+007B (LEFT CURLY BRACKET) because that might make it ambiguous with a |Block|. An |ExpressionStatement| cannot start with the `function` or `class` keywords because that would make it ambiguous with a |FunctionDeclaration|, a |GeneratorDeclaration|, or a |ClassDeclaration|. An |ExpressionStatement| cannot start with `async function` because that would make it ambiguous with an |AsyncFunctionDeclaration| or a |AsyncGeneratorDeclaration|.  An |ExpressionStatement| cannot start with the two token sequence `let [` because that would make it ambiguous with a `let` |LexicalDeclaration| whose first |LexicalBinding| was an |ArrayBindingPattern|.</p>
     </emu-note>
 
-    <!-- es6num="13.5.1" -->
     <emu-clause id="sec-expression-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ExpressionStatement : Expression `;`</emu-grammar>
@@ -16315,7 +15728,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.6" -->
   <emu-clause id="sec-if-statement">
     <h1>The `if` Statement</h1>
     <h2>Syntax</h2>
@@ -16326,7 +15738,6 @@
     </emu-grammar>
     <p>Each `else` for which the choice of associated `if` is ambiguous shall be associated with the nearest possible `if` that would otherwise have no corresponding `else`.</p>
 
-    <!-- es6num="13.6.1" -->
     <emu-clause id="sec-if-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
@@ -16344,7 +15755,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.6.2" -->
     <emu-clause id="sec-if-statement-static-semantics-containsduplicatelabels">
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
@@ -16361,7 +15771,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.6.3" -->
     <emu-clause id="sec-if-statement-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -16378,7 +15787,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.6.4" -->
     <emu-clause id="sec-if-statement-static-semantics-containsundefinedcontinuetarget">
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -16395,7 +15803,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.6.5" -->
     <emu-clause id="sec-if-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -16411,7 +15818,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.6.6" -->
     <emu-clause id="sec-if-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -16427,7 +15833,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.6.7" -->
     <emu-clause id="sec-if-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
@@ -16453,7 +15858,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.7" -->
   <emu-clause id="sec-iteration-statements">
     <h1>Iteration Statements</h1>
     <h2>Syntax</h2>
@@ -16485,11 +15889,9 @@
       <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
     </emu-note>
 
-    <!-- es6num="13.7.1" -->
     <emu-clause id="sec-iteration-statements-semantics">
       <h1>Semantics</h1>
 
-      <!-- es6num="13.7.1.1" -->
       <emu-clause id="sec-semantics-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>
@@ -16519,7 +15921,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="13.7.1.2" -->
       <emu-clause id="sec-loopcontinues" aoid="LoopContinues">
         <h1>Runtime Semantics: LoopContinues ( _completion_, _labelSet_ )</h1>
         <p>The abstract operation LoopContinues with arguments _completion_ and _labelSet_ is defined by the following steps:</p>
@@ -16536,11 +15937,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="13.7.2" -->
     <emu-clause id="sec-do-while-statement">
       <h1>The `do`-`while` Statement</h1>
 
-      <!-- es6num="13.7.2.1" -->
       <emu-clause id="sec-do-while-statement-static-semantics-containsduplicatelabels">
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
@@ -16551,7 +15950,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.2.2" -->
       <emu-clause id="sec-do-while-statement-static-semantics-containsundefinedbreaktarget">
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
@@ -16562,7 +15960,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.2.3" -->
       <emu-clause id="sec-do-while-statement-static-semantics-containsundefinedcontinuetarget">
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -16573,7 +15970,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.2.4" -->
       <emu-clause id="sec-do-while-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -16583,7 +15979,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.2.5" -->
       <emu-clause id="sec-do-while-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -16593,7 +15988,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.2.6" -->
       <emu-clause id="sec-do-while-statement-runtime-semantics-labelledevaluation">
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
@@ -16612,11 +16006,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="13.7.3" -->
     <emu-clause id="sec-while-statement">
       <h1>The `while` Statement</h1>
 
-      <!-- es6num="13.7.3.1" -->
       <emu-clause id="sec-while-statement-static-semantics-containsduplicatelabels">
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
@@ -16627,7 +16019,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.3.2" -->
       <emu-clause id="sec-while-statement-static-semantics-containsundefinedbreaktarget">
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
@@ -16638,7 +16029,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.3.3" -->
       <emu-clause id="sec-while-statement-static-semantics-containsundefinedcontinuetarget">
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -16649,7 +16039,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.3.4" -->
       <emu-clause id="sec-while-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -16659,7 +16048,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.3.5" -->
       <emu-clause id="sec-while-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -16669,7 +16057,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.3.6" -->
       <emu-clause id="sec-while-statement-runtime-semantics-labelledevaluation">
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
@@ -16688,11 +16075,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="13.7.4" -->
     <emu-clause id="sec-for-statement">
       <h1>The `for` Statement</h1>
 
-      <!-- es6num="13.7.4.1" -->
       <emu-clause id="sec-for-statement-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
@@ -16703,7 +16088,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="13.7.4.2" -->
       <emu-clause id="sec-for-statement-static-semantics-containsduplicatelabels">
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
@@ -16719,7 +16103,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.4.3" -->
       <emu-clause id="sec-for-statement-static-semantics-containsundefinedbreaktarget">
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
@@ -16735,7 +16118,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.4.4" -->
       <emu-clause id="sec-for-statement-static-semantics-containsundefinedcontinuetarget">
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -16751,7 +16133,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.4.5" -->
       <emu-clause id="sec-for-statement-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -16771,7 +16152,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.4.6" -->
       <emu-clause id="sec-for-statement-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -16791,7 +16171,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.4.7" -->
       <emu-clause id="sec-for-statement-runtime-semantics-labelledevaluation">
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
@@ -16833,7 +16212,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.4.8" -->
       <emu-clause id="sec-forbodyevaluation" aoid="ForBodyEvaluation">
         <h1>Runtime Semantics: ForBodyEvaluation ( _test_, _increment_, _stmt_, _perIterationBindings_, _labelSet_ )</h1>
         <p>The abstract operation ForBodyEvaluation with arguments _test_, _increment_, _stmt_, _perIterationBindings_, and _labelSet_ is performed as follows:</p>
@@ -16855,7 +16233,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.4.9" -->
       <emu-clause id="sec-createperiterationenvironment" aoid="CreatePerIterationEnvironment">
         <h1>Runtime Semantics: CreatePerIterationEnvironment ( _perIterationBindings_ )</h1>
         <p>The abstract operation CreatePerIterationEnvironment with argument _perIterationBindings_ is performed as follows:</p>
@@ -16877,11 +16254,9 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="13.7.5" -->
     <emu-clause id="sec-for-in-and-for-of-statements">
       <h1>The `for`-`in`, `for`-`of`, and `for`-`await`-`of` Statements</h1>
 
-      <!-- es6num="13.7.5.1" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>
@@ -16926,7 +16301,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="13.7.5.2" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -16936,7 +16310,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.5.3" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels">
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
@@ -16962,7 +16335,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="13.7.5.4" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget">
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
@@ -16987,7 +16359,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="13.7.5.5" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget">
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -17012,7 +16383,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="13.7.5.6" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-isdestructuring">
         <h1>Static Semantics: IsDestructuring</h1>
         <emu-see-also-para op="IsDestructuring"></emu-see-also-para>
@@ -17033,7 +16403,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="13.7.5.7" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -17082,7 +16451,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="13.7.5.8" -->
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -17135,7 +16503,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="13.7.5.9" -->
       <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-bindinginitialization">
         <h1>Runtime Semantics: BindingInitialization</h1>
         <p>With parameters _value_ and _environment_.</p>
@@ -17149,7 +16516,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.5.10" -->
       <emu-clause id="sec-runtime-semantics-bindinginstantiation">
         <h1>Runtime Semantics: BindingInstantiation</h1>
         <p>With parameter _environment_.</p>
@@ -17165,7 +16531,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.5.11" -->
       <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation">
         <h1>Runtime Semantics: LabelledEvaluation</h1>
         <p>With parameter _labelSet_.</p>
@@ -17226,7 +16591,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="13.7.5.12" -->
       <emu-clause id="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
         <h1>Runtime Semantics: ForIn/OfHeadEvaluation ( _TDZnames_, _expr_, _iterationKind_ )</h1>
         <p>The abstract operation ForIn/OfHeadEvaluation is called with arguments _TDZnames_, _expr_, and _iterationKind_. The value of _iterationKind_ is either ~enumerate~, ~iterate~, or ~async-iterate~.</p>
@@ -17255,7 +16619,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.5.13" -->
       <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" aoid="ForIn/OfBodyEvaluation">
         <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ] )</h1>
         <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~sync~ or ~async~.</p>
@@ -17324,7 +16687,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="13.7.5.14" -->
       <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ForBinding : BindingIdentifier</emu-grammar>
@@ -17334,7 +16696,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="9.1.11" -->
       <emu-clause id="sec-enumerate-object-properties" aoid="EnumerateObjectProperties">
         <h1>EnumerateObjectProperties ( _O_ )</h1>
         <p>When the abstract operation EnumerateObjectProperties is called with argument _O_, the following steps are taken:</p>
@@ -17369,7 +16730,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.8" -->
   <emu-clause id="sec-continue-statement">
     <h1>The `continue` Statement</h1>
     <h2>Syntax</h2>
@@ -17379,7 +16739,6 @@
         `continue` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
     </emu-grammar>
 
-    <!-- es6num="13.8.1" -->
     <emu-clause id="sec-continue-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
@@ -17394,7 +16753,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="13.8.2" -->
     <emu-clause id="sec-continue-statement-static-semantics-containsundefinedcontinuetarget">
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -17410,7 +16768,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.8.3" -->
     <emu-clause id="sec-continue-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
@@ -17425,7 +16782,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.9" -->
   <emu-clause id="sec-break-statement">
     <h1>The `break` Statement</h1>
     <h2>Syntax</h2>
@@ -17435,7 +16791,6 @@
         `break` [no LineTerminator here] LabelIdentifier[?Yield, ?Await] `;`
     </emu-grammar>
 
-    <!-- es6num="13.9.1" -->
     <emu-clause id="sec-break-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
@@ -17446,7 +16801,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="13.9.2" -->
     <emu-clause id="sec-break-statement-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -17462,7 +16816,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.9.3" -->
     <emu-clause id="sec-break-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
@@ -17477,7 +16830,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.10" -->
   <emu-clause id="sec-return-statement">
     <h1>The `return` Statement</h1>
     <h2>Syntax</h2>
@@ -17490,7 +16842,6 @@
       <p>A `return` statement causes a function to cease execution and, in most cases, returns a value to the caller. If |Expression| is omitted, the return value is *undefined*. Otherwise, the return value is the value of |Expression|. A `return` statement may not actually return a value to the caller depending on surrounding context. For example, in a `try` block, a `return` statement's completion record may be replaced with another completion record during evaluation of the `finally` block.</p>
     </emu-note>
 
-    <!-- es6num="13.10.1" -->
     <emu-clause id="sec-return-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ReturnStatement : `return` `;`</emu-grammar>
@@ -17507,7 +16858,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.11" -->
   <emu-clause id="sec-with-statement">
     <h1>The `with` Statement</h1>
     <h2>Syntax</h2>
@@ -17519,7 +16869,6 @@
       <p>The `with` statement adds an object Environment Record for a computed object to the lexical environment of the running execution context. It then executes a statement using this augmented lexical environment. Finally, it restores the original lexical environment.</p>
     </emu-note>
 
-    <!-- es6num="13.11.1" -->
     <emu-clause id="sec-with-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
@@ -17536,7 +16885,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.11.2" -->
     <emu-clause id="sec-with-statement-static-semantics-containsduplicatelabels">
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
@@ -17547,7 +16895,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.11.3" -->
     <emu-clause id="sec-with-statement-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -17558,7 +16905,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.11.4" -->
     <emu-clause id="sec-with-statement-static-semantics-containsundefinedcontinuetarget">
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -17569,7 +16915,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.11.5" -->
     <emu-clause id="sec-with-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -17579,7 +16924,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.11.6" -->
     <emu-clause id="sec-with-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -17589,7 +16933,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.11.7" -->
     <emu-clause id="sec-with-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
@@ -17610,7 +16953,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.12" -->
   <emu-clause id="sec-switch-statement">
     <h1>The `switch` Statement</h1>
     <h2>Syntax</h2>
@@ -17633,7 +16975,6 @@
         `default` `:` StatementList[?Yield, ?Await, ?Return]?
     </emu-grammar>
 
-    <!-- es6num="13.12.1" -->
     <emu-clause id="sec-switch-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
@@ -17647,7 +16988,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="13.12.2" -->
     <emu-clause id="sec-switch-statement-static-semantics-containsduplicatelabels">
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
@@ -17688,7 +17028,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.12.3" -->
     <emu-clause id="sec-switch-statement-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -17729,7 +17068,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.12.4" -->
     <emu-clause id="sec-switch-statement-static-semantics-containsundefinedcontinuetarget">
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -17770,7 +17108,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.12.5" -->
     <emu-clause id="sec-switch-statement-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
@@ -17804,7 +17141,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.12.6" -->
     <emu-clause id="sec-switch-statement-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
@@ -17838,7 +17174,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.12.7" -->
     <emu-clause id="sec-switch-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -17876,7 +17211,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.12.8" -->
     <emu-clause id="sec-switch-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -17914,7 +17248,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.12.9" -->
     <emu-clause id="sec-runtime-semantics-caseblockevaluation">
       <h1>Runtime Semantics: CaseBlockEvaluation</h1>
       <p>With parameter _input_.</p>
@@ -17990,7 +17323,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.12.11" -->
     <emu-clause id="sec-switch-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
@@ -18027,7 +17359,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.13" -->
   <emu-clause id="sec-labelled-statements">
     <h1>Labelled Statements</h1>
     <h2>Syntax</h2>
@@ -18043,7 +17374,6 @@
       <p>A |Statement| may be prefixed by a label. Labelled statements are only used in conjunction with labelled `break` and `continue` statements. ECMAScript has no `goto` statement. A |Statement| can be part of a |LabelledStatement|, which itself can be part of a |LabelledStatement|, and so on. The labels introduced this way are collectively referred to as the &ldquo;current label set&rdquo; when describing the semantics of individual statements.</p>
     </emu-note>
 
-    <!-- es6num="13.13.1" -->
     <emu-clause id="sec-labelled-statements-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
@@ -18057,7 +17387,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.13.2" -->
     <emu-clause id="sec-labelled-statements-static-semantics-containsduplicatelabels">
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
@@ -18075,7 +17404,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.3" -->
     <emu-clause id="sec-labelled-statements-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -18092,7 +17420,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.4" -->
     <emu-clause id="sec-labelled-statements-static-semantics-containsundefinedcontinuetarget">
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -18109,7 +17436,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.5" -->
     <emu-clause id="sec-islabelledfunction" aoid="IsLabelledFunction">
       <h1>Static Semantics: IsLabelledFunction ( _stmt_ )</h1>
       <p>The abstract operation IsLabelledFunction with argument _stmt_ performs the following steps:</p>
@@ -18122,7 +17448,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.6" -->
     <emu-clause id="sec-labelled-statements-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
@@ -18140,7 +17465,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.7" -->
     <emu-clause id="sec-labelled-statements-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
@@ -18158,7 +17482,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.8" -->
     <emu-clause id="sec-labelled-statements-static-semantics-toplevellexicallydeclarednames">
       <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
       <emu-see-also-para op="TopLevelLexicallyDeclaredNames"></emu-see-also-para>
@@ -18168,7 +17491,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.9" -->
     <emu-clause id="sec-labelled-statements-static-semantics-toplevellexicallyscopeddeclarations">
       <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelLexicallyScopedDeclarations"></emu-see-also-para>
@@ -18178,7 +17500,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.10" -->
     <emu-clause id="sec-labelled-statements-static-semantics-toplevelvardeclarednames">
       <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
       <emu-see-also-para op="TopLevelVarDeclaredNames"></emu-see-also-para>
@@ -18197,7 +17518,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.11" -->
     <emu-clause id="sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations">
       <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
       <emu-see-also-para op="TopLevelVarScopedDeclarations"></emu-see-also-para>
@@ -18216,7 +17536,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.12" -->
     <emu-clause id="sec-labelled-statements-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -18230,7 +17549,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.13" -->
     <emu-clause id="sec-labelled-statements-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -18244,7 +17562,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.14" -->
     <emu-clause id="sec-labelled-statements-runtime-semantics-labelledevaluation">
       <h1>Runtime Semantics: LabelledEvaluation</h1>
       <p>With parameter _labelSet_.</p>
@@ -18271,7 +17588,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.13.15" -->
     <emu-clause id="sec-labelled-statements-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
@@ -18282,7 +17598,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.14" -->
   <emu-clause id="sec-throw-statement">
     <h1>The `throw` Statement</h1>
     <h2>Syntax</h2>
@@ -18291,7 +17606,6 @@
         `throw` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
 
-    <!-- es6num="13.14.1" -->
     <emu-clause id="sec-throw-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ThrowStatement : `throw` Expression `;`</emu-grammar>
@@ -18303,7 +17617,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.15" -->
   <emu-clause id="sec-try-statement">
     <h1>The `try` Statement</h1>
     <h2>Syntax</h2>
@@ -18327,7 +17640,6 @@
       <p>The `try` statement encloses a block of code in which an exceptional condition can occur, such as a runtime error or a `throw` statement. The `catch` clause provides the exception-handling code. When a catch clause catches an exception, its |CatchParameter| is bound to that exception.</p>
     </emu-note>
 
-    <!-- es6num="13.15.1" -->
     <emu-clause id="sec-try-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
@@ -18347,7 +17659,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.15.2" -->
     <emu-clause id="sec-try-statement-static-semantics-containsduplicatelabels">
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
@@ -18378,7 +17689,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.15.3" -->
     <emu-clause id="sec-try-statement-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -18409,7 +17719,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.15.4" -->
     <emu-clause id="sec-try-statement-static-semantics-containsundefinedcontinuetarget">
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -18440,7 +17749,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.15.5" -->
     <emu-clause id="sec-try-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -18469,7 +17777,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.15.6" -->
     <emu-clause id="sec-try-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -18498,7 +17805,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="13.15.7" -->
     <emu-clause id="sec-runtime-semantics-catchclauseevaluation">
       <h1>Runtime Semantics: CatchClauseEvaluation</h1>
       <p>With parameter _thrownValue_.</p>
@@ -18523,7 +17829,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="13.15.8" -->
     <emu-clause id="sec-try-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
@@ -18552,7 +17857,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="13.16" -->
   <emu-clause id="sec-debugger-statement">
     <h1>The `debugger` Statement</h1>
     <h2>Syntax</h2>
@@ -18561,7 +17865,6 @@
         `debugger` `;`
     </emu-grammar>
 
-    <!-- es6num="13.16.1" -->
     <emu-clause id="sec-debugger-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-note>
@@ -18580,14 +17883,12 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="14" -->
 <emu-clause id="sec-ecmascript-language-functions-and-classes">
   <h1>ECMAScript Language: Functions and Classes</h1>
   <emu-note>
     <p>Various ECMAScript language elements cause the creation of ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>). Evaluation of such functions starts with the execution of their [[Call]] internal method (<emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>).</p>
   </emu-note>
 
-  <!-- es6num="14.1" -->
   <emu-clause id="sec-function-definitions">
     <h1>Function Definitions</h1>
     <h2>Syntax</h2>
@@ -18626,7 +17927,6 @@
         StatementList[?Yield, ?Await, +Return]?
     </emu-grammar>
 
-    <!-- es6num="14.1.1" -->
     <emu-clause id="sec-directive-prologues-and-the-use-strict-directive">
       <h1>Directive Prologues and the Use Strict Directive</h1>
       <p>A <dfn id="directive-prologue">Directive Prologue</dfn> is the longest sequence of |ExpressionStatement|s occurring as the initial |StatementListItem|s or |ModuleItem|s of a |FunctionBody|, a |ScriptBody|, or a |ModuleBody| and where each |ExpressionStatement| in the sequence consists entirely of a |StringLiteral| token followed by a semicolon. The semicolon may appear explicitly or may be inserted by automatic semicolon insertion. A Directive Prologue may be an empty sequence.</p>
@@ -18637,7 +17937,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.1.2" -->
     <emu-clause id="sec-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
@@ -18711,7 +18010,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="14.1.3" -->
     <emu-clause id="sec-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -18744,7 +18042,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.4" -->
     <emu-clause id="sec-function-definitions-static-semantics-contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
@@ -18764,7 +18061,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.1.5" -->
     <emu-clause id="sec-function-definitions-static-semantics-containsexpression">
       <h1>Static Semantics: ContainsExpression</h1>
       <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
@@ -18793,7 +18089,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.6" -->
     <emu-clause id="sec-function-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
@@ -18816,7 +18111,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.7" -->
     <emu-clause id="sec-function-definitions-static-semantics-hasinitializer">
       <h1>Static Semantics: HasInitializer</h1>
       <emu-see-also-para op="HasInitializer"></emu-see-also-para>
@@ -18827,7 +18121,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.8" -->
     <emu-clause id="sec-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
@@ -18841,7 +18134,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.9" -->
     <emu-clause id="sec-isanonymousfunctiondefinition" aoid="IsAnonymousFunctionDefinition">
       <h1>Static Semantics: IsAnonymousFunctionDefinition ( _expr_ )</h1>
       <p>The abstract operation IsAnonymousFunctionDefinition determines if its argument is a function definition that does not bind a name. The argument _expr_ is the result of parsing an |AssignmentExpression| or |Initializer|. The following steps are taken:</p>
@@ -18853,7 +18145,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.10" -->
     <emu-clause id="sec-function-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
@@ -18867,7 +18158,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.11" -->
     <emu-clause id="sec-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -18877,7 +18167,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.12" -->
     <emu-clause id="sec-function-definitions-static-semantics-issimpleparameterlist">
       <h1>Static Semantics: IsSimpleParameterList</h1>
       <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
@@ -18900,7 +18189,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.13" -->
     <emu-clause id="sec-function-definitions-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
@@ -18914,7 +18202,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.14" -->
     <emu-clause id="sec-function-definitions-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
@@ -18928,7 +18215,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.15" -->
     <emu-clause id="sec-function-definitions-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -18942,7 +18228,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.16" -->
     <emu-clause id="sec-function-definitions-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -18956,7 +18241,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.17" -->
     <emu-clause id="sec-function-definitions-runtime-semantics-evaluatebody">
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
@@ -18968,7 +18252,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.1.18" -->
     <emu-clause id="sec-function-definitions-runtime-semantics-iteratorbindinginitialization">
       <h1>Runtime Semantics: IteratorBindingInitialization</h1>
       <p>With parameters _iteratorRecord_ and _environment_.</p>
@@ -19028,7 +18311,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.1.19" -->
     <emu-clause id="sec-function-definitions-runtime-semantics-instantiatefunctionobject">
       <h1>Runtime Semantics: InstantiateFunctionObject</h1>
       <p>With parameter _scope_.</p>
@@ -19054,7 +18336,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.1.20" -->
     <emu-clause id="sec-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -19103,7 +18384,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="14.2" -->
   <emu-clause id="sec-arrow-function-definitions">
     <h1>Arrow Function Definitions</h1>
     <h2>Syntax</h2>
@@ -19130,7 +18410,6 @@
         `(` UniqueFormalParameters[?Yield, ?Await] `)`
     </emu-grammar>
 
-    <!-- es6num="14.2.1" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
@@ -19159,7 +18438,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="14.2.2" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -19170,7 +18448,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.3" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
@@ -19191,7 +18468,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.4" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-containsexpression">
       <h1>Static Semantics: ContainsExpression</h1>
       <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
@@ -19210,7 +18486,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.5" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
@@ -19220,7 +18495,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.7" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
@@ -19230,7 +18504,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.8" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-issimpleparameterlist">
       <h1>Static Semantics: IsSimpleParameterList</h1>
       <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
@@ -19245,7 +18518,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.9" -->
     <emu-clause id="sec-static-semantics-coveredformalslist">
       <h1>Static Semantics: CoveredFormalsList</h1>
       <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
@@ -19266,7 +18538,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.10" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
@@ -19276,7 +18547,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.11" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
@@ -19286,7 +18556,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.12" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -19296,7 +18565,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.13" -->
     <emu-clause id="sec-arrow-function-definitions-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -19306,7 +18574,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.14" -->
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-iteratorbindinginitialization">
       <h1>Runtime Semantics: IteratorBindingInitialization</h1>
       <p>With parameters _iteratorRecord_ and _environment_.</p>
@@ -19330,7 +18597,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.15" -->
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluatebody">
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
@@ -19344,7 +18610,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.2.16" -->
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
@@ -19361,7 +18626,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="14.3" -->
   <emu-clause id="sec-method-definitions">
     <h1>Method Definitions</h1>
     <h2>Syntax</h2>
@@ -19378,7 +18642,6 @@
         FormalParameter[~Yield, ~Await]
     </emu-grammar>
 
-    <!-- es6num="14.3.1" -->
     <emu-clause id="sec-method-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -19404,7 +18667,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="14.3.2" -->
     <emu-clause id="sec-method-definitions-static-semantics-computedpropertycontains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
@@ -19420,7 +18682,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.3.3" -->
     <emu-clause id="sec-method-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
@@ -19431,7 +18692,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.3.5" -->
     <emu-clause id="sec-method-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
@@ -19451,7 +18711,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.3.6" -->
     <emu-clause id="sec-method-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
@@ -19466,7 +18725,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.3.7" -->
     <emu-clause id="sec-static-semantics-specialmethod">
       <h1>Static Semantics: SpecialMethod</h1>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -19486,7 +18744,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.3.8" -->
     <emu-clause id="sec-runtime-semantics-definemethod">
       <h1>Runtime Semantics: DefineMethod</h1>
       <p>With parameters _object_ and optional parameter _functionPrototype_.</p>
@@ -19508,7 +18765,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.3.9" -->
     <emu-clause id="sec-method-definitions-runtime-semantics-propertydefinitionevaluation">
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
@@ -19549,7 +18805,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="14.4" -->
   <emu-clause id="sec-generator-function-definitions">
     <h1>Generator Function Definitions</h1>
     <h2>Syntax</h2>
@@ -19582,7 +18837,6 @@
       <p>Abstract operations relating to generator objects are defined in <emu-xref href="#sec-generator-abstract-operations"></emu-xref>.</p>
     </emu-note>
 
-    <!-- es6num="14.4.1" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
@@ -19638,7 +18892,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="14.4.2" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -19655,7 +18908,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.4.3" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-computedpropertycontains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
@@ -19666,7 +18918,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.4.4" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
@@ -19686,7 +18937,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.4.6" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasdirectsuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
@@ -19697,7 +18947,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.4.7" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
@@ -19711,7 +18960,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.4.8" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
@@ -19725,7 +18973,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.4.9" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -19735,7 +18982,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.4.10" -->
     <emu-clause id="sec-generator-function-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
@@ -19745,7 +18991,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.4.11" -->
     <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluatebody">
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
@@ -19759,7 +19004,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.4.12" -->
     <emu-clause id="sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject">
       <h1>Runtime Semantics: InstantiateFunctionObject</h1>
       <p>With parameter _scope_.</p>
@@ -19787,7 +19031,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.4.13" -->
     <emu-clause id="sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation">
       <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
       <p>With parameters _object_ and _enumerable_.</p>
@@ -19808,7 +19051,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.4.14" -->
     <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
@@ -20167,7 +19409,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="14.5" -->
   <emu-clause id="sec-class-definitions">
     <h1>Class Definitions</h1>
     <h2>Syntax</h2>
@@ -20201,7 +19442,6 @@
       <p>A class definition is always strict mode code.</p>
     </emu-note>
 
-    <!-- es6num="14.5.1" -->
     <emu-clause id="sec-class-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
@@ -20241,7 +19481,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="14.5.2" -->
     <emu-clause id="sec-class-definitions-static-semantics-boundnames">
       <h1>Static Semantics: BoundNames</h1>
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -20255,7 +19494,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.3" -->
     <emu-clause id="sec-static-semantics-constructormethod">
       <h1>Static Semantics: ConstructorMethod</h1>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
@@ -20279,7 +19517,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.5.4" -->
     <emu-clause id="sec-class-definitions-static-semantics-contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
@@ -20298,7 +19535,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.5.5" -->
     <emu-clause id="sec-class-definitions-static-semantics-computedpropertycontains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
@@ -20323,7 +19559,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.6" -->
     <emu-clause id="sec-class-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
@@ -20337,7 +19572,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.7" -->
     <emu-clause id="sec-class-definitions-static-semantics-isconstantdeclaration">
       <h1>Static Semantics: IsConstantDeclaration</h1>
       <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
@@ -20351,7 +19585,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.8" -->
     <emu-clause id="sec-class-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -20361,7 +19594,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.9" -->
     <emu-clause id="sec-static-semantics-isstatic">
       <h1>Static Semantics: IsStatic</h1>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
@@ -20378,7 +19610,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.10" -->
     <emu-clause id="sec-static-semantics-nonconstructormethoddefinitions">
       <h1>Static Semantics: NonConstructorMethodDefinitions</h1>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
@@ -20397,7 +19628,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.11" -->
     <emu-clause id="sec-static-semantics-prototypepropertynamelist">
       <h1>Static Semantics: PrototypePropertyNameList</h1>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
@@ -20416,7 +19646,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.12" -->
     <emu-clause id="sec-class-definitions-static-semantics-propname">
       <h1>Static Semantics: PropName</h1>
       <emu-see-also-para op="PropName"></emu-see-also-para>
@@ -20426,7 +19655,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.14" -->
     <emu-clause id="sec-runtime-semantics-classdefinitionevaluation">
       <h1>Runtime Semantics: ClassDefinitionEvaluation</h1>
       <p>With parameter _className_.</p>
@@ -20490,7 +19718,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="14.5.15" -->
     <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation">
       <h1>Runtime Semantics: BindingClassDeclarationEvaluation</h1>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
@@ -20513,7 +19740,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.5.16" -->
     <emu-clause id="sec-class-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
@@ -21081,11 +20307,9 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="14.6" -->
   <emu-clause id="sec-tail-position-calls">
     <h1>Tail Position Calls</h1>
 
-    <!-- es6num="14.6.1" -->
     <emu-clause id="sec-isintailposition" aoid="IsInTailPosition">
       <h1>Static Semantics: IsInTailPosition ( _call_ )</h1>
       <p>The abstract operation IsInTailPosition with argument _call_ performs the following steps:</p>
@@ -21105,7 +20329,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="14.6.2" -->
     <emu-clause id="sec-static-semantics-hascallintailposition">
       <h1>Static Semantics: HasCallInTailPosition</h1>
       <p>With parameter _call_.</p>
@@ -21113,7 +20336,6 @@
         <p>_call_ is a Parse Node that represents a specific range of source text. When the following algorithms compare _call_ to another Parse Node, it is a test of whether they represent the same source text.</p>
       </emu-note>
 
-      <!-- es6num="14.6.2.1" -->
       <emu-clause id="sec-statement-rules">
         <h1>Statement Rules</h1>
         <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
@@ -21238,7 +20460,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="14.6.2.2" -->
       <emu-clause id="sec-expression-rules">
         <h1>Expression Rules</h1>
         <emu-note>
@@ -21389,7 +20610,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="14.6.3" -->
     <emu-clause id="sec-preparefortailcall" aoid="PrepareForTailCall">
       <h1>Runtime Semantics: PrepareForTailCall ( )</h1>
       <p>The abstract operation PrepareForTailCall performs the following steps:</p>
@@ -21407,11 +20627,9 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="15" -->
 <emu-clause id="sec-ecmascript-language-scripts-and-modules">
   <h1>ECMAScript Language: Scripts and Modules</h1>
 
-  <!-- es6num="15.1" -->
   <emu-clause id="sec-scripts">
     <h1>Scripts</h1>
     <h2>Syntax</h2>
@@ -21423,7 +20641,6 @@
         StatementList[~Yield, ~Await, ~Return]
     </emu-grammar>
 
-    <!-- es6num="15.1.1" -->
     <emu-clause id="sec-scripts-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>Script : ScriptBody</emu-grammar>
@@ -21455,7 +20672,6 @@
       </ul>
     </emu-clause>
 
-    <!-- es6num="15.1.2" -->
     <emu-clause id="sec-static-semantics-isstrict">
       <h1>Static Semantics: IsStrict</h1>
       <emu-grammar>ScriptBody : StatementList</emu-grammar>
@@ -21464,7 +20680,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="15.1.3" -->
     <emu-clause id="sec-scripts-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
@@ -21477,7 +20692,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="15.1.4" -->
     <emu-clause id="sec-scripts-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
@@ -21487,7 +20701,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="15.1.5" -->
     <emu-clause id="sec-scripts-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -21497,7 +20710,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="15.1.6" -->
     <emu-clause id="sec-scripts-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -21601,7 +20813,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="15.1.7" -->
     <emu-clause id="sec-runtime-semantics-scriptevaluation" aoid="ScriptEvaluation">
       <h1>ScriptEvaluation ( _scriptRecord_ )</h1>
 
@@ -21628,7 +20839,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="15.1.8" -->
     <emu-clause id="sec-globaldeclarationinstantiation" aoid="GlobalDeclarationInstantiation">
       <h1>Runtime Semantics: GlobalDeclarationInstantiation ( _script_, _env_ )</h1>
       <emu-note>
@@ -21698,7 +20908,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="15.1.9" -->
     <emu-clause id="sec-scriptevaluationjob" aoid="ScriptEvaluationJob">
       <h1>Runtime Semantics: ScriptEvaluationJob ( _sourceText_, _hostDefined_ )</h1>
       <p>The job ScriptEvaluationJob with parameters _sourceText_ and _hostDefined_ parses, validates, and evaluates _sourceText_ as a |Script|.</p>
@@ -21714,7 +20923,6 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="15.2" -->
   <emu-clause id="sec-modules">
     <h1>Modules</h1>
     <h2>Syntax</h2>
@@ -21735,11 +20943,9 @@
         StatementListItem[~Yield, ~Await, ~Return]
     </emu-grammar>
 
-    <!-- es6num="15.2.1" -->
     <emu-clause id="sec-module-semantics">
       <h1>Module Semantics</h1>
 
-      <!-- es6num="15.2.1.1" -->
       <emu-clause id="sec-module-semantics-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
@@ -21777,7 +20983,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="15.2.1.2" -->
       <emu-clause id="sec-module-semantics-static-semantics-containsduplicatelabels">
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
@@ -21798,7 +21003,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.3" -->
       <emu-clause id="sec-module-semantics-static-semantics-containsundefinedbreaktarget">
         <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
         <p>With parameter _labelSet_.</p>
@@ -21819,7 +21023,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.4" -->
       <emu-clause id="sec-module-semantics-static-semantics-containsundefinedcontinuetarget">
         <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
         <p>With parameters _iterationSet_ and _labelSet_.</p>
@@ -21840,7 +21043,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.5" -->
       <emu-clause id="sec-module-semantics-static-semantics-exportedbindings">
         <h1>Static Semantics: ExportedBindings</h1>
         <emu-see-also-para op="ExportedBindings"></emu-see-also-para>
@@ -21863,7 +21065,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.6" -->
       <emu-clause id="sec-module-semantics-static-semantics-exportednames">
         <h1>Static Semantics: ExportedNames</h1>
         <emu-see-also-para op="ExportedNames"></emu-see-also-para>
@@ -21890,7 +21091,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.7" -->
       <emu-clause id="sec-module-semantics-static-semantics-exportentries">
         <h1>Static Semantics: ExportEntries</h1>
         <emu-see-also-para op="ExportEntries"></emu-see-also-para>
@@ -21914,7 +21114,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.8" -->
       <emu-clause id="sec-module-semantics-static-semantics-importentries">
         <h1>Static Semantics: ImportEntries</h1>
         <emu-see-also-para op="ImportEntries"></emu-see-also-para>
@@ -21938,7 +21137,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.9" -->
       <emu-clause id="sec-importedlocalnames" aoid="ImportedLocalNames">
         <h1>Static Semantics: ImportedLocalNames ( _importEntries_ )</h1>
         <p>The abstract operation ImportedLocalNames with argument _importEntries_ creates a List of all of the local name bindings defined by a List of ImportEntry Records (see <emu-xref href="#table-39"></emu-xref>). ImportedLocalNames performs the following steps:</p>
@@ -21950,7 +21148,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.10" -->
       <emu-clause id="sec-module-semantics-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
@@ -21975,7 +21172,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.11" -->
       <emu-clause id="sec-module-semantics-static-semantics-lexicallydeclarednames">
         <h1>Static Semantics: LexicallyDeclaredNames</h1>
         <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
@@ -22006,7 +21202,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="15.2.1.12" -->
       <emu-clause id="sec-module-semantics-static-semantics-lexicallyscopeddeclarations">
         <h1>Static Semantics: LexicallyScopedDeclarations</h1>
         <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
@@ -22026,7 +21221,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.13" -->
       <emu-clause id="sec-module-semantics-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
@@ -22051,7 +21245,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.14" -->
       <emu-clause id="sec-module-semantics-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
@@ -22076,7 +21269,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.1.15" -->
       <emu-clause id="sec-abstract-module-records">
         <h1>Abstract Module Records</h1>
         <p>A <dfn>Module Record</dfn> encapsulates structural information about the imports and exports of a single module. This information is used to link the imports and exports of sets of connected modules. A Module Record includes four fields that are only used when evaluating a module.</p>
@@ -22195,7 +21387,6 @@
         </emu-table>
       </emu-clause>
 
-      <!-- es6num="15.2.1.16" -->
       <emu-clause id="sec-source-text-module-records">
         <h1>Source Text Module Records</h1>
 
@@ -22714,7 +21905,6 @@
         </emu-note>
         <p>The following definitions specify the required concrete methods and other abstract operations for Source Text Module Records</p>
 
-        <!-- es6num="15.2.1.16.1" -->
         <emu-clause id="sec-parsemodule" aoid="ParseModule">
           <h1>ParseModule ( _sourceText_, _realm_, _hostDefined_ )</h1>
           <p>The abstract operation ParseModule with arguments _sourceText_, _realm_, and _hostDefined_ creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. ParseModule performs the following steps:</p>
@@ -22751,7 +21941,6 @@
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="15.2.1.16.2" -->
         <emu-clause id="sec-getexportednames">
           <h1>GetExportedNames ( _exportStarSet_ ) Concrete Method</h1>
           <p>The GetExportedNames concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
@@ -22828,7 +22017,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="15.2.1.16.4" -->
         <emu-clause id="sec-moduledeclarationinstantiation">
           <h1>Instantiate ( ) Concrete Method</h1>
 
@@ -22949,7 +22137,6 @@
           </emu-clause>
         </emu-clause>
 
-        <!-- es6num="15.2.1.16.5" -->
         <emu-clause id="sec-moduleevaluation">
           <h1>Evaluate ( ) Concrete Method</h1>
 
@@ -23090,7 +22277,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="15.2.1.17" -->
       <emu-clause id="sec-hostresolveimportedmodule" aoid="HostResolveImportedModule">
         <h1>Runtime Semantics: HostResolveImportedModule ( _referencingModule_, _specifier_ )</h1>
         <p>HostResolveImportedModule is an implementation-defined abstract operation that provides the concrete Module Record subclass instance that corresponds to the |ModuleSpecifier| String, _specifier_, occurring within the context of the module represented by the Module Record _referencingModule_.</p>
@@ -23135,7 +22321,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="15.2.1.19" -->
       <emu-clause id="sec-toplevelmoduleevaluationjob" aoid="TopLevelModuleEvaluationJob">
         <h1>Runtime Semantics: TopLevelModuleEvaluationJob ( _sourceText_, _hostDefined_ )</h1>
         <p>A TopLevelModuleEvaluationJob with parameters _sourceText_ and _hostDefined_ is a job that parses, validates, and evaluates _sourceText_ as a |Module|.</p>
@@ -23155,7 +22340,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="15.2.1.20" -->
       <emu-clause id="sec-module-semantics-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>Module : [empty]</emu-grammar>
@@ -23186,7 +22370,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="15.2.2" -->
     <emu-clause id="sec-imports">
       <h1>Imports</h1>
       <h2>Syntax</h2>
@@ -23231,7 +22414,6 @@
           BindingIdentifier[~Yield, ~Await]
       </emu-grammar>
 
-      <!-- es6num="15.2.2.1" -->
       <emu-clause id="sec-imports-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
@@ -23242,7 +22424,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="15.2.2.2" -->
       <emu-clause id="sec-imports-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -23282,7 +22463,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.2.3" -->
       <emu-clause id="sec-imports-static-semantics-importentries">
         <h1>Static Semantics: ImportEntries</h1>
         <emu-see-also-para op="ImportEntries"></emu-see-also-para>
@@ -23297,7 +22477,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.2.4" -->
       <emu-clause id="sec-static-semantics-importentriesformodule">
         <h1>Static Semantics: ImportEntriesForModule</h1>
         <p>With parameter _module_.</p>
@@ -23350,7 +22529,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.2.5" -->
       <emu-clause id="sec-imports-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
@@ -23365,7 +22543,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="15.2.3" -->
     <emu-clause id="sec-exports">
       <h1>Exports</h1>
       <h2>Syntax</h2>
@@ -23394,7 +22571,6 @@
           IdentifierName `as` IdentifierName
       </emu-grammar>
 
-      <!-- es6num="15.2.3.1" -->
       <emu-clause id="sec-exports-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>ExportDeclaration : `export` ExportClause `;`</emu-grammar>
@@ -23408,7 +22584,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="15.2.3.2" -->
       <emu-clause id="sec-exports-static-semantics-boundnames">
         <h1>Static Semantics: BoundNames</h1>
         <emu-see-also-para op="BoundNames"></emu-see-also-para>
@@ -23447,7 +22622,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.3.3" -->
       <emu-clause id="sec-exports-static-semantics-exportedbindings">
         <h1>Static Semantics: ExportedBindings</h1>
         <emu-see-also-para op="ExportedBindings"></emu-see-also-para>
@@ -23501,7 +22675,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.3.4" -->
       <emu-clause id="sec-exports-static-semantics-exportednames">
         <h1>Static Semantics: ExportedNames</h1>
         <emu-see-also-para op="ExportedNames"></emu-see-also-para>
@@ -23555,7 +22728,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.3.5" -->
       <emu-clause id="sec-exports-static-semantics-exportentries">
         <h1>Static Semantics: ExportEntries</h1>
         <emu-see-also-para op="ExportEntries"></emu-see-also-para>
@@ -23612,7 +22784,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="15.2.3.6" -->
       <emu-clause id="sec-static-semantics-exportentriesformodule">
         <h1>Static Semantics: ExportEntriesForModule</h1>
         <p>With parameter _module_.</p>
@@ -23651,7 +22822,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.3.7" -->
       <emu-clause id="sec-exports-static-semantics-isconstantdeclaration">
         <h1>Static Semantics: IsConstantDeclaration</h1>
         <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
@@ -23670,7 +22840,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="15.2.3.8" -->
       <emu-clause id="sec-exports-static-semantics-lexicallyscopeddeclarations">
         <h1>Static Semantics: LexicallyScopedDeclarations</h1>
         <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
@@ -23702,7 +22871,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.3.9" -->
       <emu-clause id="sec-exports-static-semantics-modulerequests">
         <h1>Static Semantics: ModuleRequests</h1>
         <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
@@ -23728,7 +22896,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.3.10" -->
       <emu-clause id="sec-static-semantics-referencedbindings">
         <h1>Static Semantics: ReferencedBindings</h1>
         <emu-grammar>ExportClause : `{` `}`</emu-grammar>
@@ -23751,7 +22918,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="15.2.3.11" -->
       <emu-clause id="sec-exports-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>
@@ -23803,7 +22969,6 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="16" -->
 <emu-clause id="sec-error-handling-and-language-extensions">
   <h1>Error Handling and Language Extensions</h1>
   <p>An implementation must report most errors at the time the relevant ECMAScript language construct is evaluated. An <dfn id="early-error">early error</dfn> is an error that can be detected and reported prior to the evaluation of any construct in the |Script| containing the error. The presence of an early error prevents the evaluation of the construct. An implementation must report early errors in a |Script| as part of parsing that |Script| in ParseScript. Early errors in a |Module| are reported at the point when the |Module| would be evaluated and the |Module| is never initialized. Early errors in <b>eval</b> code are reported at the time `eval` is called and prevent evaluation of the <b>eval</b> code. All errors that are not early errors are runtime errors.</p>
@@ -23831,7 +22996,6 @@
     </emu-note>
   </emu-clause>
 
-  <!-- es6num="16.1" -->
   <emu-clause id="sec-forbidden-extensions">
     <h1>Forbidden Extensions</h1>
     <p>An implementation must not extend this specification in the following ways:</p>
@@ -23870,7 +23034,6 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="17" -->
 <emu-clause id="sec-ecmascript-standard-built-in-objects">
   <h1>ECMAScript Standard Built-in Objects</h1>
   <p>There are certain built-in objects available whenever an ECMAScript |Script| or |Module| begins execution. One, the global object, is part of the lexical environment of the executing program. Others are accessible as initial properties of the global object or indirectly as properties of accessible built-in objects.</p>
@@ -23896,7 +23059,6 @@
   <p>Every accessor property described in clauses 18 through 26 and in Annex <emu-xref href="#sec-additional-built-in-properties"></emu-xref> has the attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, *undefined*. If only a set accessor is described the get accessor is the default value, *undefined*.</p>
 </emu-clause>
 
-<!-- es6num="18" -->
 <emu-clause id="sec-global-object">
   <h1>The Global Object</h1>
   <p>The <dfn>global object</dfn>:</p>
@@ -23908,34 +23070,28 @@
     <li>may have host defined properties in addition to the properties defined in this specification. This may include a property whose value is the global object itself; for example, in the HTML document object model the `window` property of the global object is the global object itself.</li>
   </ul>
 
-  <!-- es6num="18.1" -->
   <emu-clause id="sec-value-properties-of-the-global-object">
     <h1>Value Properties of the Global Object</h1>
 
-    <!-- es6num="18.1.1" -->
     <emu-clause id="sec-value-properties-of-the-global-object-infinity">
       <h1>Infinity</h1>
       <p>The value of `Infinity` is *+&infin;* (see <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>). This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
-    <!-- es6num="18.1.2" -->
     <emu-clause id="sec-value-properties-of-the-global-object-nan">
       <h1>NaN</h1>
       <p>The value of `NaN` is *NaN* (see <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>). This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
-    <!-- es6num="18.1.3" -->
     <emu-clause id="sec-undefined">
       <h1>undefined</h1>
       <p>The value of `undefined` is *undefined* (see <emu-xref href="#sec-ecmascript-language-types-undefined-type"></emu-xref>). This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="18.2" -->
   <emu-clause id="sec-function-properties-of-the-global-object">
     <h1>Function Properties of the Global Object</h1>
 
-    <!-- es6num="18.2.1" -->
     <emu-clause id="sec-eval-x">
       <h1>eval ( _x_ )</h1>
       <p>The `eval` function is the <dfn>%eval%</dfn> intrinsic object. When the `eval` function is called with one argument _x_, the following steps are taken:</p>
@@ -23948,7 +23104,6 @@
         1. Return ? PerformEval(_x_, _calleeRealm_, *false*, *false*).
       </emu-alg>
 
-      <!-- es6num="18.2.1.1" -->
       <emu-clause id="sec-performeval" aoid="PerformEval">
         <h1>Runtime Semantics: PerformEval ( _x_, _evalRealm_, _strictCaller_, _direct_ )</h1>
         <p>The abstract operation PerformEval with arguments _x_, _evalRealm_, _strictCaller_, and _direct_ performs the following steps:</p>
@@ -24036,7 +23191,6 @@
         <p>An implementation of HostEnsureCanCompileStrings may complete normally or abruptly. Any abrupt completions will be propagated to its callers. The default implementation of HostEnsureCanCompileStrings is to unconditionally return an empty normal completion.</p>
       </emu-clause>
 
-      <!-- es6num="18.2.1.2" -->
       <emu-clause id="sec-evaldeclarationinstantiation" aoid="EvalDeclarationInstantiation">
         <h1>Runtime Semantics: EvalDeclarationInstantiation ( _body_, _varEnv_, _lexEnv_, _strict_ )</h1>
         <p>When the abstract operation EvalDeclarationInstantiation is called with arguments _body_, _varEnv_, _lexEnv_, and _strict_, the following steps are taken:</p>
@@ -24131,7 +23285,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="18.2.2" -->
     <emu-clause id="sec-isfinite-number">
       <h1>isFinite ( _number_ )</h1>
       <p>The `isFinite` function is the <dfn>%isFinite%</dfn> intrinsic object. When the `isFinite` function is called with one argument _number_, the following steps are taken:</p>
@@ -24142,7 +23295,6 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="18.2.3" -->
     <emu-clause id="sec-isnan-number">
       <h1>isNaN ( _number_ )</h1>
       <p>The `isNaN` function is the <dfn>%isNaN%</dfn> intrinsic object. When the `isNaN` function is called with one argument _number_, the following steps are taken:</p>
@@ -24156,7 +23308,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="18.2.4" -->
     <emu-clause id="sec-parsefloat-string">
       <h1>parseFloat ( _string_ )</h1>
       <p>The `parseFloat` function produces a Number value dictated by interpretation of the contents of the _string_ argument as a decimal literal.</p>
@@ -24177,7 +23328,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="18.2.5" -->
     <emu-clause id="sec-parseint-string-radix">
       <h1>parseInt ( _string_, _radix_ )</h1>
       <p>The `parseInt` function produces an integer value dictated by interpretation of the contents of the _string_ argument according to the specified _radix_. Leading white space in _string_ is ignored. If _radix_ is *undefined* or 0, it is assumed to be 10 except when the number begins with the code unit pairs `0x` or `0X`, in which case a radix of 16 is assumed. If _radix_ is 16, the number may also optionally begin with the code unit pairs `0x` or `0X`.</p>
@@ -24211,7 +23361,6 @@
       </emu-note>
     </emu-clause>
 
-    <!-- es6num="18.2.6" -->
     <emu-clause id="sec-uri-handling-functions">
       <h1>URI Handling Functions</h1>
       <p>Uniform Resource Identifiers, or URIs, are Strings that identify resources (e.g. web pages or files) and transport protocols by which to access them (e.g. HTTP or FTP) on the Internet. The ECMAScript language itself does not provide any support for using URIs except for functions that encode and decode URIs as described in <emu-xref href="#sec-decodeuri-encodeduri"></emu-xref>, <emu-xref href="#sec-decodeuricomponent-encodeduricomponent"></emu-xref>, <emu-xref href="#sec-encodeuri-uri"></emu-xref> and <emu-xref href="#sec-encodeuricomponent-uricomponent"></emu-xref></p>
@@ -24219,7 +23368,6 @@
         <p>Many implementations of ECMAScript provide additional functions and methods that manipulate web pages; these functions are beyond the scope of this standard.</p>
       </emu-note>
 
-      <!-- es6num="18.2.6.1" -->
       <emu-clause id="sec-uri-syntax-and-semantics">
         <h1>URI Syntax and Semantics</h1>
         <p>A URI is composed of a sequence of components separated by component separators. The general form is:</p>
@@ -24265,7 +23413,6 @@
         <h2>Runtime Semantics</h2>
         <p>When a code unit to be included in a URI is not listed above or is not intended to have the special meaning sometimes given to the reserved code units, that code unit must be encoded. The code unit is transformed into its UTF-8 encoding, with <emu-xref href="#surrogate-pair">surrogate pairs</emu-xref> first converted from UTF-16 to the corresponding code point value. (Note that for code units in the range [0, 127] this results in a single octet with the same value.) The resulting sequence of octets is then transformed into a String with each octet represented by an escape sequence of the form `"%xx"`.</p>
 
-        <!-- es6num="18.2.6.1.1" -->
         <emu-clause id="sec-encode" aoid="Encode">
           <h1>Runtime Semantics: Encode ( _string_, _unescapedSet_ )</h1>
           <p>The encoding and escaping process is described by the abstract operation Encode taking two String arguments _string_ and _unescapedSet_.</p>
@@ -24299,7 +23446,6 @@
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="18.2.6.1.2" -->
         <emu-clause id="sec-decode" aoid="Decode">
           <h1>Runtime Semantics: Decode ( _string_, _reservedSet_ )</h1>
           <p>The unescaping and decoding process is described by the abstract operation Decode taking two String arguments _string_ and _reservedSet_.</p>
@@ -24523,7 +23669,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="18.2.6.2" -->
       <emu-clause id="sec-decodeuri-encodeduri">
         <h1>decodeURI ( _encodedURI_ )</h1>
         <p>The `decodeURI` function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURI` function is replaced with the UTF-16 encoding of the code points that it represents. Escape sequences that could not have been introduced by `encodeURI` are not replaced.</p>
@@ -24538,7 +23683,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="18.2.6.3" -->
       <emu-clause id="sec-decodeuricomponent-encodeduricomponent">
         <h1>decodeURIComponent ( _encodedURIComponent_ )</h1>
         <p>The `decodeURIComponent` function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURIComponent` function is replaced with the UTF-16 encoding of the code points that it represents.</p>
@@ -24550,7 +23694,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="18.2.6.4" -->
       <emu-clause id="sec-encodeuri-uri">
         <h1>encodeURI ( _uri_ )</h1>
         <p>The `encodeURI` function computes a new version of a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) URI in which each instance of certain code points is replaced by one, two, three, or four escape sequences representing the UTF-8 encoding of the code points.</p>
@@ -24565,7 +23708,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="18.2.6.5" -->
       <emu-clause id="sec-encodeuricomponent-uricomponent">
         <h1>encodeURIComponent ( _uriComponent_ )</h1>
         <p>The `encodeURIComponent` function computes a new version of a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) URI in which each instance of certain code points is replaced by one, two, three, or four escape sequences representing the UTF-8 encoding of the code point.</p>
@@ -24579,137 +23721,114 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="18.3" -->
   <emu-clause id="sec-constructor-properties-of-the-global-object">
     <h1>Constructor Properties of the Global Object</h1>
 
-    <!-- es6num="18.3.1" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-array">
       <h1>Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-array-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.2" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-arraybuffer">
       <h1>ArrayBuffer ( . . . )</h1>
       <p>See <emu-xref href="#sec-arraybuffer-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.3" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-boolean">
       <h1>Boolean ( . . . )</h1>
       <p>See <emu-xref href="#sec-boolean-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.4" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-dataview">
       <h1>DataView ( . . . )</h1>
       <p>See <emu-xref href="#sec-dataview-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.5" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-date">
       <h1>Date ( . . . )</h1>
       <p>See <emu-xref href="#sec-date-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.6" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-error">
       <h1>Error ( . . . )</h1>
       <p>See <emu-xref href="#sec-error-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.7" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-evalerror">
       <h1>EvalError ( . . . )</h1>
       <p>See <emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.8" -->
     <emu-clause id="sec-float32array">
       <h1>Float32Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.9" -->
     <emu-clause id="sec-float64array">
       <h1>Float64Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.10" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-function">
       <h1>Function ( . . . )</h1>
       <p>See <emu-xref href="#sec-function-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.11" -->
     <emu-clause id="sec-int8array">
       <h1>Int8Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.12" -->
     <emu-clause id="sec-int16array">
       <h1>Int16Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.13" -->
     <emu-clause id="sec-int32array">
       <h1>Int32Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.14" -->
     <emu-clause id="sec-map">
       <h1>Map ( . . . )</h1>
       <p>See <emu-xref href="#sec-map-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.15" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-number">
       <h1>Number ( . . . )</h1>
       <p>See <emu-xref href="#sec-number-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.16" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-object">
       <h1>Object ( . . . )</h1>
       <p>See <emu-xref href="#sec-object-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.18" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-promise">
       <h1>Promise ( . . . )</h1>
       <p>See <emu-xref href="#sec-promise-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.17" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-proxy">
       <h1>Proxy ( . . . )</h1>
       <p>See <emu-xref href="#sec-proxy-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.19" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-rangeerror">
       <h1>RangeError ( . . . )</h1>
       <p>See <emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.20" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-referenceerror">
       <h1>ReferenceError ( . . . )</h1>
       <p>See <emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.21" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-regexp">
       <h1>RegExp ( . . . )</h1>
       <p>See <emu-xref href="#sec-regexp-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.22" -->
     <emu-clause id="sec-set">
       <h1>Set ( . . . )</h1>
       <p>See <emu-xref href="#sec-set-constructor"></emu-xref>.</p>
@@ -24720,74 +23839,62 @@
       <p>See <emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.23" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-string">
       <h1>String ( . . . )</h1>
       <p>See <emu-xref href="#sec-string-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.24" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-symbol">
       <h1>Symbol ( . . . )</h1>
       <p>See <emu-xref href="#sec-symbol-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.25" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-syntaxerror">
       <h1>SyntaxError ( . . . )</h1>
       <p>See <emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.26" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-typeerror">
       <h1>TypeError ( . . . )</h1>
       <p>See <emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.27" -->
     <emu-clause id="sec-uint8array">
       <h1>Uint8Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.28" -->
     <emu-clause id="sec-uint8clampedarray">
       <h1>Uint8ClampedArray ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.29" -->
     <emu-clause id="sec-uint16array">
       <h1>Uint16Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.30" -->
     <emu-clause id="sec-uint32array">
       <h1>Uint32Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.31" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-urierror">
       <h1>URIError ( . . . )</h1>
       <p>See <emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.32" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-weakmap">
       <h1>WeakMap ( . . . )</h1>
       <p>See <emu-xref href="#sec-weakmap-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.3.33" -->
     <emu-clause id="sec-constructor-properties-of-the-global-object-weakset">
       <h1>WeakSet ( . . . )</h1>
       <p>See <emu-xref href="#sec-weakset-objects"></emu-xref>.</p>
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="18.4" -->
   <emu-clause id="sec-other-properties-of-the-global-object">
     <h1>Other Properties of the Global Object</h1>
 
@@ -24796,19 +23903,16 @@
       <p>See <emu-xref href="#sec-atomics-object"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.4.1" -->
     <emu-clause id="sec-json">
       <h1>JSON</h1>
       <p>See <emu-xref href="#sec-json-object"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.4.2" -->
     <emu-clause id="sec-math">
       <h1>Math</h1>
       <p>See <emu-xref href="#sec-math-object"></emu-xref>.</p>
     </emu-clause>
 
-    <!-- es6num="18.4.3" -->
     <emu-clause id="sec-reflect">
       <h1>Reflect</h1>
       <p>See <emu-xref href="#sec-reflect-object"></emu-xref>.</p>
@@ -24816,15 +23920,12 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="19" -->
 <emu-clause id="sec-fundamental-objects">
   <h1>Fundamental Objects</h1>
 
-  <!-- es6num="19.1" -->
   <emu-clause id="sec-object-objects">
     <h1>Object Objects</h1>
 
-    <!-- es6num="19.1.1" -->
     <emu-clause id="sec-object-constructor">
       <h1>The Object Constructor</h1>
       <p>The Object constructor:</p>
@@ -24836,7 +23937,6 @@
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition.</li>
       </ul>
 
-      <!-- es6num="19.1.1.1" -->
       <emu-clause id="sec-object-value">
         <h1>Object ( [ _value_ ] )</h1>
         <p>When `Object` function is called with optional argument _value_, the following steps are taken:</p>
@@ -24850,7 +23950,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.1.2" -->
     <emu-clause id="sec-properties-of-the-object-constructor">
       <h1>Properties of the Object Constructor</h1>
       <p>The Object constructor:</p>
@@ -24860,7 +23959,6 @@
         <li>has the following additional properties:</li>
       </ul>
 
-      <!-- es6num="19.1.2.1" -->
       <emu-clause id="sec-object.assign">
         <h1>Object.assign ( _target_, ..._sources_ )</h1>
         <p>The `assign` function is used to copy the values of all of the enumerable own properties from one or more source objects to a _target_ object. When the `assign` function is called, the following steps are taken:</p>
@@ -24883,7 +23981,6 @@
         <p>The `length` property of the `assign` function is 2.</p>
       </emu-clause>
 
-      <!-- es6num="19.1.2.2" -->
       <emu-clause id="sec-object.create">
         <h1>Object.create ( _O_, _Properties_ )</h1>
         <p>The `create` function creates a new object with a specified prototype. When the `create` function is called, the following steps are taken:</p>
@@ -24896,7 +23993,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.3" -->
       <emu-clause id="sec-object.defineproperties">
         <h1>Object.defineProperties ( _O_, _Properties_ )</h1>
         <p>The `defineProperties` function is used to add own properties and/or update the attributes of existing own properties of an object. When the `defineProperties` function is called, the following steps are taken:</p>
@@ -24904,7 +24000,6 @@
           1. Return ? ObjectDefineProperties(_O_, _Properties_).
         </emu-alg>
 
-        <!-- es6num="19.1.2.3.1" -->
         <emu-clause id="sec-objectdefineproperties" aoid="ObjectDefineProperties">
           <h1>Runtime Semantics: ObjectDefineProperties ( _O_, _Properties_ )</h1>
           <p>The abstract operation ObjectDefineProperties with arguments _O_ and _Properties_ performs the following steps:</p>
@@ -24928,7 +24023,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="19.1.2.4" -->
       <emu-clause id="sec-object.defineproperty">
         <h1>Object.defineProperty ( _O_, _P_, _Attributes_ )</h1>
         <p>The `defineProperty` function is used to add an own property and/or update the attributes of an existing own property of an object. When the `defineProperty` function is called, the following steps are taken:</p>
@@ -24951,7 +24045,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.5" -->
       <emu-clause id="sec-object.freeze">
         <h1>Object.freeze ( _O_ )</h1>
         <p>When the `freeze` function is called, the following steps are taken:</p>
@@ -24963,7 +24056,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.6" -->
       <emu-clause id="sec-object.getownpropertydescriptor">
         <h1>Object.getOwnPropertyDescriptor ( _O_, _P_ )</h1>
         <p>When the `getOwnPropertyDescriptor` function is called, the following steps are taken:</p>
@@ -24990,7 +24082,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.7" -->
       <emu-clause id="sec-object.getownpropertynames">
         <h1>Object.getOwnPropertyNames ( _O_ )</h1>
         <p>When the `getOwnPropertyNames` function is called, the following steps are taken:</p>
@@ -24999,7 +24090,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.8" -->
       <emu-clause id="sec-object.getownpropertysymbols">
         <h1>Object.getOwnPropertySymbols ( _O_ )</h1>
         <p>When the `getOwnPropertySymbols` function is called with argument _O_, the following steps are taken:</p>
@@ -25007,7 +24097,6 @@
           1. Return ? GetOwnPropertyKeys(_O_, Symbol).
         </emu-alg>
 
-        <!-- es6num="19.1.2.8.1" -->
         <emu-clause id="sec-getownpropertykeys" aoid="GetOwnPropertyKeys">
           <h1>Runtime Semantics: GetOwnPropertyKeys ( _O_, _Type_ )</h1>
           <p>The abstract operation GetOwnPropertyKeys is called with arguments _O_ and _Type_ where _O_ is an Object and _Type_ is one of the ECMAScript specification types String or Symbol. The following steps are taken:</p>
@@ -25023,7 +24112,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="19.1.2.9" -->
       <emu-clause id="sec-object.getprototypeof">
         <h1>Object.getPrototypeOf ( _O_ )</h1>
         <p>When the `getPrototypeOf` function is called with argument _O_, the following steps are taken:</p>
@@ -25033,7 +24121,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.10" -->
       <emu-clause id="sec-object.is">
         <h1>Object.is ( _value1_, _value2_ )</h1>
         <p>When the `is` function is called with arguments _value1_ and _value2_, the following steps are taken:</p>
@@ -25042,7 +24129,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.11" -->
       <emu-clause id="sec-object.isextensible">
         <h1>Object.isExtensible ( _O_ )</h1>
         <p>When the `isExtensible` function is called with argument _O_, the following steps are taken:</p>
@@ -25052,7 +24138,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.12" -->
       <emu-clause id="sec-object.isfrozen">
         <h1>Object.isFrozen ( _O_ )</h1>
         <p>When the `isFrozen` function is called with argument _O_, the following steps are taken:</p>
@@ -25062,7 +24147,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.13" -->
       <emu-clause id="sec-object.issealed">
         <h1>Object.isSealed ( _O_ )</h1>
         <p>When the `isSealed` function is called with argument _O_, the following steps are taken:</p>
@@ -25072,7 +24156,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.14" -->
       <emu-clause id="sec-object.keys">
         <h1>Object.keys ( _O_ )</h1>
         <p>When the `keys` function is called with argument _O_, the following steps are taken:</p>
@@ -25083,7 +24166,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.15" -->
       <emu-clause id="sec-object.preventextensions">
         <h1>Object.preventExtensions ( _O_ )</h1>
         <p>When the `preventExtensions` function is called, the following steps are taken:</p>
@@ -25095,14 +24177,12 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.16" -->
       <emu-clause id="sec-object.prototype">
         <h1>Object.prototype</h1>
         <p>The initial value of `Object.prototype` is the intrinsic object %ObjectPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.1.2.17" -->
       <emu-clause id="sec-object.seal">
         <h1>Object.seal ( _O_ )</h1>
         <p>When the `seal` function is called, the following steps are taken:</p>
@@ -25114,7 +24194,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.1.2.18" -->
       <emu-clause id="sec-object.setprototypeof">
         <h1>Object.setPrototypeOf ( _O_, _proto_ )</h1>
         <p>When the `setPrototypeOf` function is called with arguments _O_ and proto, the following steps are taken:</p>
@@ -25139,7 +24218,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.1.3" -->
     <emu-clause id="sec-properties-of-the-object-prototype-object">
       <h1>Properties of the Object Prototype Object</h1>
       <p>The Object prototype object:</p>
@@ -25149,13 +24227,11 @@
         <li>has a [[Prototype]] internal slot whose value is *null*.</li>
       </ul>
 
-      <!-- es6num="19.1.3.1" -->
       <emu-clause id="sec-object.prototype.constructor">
         <h1>Object.prototype.constructor</h1>
         <p>The initial value of `Object.prototype.constructor` is the intrinsic object %Object%.</p>
       </emu-clause>
 
-      <!-- es6num="19.1.3.2" -->
       <emu-clause id="sec-object.prototype.hasownproperty">
         <h1>Object.prototype.hasOwnProperty ( _V_ )</h1>
         <p>When the `hasOwnProperty` method is called with argument _V_, the following steps are taken:</p>
@@ -25169,7 +24245,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="19.1.3.3" -->
       <emu-clause id="sec-object.prototype.isprototypeof">
         <h1>Object.prototype.isPrototypeOf ( _V_ )</h1>
         <p>When the `isPrototypeOf` method is called with argument _V_, the following steps are taken:</p>
@@ -25186,7 +24261,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="19.1.3.4" -->
       <emu-clause id="sec-object.prototype.propertyisenumerable">
         <h1>Object.prototype.propertyIsEnumerable ( _V_ )</h1>
         <p>When the `propertyIsEnumerable` method is called with argument _V_, the following steps are taken:</p>
@@ -25205,7 +24279,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="19.1.3.5" -->
       <emu-clause id="sec-object.prototype.tolocalestring">
         <h1>Object.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>When the `toLocaleString` method is called, the following steps are taken:</p>
@@ -25222,7 +24295,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="19.1.3.6" -->
       <emu-clause id="sec-object.prototype.tostring">
         <h1>Object.prototype.toString ( )</h1>
         <p>When the `toString` method is called, the following steps are taken:</p>
@@ -25251,7 +24323,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="19.1.3.7" -->
       <emu-clause id="sec-object.prototype.valueof">
         <h1>Object.prototype.valueOf ( )</h1>
         <p>When the `valueOf` method is called, the following steps are taken:</p>
@@ -25262,18 +24333,15 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.1.4" -->
     <emu-clause id="sec-properties-of-object-instances">
       <h1>Properties of Object Instances</h1>
       <p>Object instances have no special properties beyond those inherited from the Object prototype object.</p>
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="19.2" -->
   <emu-clause id="sec-function-objects">
     <h1>Function Objects</h1>
 
-    <!-- es6num="19.2.1" -->
     <emu-clause id="sec-function-constructor">
       <h1>The Function Constructor</h1>
       <p>The Function constructor:</p>
@@ -25284,7 +24352,6 @@
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction`, `AsyncFunction`, and `AsyncGeneratorFunction` subclasses.</li>
       </ul>
 
-      <!-- es6num="19.2.1.1" -->
       <emu-clause id="sec-function-p1-p2-pn-body">
         <h1>Function ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
         <p>The last argument specifies the body (executable code) of a function; any preceding arguments specify formal parameters.</p>
@@ -25303,7 +24370,6 @@
           </code></pre>
         </emu-note>
 
-        <!-- es6num="19.2.1.1.1" -->
         <emu-clause id="sec-createdynamicfunction" aoid="CreateDynamicFunction">
           <h1>Runtime Semantics: CreateDynamicFunction ( _constructor_, _newTarget_, _kind_, _args_ )</h1>
           <p>The abstract operation CreateDynamicFunction is called with arguments _constructor_, _newTarget_, _kind_, and _args_. _constructor_ is the constructor function that is performing this action, _newTarget_ is the constructor that `new` was initially applied to, _kind_ is either `"normal"`, `"generator"`, `"async"`, or `"async generator"`, and _args_ is a List containing the actual argument values that were passed to _constructor_. The following steps are taken:</p>
@@ -25386,7 +24452,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.2.2" -->
     <emu-clause id="sec-properties-of-the-function-constructor">
       <h1>Properties of the Function Constructor</h1>
       <p>The Function constructor:</p>
@@ -25396,13 +24461,11 @@
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="19.2.2.1" -->
       <emu-clause id="sec-function.length">
         <h1>Function.length</h1>
         <p>This is a data property with a value of 1. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.2.2.2" -->
       <emu-clause id="sec-function.prototype">
         <h1>Function.prototype</h1>
         <p>The value of `Function.prototype` is %FunctionPrototype%, the intrinsic Function prototype object.</p>
@@ -25410,7 +24473,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.2.3" -->
     <emu-clause id="sec-properties-of-the-function-prototype-object">
       <h1>Properties of the Function Prototype Object</h1>
       <p>The Function prototype object:</p>
@@ -25428,7 +24490,6 @@
         <p>The Function prototype object is specified to be a function object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
       </emu-note>
 
-      <!-- es6num="19.2.3.1" -->
       <emu-clause id="sec-function.prototype.apply">
         <h1>Function.prototype.apply ( _thisArg_, _argArray_ )</h1>
         <p>When the `apply` method is called on an object _func_ with arguments _thisArg_ and _argArray_, the following steps are taken:</p>
@@ -25449,7 +24510,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="19.2.3.2" -->
       <emu-clause id="sec-function.prototype.bind">
         <h1>Function.prototype.bind ( _thisArg_, ..._args_ )</h1>
         <p>When the `bind` method is called with argument _thisArg_ and zero or more _args_, it performs the following steps:</p>
@@ -25480,7 +24540,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="19.2.3.3" -->
       <emu-clause id="sec-function.prototype.call">
         <h1>Function.prototype.call ( _thisArg_, ..._args_ )</h1>
         <p>When the `call` method is called on an object _func_ with argument, _thisArg_ and zero or more _args_, the following steps are taken:</p>
@@ -25499,13 +24558,11 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="19.2.3.4" -->
       <emu-clause id="sec-function.prototype.constructor">
         <h1>Function.prototype.constructor</h1>
         <p>The initial value of `Function.prototype.constructor` is the intrinsic object %Function%.</p>
       </emu-clause>
 
-      <!-- es6num="19.2.3.5" -->
       <emu-clause id="sec-function.prototype.tostring">
         <h1>Function.prototype.toString ( )</h1>
         <p>When the `toString` method is called on an object _func_, the following steps are taken:</p>
@@ -25533,7 +24590,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="19.2.3.6" -->
       <emu-clause id="sec-function.prototype-@@hasinstance">
         <h1>Function.prototype [ @@hasInstance ] ( _V_ )</h1>
         <p>When the @@hasInstance method of an object _F_ is called with value _V_, the following steps are taken:</p>
@@ -25558,26 +24614,22 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.2.4" -->
     <emu-clause id="sec-function-instances">
       <h1>Function Instances</h1>
       <p>Every Function instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. Function objects created using the `Function.prototype.bind` method (<emu-xref href="#sec-function.prototype.bind"></emu-xref>) have the internal slots listed in <emu-xref href="#table-28"></emu-xref>.</p>
       <p>Function instances have the following properties:</p>
 
-      <!-- es6num="19.2.4.1" -->
       <emu-clause id="sec-function-instances-length">
         <h1>length</h1>
         <p>The value of the `length` property is an integer that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a function when invoked on a number of arguments other than the number specified by its `length` property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.2.4.2" -->
       <emu-clause id="sec-function-instances-name">
         <h1>name</h1>
         <p>The value of the `name` property is a String that is descriptive of the function. The name has no semantic significance but is typically a variable or property name that is used to refer to the function at its point of definition in ECMAScript code. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         <p>Anonymous functions objects that do not have a contextual name associated with them by this specification do not have a `name` own property but inherit the `name` property of %FunctionPrototype%.</p>
       </emu-clause>
 
-      <!-- es6num="19.2.4.3" -->
       <emu-clause id="sec-function-instances-prototype">
         <h1>prototype</h1>
         <p>Function instances that can be used as a constructor have a `prototype` property. Whenever such a Function instance is created another ordinary object is also created and is the initial value of the function's `prototype` property. Unless otherwise specified, the value of the `prototype` property is used to initialize the [[Prototype]] internal slot of the object created when that function is invoked as a constructor.</p>
@@ -25589,11 +24641,9 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="19.3" -->
   <emu-clause id="sec-boolean-objects">
     <h1>Boolean Objects</h1>
 
-    <!-- es6num="19.3.1" -->
     <emu-clause id="sec-boolean-constructor">
       <h1>The Boolean Constructor</h1>
       <p>The Boolean constructor:</p>
@@ -25605,7 +24655,6 @@
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behaviour must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</li>
       </ul>
 
-      <!-- es6num="19.3.1.1" -->
       <emu-clause id="sec-boolean-constructor-boolean-value">
         <h1>Boolean ( _value_ )</h1>
         <p>When `Boolean` is called with argument _value_, the following steps are taken:</p>
@@ -25619,7 +24668,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.3.2" -->
     <emu-clause id="sec-properties-of-the-boolean-constructor">
       <h1>Properties of the Boolean Constructor</h1>
       <p>The Boolean constructor:</p>
@@ -25628,7 +24676,6 @@
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="19.3.2.1" -->
       <emu-clause id="sec-boolean.prototype">
         <h1>Boolean.prototype</h1>
         <p>The initial value of `Boolean.prototype` is the intrinsic object %BooleanPrototype%.</p>
@@ -25636,7 +24683,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.3.3" -->
     <emu-clause id="sec-properties-of-the-boolean-prototype-object">
       <h1>Properties of the Boolean Prototype Object</h1>
       <p>The Boolean prototype object:</p>
@@ -25656,13 +24702,11 @@
         1. Throw a *TypeError* exception.
       </emu-alg>
 
-      <!-- es6num="19.3.3.1" -->
       <emu-clause id="sec-boolean.prototype.constructor">
         <h1>Boolean.prototype.constructor</h1>
         <p>The initial value of `Boolean.prototype.constructor` is the intrinsic object %Boolean%.</p>
       </emu-clause>
 
-      <!-- es6num="19.3.3.2" -->
       <emu-clause id="sec-boolean.prototype.tostring">
         <h1>Boolean.prototype.toString ( )</h1>
         <p>The following steps are taken:</p>
@@ -25672,7 +24716,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.3.3.3" -->
       <emu-clause id="sec-boolean.prototype.valueof">
         <h1>Boolean.prototype.valueOf ( )</h1>
         <p>The following steps are taken:</p>
@@ -25682,18 +24725,15 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.3.4" -->
     <emu-clause id="sec-properties-of-boolean-instances">
       <h1>Properties of Boolean Instances</h1>
       <p>Boolean instances are ordinary objects that inherit properties from the Boolean prototype object. Boolean instances have a [[BooleanData]] internal slot. The [[BooleanData]] internal slot is the Boolean value represented by this Boolean object.</p>
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="19.4" -->
   <emu-clause id="sec-symbol-objects">
     <h1>Symbol Objects</h1>
 
-    <!-- es6num="19.4.1" -->
     <emu-clause id="sec-symbol-constructor">
       <h1>The Symbol Constructor</h1>
       <p>The Symbol constructor:</p>
@@ -25706,7 +24746,6 @@
         <li>may be used as the value of an `extends` clause of a class definition but a `super` call to it will cause an exception.</li>
       </ul>
 
-      <!-- es6num="19.4.1.1" -->
       <emu-clause id="sec-symbol-description">
         <h1>Symbol ( [ _description_ ] )</h1>
         <p>When `Symbol` is called with optional argument _description_, the following steps are taken:</p>
@@ -25719,7 +24758,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.4.2" -->
     <emu-clause id="sec-properties-of-the-symbol-constructor">
       <h1>Properties of the Symbol Constructor</h1>
       <p>The Symbol constructor:</p>
@@ -25734,7 +24772,6 @@
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.1" -->
       <emu-clause id="sec-symbol.for">
         <h1>Symbol.for ( _key_ )</h1>
         <p>When `Symbol.for` is called with argument _key_ it performs the following steps:</p>
@@ -25789,28 +24826,24 @@
         </emu-table>
       </emu-clause>
 
-      <!-- es6num="19.4.2.2" -->
       <emu-clause id="sec-symbol.hasinstance">
         <h1>Symbol.hasInstance</h1>
         <p>The initial value of `Symbol.hasInstance` is the well-known symbol @@hasInstance (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.3" -->
       <emu-clause id="sec-symbol.isconcatspreadable">
         <h1>Symbol.isConcatSpreadable</h1>
         <p>The initial value of `Symbol.isConcatSpreadable` is the well-known symbol @@isConcatSpreadable (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.4" -->
       <emu-clause id="sec-symbol.iterator">
         <h1>Symbol.iterator</h1>
         <p>The initial value of `Symbol.iterator` is the well-known symbol @@iterator (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.5" -->
       <emu-clause id="sec-symbol.keyfor">
         <h1>Symbol.keyFor ( _sym_ )</h1>
         <p>When `Symbol.keyFor` is called with argument _sym_ it performs the following steps:</p>
@@ -25823,63 +24856,54 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.4.2.6" -->
       <emu-clause id="sec-symbol.match">
         <h1>Symbol.match</h1>
         <p>The initial value of `Symbol.match` is the well-known symbol @@match (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.7" -->
       <emu-clause id="sec-symbol.prototype">
         <h1>Symbol.prototype</h1>
         <p>The initial value of `Symbol.prototype` is the intrinsic object %SymbolPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.8" -->
       <emu-clause id="sec-symbol.replace">
         <h1>Symbol.replace</h1>
         <p>The initial value of `Symbol.replace` is the well-known symbol @@replace (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.9" -->
       <emu-clause id="sec-symbol.search">
         <h1>Symbol.search</h1>
         <p>The initial value of `Symbol.search` is the well-known symbol @@search (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.10" -->
       <emu-clause id="sec-symbol.species">
         <h1>Symbol.species</h1>
         <p>The initial value of `Symbol.species` is the well-known symbol @@species (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.11" -->
       <emu-clause id="sec-symbol.split">
         <h1>Symbol.split</h1>
         <p>The initial value of `Symbol.split` is the well-known symbol @@split (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.12" -->
       <emu-clause id="sec-symbol.toprimitive">
         <h1>Symbol.toPrimitive</h1>
         <p>The initial value of `Symbol.toPrimitive` is the well-known symbol @@toPrimitive (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.13" -->
       <emu-clause id="sec-symbol.tostringtag">
         <h1>Symbol.toStringTag</h1>
         <p>The initial value of `Symbol.toStringTag` is the well-known symbol @@toStringTag (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.2.14" -->
       <emu-clause id="sec-symbol.unscopables">
         <h1>Symbol.unscopables</h1>
         <p>The initial value of `Symbol.unscopables` is the well-known symbol @@unscopables (<emu-xref href="#table-1"></emu-xref>).</p>
@@ -25887,7 +24911,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.4.3" -->
     <emu-clause id="sec-properties-of-the-symbol-prototype-object">
       <h1>Properties of the Symbol Prototype Object</h1>
       <p>The Symbol prototype object:</p>
@@ -25907,13 +24930,11 @@
         1. Throw a *TypeError* exception.
       </emu-alg>
 
-      <!-- es6num="19.4.3.1" -->
       <emu-clause id="sec-symbol.prototype.constructor">
         <h1>Symbol.prototype.constructor</h1>
         <p>The initial value of `Symbol.prototype.constructor` is the intrinsic object %Symbol%.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.3.2" -->
       <emu-clause id="sec-symbol.prototype.tostring">
         <h1>Symbol.prototype.toString ( )</h1>
         <p>The following steps are taken:</p>
@@ -25922,7 +24943,6 @@
           1. Return SymbolDescriptiveString(_sym_).
         </emu-alg>
 
-        <!-- es6num="19.4.3.2.1" -->
         <emu-clause id="sec-symboldescriptivestring" aoid="SymbolDescriptiveString">
           <h1>Runtime Semantics: SymbolDescriptiveString ( _sym_ )</h1>
           <p>When the abstract operation SymbolDescriptiveString is called with argument _sym_, the following steps are taken:</p>
@@ -25936,7 +24956,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="19.4.3.3" -->
       <emu-clause id="sec-symbol.prototype.valueof">
         <h1>Symbol.prototype.valueOf ( )</h1>
         <p>The following steps are taken:</p>
@@ -25945,7 +24964,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="19.4.3.4" -->
       <emu-clause id="sec-symbol.prototype-@@toprimitive">
         <h1>Symbol.prototype [ @@toPrimitive ] ( _hint_ )</h1>
         <p>This function is called by ECMAScript language operators to convert a Symbol object to a primitive value. The allowed values for _hint_ are `"default"`, `"number"`, and `"string"`.</p>
@@ -25957,7 +24975,6 @@
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <!-- es6num="19.4.3.5" -->
       <emu-clause id="sec-symbol.prototype-@@tostringtag">
         <h1>Symbol.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"Symbol"`.</p>
@@ -25965,19 +24982,16 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.4.4" -->
     <emu-clause id="sec-properties-of-symbol-instances">
       <h1>Properties of Symbol Instances</h1>
       <p>Symbol instances are ordinary objects that inherit properties from the Symbol prototype object. Symbol instances have a [[SymbolData]] internal slot. The [[SymbolData]] internal slot is the Symbol value represented by this Symbol object.</p>
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="19.5" -->
   <emu-clause id="sec-error-objects">
     <h1>Error Objects</h1>
     <p>Instances of Error objects are thrown as exceptions when runtime errors occur. The Error objects may also serve as base objects for user-defined exception classes.</p>
 
-    <!-- es6num="19.5.1" -->
     <emu-clause id="sec-error-constructor">
       <h1>The Error Constructor</h1>
       <p>The Error constructor:</p>
@@ -25988,7 +25002,6 @@
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
       </ul>
 
-      <!-- es6num="19.5.1.1" -->
       <emu-clause id="sec-error-message">
         <h1>Error ( _message_ )</h1>
         <p>When the `Error` function is called with argument _message_, the following steps are taken:</p>
@@ -26004,7 +25017,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.5.2" -->
     <emu-clause id="sec-properties-of-the-error-constructor">
       <h1>Properties of the Error Constructor</h1>
       <p>The Error constructor:</p>
@@ -26013,7 +25025,6 @@
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="19.5.2.1" -->
       <emu-clause id="sec-error.prototype">
         <h1>Error.prototype</h1>
         <p>The initial value of `Error.prototype` is the intrinsic object %ErrorPrototype%.</p>
@@ -26021,7 +25032,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.5.3" -->
     <emu-clause id="sec-properties-of-the-error-prototype-object">
       <h1>Properties of the Error Prototype Object</h1>
       <p>The Error prototype object:</p>
@@ -26032,25 +25042,21 @@
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
       </ul>
 
-      <!-- es6num="19.5.3.1" -->
       <emu-clause id="sec-error.prototype.constructor">
         <h1>Error.prototype.constructor</h1>
         <p>The initial value of `Error.prototype.constructor` is the intrinsic object %Error%.</p>
       </emu-clause>
 
-      <!-- es6num="19.5.3.2" -->
       <emu-clause id="sec-error.prototype.message">
         <h1>Error.prototype.message</h1>
         <p>The initial value of `Error.prototype.message` is the empty String.</p>
       </emu-clause>
 
-      <!-- es6num="19.5.3.3" -->
       <emu-clause id="sec-error.prototype.name">
         <h1>Error.prototype.name</h1>
         <p>The initial value of `Error.prototype.name` is `"Error"`.</p>
       </emu-clause>
 
-      <!-- es6num="19.5.3.4" -->
       <emu-clause id="sec-error.prototype.tostring">
         <h1>Error.prototype.toString ( )</h1>
         <p>The following steps are taken:</p>
@@ -26068,61 +25074,51 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.5.4" -->
     <emu-clause id="sec-properties-of-error-instances">
       <h1>Properties of Error Instances</h1>
       <p>Error instances are ordinary objects that inherit properties from the Error prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified uses of [[ErrorData]] is to identify Error and _NativeError_ instances as Error objects within `Object.prototype.toString`.</p>
     </emu-clause>
 
-    <!-- es6num="19.5.5" -->
     <emu-clause id="sec-native-error-types-used-in-this-standard">
       <h1>Native Error Types Used in This Standard</h1>
       <p>A new instance of one of the _NativeError_ objects below is thrown when a runtime error is detected. All of these objects share the same structure, as described in <emu-xref href="#sec-nativeerror-object-structure"></emu-xref>.</p>
 
-      <!-- es6num="19.5.5.1" -->
       <emu-clause id="sec-native-error-types-used-in-this-standard-evalerror">
         <h1>EvalError</h1>
         <p>This exception is not currently used within this specification. This object remains for compatibility with previous editions of this specification.</p>
       </emu-clause>
 
-      <!-- es6num="19.5.5.2" -->
       <emu-clause id="sec-native-error-types-used-in-this-standard-rangeerror">
         <h1>RangeError</h1>
         <p>Indicates a value that is not in the set or range of allowable values.</p>
       </emu-clause>
 
-      <!-- es6num="19.5.5.3" -->
       <emu-clause id="sec-native-error-types-used-in-this-standard-referenceerror">
         <h1>ReferenceError</h1>
         <p>Indicate that an invalid reference value has been detected.</p>
       </emu-clause>
 
-      <!-- es6num="19.5.5.4" -->
       <emu-clause id="sec-native-error-types-used-in-this-standard-syntaxerror">
         <h1>SyntaxError</h1>
         <p>Indicates that a parsing error has occurred.</p>
       </emu-clause>
 
-      <!-- es6num="19.5.5.5" -->
       <emu-clause id="sec-native-error-types-used-in-this-standard-typeerror">
         <h1>TypeError</h1>
         <p>TypeError is used to indicate an unsuccessful operation when none of the other _NativeError_ objects are an appropriate indication of the failure cause.</p>
       </emu-clause>
 
-      <!-- es6num="19.5.5.6" -->
       <emu-clause id="sec-native-error-types-used-in-this-standard-urierror">
         <h1>URIError</h1>
         <p>Indicates that one of the global URI handling functions was used in a way that is incompatible with its definition.</p>
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="19.5.6" -->
     <emu-clause id="sec-nativeerror-object-structure">
       <h1>_NativeError_ Object Structure</h1>
       <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the `name` property of the prototype object, and in the implementation-defined `message` property of the prototype object.</p>
       <p>For each error object, references to _NativeError_ in the definition should be replaced with the appropriate error object name from <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>.</p>
 
-      <!-- es6num="19.5.6.1" -->
       <emu-clause id="sec-nativeerror-constructors">
         <h1>The _NativeError_ Constructors</h1>
         <p>Each _NativeError_ constructor:</p>
@@ -26131,7 +25127,6 @@
           <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
         </ul>
 
-        <!-- es6num="19.5.6.1.1" -->
         <emu-clause id="sec-nativeerror">
           <h1>NativeError ( _message_ )</h1>
           <p>When a _NativeError_ function is called with argument _message_, the following steps are taken:</p>
@@ -26148,7 +25143,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="19.5.6.2" -->
       <emu-clause id="sec-properties-of-the-nativeerror-constructors">
         <h1>Properties of the _NativeError_ Constructors</h1>
         <p>Each _NativeError_ constructor:</p>
@@ -26158,7 +25152,6 @@
           <li>has the following properties:</li>
         </ul>
 
-        <!-- es6num="19.5.6.2.1" -->
         <emu-clause id="sec-nativeerror.prototype">
           <h1>NativeError.prototype</h1>
           <p>The initial value of <code><var>NativeError</var>.prototype</code> is a _NativeError_ prototype object (<emu-xref href="#sec-properties-of-the-nativeerror-prototype-objects"></emu-xref>). Each _NativeError_ constructor has a distinct prototype object.</p>
@@ -26166,7 +25159,6 @@
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="19.5.6.3" -->
       <emu-clause id="sec-properties-of-the-nativeerror-prototype-objects">
         <h1>Properties of the _NativeError_ Prototype Objects</h1>
         <p>Each _NativeError_ prototype object:</p>
@@ -26176,26 +25168,22 @@
           <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ErrorPrototype%.</li>
         </ul>
 
-        <!-- es6num="19.5.6.3.1" -->
         <emu-clause id="sec-nativeerror.prototype.constructor">
           <h1>_NativeError_.prototype.constructor</h1>
           <p>The initial value of the `constructor` property of the prototype for a given _NativeError_ constructor is the corresponding intrinsic object %_NativeError_% (<emu-xref href="#sec-nativeerror-constructors"></emu-xref>).</p>
         </emu-clause>
 
-        <!-- es6num="19.5.6.3.2" -->
         <emu-clause id="sec-nativeerror.prototype.message">
           <h1>_NativeError_.prototype.message</h1>
           <p>The initial value of the `message` property of the prototype for a given _NativeError_ constructor is the empty String.</p>
         </emu-clause>
 
-        <!-- es6num="19.5.6.3.3" -->
         <emu-clause id="sec-nativeerror.prototype.name">
           <h1>_NativeError_.prototype.name</h1>
           <p>The initial value of the `name` property of the prototype for a given _NativeError_ constructor is the String value consisting of the name of the constructor (the name used instead of _NativeError_).</p>
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="19.5.6.4" -->
       <emu-clause id="sec-properties-of-nativeerror-instances">
         <h1>Properties of _NativeError_ Instances</h1>
         <p>_NativeError_ instances are ordinary objects that inherit properties from their _NativeError_ prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified use of [[ErrorData]] is by `Object.prototype.toString` (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>) to identify Error or _NativeError_ instances.</p>
@@ -26204,15 +25192,12 @@
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="20" -->
 <emu-clause id="sec-numbers-and-dates">
   <h1>Numbers and Dates</h1>
 
-  <!-- es6num="20.1" -->
   <emu-clause id="sec-number-objects">
     <h1>Number Objects</h1>
 
-    <!-- es6num="20.1.1" -->
     <emu-clause id="sec-number-constructor">
       <h1>The Number Constructor</h1>
       <p>The Number constructor:</p>
@@ -26224,7 +25209,6 @@
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behaviour must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</li>
       </ul>
 
-      <!-- es6num="20.1.1.1" -->
       <emu-clause id="sec-number-constructor-number-value">
         <h1>Number ( _value_ )</h1>
         <p>When `Number` is called with argument _value_, the following steps are taken:</p>
@@ -26239,7 +25223,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="20.1.2" -->
     <emu-clause id="sec-properties-of-the-number-constructor">
       <h1>Properties of the Number Constructor</h1>
       <p>The Number constructor:</p>
@@ -26248,14 +25231,12 @@
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="20.1.2.1" -->
       <emu-clause id="sec-number.epsilon">
         <h1>Number.EPSILON</h1>
         <p>The value of Number.EPSILON is the difference between 1 and the smallest value greater than 1 that is representable as a Number value, which is approximately 2.2204460492503130808472633361816 x 10<sup>-16</sup>.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.2" -->
       <emu-clause id="sec-number.isfinite">
         <h1>Number.isFinite ( _number_ )</h1>
         <p>When `Number.isFinite` is called with one argument _number_, the following steps are taken:</p>
@@ -26266,7 +25247,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.1.2.3" -->
       <emu-clause id="sec-number.isinteger">
         <h1>Number.isInteger ( _number_ )</h1>
         <p>When `Number.isInteger` is called with one argument _number_, the following steps are taken:</p>
@@ -26279,7 +25259,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.1.2.4" -->
       <emu-clause id="sec-number.isnan">
         <h1>Number.isNaN ( _number_ )</h1>
         <p>When `Number.isNaN` is called with one argument _number_, the following steps are taken:</p>
@@ -26293,7 +25272,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.1.2.5" -->
       <emu-clause id="sec-number.issafeinteger">
         <h1>Number.isSafeInteger ( _number_ )</h1>
         <p>When `Number.isSafeInteger` is called with one argument _number_, the following steps are taken:</p>
@@ -26307,7 +25285,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.1.2.6" -->
       <emu-clause id="sec-number.max_safe_integer">
         <h1>Number.MAX_SAFE_INTEGER</h1>
         <emu-note>
@@ -26317,14 +25294,12 @@
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.7" -->
       <emu-clause id="sec-number.max_value">
         <h1>Number.MAX_VALUE</h1>
         <p>The value of `Number.MAX_VALUE` is the largest positive finite value of the Number type, which is approximately <emu-eqn>1.7976931348623157 &times; 10<sup>308</sup></emu-eqn>.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.8" -->
       <emu-clause id="sec-number.min_safe_integer">
         <h1>Number.MIN_SAFE_INTEGER</h1>
         <emu-note>
@@ -26334,7 +25309,6 @@
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.9" -->
       <emu-clause id="sec-number.min_value">
         <h1>Number.MIN_VALUE</h1>
         <p>The value of `Number.MIN_VALUE` is the smallest positive value of the Number type, which is approximately <emu-eqn>5 &times; 10<sup>-324</sup></emu-eqn>.</p>
@@ -26342,40 +25316,34 @@
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.10" -->
       <emu-clause id="sec-number.nan">
         <h1>Number.NaN</h1>
         <p>The value of `Number.NaN` is *NaN*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.11" -->
       <emu-clause id="sec-number.negative_infinity">
         <h1>Number.NEGATIVE_INFINITY</h1>
         <p>The value of Number.NEGATIVE_INFINITY is *-&infin;*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.12" -->
       <emu-clause id="sec-number.parsefloat">
         <h1>Number.parseFloat ( _string_ )</h1>
         <p>The value of the `Number.parseFloat` data property is the same built-in function object that is the value of the `parseFloat` property of the global object defined in <emu-xref href="#sec-parsefloat-string"></emu-xref>.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.13" -->
       <emu-clause id="sec-number.parseint">
         <h1>Number.parseInt ( _string_, _radix_ )</h1>
         <p>The value of the `Number.parseInt` data property is the same built-in function object that is the value of the `parseInt` property of the global object defined in <emu-xref href="#sec-parseint-string-radix"></emu-xref>.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.14" -->
       <emu-clause id="sec-number.positive_infinity">
         <h1>Number.POSITIVE_INFINITY</h1>
         <p>The value of Number.POSITIVE_INFINITY is *+&infin;*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.2.15" -->
       <emu-clause id="sec-number.prototype">
         <h1>Number.prototype</h1>
         <p>The initial value of `Number.prototype` is the intrinsic object %NumberPrototype%.</p>
@@ -26383,7 +25351,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="20.1.3" -->
     <emu-clause id="sec-properties-of-the-number-prototype-object">
       <h1>Properties of the Number Prototype Object</h1>
       <p>The Number prototype object:</p>
@@ -26404,13 +25371,11 @@
       </emu-alg>
       <p>The phrase &ldquo;this Number value&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisNumberValue with the *this* value of the method invocation passed as the argument.</p>
 
-      <!-- es6num="20.1.3.1" -->
       <emu-clause id="sec-number.prototype.constructor">
         <h1>Number.prototype.constructor</h1>
         <p>The initial value of `Number.prototype.constructor` is the intrinsic object %Number%.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.3.2" -->
       <emu-clause id="sec-number.prototype.toexponential">
         <h1>Number.prototype.toExponential ( _fractionDigits_ )</h1>
         <p>Return a String containing this Number value represented in decimal exponential notation with one digit before the significand's decimal point and _fractionDigits_ digits after the significand's decimal point. If _fractionDigits_ is *undefined*, include as many significand digits as necessary to uniquely specify the Number (just like in ToString except that in this case the Number is always output in exponential notation). Specifically, perform the following steps:</p>
@@ -26458,7 +25423,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.1.3.3" -->
       <emu-clause id="sec-number.prototype.tofixed">
         <h1>Number.prototype.toFixed ( _fractionDigits_ )</h1>
         <emu-note>
@@ -26497,7 +25461,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.1.3.4" -->
       <emu-clause id="sec-number.prototype.tolocalestring">
         <h1>Number.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Number.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
@@ -26505,7 +25468,6 @@
         <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.3.5" -->
       <emu-clause id="sec-number.prototype.toprecision">
         <h1>Number.prototype.toPrecision ( _precision_ )</h1>
         <p>Return a String containing this Number value represented either in decimal exponential notation with one digit before the significand's decimal point and <emu-eqn>_precision_-1</emu-eqn> digits after the significand's decimal point or in decimal fixed notation with _precision_ significant digits. If _precision_ is *undefined*, call ToString instead. Specifically, perform the following steps:</p>
@@ -26548,7 +25510,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.1.3.6" -->
       <emu-clause id="sec-number.prototype.tostring">
         <h1>Number.prototype.toString ( [ _radix_ ] )</h1>
         <emu-note>
@@ -26568,7 +25529,6 @@
         <p>The `length` property of the `toString` method is 1.</p>
       </emu-clause>
 
-      <!-- es6num="20.1.3.7" -->
       <emu-clause id="sec-number.prototype.valueof">
         <h1>Number.prototype.valueOf ( )</h1>
         <emu-alg>
@@ -26577,14 +25537,12 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="20.1.4" -->
     <emu-clause id="sec-properties-of-number-instances">
       <h1>Properties of Number Instances</h1>
       <p>Number instances are ordinary objects that inherit properties from the Number prototype object. Number instances also have a [[NumberData]] internal slot. The [[NumberData]] internal slot is the Number value represented by this Number object.</p>
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="20.2" -->
   <emu-clause id="sec-math-object">
     <h1>The Math Object</h1>
     <p>The Math object:</p>
@@ -26601,32 +25559,27 @@
       <p>In this specification, the phrase &ldquo;the Number value for _x_&rdquo; has a technical meaning defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>.</p>
     </emu-note>
 
-    <!-- es6num="20.2.1" -->
     <emu-clause id="sec-value-properties-of-the-math-object">
       <h1>Value Properties of the Math Object</h1>
 
-      <!-- es6num="20.2.1.1" -->
       <emu-clause id="sec-math.e">
         <h1>Math.E</h1>
         <p>The Number value for _e_, the base of the natural logarithms, which is approximately 2.7182818284590452354.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.2.1.2" -->
       <emu-clause id="sec-math.ln10">
         <h1>Math.LN10</h1>
         <p>The Number value for the natural logarithm of 10, which is approximately 2.302585092994046.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.2.1.3" -->
       <emu-clause id="sec-math.ln2">
         <h1>Math.LN2</h1>
         <p>The Number value for the natural logarithm of 2, which is approximately 0.6931471805599453.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.2.1.4" -->
       <emu-clause id="sec-math.log10e">
         <h1>Math.LOG10E</h1>
         <p>The Number value for the base-10 logarithm of _e_, the base of the natural logarithms; this value is approximately 0.4342944819032518.</p>
@@ -26636,7 +25589,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.1.5" -->
       <emu-clause id="sec-math.log2e">
         <h1>Math.LOG2E</h1>
         <p>The Number value for the base-2 logarithm of _e_, the base of the natural logarithms; this value is approximately 1.4426950408889634.</p>
@@ -26646,14 +25598,12 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.1.6" -->
       <emu-clause id="sec-math.pi">
         <h1>Math.PI</h1>
         <p>The Number value for &pi;, the ratio of the circumference of a circle to its diameter, which is approximately 3.1415926535897932.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.2.1.7" -->
       <emu-clause id="sec-math.sqrt1_2">
         <h1>Math.SQRT1_2</h1>
         <p>The Number value for the square root of &frac12;, which is approximately 0.7071067811865476.</p>
@@ -26663,14 +25613,12 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.1.8" -->
       <emu-clause id="sec-math.sqrt2">
         <h1>Math.SQRT2</h1>
         <p>The Number value for the square root of 2, which is approximately 1.4142135623730951.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.2.1.9" -->
       <emu-clause id="sec-math-@@tostringtag">
         <h1>Math [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"Math"`.</p>
@@ -26678,7 +25626,6 @@
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="20.2.2" -->
     <emu-clause id="sec-function-properties-of-the-math-object">
       <h1>Function Properties of the Math Object</h1>
       <p>Each of the following `Math` object functions applies the ToNumber abstract operation to each of its arguments (in left-to-right order if there is more than one). If ToNumber returns an abrupt completion, that Completion Record is immediately returned. Otherwise, the function performs a computation on the resulting Number value(s). The value returned by each function is a Number.</p>
@@ -26688,7 +25635,6 @@
         <p>Although the choice of algorithms is left to the implementation, it is recommended (but not specified by this standard) that implementations use the approximation algorithms for IEEE 754-2008 arithmetic contained in `fdlibm`, the freely distributable mathematical library from Sun Microsystems (<a href="http://www.netlib.org/fdlibm">http://www.netlib.org/fdlibm</a>).</p>
       </emu-note>
 
-      <!-- es6num="20.2.2.1" -->
       <emu-clause id="sec-math.abs">
         <h1>Math.abs ( _x_ )</h1>
         <p>Returns the absolute value of _x_; the result has the same magnitude as _x_ but has positive sign.</p>
@@ -26705,7 +25651,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.2" -->
       <emu-clause id="sec-math.acos">
         <h1>Math.acos ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the arc cosine of _x_. The result is expressed in radians and ranges from *+0* to +&pi;.</p>
@@ -26725,7 +25670,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.3" -->
       <emu-clause id="sec-math.acosh">
         <h1>Math.acosh ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the inverse hyperbolic cosine of _x_.</p>
@@ -26745,7 +25689,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.4" -->
       <emu-clause id="sec-math.asin">
         <h1>Math.asin ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the arc sine of _x_. The result is expressed in radians and ranges from -&pi;/2 to +&pi;/2.</p>
@@ -26768,7 +25711,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.5" -->
       <emu-clause id="sec-math.asinh">
         <h1>Math.asinh ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the inverse hyperbolic sine of _x_.</p>
@@ -26791,7 +25733,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.6" -->
       <emu-clause id="sec-math.atan">
         <h1>Math.atan ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the arc tangent of _x_. The result is expressed in radians and ranges from -&pi;/2 to +&pi;/2.</p>
@@ -26814,7 +25755,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.7" -->
       <emu-clause id="sec-math.atanh">
         <h1>Math.atanh ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the inverse hyperbolic tangent of _x_.</p>
@@ -26843,7 +25783,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.8" -->
       <emu-clause id="sec-math.atan2">
         <h1>Math.atan2 ( _y_, _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the arc tangent of the quotient <emu-eqn>_y_/_x_</emu-eqn> of the arguments _y_ and _x_, where the signs of _y_ and _x_ are used to determine the quadrant of the result. Note that it is intentional and traditional for the two-argument arc tangent function that the argument named _y_ be first and the argument named _x_ be second. The result is expressed in radians and ranges from -&pi; to +&pi;.</p>
@@ -26920,7 +25859,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.9" -->
       <emu-clause id="sec-math.cbrt">
         <h1>Math.cbrt ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the cube root of _x_.</p>
@@ -26943,7 +25881,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.10" -->
       <emu-clause id="sec-math.ceil">
         <h1>Math.ceil ( _x_ )</h1>
         <p>Returns the smallest (closest to *-&infin;*) Number value that is not less than _x_ and is equal to a mathematical integer. If _x_ is already an integer, the result is _x_.</p>
@@ -26970,7 +25907,6 @@
         <p>The value of `Math.ceil(x)` is the same as the value of `-Math.floor(-x)`.</p>
       </emu-clause>
 
-      <!-- es6num="20.2.2.11" -->
       <emu-clause id="sec-math.clz32">
         <h1>Math.clz32 ( _x_ )</h1>
         <p>When `Math.clz32` is called with one argument _x_, the following steps are taken:</p>
@@ -26984,7 +25920,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.2.12" -->
       <emu-clause id="sec-math.cos">
         <h1>Math.cos ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the cosine of _x_. The argument is expressed in radians.</p>
@@ -27007,7 +25942,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.13" -->
       <emu-clause id="sec-math.cosh">
         <h1>Math.cosh ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the hyperbolic cosine of _x_.</p>
@@ -27033,7 +25967,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.2.14" -->
       <emu-clause id="sec-math.exp">
         <h1>Math.exp ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the exponential function of _x_ (_e_ raised to the power of _x_, where _e_ is the base of the natural logarithms).</p>
@@ -27056,7 +25989,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.15" -->
       <emu-clause id="sec-math.expm1">
         <h1>Math.expm1 ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to subtracting 1 from the exponential function of _x_ (_e_ raised to the power of _x_, where _e_ is the base of the natural logarithms). The result is computed in a way that is accurate even when the value of x is close 0.</p>
@@ -27079,7 +26011,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.16" -->
       <emu-clause id="sec-math.floor">
         <h1>Math.floor ( _x_ )</h1>
         <p>Returns the greatest (closest to *+&infin;*) Number value that is not greater than _x_ and is equal to a mathematical integer. If _x_ is already an integer, the result is _x_.</p>
@@ -27108,7 +26039,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.2.17" -->
       <emu-clause id="sec-math.fround">
         <h1>Math.fround ( _x_ )</h1>
         <p>When `Math.fround` is called with argument _x_, the following steps are taken:</p>
@@ -27121,7 +26051,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.2.2.18" -->
       <emu-clause id="sec-math.hypot">
         <h1>Math.hypot ( _value1_, _value2_, ..._values_ )</h1>
         <p>`Math.hypot` returns an implementation-dependent approximation of the square root of the sum of squares of its arguments.</p>
@@ -27147,7 +26076,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.2.19" -->
       <emu-clause id="sec-math.imul">
         <h1>Math.imul ( _x_, _y_ )</h1>
         <p>When `Math.imul` is called with arguments _x_ and _y_, the following steps are taken:</p>
@@ -27159,7 +26087,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.2.2.20" -->
       <emu-clause id="sec-math.log">
         <h1>Math.log ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the natural logarithm of _x_.</p>
@@ -27182,7 +26109,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.21" -->
       <emu-clause id="sec-math.log1p">
         <h1>Math.log1p ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the natural logarithm of 1 + _x_. The result is computed in a way that is accurate even when the value of x is close to zero.</p>
@@ -27208,7 +26134,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.22" -->
       <emu-clause id="sec-math.log10">
         <h1>Math.log10 ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the base 10 logarithm of _x_.</p>
@@ -27234,7 +26159,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.23" -->
       <emu-clause id="sec-math.log2">
         <h1>Math.log2 ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the base 2 logarithm of _x_.</p>
@@ -27260,7 +26184,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.24" -->
       <emu-clause id="sec-math.max">
         <h1>Math.max ( _value1_, _value2_, ..._values_ )</h1>
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the largest of the resulting values.</p>
@@ -27277,7 +26200,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.25" -->
       <emu-clause id="sec-math.min">
         <h1>Math.min ( _value1_, _value2_, ..._values_ )</h1>
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the smallest of the resulting values.</p>
@@ -27294,7 +26216,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.26" -->
       <emu-clause id="sec-math.pow">
         <h1>Math.pow ( _base_, _exponent_ )</h1>
         <ol>
@@ -27304,14 +26225,12 @@
         </ol>
       </emu-clause>
 
-      <!-- es6num="20.2.2.27" -->
       <emu-clause id="sec-math.random">
         <h1>Math.random ( )</h1>
         <p>Returns a Number value with positive sign, greater than or equal to 0 but less than 1, chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an implementation-dependent algorithm or strategy. This function takes no arguments.</p>
         <p>Each `Math.random` function created for distinct realms must produce a distinct sequence of values from successive calls.</p>
       </emu-clause>
 
-      <!-- es6num="20.2.2.28" -->
       <emu-clause id="sec-math.round">
         <h1>Math.round ( _x_ )</h1>
         <p>Returns the Number value that is closest to _x_ and is equal to a mathematical integer. If two integer Number values are equally close to _x_, then the result is the Number value that is closer to *+&infin;*. If _x_ is already an integer, the result is _x_.</p>
@@ -27346,7 +26265,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.2.29" -->
       <emu-clause id="sec-math.sign">
         <h1>Math.sign ( _x_ )</h1>
         <p>Returns the sign of _x_, indicating whether _x_ is positive, negative, or zero.</p>
@@ -27369,7 +26287,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.30" -->
       <emu-clause id="sec-math.sin">
         <h1>Math.sin ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the sine of _x_. The argument is expressed in radians.</p>
@@ -27389,7 +26306,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.31" -->
       <emu-clause id="sec-math.sinh">
         <h1>Math.sinh ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the hyperbolic sine of _x_.</p>
@@ -27415,7 +26331,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.2.32" -->
       <emu-clause id="sec-math.sqrt">
         <h1>Math.sqrt ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the square root of _x_.</p>
@@ -27438,7 +26353,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.33" -->
       <emu-clause id="sec-math.tan">
         <h1>Math.tan ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the tangent of _x_. The argument is expressed in radians.</p>
@@ -27458,7 +26372,6 @@
         </ul>
       </emu-clause>
 
-      <!-- es6num="20.2.2.34" -->
       <emu-clause id="sec-math.tanh">
         <h1>Math.tanh ( _x_ )</h1>
         <p>Returns an implementation-dependent approximation to the hyperbolic tangent of _x_.</p>
@@ -27484,7 +26397,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.2.2.35" -->
       <emu-clause id="sec-math.trunc">
         <h1>Math.trunc ( _x_ )</h1>
         <p>Returns the integral part of the number _x_, removing any fractional digits. If _x_ is already an integer, the result is _x_.</p>
@@ -27515,16 +26427,13 @@
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="20.3" -->
   <emu-clause id="sec-date-objects">
     <h1>Date Objects</h1>
 
-    <!-- es6num="20.3.1" -->
     <emu-clause id="sec-overview-of-date-objects-and-definitions-of-abstract-operations">
       <h1>Overview of Date Objects and Definitions of Abstract Operations</h1>
       <p>The following functions are abstract operations that operate on time values (defined in <emu-xref href="#sec-time-values-and-time-range"></emu-xref>). Note that, in every case, if any argument to one of these functions is *NaN*, the result will be *NaN*.</p>
 
-      <!-- es6num="20.3.1.1" -->
       <emu-clause id="sec-time-values-and-time-range">
         <h1>Time Values and Time Range</h1>
         <p>A Date object contains a Number indicating a particular instant in time to within a millisecond. Such a Number is called a <dfn>time value</dfn>. A time value may also be *NaN*, indicating that the Date object does not represent a specific instant of time.</p>
@@ -27533,7 +26442,6 @@
         <p>The exact moment of midnight at the beginning of 01 January, 1970 UTC is represented by the value *+0*.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.1.2" -->
       <emu-clause id="sec-day-number-and-time-within-day">
         <h1>Day Number and Time within Day</h1>
         <p>A given time value _t_ belongs to day number</p>
@@ -27544,7 +26452,6 @@
         <emu-eqn id="eqn-TimeWithinDay" aoid="TimeWithinDay">TimeWithinDay(_t_) = _t_ modulo msPerDay</emu-eqn>
       </emu-clause>
 
-      <!-- es6num="20.3.1.3" -->
       <emu-clause id="sec-year-number">
         <h1>Year Number</h1>
         <p>ECMAScript uses a proleptic Gregorian calendar to map a day number to a year number and to determine the month and date within that year. In this calendar, leap years are precisely those which are (divisible by 4) and ((not divisible by 100) or (divisible by 400)). The number of days in year number _y_ is therefore defined by</p>
@@ -27567,7 +26474,6 @@
         </emu-eqn>
       </emu-clause>
 
-      <!-- es6num="20.3.1.4" -->
       <emu-clause id="sec-month-number">
         <h1>Month Number</h1>
         <p>Months are identified by an integer in the range 0 to 11, inclusive. The mapping MonthFromTime(_t_) from a time value _t_ to a month number is defined by:</p>
@@ -27590,7 +26496,6 @@
         <p>A month value of 0 specifies January; 1 specifies February; 2 specifies March; 3 specifies April; 4 specifies May; 5 specifies June; 6 specifies July; 7 specifies August; 8 specifies September; 9 specifies October; 10 specifies November; and 11 specifies December. Note that <emu-eqn>MonthFromTime(0) = 0</emu-eqn>, corresponding to Thursday, 01 January, 1970.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.1.5" -->
       <emu-clause id="sec-date-number">
         <h1>Date Number</h1>
         <p>A date number is identified by an integer in the range 1 through 31, inclusive. The mapping DateFromTime(_t_) from a time value _t_ to a date number is defined by:</p>
@@ -27610,7 +26515,6 @@
         </emu-eqn>
       </emu-clause>
 
-      <!-- es6num="20.3.1.6" -->
       <emu-clause id="sec-week-day">
         <h1>Week Day</h1>
         <p>The weekday for a particular time value _t_ is defined as</p>
@@ -27618,7 +26522,6 @@
         <p>A weekday value of 0 specifies Sunday; 1 specifies Monday; 2 specifies Tuesday; 3 specifies Wednesday; 4 specifies Thursday; 5 specifies Friday; and 6 specifies Saturday. Note that <emu-eqn>WeekDay(0) = 4</emu-eqn>, corresponding to Thursday, 01 January, 1970.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.1.7" -->
       <emu-clause id="sec-local-time-zone-adjustment">
         <h1>LocalTZA ( _t_, _isUTC_ )</h1>
         <p>LocalTZA( _t_, _isUTC_ ) is an implementation-defined algorithm that must return a number representing milliseconds suitable for adding to a Time Value. The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in the following three paragraphs.</p>
@@ -27633,7 +26536,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.1.9" -->
       <emu-clause id="sec-localtime" aoid="LocalTime">
         <h1>LocalTime ( _t_ )</h1>
         <p>The abstract operation LocalTime with argument _t_ converts _t_ from UTC to local time by performing the following steps:</p>
@@ -27645,7 +26547,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.1.10" -->
       <emu-clause id="sec-utc-t" aoid="UTC">
         <h1>UTC ( _t_ )</h1>
         <p>The abstract operation UTC with argument _t_ converts _t_ from local time to UTC. It performs the following steps:</p>
@@ -27657,7 +26558,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.1.11" -->
       <emu-clause id="sec-hours-minutes-second-and-milliseconds">
         <h1>Hours, Minutes, Second, and Milliseconds</h1>
         <p>The following abstract operations are useful in decomposing time values:</p>
@@ -27674,7 +26574,6 @@
         <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = 3600000 = msPerMinute &times; MinutesPerHour</emu-eqn>
       </emu-clause>
 
-      <!-- es6num="20.3.1.12" -->
       <emu-clause id="sec-maketime" aoid="MakeTime">
         <h1>MakeTime ( _hour_, _min_, _sec_, _ms_ )</h1>
         <p>The abstract operation MakeTime calculates a number of milliseconds from its four arguments, which must be ECMAScript Number values. This operator functions as follows:</p>
@@ -27689,7 +26588,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.1.13" -->
       <emu-clause id="sec-makeday" aoid="MakeDay">
         <h1>MakeDay ( _year_, _month_, _date_ )</h1>
         <p>The abstract operation MakeDay calculates a number of days from its three arguments, which must be ECMAScript Number values. This operator functions as follows:</p>
@@ -27705,7 +26603,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.1.14" -->
       <emu-clause id="sec-makedate" aoid="MakeDate">
         <h1>MakeDate ( _day_, _time_ )</h1>
         <p>The abstract operation MakeDate calculates a number of milliseconds from its two arguments, which must be ECMAScript Number values. This operator functions as follows:</p>
@@ -27715,7 +26612,6 @@
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.1.15" -->
       <emu-clause id="sec-timeclip" aoid="TimeClip">
         <h1>TimeClip ( _time_ )</h1>
         <p>The abstract operation TimeClip calculates a number of milliseconds from its argument, which must be an ECMAScript Number value. This operator functions as follows:</p>
@@ -27731,7 +26627,6 @@
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.1.16" -->
       <emu-clause id="sec-date-time-string-format">
         <h1>Date Time String Format</h1>
         <p>ECMAScript defines a string interchange format for date-times based upon a simplification of the ISO 8601 Extended Format. The format is as follows: `YYYY-MM-DDTHH:mm:ss.sssZ`</p>
@@ -27859,7 +26754,6 @@ THH:mm:ss.sss
           <p>There exists no international standard that specifies abbreviations for civil time zones like CET, EST, etc. and sometimes the same abbreviation is even used for two very different time zones. For this reason, ISO 8601 and this format specifies numeric representations of date and time.</p>
         </emu-note>
 
-        <!-- es6num="20.3.1.16.1" -->
         <emu-clause id="sec-extended-years">
           <h1>Extended Years</h1>
           <p>ECMAScript requires the ability to specify 6 digit years (extended years); approximately 285,426 years, either forward or backward, from 01 January, 1970 UTC. To represent years before 0 or after 9999, ISO 8601 permits the expansion of the year representation, but only by prior agreement between the sender and the receiver. In the simplified ECMAScript format such an expanded year representation shall have 2 extra year digits and is always prefixed with a + or - sign. The year 0 is considered positive and hence prefixed with a + sign.</p>
@@ -27904,7 +26798,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="20.3.2" -->
     <emu-clause id="sec-date-constructor">
       <h1>The Date Constructor</h1>
       <p>The Date constructor:</p>
@@ -27918,7 +26811,6 @@ THH:mm:ss.sss
         <li>has a `length` property whose value is 7.</li>
       </ul>
 
-      <!-- es6num="20.3.2.1" -->
       <emu-clause id="sec-date-year-month-date-hours-minutes-seconds-ms">
         <h1>Date ( _year_, _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] )</h1>
         <p>This description applies only if the Date constructor is called with at least two arguments.</p>
@@ -27945,7 +26837,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.2.2" -->
       <emu-clause id="sec-date-value">
         <h1>Date ( _value_ )</h1>
         <p>This description applies only if the Date constructor is called with exactly one argument.</p>
@@ -27972,7 +26863,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.2.3" -->
       <emu-clause id="sec-date-constructor-date">
         <h1>Date ( )</h1>
         <p>This description applies only if the Date constructor is called with no arguments.</p>
@@ -27991,7 +26881,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="20.3.3" -->
     <emu-clause id="sec-properties-of-the-date-constructor">
       <h1>Properties of the Date Constructor</h1>
       <p>The Date constructor:</p>
@@ -28000,13 +26889,11 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="20.3.3.1" -->
       <emu-clause id="sec-date.now">
         <h1>Date.now ( )</h1>
         <p>The `now` function returns a Number value that is the time value designating the UTC date and time of the occurrence of the call to `now`.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.3.2" -->
       <emu-clause id="sec-date.parse">
         <h1>Date.parse ( _string_ )</h1>
         <p>The `parse` function applies the ToString operator to its argument. If ToString results in an abrupt completion the Completion Record is immediately returned. Otherwise, `parse` interprets the resulting String as a date and time; it returns a Number, the UTC time value corresponding to the date and time. The String may be interpreted as a local time, a UTC time, or a time in some other time zone, depending on the contents of the String. The function first attempts to parse the format of the String according to the rules (including extended years) called out in Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>). If the String does not conform to that format the function may fall back to any implementation-specific heuristics or implementation-specific date formats. Unrecognizable Strings or dates containing illegal element values in the format String shall cause `Date.parse` to return *NaN*.</p>
@@ -28024,14 +26911,12 @@ THH:mm:ss.sss
         <p>is not required to produce the same Number value as the preceding three expressions and, in general, the value produced by `Date.parse` is implementation-dependent when given any String value that does not conform to the Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>) and that could not be produced in that implementation by the `toString` or `toUTCString` method.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.3.3" -->
       <emu-clause id="sec-date.prototype">
         <h1>Date.prototype</h1>
         <p>The initial value of `Date.prototype` is the intrinsic object %DatePrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.3.4" -->
       <emu-clause id="sec-date.utc">
         <h1>Date.UTC ( _year_ [ , _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] ] )</h1>
         <p>When the `UTC` function is called, the following steps are taken:</p>
@@ -28053,7 +26938,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="20.3.4" -->
     <emu-clause id="sec-properties-of-the-date-prototype-object">
       <h1>Properties of the Date Prototype Object</h1>
       <p>The Date prototype object:</p>
@@ -28072,13 +26956,11 @@ THH:mm:ss.sss
       </emu-alg>
       <p>In following descriptions of functions that are properties of the Date prototype object, the phrase &ldquo;<dfn id="this-Date-object">this Date object</dfn>&rdquo; refers to the object that is the *this* value for the invocation of the function. If the Type of the *this* value is not Object, a *TypeError* exception is thrown. The phrase &ldquo;<dfn id="this-time-value">this time value</dfn>&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisTimeValue with the *this* value of the method invocation passed as the argument.</p>
 
-      <!-- es6num="20.3.4.1" -->
       <emu-clause id="sec-date.prototype.constructor">
         <h1>Date.prototype.constructor</h1>
         <p>The initial value of `Date.prototype.constructor` is the intrinsic object %Date%.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.4.2" -->
       <emu-clause id="sec-date.prototype.getdate">
         <h1>Date.prototype.getDate ( )</h1>
         <p>The following steps are performed:</p>
@@ -28089,7 +26971,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.3" -->
       <emu-clause id="sec-date.prototype.getday">
         <h1>Date.prototype.getDay ( )</h1>
         <p>The following steps are performed:</p>
@@ -28100,7 +26981,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.4" -->
       <emu-clause id="sec-date.prototype.getfullyear">
         <h1>Date.prototype.getFullYear ( )</h1>
         <p>The following steps are performed:</p>
@@ -28111,7 +26991,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.5" -->
       <emu-clause id="sec-date.prototype.gethours">
         <h1>Date.prototype.getHours ( )</h1>
         <p>The following steps are performed:</p>
@@ -28122,7 +27001,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.6" -->
       <emu-clause id="sec-date.prototype.getmilliseconds">
         <h1>Date.prototype.getMilliseconds ( )</h1>
         <p>The following steps are performed:</p>
@@ -28133,7 +27011,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.7" -->
       <emu-clause id="sec-date.prototype.getminutes">
         <h1>Date.prototype.getMinutes ( )</h1>
         <p>The following steps are performed:</p>
@@ -28144,7 +27021,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.8" -->
       <emu-clause id="sec-date.prototype.getmonth">
         <h1>Date.prototype.getMonth ( )</h1>
         <p>The following steps are performed:</p>
@@ -28155,7 +27031,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.9" -->
       <emu-clause id="sec-date.prototype.getseconds">
         <h1>Date.prototype.getSeconds ( )</h1>
         <p>The following steps are performed:</p>
@@ -28166,7 +27041,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.10" -->
       <emu-clause id="sec-date.prototype.gettime">
         <h1>Date.prototype.getTime ( )</h1>
         <p>The following steps are performed:</p>
@@ -28175,7 +27049,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.11" -->
       <emu-clause id="sec-date.prototype.gettimezoneoffset">
         <h1>Date.prototype.getTimezoneOffset ( )</h1>
         <p>The following steps are performed:</p>
@@ -28186,7 +27059,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.12" -->
       <emu-clause id="sec-date.prototype.getutcdate">
         <h1>Date.prototype.getUTCDate ( )</h1>
         <p>The following steps are performed:</p>
@@ -28197,7 +27069,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.13" -->
       <emu-clause id="sec-date.prototype.getutcday">
         <h1>Date.prototype.getUTCDay ( )</h1>
         <p>The following steps are performed:</p>
@@ -28208,7 +27079,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.14" -->
       <emu-clause id="sec-date.prototype.getutcfullyear">
         <h1>Date.prototype.getUTCFullYear ( )</h1>
         <p>The following steps are performed:</p>
@@ -28219,7 +27089,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.15" -->
       <emu-clause id="sec-date.prototype.getutchours">
         <h1>Date.prototype.getUTCHours ( )</h1>
         <p>The following steps are performed:</p>
@@ -28230,7 +27099,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.16" -->
       <emu-clause id="sec-date.prototype.getutcmilliseconds">
         <h1>Date.prototype.getUTCMilliseconds ( )</h1>
         <p>The following steps are performed:</p>
@@ -28241,7 +27109,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.17" -->
       <emu-clause id="sec-date.prototype.getutcminutes">
         <h1>Date.prototype.getUTCMinutes ( )</h1>
         <p>The following steps are performed:</p>
@@ -28252,7 +27119,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.18" -->
       <emu-clause id="sec-date.prototype.getutcmonth">
         <h1>Date.prototype.getUTCMonth ( )</h1>
         <p>The following steps are performed:</p>
@@ -28263,7 +27129,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.19" -->
       <emu-clause id="sec-date.prototype.getutcseconds">
         <h1>Date.prototype.getUTCSeconds ( )</h1>
         <p>The following steps are performed:</p>
@@ -28274,7 +27139,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.20" -->
       <emu-clause id="sec-date.prototype.setdate">
         <h1>Date.prototype.setDate ( _date_ )</h1>
         <p>The following steps are performed:</p>
@@ -28288,7 +27152,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.21" -->
       <emu-clause id="sec-date.prototype.setfullyear">
         <h1>Date.prototype.setFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
         <p>The following steps are performed:</p>
@@ -28309,7 +27172,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.22" -->
       <emu-clause id="sec-date.prototype.sethours">
         <h1>Date.prototype.setHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
         <p>The following steps are performed:</p>
@@ -28330,7 +27192,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.23" -->
       <emu-clause id="sec-date.prototype.setmilliseconds">
         <h1>Date.prototype.setMilliseconds ( _ms_ )</h1>
         <p>The following steps are performed:</p>
@@ -28344,7 +27205,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.24" -->
       <emu-clause id="sec-date.prototype.setminutes">
         <h1>Date.prototype.setMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
         <p>The following steps are performed:</p>
@@ -28364,7 +27224,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.25" -->
       <emu-clause id="sec-date.prototype.setmonth">
         <h1>Date.prototype.setMonth ( _month_ [ , _date_ ] )</h1>
         <p>The following steps are performed:</p>
@@ -28383,7 +27242,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.26" -->
       <emu-clause id="sec-date.prototype.setseconds">
         <h1>Date.prototype.setSeconds ( _sec_ [ , _ms_ ] )</h1>
         <p>The following steps are performed:</p>
@@ -28402,7 +27260,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.27" -->
       <emu-clause id="sec-date.prototype.settime">
         <h1>Date.prototype.setTime ( _time_ )</h1>
         <p>The following steps are performed:</p>
@@ -28415,7 +27272,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.28" -->
       <emu-clause id="sec-date.prototype.setutcdate">
         <h1>Date.prototype.setUTCDate ( _date_ )</h1>
         <p>The following steps are performed:</p>
@@ -28429,7 +27285,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.29" -->
       <emu-clause id="sec-date.prototype.setutcfullyear">
         <h1>Date.prototype.setUTCFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
         <p>The following steps are performed:</p>
@@ -28450,7 +27305,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.30" -->
       <emu-clause id="sec-date.prototype.setutchours">
         <h1>Date.prototype.setUTCHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
         <p>The following steps are performed:</p>
@@ -28471,7 +27325,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.31" -->
       <emu-clause id="sec-date.prototype.setutcmilliseconds">
         <h1>Date.prototype.setUTCMilliseconds ( _ms_ )</h1>
         <p>The following steps are performed:</p>
@@ -28485,7 +27338,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.32" -->
       <emu-clause id="sec-date.prototype.setutcminutes">
         <h1>Date.prototype.setUTCMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
         <p>The following steps are performed:</p>
@@ -28509,7 +27361,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.33" -->
       <emu-clause id="sec-date.prototype.setutcmonth">
         <h1>Date.prototype.setUTCMonth ( _month_ [ , _date_ ] )</h1>
         <p>The following steps are performed:</p>
@@ -28530,7 +27381,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.34" -->
       <emu-clause id="sec-date.prototype.setutcseconds">
         <h1>Date.prototype.setUTCSeconds ( _sec_ [ , _ms_ ] )</h1>
         <p>The following steps are performed:</p>
@@ -28551,7 +27401,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.35" -->
       <emu-clause id="sec-date.prototype.todatestring">
         <h1>Date.prototype.toDateString ( )</h1>
         <p>The following steps are performed:</p>
@@ -28564,13 +27413,11 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.36" -->
       <emu-clause id="sec-date.prototype.toisostring">
         <h1>Date.prototype.toISOString ( )</h1>
         <p>This function returns a String value representing the instance in time corresponding to this time value. The format of the String is the Date Time string format defined in <emu-xref href="#sec-date-time-string-format"></emu-xref>. All fields are present in the String. The time zone is always UTC, denoted by the suffix Z. If this time value is not a finite Number or if the year is not a value that can be represented in that format (if necessary using extended year format), a *RangeError* exception is thrown.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.4.37" -->
       <emu-clause id="sec-date.prototype.tojson">
         <h1>Date.prototype.toJSON ( _key_ )</h1>
         <p>This function provides a String representation of a Date object for use by `JSON.stringify` (<emu-xref href="#sec-json.stringify"></emu-xref>).</p>
@@ -28589,7 +27436,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="20.3.4.38" -->
       <emu-clause id="sec-date.prototype.tolocaledatestring">
         <h1>Date.prototype.toLocaleDateString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleDateString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleDateString` method is used.</p>
@@ -28597,7 +27443,6 @@ THH:mm:ss.sss
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.4.39" -->
       <emu-clause id="sec-date.prototype.tolocalestring">
         <h1>Date.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
@@ -28605,7 +27450,6 @@ THH:mm:ss.sss
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.4.40" -->
       <emu-clause id="sec-date.prototype.tolocaletimestring">
         <h1>Date.prototype.toLocaleTimeString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleTimeString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleTimeString` method is used.</p>
@@ -28613,7 +27457,6 @@ THH:mm:ss.sss
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
-      <!-- es6num="20.3.4.41" -->
       <emu-clause id="sec-date.prototype.tostring">
         <h1>Date.prototype.toString ( )</h1>
         <p>The following steps are performed:</p>
@@ -28850,7 +27693,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="20.3.4.41.1" -->
         <emu-clause id="sec-todatestring" aoid="ToDateString">
           <h1>Runtime Semantics: ToDateString ( _tv_ )</h1>
           <p>The following steps are performed:</p>
@@ -28863,7 +27705,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="20.3.4.42" -->
       <emu-clause id="sec-date.prototype.totimestring">
         <h1>Date.prototype.toTimeString ( )</h1>
         <p>The following steps are performed:</p>
@@ -28876,7 +27717,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.43" -->
       <emu-clause id="sec-date.prototype.toutcstring">
         <h1>Date.prototype.toUTCString ( )</h1>
         <p>The following steps are performed:</p>
@@ -28892,7 +27732,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.44" -->
       <emu-clause id="sec-date.prototype.valueof">
         <h1>Date.prototype.valueOf ( )</h1>
         <p>The following steps are performed:</p>
@@ -28901,7 +27740,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="20.3.4.45" -->
       <emu-clause id="sec-date.prototype-@@toprimitive">
         <h1>Date.prototype [ @@toPrimitive ] ( _hint_ )</h1>
         <p>This function is called by ECMAScript language operators to convert a Date object to a primitive value. The allowed values for _hint_ are `"default"`, `"number"`, and `"string"`. Date objects, are unique among built-in ECMAScript object in that they treat `"default"` as being equivalent to `"string"`, All other built-in ECMAScript objects treat `"default"` as being equivalent to `"number"`.</p>
@@ -28921,7 +27759,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="20.3.5" -->
     <emu-clause id="sec-properties-of-date-instances">
       <h1>Properties of Date Instances</h1>
       <p>Date instances are ordinary objects that inherit properties from the Date prototype object. Date instances also have a [[DateValue]] internal slot. The [[DateValue]] internal slot is the time value represented by this Date object.</p>
@@ -28929,15 +27766,12 @@ THH:mm:ss.sss
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="21" -->
 <emu-clause id="sec-text-processing">
   <h1>Text Processing</h1>
 
-  <!-- es6num="21.1" -->
   <emu-clause id="sec-string-objects">
     <h1>String Objects</h1>
 
-    <!-- es6num="21.1.1" -->
     <emu-clause id="sec-string-constructor">
       <h1>The String Constructor</h1>
       <p>The String constructor:</p>
@@ -28949,7 +27783,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behaviour must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</li>
       </ul>
 
-      <!-- es6num="21.1.1.1" -->
       <emu-clause id="sec-string-constructor-string-value">
         <h1>String ( _value_ )</h1>
         <p>When `String` is called with argument _value_, the following steps are taken:</p>
@@ -28964,7 +27797,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.1.2" -->
     <emu-clause id="sec-properties-of-the-string-constructor">
       <h1>Properties of the String Constructor</h1>
       <p>The String constructor:</p>
@@ -28973,7 +27805,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="21.1.2.1" -->
       <emu-clause id="sec-string.fromcharcode">
         <h1>String.fromCharCode ( ..._codeUnits_ )</h1>
         <p>The `String.fromCharCode` function may be called with any number of arguments which form the rest parameter _codeUnits_. The following steps are taken:</p>
@@ -28992,7 +27823,6 @@ THH:mm:ss.sss
         <p>The `length` property of the `fromCharCode` function is 1.</p>
       </emu-clause>
 
-      <!-- es6num="21.1.2.2" -->
       <emu-clause id="sec-string.fromcodepoint">
         <h1>String.fromCodePoint ( ..._codePoints_ )</h1>
         <p>The `String.fromCodePoint` function may be called with any number of arguments which form the rest parameter _codePoints_. The following steps are taken:</p>
@@ -29013,14 +27843,12 @@ THH:mm:ss.sss
         <p>The `length` property of the `fromCodePoint` function is 1.</p>
       </emu-clause>
 
-      <!-- es6num="21.1.2.3" -->
       <emu-clause id="sec-string.prototype">
         <h1>String.prototype</h1>
         <p>The initial value of `String.prototype` is the intrinsic object %StringPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="21.1.2.4" -->
       <emu-clause id="sec-string.raw">
         <h1>String.raw ( _template_, ..._substitutions_ )</h1>
         <p>The `String.raw` function may be called with a variable number of arguments. The first argument is _template_ and the remainder of the arguments form the List _substitutions_. The following steps are taken:</p>
@@ -29051,7 +27879,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.1.3" -->
     <emu-clause id="sec-properties-of-the-string-prototype-object">
       <h1>Properties of the String Prototype Object</h1>
       <p>The String prototype object:</p>
@@ -29072,7 +27899,6 @@ THH:mm:ss.sss
         1. Throw a *TypeError* exception.
       </emu-alg>
 
-      <!-- es6num="21.1.3.1" -->
       <emu-clause id="sec-string.prototype.charat">
         <h1>String.prototype.charAt ( _pos_ )</h1>
         <emu-note>
@@ -29093,7 +27919,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.2" -->
       <emu-clause id="sec-string.prototype.charcodeat">
         <h1>String.prototype.charCodeAt ( _pos_ )</h1>
         <emu-note>
@@ -29113,7 +27938,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.3" -->
       <emu-clause id="sec-string.prototype.codepointat">
         <h1>String.prototype.codePointAt ( _pos_ )</h1>
         <emu-note>
@@ -29137,7 +27961,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.4" -->
       <emu-clause id="sec-string.prototype.concat">
         <h1>String.prototype.concat ( ..._args_ )</h1>
         <emu-note>
@@ -29161,13 +27984,11 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.5" -->
       <emu-clause id="sec-string.prototype.constructor">
         <h1>String.prototype.constructor</h1>
         <p>The initial value of `String.prototype.constructor` is the intrinsic object %String%.</p>
       </emu-clause>
 
-      <!-- es6num="21.1.3.6" -->
       <emu-clause id="sec-string.prototype.endswith">
         <h1>String.prototype.endsWith ( _searchString_ [ , _endPosition_ ] )</h1>
         <p>The following steps are taken:</p>
@@ -29197,7 +28018,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.7" -->
       <emu-clause id="sec-string.prototype.includes">
         <h1>String.prototype.includes ( _searchString_ [ , _position_ ] )</h1>
         <p>The `includes` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
@@ -29224,7 +28044,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.8" -->
       <emu-clause id="sec-string.prototype.indexof">
         <h1>String.prototype.indexOf ( _searchString_ [ , _position_ ] )</h1>
         <emu-note>
@@ -29246,7 +28065,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.9" -->
       <emu-clause id="sec-string.prototype.lastindexof">
         <h1>String.prototype.lastIndexOf ( _searchString_ [ , _position_ ] )</h1>
         <emu-note>
@@ -29269,7 +28087,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.10" -->
       <emu-clause id="sec-string.prototype.localecompare">
         <h1>String.prototype.localeCompare ( _that_ [ , _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `localeCompare` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `localeCompare` method is used.</p>
@@ -29294,7 +28111,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.11" -->
       <emu-clause id="sec-string.prototype.match">
         <h1>String.prototype.match ( _regexp_ )</h1>
         <p>When the `match` method is called with argument _regexp_, the following steps are taken:</p>
@@ -29313,7 +28129,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.12" -->
       <emu-clause id="sec-string.prototype.normalize">
         <h1>String.prototype.normalize ( [ _form_ ] )</h1>
         <p>When the `normalize` method is called with one argument _form_, the following steps are taken:</p>
@@ -29379,7 +28194,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.13" -->
       <emu-clause id="sec-string.prototype.repeat">
         <h1>String.prototype.repeat ( _count_ )</h1>
         <p>The following steps are taken:</p>
@@ -29400,7 +28214,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.14" -->
       <emu-clause id="sec-string.prototype.replace">
         <h1>String.prototype.replace ( _searchValue_, _replaceValue_ )</h1>
         <p>When the `replace` method is called with arguments _searchValue_ and _replaceValue_, the following steps are taken:</p>
@@ -29430,7 +28243,6 @@ THH:mm:ss.sss
           <p>The `replace` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <!-- es6num="21.1.3.14.1" -->
         <emu-clause id="sec-getsubstitution" aoid="GetSubstitution">
           <h1>Runtime Semantics: GetSubstitution ( _matched_, _str_, _position_, _captures_, _namedCaptures_, _replacement_ )</h1>
           <p>The abstract operation GetSubstitution performs the following steps:</p>
@@ -29580,7 +28392,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="21.1.3.15" -->
       <emu-clause id="sec-string.prototype.search">
         <h1>String.prototype.search ( _regexp_ )</h1>
         <p>When the search method is called with argument _regexp_, the following steps are taken:</p>
@@ -29599,7 +28410,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.16" -->
       <emu-clause id="sec-string.prototype.slice">
         <h1>String.prototype.slice ( _start_, _end_ )</h1>
         <p>The `slice` method takes two arguments, _start_ and _end_, and returns a substring of the result of converting this object to a String, starting from index _start_ and running to, but not including, index _end_ (or through the end of the String if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_sourceLength_+_start_</emu-eqn> where _sourceLength_ is the length of the String. If _end_ is negative, it is treated as <emu-eqn>_sourceLength_+_end_</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object. The following steps are taken:</p>
@@ -29619,7 +28429,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.17" -->
       <emu-clause id="sec-string.prototype.split">
         <h1>String.prototype.split ( _separator_, _limit_ )</h1>
         <p>Returns an Array object into which substrings of the result of converting this object to a String have been stored. The substrings are determined by searching from left to right for occurrences of _separator_; these occurrences are not part of any substring in the returned array, but serve to divide up the String value. The value of _separator_ may be a String of any length or it may be an object, such as a RegExp, that has a @@split method.</p>
@@ -29672,7 +28481,6 @@ THH:mm:ss.sss
           <p>The `split` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <!-- es6num="21.1.3.17.1" -->
         <emu-clause id="sec-splitmatch" aoid="SplitMatch">
           <h1>Runtime Semantics: SplitMatch ( _S_, _q_, _R_ )</h1>
           <p>The abstract operation SplitMatch takes three parameters, a String _S_, an integer _q_, and a String _R_, and performs the following steps in order to return either *false* or the end index of a match:</p>
@@ -29687,7 +28495,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="21.1.3.18" -->
       <emu-clause id="sec-string.prototype.startswith">
         <h1>String.prototype.startsWith ( _searchString_ [ , _position_ ] )</h1>
         <p>The following steps are taken:</p>
@@ -29716,7 +28523,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.19" -->
       <emu-clause id="sec-string.prototype.substring">
         <h1>String.prototype.substring ( _start_, _end_ )</h1>
         <p>The `substring` method takes two arguments, _start_ and _end_, and returns a substring of the result of converting this object to a String, starting from index _start_ and running to, but not including, index _end_ of the String (or through the end of the String if _end_ is *undefined*). The result is a String value, not a String object.</p>
@@ -29740,7 +28546,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.20" -->
       <emu-clause id="sec-string.prototype.tolocalelowercase">
         <h1>String.prototype.toLocaleLowerCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `toLocaleLowerCase` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleLowerCase` method is used.</p>
@@ -29752,7 +28557,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.21" -->
       <emu-clause id="sec-string.prototype.tolocaleuppercase">
         <h1>String.prototype.toLocaleUpperCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `toLocaleUpperCase` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleUpperCase` method is used.</p>
@@ -29764,7 +28568,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.22" -->
       <emu-clause id="sec-string.prototype.tolowercase">
         <h1>String.prototype.toLowerCase ( )</h1>
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. The following steps are taken:</p>
@@ -29785,7 +28588,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.23" -->
       <emu-clause id="sec-string.prototype.tostring">
         <h1>String.prototype.toString ( )</h1>
         <p>When the `toString` method is called, the following steps are taken:</p>
@@ -29797,7 +28599,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.24" -->
       <emu-clause id="sec-string.prototype.touppercase">
         <h1>String.prototype.toUpperCase ( )</h1>
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
@@ -29807,7 +28608,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.25" -->
       <emu-clause id="sec-string.prototype.trim">
         <h1>String.prototype.trim ( )</h1>
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
@@ -29823,7 +28623,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.1.3.26" -->
       <emu-clause id="sec-string.prototype.valueof">
         <h1>String.prototype.valueOf ( )</h1>
         <p>When the `valueOf` method is called, the following steps are taken:</p>
@@ -29832,7 +28631,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.1.3.27" -->
       <emu-clause id="sec-string.prototype-@@iterator">
         <h1>String.prototype [ @@iterator ] ( )</h1>
         <p>When the @@iterator method is called it returns an Iterator object (<emu-xref href="#sec-iterator-interface"></emu-xref>) that iterates over the code points of a String value, returning each code point as a String value. The following steps are taken:</p>
@@ -29845,13 +28643,11 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.1.4" -->
     <emu-clause id="sec-properties-of-string-instances">
       <h1>Properties of String Instances</h1>
       <p>String instances are String exotic objects and have the internal methods specified for such objects. String instances inherit properties from the String prototype object. String instances also have a [[StringData]] internal slot.</p>
       <p>String instances have a `length` property, and a set of enumerable properties with integer-indexed names.</p>
 
-      <!-- es6num="21.1.4.1" -->
       <emu-clause id="sec-properties-of-string-instances-length">
         <h1>length</h1>
         <p>The number of elements in the String value represented by this String object.</p>
@@ -29859,12 +28655,10 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.1.5" -->
     <emu-clause id="sec-string-iterator-objects">
       <h1>String Iterator Objects</h1>
       <p>A String Iterator is an object, that represents a specific iteration over some specific String instance object. There is not a named constructor for String Iterator objects. Instead, String iterator objects are created by calling certain methods of String instance objects.</p>
 
-      <!-- es6num="21.1.5.1" -->
       <emu-clause id="sec-createstringiterator" aoid="CreateStringIterator">
         <h1>CreateStringIterator ( _string_ )</h1>
         <p>Several methods of String objects return Iterator objects. The abstract operation CreateStringIterator with argument _string_ is used to create such iterator objects. It performs the following steps:</p>
@@ -29877,7 +28671,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.1.5.2" -->
       <emu-clause id="sec-%stringiteratorprototype%-object">
         <h1>The %StringIteratorPrototype% Object</h1>
         <p>The <dfn>%StringIteratorPrototype%</dfn> object:</p>
@@ -29888,7 +28681,6 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <!-- es6num="21.1.5.2.1" -->
         <emu-clause id="sec-%stringiteratorprototype%.next">
           <h1>%StringIteratorPrototype%.next ( )</h1>
           <emu-alg>
@@ -29914,7 +28706,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="21.1.5.2.2" -->
         <emu-clause id="sec-%stringiteratorprototype%-@@tostringtag">
           <h1>%StringIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value `"String Iterator"`.</p>
@@ -29922,7 +28713,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="21.1.5.3" -->
       <emu-clause id="sec-properties-of-string-iterator-instances">
         <h1>Properties of String Iterator Instances</h1>
         <p>String Iterator instances are ordinary objects that inherit properties from the %StringIteratorPrototype% intrinsic object. String Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-46"></emu-xref>.</p>
@@ -29960,7 +28750,6 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="21.2" -->
   <emu-clause id="sec-regexp-regular-expression-objects">
     <h1>RegExp (Regular Expression) Objects</h1>
     <p>A RegExp object contains a regular expression and the associated flags.</p>
@@ -29968,7 +28757,6 @@ THH:mm:ss.sss
       <p>The form and functionality of regular expressions is modelled after the regular expression facility in the Perl 5 programming language.</p>
     </emu-note>
 
-    <!-- es6num="21.2.1" -->
     <emu-clause id="sec-patterns">
       <h1>Patterns</h1>
       <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
@@ -30177,7 +28965,6 @@ THH:mm:ss.sss
           CharacterEscape[?U]
       </emu-grammar>
 
-      <!-- es6num="21.2.1.1" -->
       <emu-clause id="sec-patterns-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>Pattern :: Disjunction</emu-grammar>
@@ -30513,7 +29300,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.2.2" -->
     <emu-clause id="sec-pattern-semantics">
       <h1>Pattern Semantics</h1>
       <p>A regular expression pattern is converted into an internal procedure using the process described below. An implementation is encouraged to use more efficient algorithms than the ones listed below, as long as the results are the same. The internal procedure is used as the value of a RegExp object's [[RegExpMatcher]] internal slot.</p>
@@ -30525,7 +29311,6 @@ THH:mm:ss.sss
         <p>An implementation may not actually perform such translations to or from UTF-16, but the semantics of this specification requires that the result of pattern matching be as if such translations were performed.</p>
       </emu-note>
 
-      <!-- es6num="21.2.2.1" -->
       <emu-clause id="sec-notation">
         <h1>Notation</h1>
         <p>The descriptions below use the following variables:</p>
@@ -30575,7 +29360,6 @@ THH:mm:ss.sss
         </ul>
       </emu-clause>
 
-      <!-- es6num="21.2.2.2" -->
       <emu-clause id="sec-pattern">
         <h1>Pattern</h1>
         <p>The production <emu-grammar>Pattern :: Disjunction</emu-grammar> evaluates as follows:</p>
@@ -30596,7 +29380,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.2.3" -->
       <emu-clause id="sec-disjunction">
         <h1>Disjunction</h1>
         <p>With parameter _direction_.</p>
@@ -30627,7 +29410,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.2.4" -->
       <emu-clause id="sec-alternative">
         <h1>Alternative</h1>
         <p>With parameter _direction_.</p>
@@ -30654,7 +29436,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.2.5" -->
       <emu-clause id="sec-term">
         <h1>Term</h1>
         <p>With parameter _direction_.</p>
@@ -30684,7 +29465,6 @@ THH:mm:ss.sss
             1. Call RepeatMatcher(_m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_) and return its result.
         </emu-alg>
 
-        <!-- es6num="21.2.2.5.1" -->
         <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" aoid="RepeatMatcher">
           <h1>Runtime Semantics: RepeatMatcher ( _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_ )</h1>
           <p>The abstract operation RepeatMatcher takes eight parameters, a Matcher _m_, an integer _min_, an integer (or &infin;) _max_, a Boolean _greedy_, a State _x_, a Continuation _c_, an integer _parenIndex_, and an integer _parenCount_, and performs the following steps:</p>
@@ -30751,7 +29531,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="21.2.2.6" -->
       <emu-clause id="sec-assertion">
         <h1>Assertion</h1>
         <p>The production <emu-grammar>Assertion :: `^`</emu-grammar> evaluates as follows:</p>
@@ -30840,7 +29619,6 @@ THH:mm:ss.sss
             1. Call _c_(_x_) and return its result.
         </emu-alg>
 
-        <!-- es6num="21.2.2.6.1" -->
         <emu-clause id="sec-runtime-semantics-wordcharacters-abstract-operation" aoid="WordCharacters">
           <h1>Runtime Semantics: WordCharacters ( )</h1>
           <p>The abstract operation WordCharacters performs the following steps:</p>
@@ -31084,7 +29862,6 @@ THH:mm:ss.sss
             1. Return _A_.
           </emu-alg>
         </emu-clause>
-        <!-- es6num="21.2.2.6.2" -->
         <emu-clause id="sec-runtime-semantics-iswordchar-abstract-operation" aoid="IsWordChar">
           <h1>Runtime Semantics: IsWordChar ( _e_ )</h1>
           <p>The abstract operation IsWordChar takes an integer parameter _e_ and performs the following steps:</p>
@@ -31097,7 +29874,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
       </emu-clause>
-      <!-- es6num="21.2.2.7" -->
       <emu-clause id="sec-quantifier">
         <h1>Quantifier</h1>
         <p>The production <emu-grammar>Quantifier :: QuantifierPrefix</emu-grammar> evaluates as follows:</p>
@@ -31140,7 +29916,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.2.8" -->
       <emu-clause id="sec-atom">
         <h1>Atom</h1>
         <p>With parameter _direction_.</p>
@@ -31192,7 +29967,6 @@ THH:mm:ss.sss
           1. Return the Matcher that is the result of evaluating |Disjunction| with argument _direction_.
         </emu-alg>
 
-        <!-- es6num="21.2.2.8.1" -->
         <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" aoid="CharacterSetMatcher">
           <h1>Runtime Semantics: CharacterSetMatcher ( _A_, _invert_, _direction_ )</h1>
           <p>The abstract operation CharacterSetMatcher takes three arguments, a CharSet _A_, a Boolean flag _invert_, and an integer _direction_, and performs the following steps:</p>
@@ -31215,7 +29989,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="21.2.2.8.2" -->
         <emu-clause id="sec-runtime-semantics-canonicalize-ch" aoid="Canonicalize">
           <h1>Runtime Semantics: Canonicalize ( _ch_ )</h1>
           <p>The abstract operation Canonicalize takes a character parameter _ch_ and performs the following steps:</p>
@@ -31299,7 +30072,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="21.2.2.9" -->
       <emu-clause id="sec-atomescape">
         <h1>AtomEscape</h1>
         <p>With parameter _direction_.</p>
@@ -31351,7 +30123,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="21.2.2.10" -->
       <emu-clause id="sec-characterescape">
         <h1>CharacterEscape</h1>
         <p>The |CharacterEscape| productions evaluate as follows:</p>
@@ -31370,7 +30141,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.2.11" -->
       <emu-clause id="sec-decimalescape">
         <h1>DecimalEscape</h1>
         <p>The |DecimalEscape| productions evaluate as follows:</p>
@@ -31383,7 +30153,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.2.12" -->
       <emu-clause id="sec-characterclassescape">
         <h1>CharacterClassEscape</h1>
         <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates as follows:</p>
@@ -31432,7 +30201,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.2.13" -->
       <emu-clause id="sec-characterclass">
         <h1>CharacterClass</h1>
         <p>The production <emu-grammar>CharacterClass :: `[` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
@@ -31447,7 +30215,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.2.14" -->
       <emu-clause id="sec-classranges">
         <h1>ClassRanges</h1>
         <p>The production <emu-grammar>ClassRanges :: [empty]</emu-grammar> evaluates as follows:</p>
@@ -31460,7 +30227,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.2.15" -->
       <emu-clause id="sec-nonemptyclassranges">
         <h1>NonemptyClassRanges</h1>
         <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom</emu-grammar> evaluates as follows:</p>
@@ -31482,7 +30248,6 @@ THH:mm:ss.sss
           1. Return the union of CharSets _D_ and _C_.
         </emu-alg>
 
-        <!-- es6num="21.2.2.15.1" -->
         <emu-clause id="sec-runtime-semantics-characterrange-abstract-operation" aoid="CharacterRange">
           <h1>Runtime Semantics: CharacterRange ( _A_, _B_ )</h1>
           <p>The abstract operation CharacterRange takes two CharSet parameters _A_ and _B_ and performs the following steps:</p>
@@ -31498,7 +30263,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="21.2.2.16" -->
       <emu-clause id="sec-nonemptyclassrangesnodash">
         <h1>NonemptyClassRangesNoDash</h1>
         <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtom</emu-grammar> evaluates as follows:</p>
@@ -31530,7 +30294,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.2.17" -->
       <emu-clause id="sec-classatom">
         <h1>ClassAtom</h1>
         <p>The production <emu-grammar>ClassAtom :: `-`</emu-grammar> evaluates as follows:</p>
@@ -31543,7 +30306,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.2.18" -->
       <emu-clause id="sec-classatomnodash">
         <h1>ClassAtomNoDash</h1>
         <p>The production <emu-grammar>ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`</emu-grammar> evaluates as follows:</p>
@@ -31556,7 +30318,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.2.19" -->
       <emu-clause id="sec-classescape">
         <h1>ClassEscape</h1>
         <p>The |ClassEscape| productions evaluate as follows:</p>
@@ -31584,7 +30345,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.2.3" -->
     <emu-clause id="sec-regexp-constructor">
       <h1>The RegExp Constructor</h1>
       <p>The RegExp constructor:</p>
@@ -31595,7 +30355,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behaviour must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</li>
       </ul>
 
-      <!-- es6num="21.2.3.1" -->
       <emu-clause id="sec-regexp-pattern-flags">
         <h1>RegExp ( _pattern_, _flags_ )</h1>
         <p>The following steps are taken:</p>
@@ -31627,11 +30386,9 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.3.2" -->
       <emu-clause id="sec-abstract-operations-for-the-regexp-constructor">
         <h1>Abstract Operations for the RegExp Constructor</h1>
 
-        <!-- es6num="21.2.3.2.1" -->
         <emu-clause id="sec-regexpalloc" aoid="RegExpAlloc">
           <h1>Runtime Semantics: RegExpAlloc ( _newTarget_ )</h1>
           <p>When the abstract operation RegExpAlloc with argument _newTarget_ is called, the following steps are taken:</p>
@@ -31642,7 +30399,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="21.2.3.2.2" -->
         <emu-clause id="sec-regexpinitialize" aoid="RegExpInitialize">
           <h1>Runtime Semantics: RegExpInitialize ( _obj_, _pattern_, _flags_ )</h1>
           <p>When the abstract operation RegExpInitialize with arguments _obj_, _pattern_, and _flags_ is called, the following steps are taken:</p>
@@ -31667,7 +30423,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="21.2.3.2.3" -->
         <emu-clause id="sec-regexpcreate" aoid="RegExpCreate">
           <h1>Runtime Semantics: RegExpCreate ( _P_, _F_ )</h1>
           <p>When the abstract operation RegExpCreate with arguments _P_ and _F_ is called, the following steps are taken:</p>
@@ -31677,7 +30432,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="21.2.3.2.4" -->
         <emu-clause id="sec-escaperegexppattern" aoid="EscapeRegExpPattern">
           <h1>Runtime Semantics: EscapeRegExpPattern ( _P_, _F_ )</h1>
           <p>When the abstract operation EscapeRegExpPattern with arguments _P_ and _F_ is called, the following occurs:</p>
@@ -31690,7 +30444,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.2.4" -->
     <emu-clause id="sec-properties-of-the-regexp-constructor">
       <h1>Properties of the RegExp Constructor</h1>
       <p>The RegExp constructor:</p>
@@ -31699,14 +30452,12 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="21.2.4.1" -->
       <emu-clause id="sec-regexp.prototype">
         <h1>RegExp.prototype</h1>
         <p>The initial value of `RegExp.prototype` is the intrinsic object %RegExpPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="21.2.4.2" -->
       <emu-clause id="sec-get-regexp-@@species">
         <h1>get RegExp [ @@species ]</h1>
         <p>`RegExp[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -31720,7 +30471,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.2.5" -->
     <emu-clause id="sec-properties-of-the-regexp-prototype-object">
       <h1>Properties of the RegExp Prototype Object</h1>
       <p>The RegExp prototype object:</p>
@@ -31734,13 +30484,11 @@ THH:mm:ss.sss
         <p>The RegExp prototype object does not have a `valueOf` property of its own; however, it inherits the `valueOf` property from the Object prototype object.</p>
       </emu-note>
 
-      <!-- es6num="21.2.5.1" -->
       <emu-clause id="sec-regexp.prototype.constructor">
         <h1>RegExp.prototype.constructor</h1>
         <p>The initial value of `RegExp.prototype.constructor` is the intrinsic object %RegExp%.</p>
       </emu-clause>
 
-      <!-- es6num="21.2.5.2" -->
       <emu-clause id="sec-regexp.prototype.exec">
         <h1>RegExp.prototype.exec ( _string_ )</h1>
         <p>Performs a regular expression match of _string_ against the regular expression and returns an Array object containing the results of the match, or *null* if _string_ did not match.</p>
@@ -31753,7 +30501,6 @@ THH:mm:ss.sss
           1. Return ? RegExpBuiltinExec(_R_, _S_).
         </emu-alg>
 
-        <!-- es6num="21.2.5.2.1" -->
         <emu-clause id="sec-regexpexec" aoid="RegExpExec">
           <h1>Runtime Semantics: RegExpExec ( _R_, _S_ )</h1>
           <p>The abstract operation RegExpExec with arguments _R_ and _S_ performs the following steps:</p>
@@ -31773,7 +30520,6 @@ THH:mm:ss.sss
           </emu-note>
         </emu-clause>
 
-        <!-- es6num="21.2.5.2.2" -->
         <emu-clause id="sec-regexpbuiltinexec" aoid="RegExpBuiltinExec">
           <h1>Runtime Semantics: RegExpBuiltinExec ( _R_, _S_ )</h1>
           <p>The abstract operation RegExpBuiltinExec with arguments _R_ and _S_ performs the following steps:</p>
@@ -31839,7 +30585,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="21.2.5.2.3" -->
         <emu-clause id="sec-advancestringindex" aoid="AdvanceStringIndex">
           <h1>AdvanceStringIndex ( _S_, _index_, _unicode_ )</h1>
           <p>The abstract operation AdvanceStringIndex with arguments _S_, _index_, and _unicode_ performs the following steps:</p>
@@ -31874,7 +30619,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.5.3" -->
       <emu-clause id="sec-get-regexp.prototype.flags">
         <h1>get RegExp.prototype.flags</h1>
         <p>`RegExp.prototype.flags` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -31898,7 +30642,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.5.4" -->
       <emu-clause id="sec-get-regexp.prototype.global">
         <h1>get RegExp.prototype.global</h1>
         <p>`RegExp.prototype.global` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -31914,7 +30657,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.5.5" -->
       <emu-clause id="sec-get-regexp.prototype.ignorecase">
         <h1>get RegExp.prototype.ignoreCase</h1>
         <p>`RegExp.prototype.ignoreCase` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -31930,7 +30672,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.5.6" -->
       <emu-clause id="sec-regexp.prototype-@@match">
         <h1>RegExp.prototype [ @@match ] ( _string_ )</h1>
         <p>When the `@@match` method is called with argument _string_, the following steps are taken:</p>
@@ -31967,7 +30708,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.5.7" -->
       <emu-clause id="sec-get-regexp.prototype.multiline">
         <h1>get RegExp.prototype.multiline</h1>
         <p>`RegExp.prototype.multiline` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -31983,7 +30723,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.5.8" -->
       <emu-clause id="sec-regexp.prototype-@@replace">
         <h1>RegExp.prototype [ @@replace ] ( _string_, _replaceValue_ )</h1>
         <p>When the `@@replace` method is called with arguments _string_ and _replaceValue_, the following steps are taken:</p>
@@ -32051,7 +30790,6 @@ THH:mm:ss.sss
         <p>The value of the `name` property of this function is `"[Symbol.replace]"`.</p>
       </emu-clause>
 
-      <!-- es6num="21.2.5.9" -->
       <emu-clause id="sec-regexp.prototype-@@search">
         <h1>RegExp.prototype [ @@search ] ( _string_ )</h1>
         <p>When the @@search method is called with argument _string_, the following steps are taken:</p>
@@ -32075,7 +30813,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.5.10" -->
       <emu-clause id="sec-get-regexp.prototype.source">
         <h1>get RegExp.prototype.source</h1>
         <p>`RegExp.prototype.source` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -32092,7 +30829,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.5.11" -->
       <emu-clause id="sec-regexp.prototype-@@split">
         <h1>RegExp.prototype [ @@split ] ( _string_, _limit_ )</h1>
         <emu-note>
@@ -32163,7 +30899,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.5.12" -->
       <emu-clause id="sec-get-regexp.prototype.sticky">
         <h1>get RegExp.prototype.sticky</h1>
         <p>`RegExp.prototype.sticky` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -32179,7 +30914,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.5.13" -->
       <emu-clause id="sec-regexp.prototype.test">
         <h1>RegExp.prototype.test ( _S_ )</h1>
         <p>The following steps are taken:</p>
@@ -32192,7 +30926,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="21.2.5.14" -->
       <emu-clause id="sec-regexp.prototype.tostring">
         <h1>RegExp.prototype.toString ( )</h1>
         <emu-alg>
@@ -32208,7 +30941,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="21.2.5.15" -->
       <emu-clause id="sec-get-regexp.prototype.unicode">
         <h1>get RegExp.prototype.unicode</h1>
         <p>`RegExp.prototype.unicode` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -32225,7 +30957,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="21.2.6" -->
     <emu-clause id="sec-properties-of-regexp-instances">
       <h1>Properties of RegExp Instances</h1>
       <p>RegExp instances are ordinary objects that inherit properties from the RegExp prototype object. RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and [[OriginalFlags]]. The value of the [[RegExpMatcher]] internal slot is an implementation-dependent representation of the |Pattern| of the RegExp object.</p>
@@ -32234,7 +30965,6 @@ THH:mm:ss.sss
       </emu-note>
       <p>RegExp instances also have the following property:</p>
 
-      <!-- es6num="21.2.6.1" -->
       <emu-clause id="sec-lastindex">
         <h1>lastIndex</h1>
         <p>The value of the `lastIndex` property specifies the String index at which to start the next match. It is coerced to an integer when used (see <emu-xref href="#sec-regexpbuiltinexec"></emu-xref>). This property shall have the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
@@ -32243,16 +30973,13 @@ THH:mm:ss.sss
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="22" -->
 <emu-clause id="sec-indexed-collections">
   <h1>Indexed Collections</h1>
 
-  <!-- es6num="22.1" -->
   <emu-clause id="sec-array-objects">
     <h1>Array Objects</h1>
     <p>Array objects are exotic objects that give special treatment to a certain class of property names. See <emu-xref href="#sec-array-exotic-objects"></emu-xref> for a definition of this special treatment.</p>
 
-    <!-- es6num="22.1.1" -->
     <emu-clause id="sec-array-constructor">
       <h1>The Array Constructor</h1>
       <p>The Array constructor:</p>
@@ -32266,7 +30993,6 @@ THH:mm:ss.sss
         <li>has a `length` property whose value is 1.</li>
       </ul>
 
-      <!-- es6num="22.1.1.1" -->
       <emu-clause id="sec-array-constructor-array">
         <h1>Array ( )</h1>
         <p>This description applies if and only if the Array constructor is called with no arguments.</p>
@@ -32279,7 +31005,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.1.1.2" -->
       <emu-clause id="sec-array-len">
         <h1>Array ( _len_ )</h1>
         <p>This description applies if and only if the Array constructor is called with exactly one argument.</p>
@@ -32301,7 +31026,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.1.1.3" -->
       <emu-clause id="sec-array-items">
         <h1>Array ( ..._items_ )</h1>
         <p>This description applies if and only if the Array constructor is called with at least two arguments.</p>
@@ -32326,7 +31050,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.1.2" -->
     <emu-clause id="sec-properties-of-the-array-constructor">
       <h1>Properties of the Array Constructor</h1>
       <p>The Array constructor:</p>
@@ -32335,7 +31058,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="22.1.2.1" -->
       <emu-clause id="sec-array.from">
         <h1>Array.from ( _items_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
         <p>When the `from` method is called with argument _items_ and optional arguments _mapfn_ and _thisArg_, the following steps are taken:</p>
@@ -32396,7 +31118,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.2.2" -->
       <emu-clause id="sec-array.isarray">
         <h1>Array.isArray ( _arg_ )</h1>
         <p>The `isArray` function takes one argument _arg_, and performs the following steps:</p>
@@ -32405,7 +31126,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.1.2.3" -->
       <emu-clause id="sec-array.of">
         <h1>Array.of ( ..._items_ )</h1>
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
@@ -32434,14 +31154,12 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.2.4" -->
       <emu-clause id="sec-array.prototype">
         <h1>Array.prototype</h1>
         <p>The value of `Array.prototype` is %ArrayPrototype%, the intrinsic Array prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="22.1.2.5" -->
       <emu-clause id="sec-get-array-@@species">
         <h1>get Array [ @@species ]</h1>
         <p>`Array[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -32455,7 +31173,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.1.3" -->
     <emu-clause id="sec-properties-of-the-array-prototype-object">
       <h1>Properties of the Array Prototype Object</h1>
       <p>The Array prototype object:</p>
@@ -32469,7 +31186,6 @@ THH:mm:ss.sss
         <p>The Array prototype object is specified to be an Array exotic object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
       </emu-note>
 
-      <!-- es6num="22.1.3.1" -->
       <emu-clause id="sec-array.prototype.concat">
         <h1>Array.prototype.concat ( ..._arguments_ )</h1>
         <p>When the `concat` method is called with zero or more arguments, it returns an array containing the array elements of the object followed by the array elements of each argument in order.</p>
@@ -32509,7 +31225,6 @@ THH:mm:ss.sss
           <p>The `concat` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <!-- es6num="22.1.3.1.1" -->
         <emu-clause id="sec-isconcatspreadable" aoid="IsConcatSpreadable">
           <h1>Runtime Semantics: IsConcatSpreadable ( _O_ )</h1>
           <p>The abstract operation IsConcatSpreadable with argument _O_ performs the following steps:</p>
@@ -32522,13 +31237,11 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="22.1.3.2" -->
       <emu-clause id="sec-array.prototype.constructor">
         <h1>Array.prototype.constructor</h1>
         <p>The initial value of `Array.prototype.constructor` is the intrinsic object %Array%.</p>
       </emu-clause>
 
-      <!-- es6num="22.1.3.3" -->
       <emu-clause id="sec-array.prototype.copywithin">
         <h1>Array.prototype.copyWithin ( _target_, _start_ [ , _end_ ] )</h1>
         <p>The `copyWithin` method takes up to three arguments _target_, _start_ and _end_.</p>
@@ -32571,7 +31284,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.4" -->
       <emu-clause id="sec-array.prototype.entries">
         <h1>Array.prototype.entries ( )</h1>
         <p>The following steps are taken:</p>
@@ -32582,7 +31294,6 @@ THH:mm:ss.sss
         <p>This function is the <dfn>%ArrayProto_entries%</dfn> intrinsic object.</p>
       </emu-clause>
 
-      <!-- es6num="22.1.3.5" -->
       <emu-clause id="sec-array.prototype.every">
         <h1>Array.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
@@ -32614,7 +31325,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.6" -->
       <emu-clause id="sec-array.prototype.fill">
         <h1>Array.prototype.fill ( _value_ [ , _start_ [ , _end_ ] ] )</h1>
         <p>The `fill` method takes up to three arguments _value_, _start_ and _end_.</p>
@@ -32640,7 +31350,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.7" -->
       <emu-clause id="sec-array.prototype.filter">
         <h1>Array.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
@@ -32676,7 +31385,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.8" -->
       <emu-clause id="sec-array.prototype.find">
         <h1>Array.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>The `find` method is called with one or two arguments, _predicate_ and _thisArg_.</p>
@@ -32707,7 +31415,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.9" -->
       <emu-clause id="sec-array.prototype.findindex">
         <h1>Array.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
         <emu-note>
@@ -32737,7 +31444,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.10" -->
       <emu-clause id="sec-array.prototype.foreach">
         <h1>Array.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
@@ -32805,7 +31511,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.11" -->
       <emu-clause id="sec-array.prototype.indexof">
         <h1>Array.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
@@ -32838,7 +31543,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.12" -->
       <emu-clause id="sec-array.prototype.join">
         <h1>Array.prototype.join ( _separator_ )</h1>
         <emu-note>
@@ -32865,7 +31569,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.13" -->
       <emu-clause id="sec-array.prototype.keys">
         <h1>Array.prototype.keys ( )</h1>
         <p>The following steps are taken:</p>
@@ -32876,7 +31579,6 @@ THH:mm:ss.sss
         <p>This function is the <dfn>%ArrayProto_keys%</dfn> intrinsic object.</p>
       </emu-clause>
 
-      <!-- es6num="22.1.3.14" -->
       <emu-clause id="sec-array.prototype.lastindexof">
         <h1>Array.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
@@ -32907,7 +31609,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.15" -->
       <emu-clause id="sec-array.prototype.map">
         <h1>Array.prototype.map ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
@@ -32940,7 +31641,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.16" -->
       <emu-clause id="sec-array.prototype.pop">
         <h1>Array.prototype.pop ( )</h1>
         <emu-note>
@@ -32966,7 +31666,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.17" -->
       <emu-clause id="sec-array.prototype.push">
         <h1>Array.prototype.push ( ..._items_ )</h1>
         <emu-note>
@@ -32992,7 +31691,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.18" -->
       <emu-clause id="sec-array.prototype.reduce">
         <h1>Array.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <emu-note>
@@ -33034,7 +31732,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.19" -->
       <emu-clause id="sec-array.prototype.reduceright">
         <h1>Array.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <emu-note>
@@ -33076,7 +31773,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.20" -->
       <emu-clause id="sec-array.prototype.reverse">
         <h1>Array.prototype.reverse ( )</h1>
         <emu-note>
@@ -33117,7 +31813,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.21" -->
       <emu-clause id="sec-array.prototype.shift">
         <h1>Array.prototype.shift ( )</h1>
         <emu-note>
@@ -33151,7 +31846,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.22" -->
       <emu-clause id="sec-array.prototype.slice">
         <h1>Array.prototype.slice ( _start_, _end_ )</h1>
         <emu-note>
@@ -33187,7 +31881,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.23" -->
       <emu-clause id="sec-array.prototype.some">
         <h1>Array.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
@@ -33219,7 +31912,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.24" -->
       <emu-clause id="sec-array.prototype.sort">
         <h1>Array.prototype.sort ( _comparefn_ )</h1>
         <p>The elements of this array are sorted. The sort is not necessarily stable (that is, elements that compare equal do not necessarily remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative value if _x_ &lt; _y_, zero if _x_ = _y_, or a positive value if _x_ &gt; _y_.</p>
@@ -33325,7 +32017,6 @@ THH:mm:ss.sss
           <p>The `sort` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
-        <!-- es6num="22.1.3.24.1" -->
         <emu-clause id="sec-sortcompare" aoid="SortCompare">
           <h1>Runtime Semantics: SortCompare ( _x_, _y_ )</h1>
           <p>The SortCompare abstract operation is called with two arguments _x_ and _y_. It also has access to the _comparefn_ argument passed to the current invocation of the `sort` method. The following steps are taken:</p>
@@ -33354,7 +32045,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="22.1.3.25" -->
       <emu-clause id="sec-array.prototype.splice">
         <h1>Array.prototype.splice ( _start_, _deleteCount_, ..._items_ )</h1>
         <emu-note>
@@ -33433,7 +32123,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.26" -->
       <emu-clause id="sec-array.prototype.tolocalestring">
         <h1>Array.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Array.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
@@ -33466,7 +32155,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.27" -->
       <emu-clause id="sec-array.prototype.tostring">
         <h1>Array.prototype.toString ( )</h1>
         <p>When the `toString` method is called, the following steps are taken:</p>
@@ -33481,7 +32169,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.28" -->
       <emu-clause id="sec-array.prototype.unshift">
         <h1>Array.prototype.unshift ( ..._items_ )</h1>
         <emu-note>
@@ -33520,7 +32207,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.1.3.29" -->
       <emu-clause id="sec-array.prototype.values">
         <h1>Array.prototype.values ( )</h1>
         <p>The following steps are taken:</p>
@@ -33531,13 +32217,11 @@ THH:mm:ss.sss
         <p>This function is the <dfn>%ArrayProto_values%</dfn> intrinsic object.</p>
       </emu-clause>
 
-      <!-- es6num="22.1.3.30" -->
       <emu-clause id="sec-array.prototype-@@iterator">
         <h1>Array.prototype [ @@iterator ] ( )</h1>
         <p>The initial value of the @@iterator property is the same function object as the initial value of the `Array.prototype.values` property.</p>
       </emu-clause>
 
-      <!-- es6num="22.1.3.31" -->
       <emu-clause id="sec-array.prototype-@@unscopables">
         <h1>Array.prototype [ @@unscopables ]</h1>
         <p>The initial value of the @@unscopables data property is an object created by the following steps:</p>
@@ -33561,13 +32245,11 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.1.4" -->
     <emu-clause id="sec-properties-of-array-instances">
       <h1>Properties of Array Instances</h1>
       <p>Array instances are Array exotic objects and have the internal methods specified for such objects. Array instances inherit properties from the Array prototype object.</p>
       <p>Array instances have a `length` property, and a set of enumerable properties with array index names.</p>
 
-      <!-- es6num="22.1.4.1" -->
       <emu-clause id="sec-properties-of-array-instances-length">
         <h1>length</h1>
         <p>The `length` property of an Array instance is a data property whose value is always numerically greater than the name of every configurable own property whose name is an array index.</p>
@@ -33578,12 +32260,10 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.1.5" -->
     <emu-clause id="sec-array-iterator-objects">
       <h1>Array Iterator Objects</h1>
       <p>An Array Iterator is an object, that represents a specific iteration over some specific Array instance object. There is not a named constructor for Array Iterator objects. Instead, Array iterator objects are created by calling certain methods of Array instance objects.</p>
 
-      <!-- es6num="22.1.5.1" -->
       <emu-clause id="sec-createarrayiterator" aoid="CreateArrayIterator">
         <h1>CreateArrayIterator ( _array_, _kind_ )</h1>
         <p>Several methods of Array objects return Iterator objects. The abstract operation CreateArrayIterator with arguments _array_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
@@ -33597,7 +32277,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.1.5.2" -->
       <emu-clause id="sec-%arrayiteratorprototype%-object">
         <h1>The %ArrayIteratorPrototype% Object</h1>
         <p>The <dfn>%ArrayIteratorPrototype%</dfn> object:</p>
@@ -33608,7 +32287,6 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <!-- es6num="22.1.5.2.1" -->
         <emu-clause id="sec-%arrayiteratorprototype%.next">
           <h1>%ArrayIteratorPrototype%.next ( )</h1>
           <emu-alg>
@@ -33639,7 +32317,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="22.1.5.2.2" -->
         <emu-clause id="sec-%arrayiteratorprototype%-@@tostringtag">
           <h1>%ArrayIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value `"Array Iterator"`.</p>
@@ -33647,7 +32324,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="22.1.5.3" -->
       <emu-clause id="sec-properties-of-array-iterator-instances">
         <h1>Properties of Array Iterator Instances</h1>
         <p>Array Iterator instances are ordinary objects that inherit properties from the %ArrayIteratorPrototype% intrinsic object. Array Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-48"></emu-xref>.</p>
@@ -33693,7 +32369,6 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="22.2" -->
   <emu-clause id="sec-typedarray-objects">
     <h1>TypedArray Objects</h1>
     <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). Each element of a _TypedArray_ instance has the same underlying binary scalar data type. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-49"></emu-xref>, for each of the nine supported element types. Each constructor in <emu-xref href="#table-49"></emu-xref> has a corresponding distinct prototype object.</p>
@@ -33921,7 +32596,6 @@ THH:mm:ss.sss
     </emu-table>
     <p>In the definitions below, references to _TypedArray_ should be replaced with the appropriate constructor name from the above table. The phrase &ldquo;the element size in bytes&rdquo; refers to the value in the Element Size column of the table in the row corresponding to the constructor. The phrase &ldquo;element Type&rdquo; refers to the value in the Element Type column for that row.</p>
 
-    <!-- es6num="22.2.1" -->
     <emu-clause id="sec-%typedarray%-intrinsic-object">
       <h1>The %TypedArray% Intrinsic Object</h1>
       <p>The <dfn>%TypedArray%</dfn> intrinsic object:</p>
@@ -33933,7 +32607,6 @@ THH:mm:ss.sss
         <li>will throw an error when invoked, because it is an abstract class constructor. The _TypedArray_ constructors do not perform a `super` call to it.</li>
       </ul>
 
-      <!-- es6num="22.2.4.1" -->
       <emu-clause id="sec-%typedarray%">
         <h1>%TypedArray% ( )</h1>
         <p>The %TypedArray% constructor performs the following steps:</p>
@@ -33945,7 +32618,6 @@ THH:mm:ss.sss
     </emu-clause>
 
 
-    <!-- es6num="22.2.2" -->
     <emu-clause id="sec-properties-of-the-%typedarray%-intrinsic-object">
       <h1>Properties of the %TypedArray% Intrinsic Object</h1>
       <p>The %TypedArray% intrinsic object:</p>
@@ -33955,7 +32627,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="22.2.2.1" -->
       <emu-clause id="sec-%typedarray%.from">
         <h1>%TypedArray%.from ( _source_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
         <p>When the `from` method is called with argument _source_, and optional arguments _mapfn_ and _thisArg_, the following steps are taken:</p>
@@ -34016,7 +32687,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="22.2.2.2" -->
       <emu-clause id="sec-%typedarray%.of">
         <h1>%TypedArray%.of ( ..._items_ )</h1>
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
@@ -34039,14 +32709,12 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.2.2.3" -->
       <emu-clause id="sec-%typedarray%.prototype">
         <h1>%TypedArray%.prototype</h1>
         <p>The initial value of %TypedArray%.prototype is the %TypedArrayPrototype% intrinsic object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.2.4" -->
       <emu-clause id="sec-get-%typedarray%-@@species">
         <h1>get %TypedArray% [ @@species ]</h1>
         <p>%TypedArray%[@@species] is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -34060,7 +32728,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.2.3" -->
     <emu-clause id="sec-properties-of-the-%typedarrayprototype%-object">
       <h1>Properties of the %TypedArrayPrototype% Object</h1>
       <p>The <dfn>%TypedArrayPrototype%</dfn> object:</p>
@@ -34070,7 +32737,6 @@ THH:mm:ss.sss
         <li>does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</li>
       </ul>
 
-      <!-- es6num="22.2.3.1" -->
       <emu-clause id="sec-get-%typedarray%.prototype.buffer">
         <h1>get %TypedArray%.prototype.buffer</h1>
         <p>%TypedArray%.`prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -34084,7 +32750,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.3.2" -->
       <emu-clause id="sec-get-%typedarray%.prototype.bytelength">
         <h1>get %TypedArray%.prototype.byteLength</h1>
         <p>%TypedArray%.`prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -34100,7 +32765,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.3.3" -->
       <emu-clause id="sec-get-%typedarray%.prototype.byteoffset">
         <h1>get %TypedArray%.prototype.byteOffset</h1>
         <p>%TypedArray%.`prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -34116,13 +32780,11 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.3.4" -->
       <emu-clause id="sec-%typedarray%.prototype.constructor">
         <h1>%TypedArray%.prototype.constructor</h1>
         <p>The initial value of %TypedArray%.prototype.constructor is the %TypedArray% intrinsic object.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.5" -->
       <emu-clause id="sec-%typedarray%.prototype.copywithin">
         <h1>%TypedArray%.prototype.copyWithin ( _target_, _start_ [ , _end_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.copyWithin` are the same as for `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref>.</p>
@@ -34163,7 +32825,6 @@ THH:mm:ss.sss
           1. Return _O_.
         </emu-alg>
 
-        <!-- es6num="22.2.3.5.1" -->
         <emu-clause id="sec-validatetypedarray" aoid="ValidateTypedArray">
           <h1>Runtime Semantics: ValidateTypedArray ( _O_ )</h1>
           <p>When called with argument _O_, the following steps are taken:</p>
@@ -34178,7 +32839,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="22.2.3.6" -->
       <emu-clause id="sec-%typedarray%.prototype.entries">
         <h1>%TypedArray%.prototype.entries ( )</h1>
         <p>The following steps are taken:</p>
@@ -34189,14 +32849,12 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.3.7" -->
       <emu-clause id="sec-%typedarray%.prototype.every">
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.8" -->
       <emu-clause id="sec-%typedarray%.prototype.fill">
         <h1>%TypedArray%.prototype.fill ( _value_ [ , _start_ [ , _end_ ] ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.fill` are the same as for `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref>.</p>
@@ -34219,7 +32877,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.3.9" -->
       <emu-clause id="sec-%typedarray%.prototype.filter">
         <h1>%TypedArray%.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.filter` are the same as for `Array.prototype.filter` as defined in <emu-xref href="#sec-array.prototype.filter"></emu-xref>.</p>
@@ -34251,21 +32908,18 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.10" -->
       <emu-clause id="sec-%typedarray%.prototype.find">
         <h1>%TypedArray%.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.11" -->
       <emu-clause id="sec-%typedarray%.prototype.findindex">
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.12" -->
       <emu-clause id="sec-%typedarray%.prototype.foreach">
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
@@ -34278,21 +32932,18 @@ THH:mm:ss.sss
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.13" -->
       <emu-clause id="sec-%typedarray%.prototype.indexof">
         <h1>%TypedArray%.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.14" -->
       <emu-clause id="sec-%typedarray%.prototype.join">
         <h1>%TypedArray%.prototype.join ( _separator_ )</h1>
         <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.15" -->
       <emu-clause id="sec-%typedarray%.prototype.keys">
         <h1>%TypedArray%.prototype.keys ( )</h1>
         <p>The following steps are taken:</p>
@@ -34303,14 +32954,12 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.3.16" -->
       <emu-clause id="sec-%typedarray%.prototype.lastindexof">
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.17" -->
       <emu-clause id="sec-get-%typedarray%.prototype.length">
         <h1>get %TypedArray%.prototype.length</h1>
         <p>%TypedArray%.`prototype.length` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -34327,7 +32976,6 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.18" -->
       <emu-clause id="sec-%typedarray%.prototype.map">
         <h1>%TypedArray%.prototype.map ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.map` are the same as for `Array.prototype.map` as defined in <emu-xref href="#sec-array.prototype.map"></emu-xref>.</p>
@@ -34351,34 +32999,29 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.19" -->
       <emu-clause id="sec-%typedarray%.prototype.reduce">
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.20" -->
       <emu-clause id="sec-%typedarray%.prototype.reduceright">
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.21" -->
       <emu-clause id="sec-%typedarray%.prototype.reverse">
         <h1>%TypedArray%.prototype.reverse ( )</h1>
         <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.22" -->
       <emu-clause id="sec-%typedarray%.prototype.set-overloaded-offset">
         <h1>%TypedArray%.prototype.set ( _overloaded_ [ , _offset_ ] )</h1>
         <p>%TypedArray%`.prototype.set` is a single function whose behaviour is overloaded based upon the type of its first argument.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
 
-        <!-- es6num="22.2.3.22.1" -->
         <emu-clause id="sec-%typedarray%.prototype.set-array-offset">
           <h1>%TypedArray%.prototype.set ( _array_ [ , _offset_ ] )</h1>
           <p>Sets multiple values in this _TypedArray_, reading the values from the object _array_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
@@ -34414,7 +33057,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="22.2.3.22.2" -->
         <emu-clause id="sec-%typedarray%.prototype.set-typedarray-offset">
           <h1>%TypedArray%.prototype.set ( _typedArray_ [ , _offset_ ] )</h1>
           <p>Sets multiple values in this _TypedArray_, reading the values from the _typedArray_ argument object. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
@@ -34470,7 +33112,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="22.2.3.23" -->
       <emu-clause id="sec-%typedarray%.prototype.slice">
         <h1>%TypedArray%.prototype.slice ( _start_, _end_ )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.slice` are the same as for `Array.prototype.slice` as defined in <emu-xref href="#sec-array.prototype.slice"></emu-xref>. The following steps are taken:</p>
@@ -34516,14 +33157,12 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.24" -->
       <emu-clause id="sec-%typedarray%.prototype.some">
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.25" -->
       <emu-clause id="sec-%typedarray%.prototype.sort">
         <h1>%TypedArray%.prototype.sort ( _comparefn_ )</h1>
         <p>%TypedArray%`.prototype.sort` is a distinct function that, except as described below, implements the same requirements as those of `Array.prototype.sort` as defined in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. The implementation of the %TypedArray%`.prototype.sort` specification may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. The only internal methods of the *this* object that the algorithm may call are [[Get]] and [[Set]].</p>
@@ -34559,7 +33198,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.2.3.26" -->
       <emu-clause id="sec-%typedarray%.prototype.subarray">
         <h1>%TypedArray%.prototype.subarray ( _begin_, _end_ )</h1>
         <p>Returns a new _TypedArray_ object whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
@@ -34585,7 +33223,6 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.27" -->
       <emu-clause id="sec-%typedarray%.prototype.tolocalestring">
         <h1>%TypedArray%.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
@@ -34595,13 +33232,11 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="22.2.3.28" -->
       <emu-clause id="sec-%typedarray%.prototype.tostring">
         <h1>%TypedArray%.prototype.toString ( )</h1>
         <p>The initial value of the %TypedArray%`.prototype.toString` data property is the same built-in function object as the `Array.prototype.toString` method defined in <emu-xref href="#sec-array.prototype.tostring"></emu-xref>.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.29" -->
       <emu-clause id="sec-%typedarray%.prototype.values">
         <h1>%TypedArray%.prototype.values ( )</h1>
         <p>The following steps are taken:</p>
@@ -34612,13 +33247,11 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.3.30" -->
       <emu-clause id="sec-%typedarray%.prototype-@@iterator">
         <h1>%TypedArray%.prototype [ @@iterator ] ( )</h1>
         <p>The initial value of the @@iterator property is the same function object as the initial value of the %TypedArray%`.prototype.values` property.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.3.31" -->
       <emu-clause id="sec-get-%typedarray%.prototype-@@tostringtag">
         <h1>get %TypedArray%.prototype [ @@toStringTag ]</h1>
         <p>%TypedArray%.`prototype[@@toStringTag]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -34635,7 +33268,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.2.4" -->
     <emu-clause id="sec-typedarray-constructors">
       <h1>The _TypedArray_ Constructors</h1>
       <p>Each _TypedArray_ constructor:</p>
@@ -34647,7 +33279,6 @@ THH:mm:ss.sss
         <li>has a `length` property whose value is 3.</li>
       </ul>
 
-      <!-- es6num="22.2.4.1" -->
       <emu-clause id="sec-typedarray">
         <h1>_TypedArray_ ( )</h1>
         <p>This description applies only if the _TypedArray_ function is called with no arguments.</p>
@@ -34658,7 +33289,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.1.2" -->
       <emu-clause id="sec-typedarray-length">
         <h1>_TypedArray_ ( _length_ )</h1>
         <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is not Object.</p>
@@ -34671,7 +33301,6 @@ THH:mm:ss.sss
           1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>, _elementLength_).
         </emu-alg>
 
-        <!-- es6num="22.2.1.2.1" -->
         <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
           <h1>Runtime Semantics: AllocateTypedArray ( _constructorName_, _newTarget_, _defaultProto_ [ , _length_ ] )</h1>
           <p>The abstract operation AllocateTypedArray with arguments _constructorName_, _newTarget_, _defaultProto_ and optional argument _length_ is used to validate and create an instance of a TypedArray constructor. _constructorName_ is required to be the name of a TypedArray constructor in <emu-xref href="#table-49"></emu-xref>. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypedArray_ overloads. AllocateTypedArray performs the following steps:</p>
@@ -34710,7 +33339,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="22.2.1.3" -->
       <emu-clause id="sec-typedarray-typedarray">
         <h1>_TypedArray_ ( _typedArray_ )</h1>
         <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object has a [[TypedArrayName]] internal slot.</p>
@@ -34758,7 +33386,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.1.4" -->
       <emu-clause id="sec-typedarray-object">
         <h1>_TypedArray_ ( _object_ )</h1>
         <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.</p>
@@ -34795,7 +33422,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="22.2.1.5" -->
       <emu-clause id="sec-typedarray-buffer-byteoffset-length">
         <h1>_TypedArray_ ( _buffer_ [ , _byteOffset_ [ , _length_ ] ] )</h1>
         <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object has an [[ArrayBufferData]] internal slot.</p>
@@ -34851,7 +33477,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.2.5" -->
     <emu-clause id="sec-properties-of-the-typedarray-constructors">
       <h1>Properties of the _TypedArray_ Constructors</h1>
       <p>Each _TypedArray_ constructor:</p>
@@ -34861,14 +33486,12 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="22.2.5.1" -->
       <emu-clause id="sec-typedarray.bytes_per_element">
         <h1>_TypedArray_.BYTES_PER_ELEMENT</h1>
         <p>The value of _TypedArray_.BYTES_PER_ELEMENT is the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.5.2" -->
       <emu-clause id="sec-typedarray.prototype">
         <h1>_TypedArray_.prototype</h1>
         <p>The initial value of _TypedArray_.prototype is the corresponding _TypedArray_ prototype intrinsic object (<emu-xref href="#sec-properties-of-typedarray-prototype-objects"></emu-xref>).</p>
@@ -34876,7 +33499,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.2.6" -->
     <emu-clause id="sec-properties-of-typedarray-prototype-objects">
       <h1>Properties of the _TypedArray_ Prototype Objects</h1>
       <p>Each _TypedArray_ prototype object:</p>
@@ -34886,21 +33508,18 @@ THH:mm:ss.sss
         <li>does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</li>
       </ul>
 
-      <!-- es6num="22.2.6.1" -->
       <emu-clause id="sec-typedarray.prototype.bytes_per_element">
         <h1>_TypedArray_.prototype.BYTES_PER_ELEMENT</h1>
         <p>The value of <code><var>TypedArray</var>.prototype.BYTES_PER_ELEMENT</code> is the Number value of the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="22.2.6.2" -->
       <emu-clause id="sec-typedarray.prototype.constructor">
         <h1>_TypedArray_.prototype.constructor</h1>
         <p>The initial value of a <code><var>TypedArray</var>.prototype.constructor</code> is the corresponding %_TypedArray_% intrinsic object.</p>
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="22.2.7" -->
     <emu-clause id="sec-properties-of-typedarray-instances">
       <h1>Properties of _TypedArray_ Instances</h1>
       <p>_TypedArray_ instances are <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>. Each _TypedArray_ instance inherits properties from the corresponding _TypedArray_ prototype object. Each _TypedArray_ instance has the following internal slots: [[TypedArrayName]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]].</p>
@@ -34908,17 +33527,14 @@ THH:mm:ss.sss
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="23" -->
 <emu-clause id="sec-keyed-collections" oldids="sec-keyed-collection">
   <h1>Keyed Collections</h1>
 
-  <!-- es6num="23.1" -->
   <emu-clause id="sec-map-objects">
     <h1>Map Objects</h1>
     <p>Map objects are collections of key/value pairs where both the keys and values may be arbitrary ECMAScript language values. A distinct key value may only occur in one key/value pair within the Map's collection. Distinct key values are discriminated using the SameValueZero comparison algorithm.</p>
     <p>Map object must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structures used in this Map objects specification is only intended to describe the required observable semantics of Map objects. It is not intended to be a viable implementation model.</p>
 
-    <!-- es6num="23.1.1" -->
     <emu-clause id="sec-map-constructor">
       <h1>The Map Constructor</h1>
       <p>The Map constructor:</p>
@@ -34930,7 +33546,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behaviour must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
       </ul>
 
-      <!-- es6num="23.1.1.1" -->
       <emu-clause id="sec-map-iterable">
         <h1>Map ( [ _iterable_ ] )</h1>
         <p>When the `Map` function is called with optional argument, the following steps are taken:</p>
@@ -34963,7 +33578,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.1.2" -->
     <emu-clause id="sec-properties-of-the-map-constructor">
       <h1>Properties of the Map Constructor</h1>
       <p>The Map constructor:</p>
@@ -34972,14 +33586,12 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="23.1.2.1" -->
       <emu-clause id="sec-map.prototype">
         <h1>Map.prototype</h1>
         <p>The initial value of `Map.prototype` is the intrinsic object %MapPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="23.1.2.2" -->
       <emu-clause id="sec-get-map-@@species">
         <h1>get Map [ @@species ]</h1>
         <p>`Map[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -34993,7 +33605,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.1.3" -->
     <emu-clause id="sec-properties-of-the-map-prototype-object">
       <h1>Properties of the Map Prototype Object</h1>
       <p>The Map prototype object:</p>
@@ -35004,7 +33615,6 @@ THH:mm:ss.sss
         <li>does not have a [[MapData]] internal slot.</li>
       </ul>
 
-      <!-- es6num="23.1.3.1" -->
       <emu-clause id="sec-map.prototype.clear">
         <h1>Map.prototype.clear ( )</h1>
         <p>The following steps are taken:</p>
@@ -35023,13 +33633,11 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.1.3.2" -->
       <emu-clause id="sec-map.prototype.constructor">
         <h1>Map.prototype.constructor</h1>
         <p>The initial value of `Map.prototype.constructor` is the intrinsic object %Map%.</p>
       </emu-clause>
 
-      <!-- es6num="23.1.3.3" -->
       <emu-clause id="sec-map.prototype.delete">
         <h1>Map.prototype.delete ( _key_ )</h1>
         <p>The following steps are taken:</p>
@@ -35050,7 +33658,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.1.3.4" -->
       <emu-clause id="sec-map.prototype.entries">
         <h1>Map.prototype.entries ( )</h1>
         <p>The following steps are taken:</p>
@@ -35060,7 +33667,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.1.3.5" -->
       <emu-clause id="sec-map.prototype.foreach">
         <h1>Map.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
@@ -35084,7 +33690,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.1.3.6" -->
       <emu-clause id="sec-map.prototype.get">
         <h1>Map.prototype.get ( _key_ )</h1>
         <p>The following steps are taken:</p>
@@ -35099,7 +33704,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.1.3.7" -->
       <emu-clause id="sec-map.prototype.has">
         <h1>Map.prototype.has ( _key_ )</h1>
         <p>The following steps are taken:</p>
@@ -35114,7 +33718,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.1.3.8" -->
       <emu-clause id="sec-map.prototype.keys">
         <h1>Map.prototype.keys ( )</h1>
         <p>The following steps are taken:</p>
@@ -35124,7 +33727,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.1.3.9" -->
       <emu-clause id="sec-map.prototype.set">
         <h1>Map.prototype.set ( _key_, _value_ )</h1>
         <p>The following steps are taken:</p>
@@ -35144,7 +33746,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.1.3.10" -->
       <emu-clause id="sec-get-map.prototype.size">
         <h1>get Map.prototype.size</h1>
         <p>Map.prototype.size is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -35160,7 +33761,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.1.3.11" -->
       <emu-clause id="sec-map.prototype.values">
         <h1>Map.prototype.values ( )</h1>
         <p>The following steps are taken:</p>
@@ -35170,13 +33770,11 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.1.3.12" -->
       <emu-clause id="sec-map.prototype-@@iterator">
         <h1>Map.prototype [ @@iterator ] ( )</h1>
         <p>The initial value of the @@iterator property is the same function object as the initial value of the `entries` property.</p>
       </emu-clause>
 
-      <!-- es6num="23.1.3.13" -->
       <emu-clause id="sec-map.prototype-@@tostringtag">
         <h1>Map.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"Map"`.</p>
@@ -35184,18 +33782,15 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.1.4" -->
     <emu-clause id="sec-properties-of-map-instances">
       <h1>Properties of Map Instances</h1>
       <p>Map instances are ordinary objects that inherit properties from the Map prototype. Map instances also have a [[MapData]] internal slot.</p>
     </emu-clause>
 
-    <!-- es6num="23.1.5" -->
     <emu-clause id="sec-map-iterator-objects">
       <h1>Map Iterator Objects</h1>
       <p>A Map Iterator is an object, that represents a specific iteration over some specific Map instance object. There is not a named constructor for Map Iterator objects. Instead, map iterator objects are created by calling certain methods of Map instance objects.</p>
 
-      <!-- es6num="23.1.5.1" -->
       <emu-clause id="sec-createmapiterator" aoid="CreateMapIterator">
         <h1>CreateMapIterator ( _map_, _kind_ )</h1>
         <p>Several methods of Map objects return Iterator objects. The abstract operation CreateMapIterator with arguments _map_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
@@ -35210,7 +33805,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.1.5.2" -->
       <emu-clause id="sec-%mapiteratorprototype%-object">
         <h1>The %MapIteratorPrototype% Object</h1>
         <p>The <dfn>%MapIteratorPrototype%</dfn> object:</p>
@@ -35221,7 +33815,6 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <!-- es6num="23.1.5.2.1" -->
         <emu-clause id="sec-%mapiteratorprototype%.next">
           <h1>%MapIteratorPrototype%.next ( )</h1>
           <emu-alg>
@@ -35252,7 +33845,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="23.1.5.2.2" -->
         <emu-clause id="sec-%mapiteratorprototype%-@@tostringtag">
           <h1>%MapIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value `"Map Iterator"`.</p>
@@ -35260,7 +33852,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="23.1.5.3" -->
       <emu-clause id="sec-properties-of-map-iterator-instances">
         <h1>Properties of Map Iterator Instances</h1>
         <p>Map Iterator instances are ordinary objects that inherit properties from the %MapIteratorPrototype% intrinsic object. Map Iterator instances are initially created with the internal slots described in <emu-xref href="#table-50"></emu-xref>.</p>
@@ -35306,13 +33897,11 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="23.2" -->
   <emu-clause id="sec-set-objects">
     <h1>Set Objects</h1>
     <p>Set objects are collections of ECMAScript language values. A distinct value may only occur once as an element of a Set's collection. Distinct values are discriminated using the SameValueZero comparison algorithm.</p>
     <p>Set objects must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structures used in this Set objects specification is only intended to describe the required observable semantics of Set objects. It is not intended to be a viable implementation model.</p>
 
-    <!-- es6num="23.2.1" -->
     <emu-clause id="sec-set-constructor">
       <h1>The Set Constructor</h1>
       <p>The Set constructor:</p>
@@ -35324,7 +33913,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behaviour must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
       </ul>
 
-      <!-- es6num="23.2.1.1" -->
       <emu-clause id="sec-set-iterable">
         <h1>Set ( [ _iterable_ ] )</h1>
         <p>When the `Set` function is called with optional argument _iterable_, the following steps are taken:</p>
@@ -35347,7 +33935,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.2.2" -->
     <emu-clause id="sec-properties-of-the-set-constructor">
       <h1>Properties of the Set Constructor</h1>
       <p>The Set constructor:</p>
@@ -35356,14 +33943,12 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="23.2.2.1" -->
       <emu-clause id="sec-set.prototype">
         <h1>Set.prototype</h1>
         <p>The initial value of `Set.prototype` is the intrinsic %SetPrototype% object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="23.2.2.2" -->
       <emu-clause id="sec-get-set-@@species">
         <h1>get Set [ @@species ]</h1>
         <p>`Set[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -35377,7 +33962,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.2.3" -->
     <emu-clause id="sec-properties-of-the-set-prototype-object">
       <h1>Properties of the Set Prototype Object</h1>
       <p>The Set prototype object:</p>
@@ -35388,7 +33972,6 @@ THH:mm:ss.sss
         <li>does not have a [[SetData]] internal slot.</li>
       </ul>
 
-      <!-- es6num="23.2.3.1" -->
       <emu-clause id="sec-set.prototype.add">
         <h1>Set.prototype.add ( _value_ )</h1>
         <p>The following steps are taken:</p>
@@ -35406,7 +33989,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.2.3.2" -->
       <emu-clause id="sec-set.prototype.clear">
         <h1>Set.prototype.clear ( )</h1>
         <p>The following steps are taken:</p>
@@ -35424,13 +34006,11 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.2.3.3" -->
       <emu-clause id="sec-set.prototype.constructor">
         <h1>Set.prototype.constructor</h1>
         <p>The initial value of `Set.prototype.constructor` is the intrinsic object %Set%.</p>
       </emu-clause>
 
-      <!-- es6num="23.2.3.4" -->
       <emu-clause id="sec-set.prototype.delete">
         <h1>Set.prototype.delete ( _value_ )</h1>
         <p>The following steps are taken:</p>
@@ -35450,7 +34030,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.2.3.5" -->
       <emu-clause id="sec-set.prototype.entries">
         <h1>Set.prototype.entries ( )</h1>
         <p>The following steps are taken:</p>
@@ -35463,7 +34042,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.2.3.6" -->
       <emu-clause id="sec-set.prototype.foreach">
         <h1>Set.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
@@ -35489,7 +34067,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.2.3.7" -->
       <emu-clause id="sec-set.prototype.has">
         <h1>Set.prototype.has ( _value_ )</h1>
         <p>The following steps are taken:</p>
@@ -35504,7 +34081,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.2.3.8" -->
       <emu-clause id="sec-set.prototype.keys">
         <h1>Set.prototype.keys ( )</h1>
         <p>The initial value of the `keys` property is the same function object as the initial value of the `values` property.</p>
@@ -35513,7 +34089,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.2.3.9" -->
       <emu-clause id="sec-get-set.prototype.size">
         <h1>get Set.prototype.size</h1>
         <p>`Set.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -35529,7 +34104,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.2.3.10" -->
       <emu-clause id="sec-set.prototype.values">
         <h1>Set.prototype.values ( )</h1>
         <p>The following steps are taken:</p>
@@ -35539,13 +34113,11 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.2.3.11" -->
       <emu-clause id="sec-set.prototype-@@iterator">
         <h1>Set.prototype [ @@iterator ] ( )</h1>
         <p>The initial value of the @@iterator property is the same function object as the initial value of the `values` property.</p>
       </emu-clause>
 
-      <!-- es6num="23.2.3.12" -->
       <emu-clause id="sec-set.prototype-@@tostringtag">
         <h1>Set.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"Set"`.</p>
@@ -35553,18 +34125,15 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.2.4" -->
     <emu-clause id="sec-properties-of-set-instances">
       <h1>Properties of Set Instances</h1>
       <p>Set instances are ordinary objects that inherit properties from the Set prototype. Set instances also have a [[SetData]] internal slot.</p>
     </emu-clause>
 
-    <!-- es6num="23.2.5" -->
     <emu-clause id="sec-set-iterator-objects">
       <h1>Set Iterator Objects</h1>
       <p>A Set Iterator is an ordinary object, with the structure defined below, that represents a specific iteration over some specific Set instance object. There is not a named constructor for Set Iterator objects. Instead, set iterator objects are created by calling certain methods of Set instance objects.</p>
 
-      <!-- es6num="23.2.5.1" -->
       <emu-clause id="sec-createsetiterator" aoid="CreateSetIterator">
         <h1>CreateSetIterator ( _set_, _kind_ )</h1>
         <p>Several methods of Set objects return Iterator objects. The abstract operation CreateSetIterator with arguments _set_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
@@ -35579,7 +34148,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.2.5.2" -->
       <emu-clause id="sec-%setiteratorprototype%-object">
         <h1>The %SetIteratorPrototype% Object</h1>
         <p>The <dfn>%SetIteratorPrototype%</dfn> object:</p>
@@ -35590,7 +34158,6 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <!-- es6num="23.2.5.2.1" -->
         <emu-clause id="sec-%setiteratorprototype%.next">
           <h1>%SetIteratorPrototype%.next ( )</h1>
           <emu-alg>
@@ -35618,7 +34185,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="23.2.5.2.2" -->
         <emu-clause id="sec-%setiteratorprototype%-@@tostringtag">
           <h1>%SetIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value `"Set Iterator"`.</p>
@@ -35626,7 +34192,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="23.2.5.3" -->
       <emu-clause id="sec-properties-of-set-iterator-instances">
         <h1>Properties of Set Iterator Instances</h1>
         <p>Set Iterator instances are ordinary objects that inherit properties from the %SetIteratorPrototype% intrinsic object. Set Iterator instances are initially created with the internal slots specified in <emu-xref href="#table-51"></emu-xref>.</p>
@@ -35672,7 +34237,6 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="23.3" -->
   <emu-clause id="sec-weakmap-objects">
     <h1>WeakMap Objects</h1>
     <p>WeakMap objects are collections of key/value pairs where the keys are objects and values may be arbitrary ECMAScript language values. A WeakMap may be queried to see if it contains a key/value pair with a specific key, but no mechanism is provided for enumerating the objects it holds as keys. If an object that is being used as the key of a WeakMap key/value pair is only reachable by following a chain of references that start within that WeakMap, then that key/value pair is inaccessible and is automatically removed from the WeakMap. WeakMap implementations must detect and remove such key/value pairs and any associated resources.</p>
@@ -35684,7 +34248,6 @@ THH:mm:ss.sss
       <p>Alexandra Barros, Roberto Ierusalimschy, Eliminating Cycles in Weak Tables. Journal of Universal Computer Science - J.UCS, vol. 14, no. 21, pp. 3481-3497, 2008, <a href="http://www.jucs.org/jucs_14_21/eliminating_cycles_in_weak">http://www.jucs.org/jucs_14_21/eliminating_cycles_in_weak</a></p>
     </emu-note>
 
-    <!-- es6num="23.3.1" -->
     <emu-clause id="sec-weakmap-constructor">
       <h1>The WeakMap Constructor</h1>
       <p>The WeakMap constructor:</p>
@@ -35696,7 +34259,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behaviour must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
       </ul>
 
-      <!-- es6num="23.3.1.1" -->
       <emu-clause id="sec-weakmap-iterable">
         <h1>WeakMap ( [ _iterable_ ] )</h1>
         <p>When the `WeakMap` function is called with optional argument _iterable_, the following steps are taken:</p>
@@ -35729,7 +34291,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.3.2" -->
     <emu-clause id="sec-properties-of-the-weakmap-constructor">
       <h1>Properties of the WeakMap Constructor</h1>
       <p>The WeakMap constructor:</p>
@@ -35738,7 +34299,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="23.3.2.1" -->
       <emu-clause id="sec-weakmap.prototype">
         <h1>WeakMap.prototype</h1>
         <p>The initial value of `WeakMap.prototype` is the intrinsic object %WeakMapPrototype%.</p>
@@ -35746,7 +34306,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.3.3" -->
     <emu-clause id="sec-properties-of-the-weakmap-prototype-object">
       <h1>Properties of the WeakMap Prototype Object</h1>
       <p>The WeakMap prototype object:</p>
@@ -35757,13 +34316,11 @@ THH:mm:ss.sss
         <li>does not have a [[WeakMapData]] internal slot.</li>
       </ul>
 
-      <!-- es6num="23.3.3.1" -->
       <emu-clause id="sec-weakmap.prototype.constructor">
         <h1>WeakMap.prototype.constructor</h1>
         <p>The initial value of `WeakMap.prototype.constructor` is the intrinsic object %WeakMap%.</p>
       </emu-clause>
 
-      <!-- es6num="23.3.3.2" -->
       <emu-clause id="sec-weakmap.prototype.delete">
         <h1>WeakMap.prototype.delete ( _key_ )</h1>
         <p>The following steps are taken:</p>
@@ -35785,7 +34342,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.3.3.3" -->
       <emu-clause id="sec-weakmap.prototype.get">
         <h1>WeakMap.prototype.get ( _key_ )</h1>
         <p>The following steps are taken:</p>
@@ -35801,7 +34357,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.3.3.4" -->
       <emu-clause id="sec-weakmap.prototype.has">
         <h1>WeakMap.prototype.has ( _key_ )</h1>
         <p>The following steps are taken:</p>
@@ -35817,7 +34372,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.3.3.5" -->
       <emu-clause id="sec-weakmap.prototype.set">
         <h1>WeakMap.prototype.set ( _key_, _value_ )</h1>
         <p>The following steps are taken:</p>
@@ -35837,7 +34391,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.3.3.6" -->
       <emu-clause id="sec-weakmap.prototype-@@tostringtag">
         <h1>WeakMap.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"WeakMap"`.</p>
@@ -35845,14 +34398,12 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.3.4" -->
     <emu-clause id="sec-properties-of-weakmap-instances">
       <h1>Properties of WeakMap Instances</h1>
       <p>WeakMap instances are ordinary objects that inherit properties from the WeakMap prototype. WeakMap instances also have a [[WeakMapData]] internal slot.</p>
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="23.4" -->
   <emu-clause id="sec-weakset-objects">
     <h1>WeakSet Objects</h1>
     <p>WeakSet objects are collections of objects. A distinct object may only occur once as an element of a WeakSet's collection. A WeakSet may be queried to see if it contains a specific object, but no mechanism is provided for enumerating the objects it holds. If an object that is contained by a WeakSet is only reachable by following a chain of references that start within that WeakSet, then that object is inaccessible and is automatically removed from the WeakSet. WeakSet implementations must detect and remove such objects and any associated resources.</p>
@@ -35862,7 +34413,6 @@ THH:mm:ss.sss
       <p>See the NOTE in <emu-xref href="#sec-weakmap-objects"></emu-xref>.</p>
     </emu-note>
 
-    <!-- es6num="23.4.1" -->
     <emu-clause id="sec-weakset-constructor">
       <h1>The WeakSet Constructor</h1>
       <p>The WeakSet constructor:</p>
@@ -35874,7 +34424,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behaviour must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
       </ul>
 
-      <!-- es6num="23.4.1.1" -->
       <emu-clause id="sec-weakset-iterable">
         <h1>WeakSet ( [ _iterable_ ] )</h1>
         <p>When the `WeakSet` function is called with optional argument _iterable_, the following steps are taken:</p>
@@ -35897,7 +34446,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.4.2" -->
     <emu-clause id="sec-properties-of-the-weakset-constructor">
       <h1>Properties of the WeakSet Constructor</h1>
       <p>The WeakSet constructor:</p>
@@ -35906,7 +34454,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="23.4.2.1" -->
       <emu-clause id="sec-weakset.prototype">
         <h1>WeakSet.prototype</h1>
         <p>The initial value of `WeakSet.prototype` is the intrinsic %WeakSetPrototype% object.</p>
@@ -35914,7 +34461,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.4.3" -->
     <emu-clause id="sec-properties-of-the-weakset-prototype-object">
       <h1>Properties of the WeakSet Prototype Object</h1>
       <p>The WeakSet prototype object:</p>
@@ -35925,7 +34471,6 @@ THH:mm:ss.sss
         <li>does not have a [[WeakSetData]] internal slot.</li>
       </ul>
 
-      <!-- es6num="23.4.3.1" -->
       <emu-clause id="sec-weakset.prototype.add">
         <h1>WeakSet.prototype.add ( _value_ )</h1>
         <p>The following steps are taken:</p>
@@ -35943,13 +34488,11 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.4.3.2" -->
       <emu-clause id="sec-weakset.prototype.constructor">
         <h1>WeakSet.prototype.constructor</h1>
         <p>The initial value of `WeakSet.prototype.constructor` is the %WeakSet% intrinsic object.</p>
       </emu-clause>
 
-      <!-- es6num="23.4.3.3" -->
       <emu-clause id="sec-weakset.prototype.delete">
         <h1>WeakSet.prototype.delete ( _value_ )</h1>
         <p>The following steps are taken:</p>
@@ -35970,7 +34513,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="23.4.3.4" -->
       <emu-clause id="sec-weakset.prototype.has">
         <h1>WeakSet.prototype.has ( _value_ )</h1>
         <p>The following steps are taken:</p>
@@ -35986,7 +34528,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="23.4.3.5" -->
       <emu-clause id="sec-weakset.prototype-@@tostringtag">
         <h1>WeakSet.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"WeakSet"`.</p>
@@ -35994,7 +34535,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="23.4.4" -->
     <emu-clause id="sec-properties-of-weakset-instances">
       <h1>Properties of WeakSet Instances</h1>
       <p>WeakSet instances are ordinary objects that inherit properties from the WeakSet prototype. WeakSet instances also have a [[WeakSetData]] internal slot.</p>
@@ -36002,19 +34542,15 @@ THH:mm:ss.sss
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="24" -->
 <emu-clause id="sec-structured-data">
   <h1>Structured Data</h1>
 
-  <!-- es6num="24.1" -->
   <emu-clause id="sec-arraybuffer-objects">
     <h1>ArrayBuffer Objects</h1>
 
-    <!-- es6num="24.1.1" -->
     <emu-clause id="sec-abstract-operations-for-arraybuffer-objects">
       <h1>Abstract Operations For ArrayBuffer Objects</h1>
 
-      <!-- es6num="24.1.1.1" -->
       <emu-clause id="sec-allocatearraybuffer" aoid="AllocateArrayBuffer">
         <h1>AllocateArrayBuffer ( _constructor_, _byteLength_ )</h1>
         <p>The abstract operation AllocateArrayBuffer with arguments _constructor_ and _byteLength_ is used to create an ArrayBuffer object. It performs the following steps:</p>
@@ -36028,7 +34564,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.1.2" -->
       <emu-clause id="sec-isdetachedbuffer" aoid="IsDetachedBuffer">
         <h1>IsDetachedBuffer ( _arrayBuffer_ )</h1>
         <p>The abstract operation IsDetachedBuffer with argument _arrayBuffer_ performs the following steps:</p>
@@ -36039,7 +34574,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.1.3" -->
       <emu-clause id="sec-detacharraybuffer" aoid="DetachArrayBuffer">
         <h1>DetachArrayBuffer ( _arrayBuffer_ [ , _key_ ] )</h1>
         <p>The abstract operation DetachArrayBuffer with argument _arrayBuffer_ and optional argument _key_ performs the following steps:</p>
@@ -36057,7 +34591,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="24.1.1.4" -->
       <emu-clause id="sec-clonearraybuffer" aoid="CloneArrayBuffer">
         <h1>CloneArrayBuffer ( _srcBuffer_, _srcByteOffset_, _srcLength_, _cloneConstructor_ )</h1>
         <p>The abstract operation CloneArrayBuffer takes four parameters, an ArrayBuffer _srcBuffer_, an integer offset _srcByteOffset_, an integer length _srcLength_, and a constructor function _cloneConstructor_. It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. This operation performs the following steps:</p>
@@ -36095,7 +34628,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.1.5" -->
       <emu-clause id="sec-getvaluefrombuffer" aoid="GetValueFromBuffer">
         <h1>GetValueFromBuffer ( _arrayBuffer_, _byteIndex_, _type_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
         <p>The abstract operation GetValueFromBuffer takes six parameters, an ArrayBuffer or SharedArrayBuffer _arrayBuffer_, an integer _byteIndex_, a String _type_, a Boolean _isTypedArray_, a String _order_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
@@ -36140,7 +34672,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.1.6" -->
       <emu-clause id="sec-setvalueinbuffer" aoid="SetValueInBuffer">
         <h1>SetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
         <p>The abstract operation SetValueInBuffer takes seven parameters, an ArrayBuffer or SharedArrayBuffer _arrayBuffer_, an integer _byteIndex_, a String _type_, a Number _value_, a Boolean _isTypedArray_, a String _order_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
@@ -36187,7 +34718,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.1.2" -->
     <emu-clause id="sec-arraybuffer-constructor">
       <h1>The ArrayBuffer Constructor</h1>
       <p>The ArrayBuffer constructor:</p>
@@ -36199,7 +34729,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behaviour must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
       </ul>
 
-      <!-- es6num="24.1.2.1" -->
       <emu-clause id="sec-arraybuffer-length">
         <h1>ArrayBuffer ( _length_ )</h1>
         <p>When the `ArrayBuffer` function is called with argument _length_, the following steps are taken:</p>
@@ -36211,7 +34740,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.1.3" -->
     <emu-clause id="sec-properties-of-the-arraybuffer-constructor">
       <h1>Properties of the ArrayBuffer Constructor</h1>
       <p>The ArrayBuffer constructor:</p>
@@ -36220,7 +34748,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="24.1.3.1" -->
       <emu-clause id="sec-arraybuffer.isview">
         <h1>ArrayBuffer.isView ( _arg_ )</h1>
         <p>The isView function takes one argument _arg_, and performs, the following steps are taken:</p>
@@ -36231,14 +34758,12 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.3.2" -->
       <emu-clause id="sec-arraybuffer.prototype">
         <h1>ArrayBuffer.prototype</h1>
         <p>The initial value of ArrayBuffer.prototype is the intrinsic object %ArrayBufferPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="24.1.3.3" -->
       <emu-clause id="sec-get-arraybuffer-@@species">
         <h1>get ArrayBuffer [ @@species ]</h1>
         <p>`ArrayBuffer[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -36252,7 +34777,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.1.4" -->
     <emu-clause id="sec-properties-of-the-arraybuffer-prototype-object">
       <h1>Properties of the ArrayBuffer Prototype Object</h1>
       <p>The ArrayBuffer prototype object:</p>
@@ -36263,7 +34787,6 @@ THH:mm:ss.sss
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
       </ul>
 
-      <!-- es6num="24.1.4.1" -->
       <emu-clause id="sec-get-arraybuffer.prototype.bytelength">
         <h1>get ArrayBuffer.prototype.byteLength</h1>
         <p>`ArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -36278,13 +34801,11 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.4.2" -->
       <emu-clause id="sec-arraybuffer.prototype.constructor">
         <h1>ArrayBuffer.prototype.constructor</h1>
         <p>The initial value of `ArrayBuffer.prototype.constructor` is the intrinsic object %ArrayBuffer%.</p>
       </emu-clause>
 
-      <!-- es6num="24.1.4.3" -->
       <emu-clause id="sec-arraybuffer.prototype.slice">
         <h1>ArrayBuffer.prototype.slice ( _start_, _end_ )</h1>
         <p>The following steps are taken:</p>
@@ -36316,7 +34837,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.1.4.4" -->
       <emu-clause id="sec-arraybuffer.prototype-@@tostringtag">
         <h1>ArrayBuffer.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"ArrayBuffer"`.</p>
@@ -36324,7 +34844,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.1.5" -->
     <emu-clause id="sec-properties-of-the-arraybuffer-instances">
       <h1>Properties of ArrayBuffer Instances</h1>
       <p>ArrayBuffer instances inherit properties from the ArrayBuffer prototype object. ArrayBuffer instances each have an [[ArrayBufferData]] internal slot, an [[ArrayBufferByteLength]] internal slot, and an [[ArrayBufferDetachKey]] internal slot.</p>
@@ -36488,15 +35007,12 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="24.2" -->
   <emu-clause id="sec-dataview-objects">
     <h1>DataView Objects</h1>
 
-    <!-- es6num="24.2.1" -->
     <emu-clause id="sec-abstract-operations-for-dataview-objects">
       <h1>Abstract Operations For DataView Objects</h1>
 
-      <!-- es6num="24.2.1.1" -->
       <emu-clause id="sec-getviewvalue" aoid="GetViewValue">
         <h1>GetViewValue ( _view_, _requestIndex_, _isLittleEndian_, _type_ )</h1>
         <p>The abstract operation GetViewValue with arguments _view_, _requestIndex_, _isLittleEndian_, and _type_ is used by functions on DataView instances to retrieve values from the view's buffer. It performs the following steps:</p>
@@ -36517,7 +35033,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.1.2" -->
       <emu-clause id="sec-setviewvalue" aoid="SetViewValue">
         <h1>SetViewValue ( _view_, _requestIndex_, _isLittleEndian_, _type_, _value_ )</h1>
         <p>The abstract operation SetViewValue with arguments _view_, _requestIndex_, _isLittleEndian_, _type_, and _value_ is used by functions on DataView instances to store values into the view's buffer. It performs the following steps:</p>
@@ -36540,7 +35055,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.2.2" -->
     <emu-clause id="sec-dataview-constructor">
       <h1>The DataView Constructor</h1>
       <p>The DataView constructor:</p>
@@ -36552,7 +35066,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behaviour must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
       </ul>
 
-      <!-- es6num="24.2.2.1" -->
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
         <h1>DataView ( _buffer_ [ , _byteOffset_ [ , _byteLength_  ] ] )</h1>
         <p>When the `DataView` is called with at least one argument _buffer_, the following steps are taken:</p>
@@ -36578,7 +35091,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.2.3" -->
     <emu-clause id="sec-properties-of-the-dataview-constructor">
       <h1>Properties of the DataView Constructor</h1>
       <p>The DataView constructor:</p>
@@ -36587,7 +35099,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="24.2.3.1" -->
       <emu-clause id="sec-dataview.prototype">
         <h1>DataView.prototype</h1>
         <p>The initial value of `DataView.prototype` is the intrinsic object %DataViewPrototype%.</p>
@@ -36595,7 +35106,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.2.4" -->
     <emu-clause id="sec-properties-of-the-dataview-prototype-object">
       <h1>Properties of the DataView Prototype Object</h1>
       <p>The DataView prototype object:</p>
@@ -36606,7 +35116,6 @@ THH:mm:ss.sss
         <li>does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</li>
       </ul>
 
-      <!-- es6num="24.2.4.1" -->
       <emu-clause id="sec-get-dataview.prototype.buffer">
         <h1>get DataView.prototype.buffer</h1>
         <p>`DataView.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -36620,7 +35129,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.2" -->
       <emu-clause id="sec-get-dataview.prototype.bytelength">
         <h1>get DataView.prototype.byteLength</h1>
         <p>`DataView`.`prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -36636,7 +35144,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.3" -->
       <emu-clause id="sec-get-dataview.prototype.byteoffset">
         <h1>get DataView.prototype.byteOffset</h1>
         <p>`DataView`.`prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -36652,13 +35159,11 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.4" -->
       <emu-clause id="sec-dataview.prototype.constructor">
         <h1>DataView.prototype.constructor</h1>
         <p>The initial value of `DataView.prototype.constructor` is the intrinsic object %DataView%.</p>
       </emu-clause>
 
-      <!-- es6num="24.2.4.5" -->
       <emu-clause id="sec-dataview.prototype.getfloat32">
         <h1>DataView.prototype.getFloat32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>When the `getFloat32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36669,7 +35174,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.6" -->
       <emu-clause id="sec-dataview.prototype.getfloat64">
         <h1>DataView.prototype.getFloat64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>When the `getFloat64` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36680,7 +35184,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.7" -->
       <emu-clause id="sec-dataview.prototype.getint8">
         <h1>DataView.prototype.getInt8 ( _byteOffset_ )</h1>
         <p>When the `getInt8` method is called with argument _byteOffset_, the following steps are taken:</p>
@@ -36690,7 +35193,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.8" -->
       <emu-clause id="sec-dataview.prototype.getint16">
         <h1>DataView.prototype.getInt16 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>When the `getInt16` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36701,7 +35203,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.9" -->
       <emu-clause id="sec-dataview.prototype.getint32">
         <h1>DataView.prototype.getInt32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>When the `getInt32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36712,7 +35213,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.10" -->
       <emu-clause id="sec-dataview.prototype.getuint8">
         <h1>DataView.prototype.getUint8 ( _byteOffset_ )</h1>
         <p>When the `getUint8` method is called with argument _byteOffset_, the following steps are taken:</p>
@@ -36722,7 +35222,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.11" -->
       <emu-clause id="sec-dataview.prototype.getuint16">
         <h1>DataView.prototype.getUint16 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>When the `getUint16` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36733,7 +35232,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.12" -->
       <emu-clause id="sec-dataview.prototype.getuint32">
         <h1>DataView.prototype.getUint32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>When the `getUint32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36744,7 +35242,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.13" -->
       <emu-clause id="sec-dataview.prototype.setfloat32">
         <h1>DataView.prototype.setFloat32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>When the `setFloat32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36755,7 +35252,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.14" -->
       <emu-clause id="sec-dataview.prototype.setfloat64">
         <h1>DataView.prototype.setFloat64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>When the `setFloat64` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36766,7 +35262,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.15" -->
       <emu-clause id="sec-dataview.prototype.setint8">
         <h1>DataView.prototype.setInt8 ( _byteOffset_, _value_ )</h1>
         <p>When the `setInt8` method is called with arguments _byteOffset_ and _value_, the following steps are taken:</p>
@@ -36776,7 +35271,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.16" -->
       <emu-clause id="sec-dataview.prototype.setint16">
         <h1>DataView.prototype.setInt16 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>When the `setInt16` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36787,7 +35281,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.17" -->
       <emu-clause id="sec-dataview.prototype.setint32">
         <h1>DataView.prototype.setInt32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>When the `setInt32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36798,7 +35291,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.18" -->
       <emu-clause id="sec-dataview.prototype.setuint8">
         <h1>DataView.prototype.setUint8 ( _byteOffset_, _value_ )</h1>
         <p>When the `setUint8` method is called with arguments _byteOffset_ and _value_, the following steps are taken:</p>
@@ -36808,7 +35300,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.19" -->
       <emu-clause id="sec-dataview.prototype.setuint16">
         <h1>DataView.prototype.setUint16 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>When the `setUint16` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36819,7 +35310,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.20" -->
       <emu-clause id="sec-dataview.prototype.setuint32">
         <h1>DataView.prototype.setUint32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>When the `setUint32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -36830,7 +35320,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.2.4.21" -->
       <emu-clause id="sec-dataview.prototype-@@tostringtag">
         <h1>DataView.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"DataView"`.</p>
@@ -36838,7 +35327,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.2.5" -->
     <emu-clause id="sec-properties-of-dataview-instances">
       <h1>Properties of DataView Instances</h1>
       <p>DataView instances are ordinary objects that inherit properties from the DataView prototype object. DataView instances each have [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], and [[ByteOffset]] internal slots.</p>
@@ -37209,7 +35697,6 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="24.3" -->
   <emu-clause id="sec-json-object">
     <h1>The JSON Object</h1>
     <p>The JSON object:</p>
@@ -37224,7 +35711,6 @@ THH:mm:ss.sss
     </ul>
     <p>The JSON Data Interchange Format is defined in ECMA-404. The JSON interchange format used in this specification is exactly that described by ECMA-404. Conforming implementations of `JSON.parse` and `JSON.stringify` must support the exact interchange format described in the ECMA-404 specification without any deletions or extensions to the format.</p>
 
-    <!-- es6num="24.3.1" -->
     <emu-clause id="sec-json.parse">
       <h1>JSON.parse ( _text_ [ , _reviver_ ] )</h1>
       <p>The `parse` function parses a JSON text (a JSON-formatted String) and produces an ECMAScript value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
@@ -37262,7 +35748,6 @@ THH:mm:ss.sss
         <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by Step 4 above. Step 2 verifies that _JText_ conforms to that subset, and step 6 verifies that that parsing and evaluation returns a value of an appropriate type.</p>
       </emu-note>
 
-      <!-- es6num="24.3.1.1" -->
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">
         <h1>Runtime Semantics: InternalizeJSONProperty ( _holder_, _name_ )</h1>
         <p>The abstract operation InternalizeJSONProperty is a recursive abstract operation that takes two parameters: a _holder_ object and the String _name_ of a property in that object. InternalizeJSONProperty uses the value of _reviver_ that was originally passed to the above parse function.</p>
@@ -37299,7 +35784,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.3.2" -->
     <emu-clause id="sec-json.stringify">
       <h1>JSON.stringify ( _value_ [ , _replacer_ [ , _space_ ] ] )</h1>
       <p>The `stringify` function returns a String in UTF-16 encoded JSON format representing an ECMAScript value. It can take three parameters. The _value_ parameter is an ECMAScript value, which is usually an object or array, although it can also be a String, Boolean, Number or *null*. The optional _replacer_ parameter is either a function that alters the way objects and arrays are stringified, or an array of Strings and Numbers that acts as an inclusion list for selecting the object properties that will be stringified. The optional _space_ parameter is a String or Number that allows the result to have white space injected into it to improve human readability.</p>
@@ -37383,7 +35867,6 @@ THH:mm:ss.sss
         <p>An object is rendered as U+007B (LEFT CURLY BRACKET) followed by zero or more properties, separated with a U+002C (COMMA), closed with a U+007D (RIGHT CURLY BRACKET). A property is a quoted String representing the key or property name, a U+003A (COLON), and then the stringified property value. An array is rendered as an opening U+005B (LEFT SQUARE BRACKET followed by zero or more values, separated with a U+002C (COMMA), closed with a U+005D (RIGHT SQUARE BRACKET).</p>
       </emu-note>
 
-      <!-- es6num="24.3.2.1" -->
       <emu-clause id="sec-serializejsonproperty" aoid="SerializeJSONProperty">
         <h1>Runtime Semantics: SerializeJSONProperty ( _key_, _holder_ )</h1>
         <p>The abstract operation SerializeJSONProperty with arguments _key_, and _holder_ has access to _ReplacerFunction_ from the invocation of the `stringify` method. Its algorithm is as follows:</p>
@@ -37417,7 +35900,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.3.2.2" -->
       <emu-clause id="sec-quotejsonstring" aoid="QuoteJSONString">
         <h1>Runtime Semantics: QuoteJSONString ( _value_ )</h1>
         <p>The abstract operation QuoteJSONString with argument _value_ wraps a String value in QUOTATION MARK code units and escapes certain other code units within it.</p>
@@ -37542,7 +36024,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.3.2.3" -->
       <emu-clause id="sec-serializejsonobject" aoid="SerializeJSONObject">
         <h1>Runtime Semantics: SerializeJSONObject ( _value_ )</h1>
         <p>The abstract operation SerializeJSONObject with argument _value_ serializes an object. It has access to the _stack_, _indent_, _gap_, and _PropertyList_ values of the current invocation of the `stringify` method.</p>
@@ -37581,7 +36062,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="24.3.2.4" -->
       <emu-clause id="sec-serializejsonarray" aoid="SerializeJSONArray">
         <h1>Runtime Semantics: SerializeJSONArray ( _value_ )</h1>
         <p>The abstract operation SerializeJSONArray with argument _value_ serializes an array. It has access to the _stack_, _indent_, and _gap_ values of the current invocation of the `stringify` method.</p>
@@ -37620,7 +36100,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="24.3.3" -->
     <emu-clause id="sec-json-@@tostringtag">
       <h1>JSON [ @@toStringTag ]</h1>
       <p>The initial value of the @@toStringTag property is the String value `"JSON"`.</p>
@@ -37629,20 +36108,16 @@ THH:mm:ss.sss
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="25" -->
 <emu-clause id="sec-control-abstraction-objects">
   <h1>Control Abstraction Objects</h1>
 
-  <!-- es6num="25.1" -->
   <emu-clause id="sec-iteration">
     <h1>Iteration</h1>
 
-    <!-- es6num="25.1.1" -->
     <emu-clause id="sec-common-iteration-interfaces">
       <h1>Common Iteration Interfaces</h1>
       <p>An interface is a set of property keys whose associated values match a specific specification. Any object that provides all the properties as described by an interface's specification <em>conforms</em> to that interface. An interface is not represented by a distinct object. There may be many separately implemented objects that conform to any interface. An individual object may conform to multiple interfaces.</p>
 
-      <!-- es6num="25.1.1.1" -->
       <emu-clause id="sec-iterable-interface">
         <h1>The <i>Iterable</i> Interface</h1>
         <p>The <i>Iterable</i> interface includes the property described in <emu-xref href="#table-52"></emu-xref>:</p>
@@ -37676,7 +36151,6 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <!-- es6num="25.1.1.2" -->
       <emu-clause id="sec-iterator-interface">
         <h1>The <i>Iterator</i> Interface</h1>
         <p>An object that implements the <i>Iterator</i> interface must include the property in <emu-xref href="#table-53"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-54"></emu-xref>.</p>
@@ -37836,7 +36310,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="25.1.1.3" -->
       <emu-clause id="sec-iteratorresult-interface">
         <h1>The IteratorResult Interface</h1>
         <p>The <i>IteratorResult</i> interface includes the properties listed in <emu-xref href="#table-55"></emu-xref>:</p>
@@ -37882,7 +36355,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.1.2" -->
     <emu-clause id="sec-%iteratorprototype%-object">
       <h1>The %IteratorPrototype% Object</h1>
       <p>The <dfn>%IteratorPrototype%</dfn> object:</p>
@@ -37896,7 +36368,6 @@ THH:mm:ss.sss
         <pre><code class="javascript">Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))</code></pre>
       </emu-note>
 
-      <!-- es6num="25.1.2.1" -->
       <emu-clause id="sec-%iteratorprototype%-@@iterator">
         <h1>%IteratorPrototype% [ @@iterator ] ( )</h1>
         <p>The following steps are taken:</p>
@@ -38099,7 +36570,6 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="25.2" -->
   <emu-clause id="sec-generatorfunction-objects">
     <h1>GeneratorFunction Objects</h1>
     <p>GeneratorFunction objects are functions that are usually created by evaluating |GeneratorDeclaration|s, |GeneratorExpression|s, and |GeneratorMethod|s. They may also be created by calling the %GeneratorFunction% intrinsic.</p>
@@ -38107,7 +36577,6 @@ THH:mm:ss.sss
       <img alt="A staggering variety of boxes and arrows." src="img/figure-2.png">
     </emu-figure>
 
-    <!-- es6num="25.2.1" -->
     <emu-clause id="sec-generatorfunction-constructor">
       <h1>The GeneratorFunction Constructor</h1>
       <p>The GeneratorFunction constructor:</p>
@@ -38117,7 +36586,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `GeneratorFunction` behaviour must include a `super` call to the `GeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of `GeneratorFunction`. There is no syntactic means to create instances of `GeneratorFunction` subclasses.</li>
       </ul>
 
-      <!-- es6num="25.2.1.1" -->
       <emu-clause id="sec-generatorfunction">
         <h1>GeneratorFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
         <p>The last argument specifies the body (executable code) of a generator function; any preceding arguments specify formal parameters.</p>
@@ -38133,7 +36601,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.2.2" -->
     <emu-clause id="sec-properties-of-the-generatorfunction-constructor">
       <h1>Properties of the GeneratorFunction Constructor</h1>
       <p>The GeneratorFunction constructor:</p>
@@ -38144,13 +36611,11 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="25.2.2.1" -->
       <emu-clause id="sec-generatorfunction.length">
         <h1>GeneratorFunction.length</h1>
         <p>This is a data property with a value of 1. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <!-- es6num="25.2.2.2" -->
       <emu-clause id="sec-generatorfunction.prototype">
         <h1>GeneratorFunction.prototype</h1>
         <p>The initial value of `GeneratorFunction.prototype` is the intrinsic object %Generator%.</p>
@@ -38158,7 +36623,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.2.3" -->
     <emu-clause id="sec-properties-of-the-generatorfunction-prototype-object">
       <h1>Properties of the GeneratorFunction Prototype Object</h1>
       <p>The GeneratorFunction prototype object:</p>
@@ -38170,21 +36634,18 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
       </ul>
 
-      <!-- es6num="25.2.3.1" -->
       <emu-clause id="sec-generatorfunction.prototype.constructor">
         <h1>GeneratorFunction.prototype.constructor</h1>
         <p>The initial value of `GeneratorFunction.prototype.constructor` is the intrinsic object %GeneratorFunction%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <!-- es6num="25.2.3.2" -->
       <emu-clause id="sec-generatorfunction.prototype.prototype">
         <h1>GeneratorFunction.prototype.prototype</h1>
         <p>The value of `GeneratorFunction.prototype.prototype` is the %GeneratorPrototype% intrinsic object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <!-- es6num="25.2.3.3" -->
       <emu-clause id="sec-generatorfunction.prototype-@@tostringtag">
         <h1>GeneratorFunction.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"GeneratorFunction"`.</p>
@@ -38192,25 +36653,21 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.2.4" -->
     <emu-clause id="sec-generatorfunction-instances">
       <h1>GeneratorFunction Instances</h1>
       <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is `"generator"`.</p>
       <p>Each GeneratorFunction instance has the following own properties:</p>
 
-      <!-- es6num="25.2.4.1" -->
       <emu-clause id="sec-generatorfunction-instances-length">
         <h1>length</h1>
         <p>The specification for the `length` property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to GeneratorFunction instances.</p>
       </emu-clause>
 
-      <!-- es6num="25.2.4.2" -->
       <emu-clause id="sec-generatorfunction-instances-name">
         <h1>name</h1>
         <p>The specification for the `name` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to GeneratorFunction instances.</p>
       </emu-clause>
 
-      <!-- es6num="25.2.4.3" -->
       <emu-clause id="sec-generatorfunction-instances-prototype">
         <h1>prototype</h1>
         <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's `prototype` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
@@ -38329,13 +36786,11 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="25.3" -->
   <emu-clause id="sec-generator-objects">
     <h1>Generator Objects</h1>
     <p>A Generator object is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
     <p>Generator instances directly inherit properties from the object that is the value of the `prototype` property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %GeneratorPrototype%.</p>
 
-    <!-- es6num="25.3.1" -->
     <emu-clause id="sec-properties-of-generator-prototype">
       <h1>Properties of the Generator Prototype Object</h1>
       <p>The Generator prototype object:</p>
@@ -38348,14 +36803,12 @@ THH:mm:ss.sss
         <li>has properties that are indirectly inherited by all Generator instances.</li>
       </ul>
 
-      <!-- es6num="25.3.1.1" -->
       <emu-clause id="sec-generator.prototype.constructor">
         <h1>Generator.prototype.constructor</h1>
         <p>The initial value of `Generator.prototype.constructor` is the intrinsic object %Generator%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <!-- es6num="25.3.1.2" -->
       <emu-clause id="sec-generator.prototype.next">
         <h1>Generator.prototype.next ( _value_ )</h1>
         <p>The `next` method performs the following steps:</p>
@@ -38365,7 +36818,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.3.1.3" -->
       <emu-clause id="sec-generator.prototype.return">
         <h1>Generator.prototype.return ( _value_ )</h1>
         <p>The `return` method performs the following steps:</p>
@@ -38376,7 +36828,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.3.1.4" -->
       <emu-clause id="sec-generator.prototype.throw">
         <h1>Generator.prototype.throw ( _exception_ )</h1>
         <p>The `throw` method performs the following steps:</p>
@@ -38387,7 +36838,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.3.1.5" -->
       <emu-clause id="sec-generator.prototype-@@tostringtag">
         <h1>Generator.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"Generator"`.</p>
@@ -38395,7 +36845,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.3.2" -->
     <emu-clause id="sec-properties-of-generator-instances">
       <h1>Properties of Generator Instances</h1>
       <p>Generator instances are initially created with the internal slots described in <emu-xref href="#table-56"></emu-xref>.</p>
@@ -38431,11 +36880,9 @@ THH:mm:ss.sss
       </emu-table>
     </emu-clause>
 
-    <!-- es6num="25.3.3" -->
     <emu-clause id="sec-generator-abstract-operations">
       <h1>Generator Abstract Operations</h1>
 
-      <!-- es6num="25.3.3.1" -->
       <emu-clause id="sec-generatorstart" aoid="GeneratorStart">
         <h1>GeneratorStart ( _generator_, _generatorBody_ )</h1>
         <p>The abstract operation GeneratorStart with arguments _generator_ and _generatorBody_ performs the following steps:</p>
@@ -38461,7 +36908,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.3.3.2" -->
       <emu-clause id="sec-generatorvalidate" aoid="GeneratorValidate">
         <h1>GeneratorValidate ( _generator_ )</h1>
         <p>The abstract operation GeneratorValidate with argument _generator_ performs the following steps:</p>
@@ -38475,7 +36921,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.3.3.3" -->
       <emu-clause id="sec-generatorresume" aoid="GeneratorResume">
         <h1>GeneratorResume ( _generator_, _value_ )</h1>
         <p>The abstract operation GeneratorResume with arguments _generator_ and _value_ performs the following steps:</p>
@@ -38494,7 +36939,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.3.3.4" -->
       <emu-clause id="sec-generatorresumeabrupt" aoid="GeneratorResumeAbrupt">
         <h1>GeneratorResumeAbrupt ( _generator_, _abruptCompletion_ )</h1>
         <p>The abstract operation GeneratorResumeAbrupt with arguments _generator_ and _abruptCompletion_ performs the following steps:</p>
@@ -38531,7 +36975,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.3.3.5" -->
       <emu-clause id="sec-generatoryield" aoid="GeneratorYield">
         <h1>GeneratorYield ( _iterNextObj_ )</h1>
         <p>The abstract operation GeneratorYield with argument _iterNextObj_ performs the following steps:</p>
@@ -38845,7 +37288,6 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="25.4" -->
   <emu-clause id="sec-promise-objects">
     <h1>Promise Objects</h1>
     <p>A Promise is an object that is used as a placeholder for the eventual results of a deferred (and possibly asynchronous) computation.</p>
@@ -38864,11 +37306,9 @@ THH:mm:ss.sss
     <p>A promise is said to be <em>settled</em> if it is not pending, i.e. if it is either fulfilled or rejected.</p>
     <p>A promise is <em>resolved</em> if it is settled or if it has been &ldquo;locked in&rdquo; to match the state of another promise. Attempting to resolve or reject a resolved promise has no effect. A promise is <em>unresolved</em> if it is not resolved. An unresolved promise is always in the pending state. A resolved promise may be pending, fulfilled or rejected.</p>
 
-    <!-- es6num="25.4.1" -->
     <emu-clause id="sec-promise-abstract-operations">
       <h1>Promise Abstract Operations</h1>
 
-      <!-- es6num="25.4.1.1" -->
       <emu-clause id="sec-promisecapability-records">
         <h1>PromiseCapability Records</h1>
         <p>A PromiseCapability is a Record value used to encapsulate a promise object along with the functions that are capable of resolving or rejecting that promise object. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
@@ -38924,7 +37364,6 @@ THH:mm:ss.sss
           </table>
         </emu-table>
 
-        <!-- es6num="25.4.1.1.1" -->
         <emu-clause id="sec-ifabruptrejectpromise" aoid="IfAbruptRejectPromise">
           <h1>IfAbruptRejectPromise ( _value_, _capability_ )</h1>
           <p>IfAbruptRejectPromise is a shorthand for a sequence of algorithm steps that use a PromiseCapability Record. An algorithm step of the form:</p>
@@ -38941,7 +37380,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="25.4.1.2" -->
       <emu-clause id="sec-promisereaction-records">
         <h1>PromiseReaction Records</h1>
         <p>The PromiseReaction is a Record value used to store information about how a promise should react when it becomes resolved or rejected with a given value. PromiseReaction records are created by the PerformPromiseThen abstract operation, and are used by a PromiseReactionJob.</p>
@@ -38998,7 +37436,6 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <!-- es6num="25.4.1.3" -->
       <emu-clause id="sec-createresolvingfunctions" aoid="CreateResolvingFunctions">
         <h1>CreateResolvingFunctions ( _promise_ )</h1>
         <p>When CreateResolvingFunctions is performed with argument _promise_, the following steps are taken:</p>
@@ -39015,7 +37452,6 @@ THH:mm:ss.sss
           1. Return a new Record { [[Resolve]]: _resolve_, [[Reject]]: _reject_ }.
         </emu-alg>
 
-        <!-- es6num="25.4.1.3.1" -->
         <emu-clause id="sec-promise-reject-functions">
           <h1>Promise Reject Functions</h1>
           <p>A promise reject function is an anonymous built-in function that has [[Promise]] and [[AlreadyResolved]] internal slots.</p>
@@ -39031,7 +37467,6 @@ THH:mm:ss.sss
           <p>The `length` property of a promise reject function is 1.</p>
         </emu-clause>
 
-        <!-- es6num="25.4.1.3.2" -->
         <emu-clause id="sec-promise-resolve-functions">
           <h1>Promise Resolve Functions</h1>
           <p>A promise resolve function is an anonymous built-in function that has [[Promise]] and [[AlreadyResolved]] internal slots.</p>
@@ -39060,7 +37495,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="25.4.1.4" -->
       <emu-clause id="sec-fulfillpromise" aoid="FulfillPromise">
         <h1>FulfillPromise ( _promise_, _value_ )</h1>
         <p>When the FulfillPromise abstract operation is called with arguments _promise_ and _value_, the following steps are taken:</p>
@@ -39075,7 +37509,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.4.1.5" -->
       <emu-clause id="sec-newpromisecapability" aoid="NewPromiseCapability">
         <h1>NewPromiseCapability ( _C_ )</h1>
         <p>The abstract operation NewPromiseCapability takes a constructor function, and attempts to use that constructor function in the fashion of the built-in `Promise` constructor to create a Promise object and extract its resolve and reject functions. The promise plus the resolve and reject functions are used to initialize a new PromiseCapability Record which is returned as the value of this abstract operation.</p>
@@ -39096,7 +37529,6 @@ THH:mm:ss.sss
           <p>This abstract operation supports Promise subclassing, as it is generic on any constructor that calls a passed executor function argument in the same way as the Promise constructor. It is used to generalize static methods of the Promise constructor to any subclass.</p>
         </emu-note>
 
-        <!-- es6num="25.4.1.5.1" -->
         <emu-clause id="sec-getcapabilitiesexecutor-functions">
           <h1>GetCapabilitiesExecutor Functions</h1>
           <p>A GetCapabilitiesExecutor function is an anonymous built-in function that has a [[Capability]] internal slot.</p>
@@ -39114,7 +37546,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="25.4.1.6" -->
       <emu-clause id="sec-ispromise" aoid="IsPromise">
         <h1>IsPromise ( _x_ )</h1>
         <p>The abstract operation IsPromise checks for the promise brand on an object.</p>
@@ -39125,7 +37556,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.4.1.7" -->
       <emu-clause id="sec-rejectpromise" aoid="RejectPromise">
         <h1>RejectPromise ( _promise_, _reason_ )</h1>
         <p>When the RejectPromise abstract operation is called with arguments _promise_ and _reason_, the following steps are taken:</p>
@@ -39141,7 +37571,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.4.1.8" -->
       <emu-clause id="sec-triggerpromisereactions" aoid="TriggerPromiseReactions">
         <h1>TriggerPromiseReactions ( _reactions_, _argument_ )</h1>
         <p>The abstract operation TriggerPromiseReactions takes a collection of PromiseReactionRecords and enqueues a new Job for each record. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReactionRecord, and if the [[Handler]] is a function, calls it passing the given argument. If the [[Handler]] is *undefined*, the behaviour is determined by the [[Type]].</p>
@@ -39176,11 +37605,9 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.4.2" -->
     <emu-clause id="sec-promise-jobs">
       <h1>Promise Jobs</h1>
 
-      <!-- es6num="25.4.2.1" -->
       <emu-clause id="sec-promisereactionjob" aoid="PromiseReactionJob">
         <h1>PromiseReactionJob ( _reaction_, _argument_ )</h1>
         <p>The job PromiseReactionJob with parameters _reaction_ and _argument_ applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler.</p>
@@ -39203,7 +37630,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.4.2.2" -->
       <emu-clause id="sec-promiseresolvethenablejob" aoid="PromiseResolveThenableJob">
         <h1>PromiseResolveThenableJob ( _promiseToResolve_, _thenable_, _then_ )</h1>
         <p>The job PromiseResolveThenableJob with parameters _promiseToResolve_, _thenable_, and _then_ performs the following steps:</p>
@@ -39221,7 +37647,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.4.3" -->
     <emu-clause id="sec-promise-constructor">
       <h1>The Promise Constructor</h1>
       <p>The Promise constructor:</p>
@@ -39233,7 +37658,6 @@ THH:mm:ss.sss
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behaviour must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
       </ul>
 
-      <!-- es6num="25.4.3.1" -->
       <emu-clause id="sec-promise-executor">
         <h1>Promise ( _executor_ )</h1>
         <p>When the `Promise` function is called with argument _executor_, the following steps are taken:</p>
@@ -39260,7 +37684,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.4.4" -->
     <emu-clause id="sec-properties-of-the-promise-constructor">
       <h1>Properties of the Promise Constructor</h1>
       <p>The Promise constructor:</p>
@@ -39269,7 +37692,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="25.4.4.1" -->
       <emu-clause id="sec-promise.all">
         <h1>Promise.all ( _iterable_ )</h1>
         <p>The `all` function returns a new promise which is fulfilled with an array of fulfillment values for the passed promises, or rejects with the reason of the first passed promise that rejects. It resolves all elements of the passed iterable to promises as it runs this algorithm.</p>
@@ -39290,7 +37712,6 @@ THH:mm:ss.sss
           <p>The `all` function requires its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
         </emu-note>
 
-        <!-- es6num="25.4.4.1.1" -->
         <emu-clause id="sec-performpromiseall" aoid="PerformPromiseAll">
           <h1>Runtime Semantics: PerformPromiseAll ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
           <p>When the PerformPromiseAll abstract operation is called with arguments _iteratorRecord_, _constructor_, and _resultCapability_, the following steps are taken:</p>
@@ -39329,7 +37750,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <!-- es6num="25.4.4.1.2" -->
         <emu-clause id="sec-promise.all-resolve-element-functions">
           <h1>`Promise.all` Resolve Element Functions</h1>
           <p>A `Promise.all` resolve element function is an anonymous built-in function that is used to resolve a specific `Promise.all` element. Each `Promise.all` resolve element function has [[Index]], [[Values]], [[Capability]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
@@ -39353,14 +37773,12 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="25.4.4.2" -->
       <emu-clause id="sec-promise.prototype">
         <h1>Promise.prototype</h1>
         <p>The initial value of `Promise.prototype` is the intrinsic object %PromisePrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <!-- es6num="25.4.4.3" -->
       <emu-clause id="sec-promise.race">
         <h1>Promise.race ( _iterable_ )</h1>
         <p>The `race` function returns a new promise which is settled in the same way as the first passed promise to settle. It resolves all elements of the passed _iterable_ to promises as it runs this algorithm.</p>
@@ -39383,7 +37801,6 @@ THH:mm:ss.sss
           <p>The `race` function expects its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor. It also expects that its *this* value provides a `resolve` method.</p>
         </emu-note>
 
-        <!-- es6num="25.4.4.3.1" -->
         <emu-clause id="sec-performpromiserace" aoid="PerformPromiseRace">
           <h1>Runtime Semantics: PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
           <p>When the PerformPromiseRace abstract operation is called with arguments _iteratorRecord_, _constructor_, and _resultCapability_, the following steps are taken:</p>
@@ -39406,7 +37823,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="25.4.4.4" -->
       <emu-clause id="sec-promise.reject">
         <h1>Promise.reject ( _r_ )</h1>
         <p>The `reject` function returns a new promise rejected with the passed argument.</p>
@@ -39423,7 +37839,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <!-- es6num="25.4.4.5" -->
       <emu-clause id="sec-promise.resolve">
         <h1>Promise.resolve ( _x_ )</h1>
         <p>The `resolve` function returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.</p>
@@ -39452,7 +37867,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="25.4.4.6" -->
       <emu-clause id="sec-get-promise-@@species">
         <h1>get Promise [ @@species ]</h1>
         <p>`Promise[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -39466,7 +37880,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.4.5" -->
     <emu-clause id="sec-properties-of-the-promise-prototype-object">
       <h1>Properties of the Promise Prototype Object</h1>
       <p>The Promise prototype object:</p>
@@ -39477,7 +37890,6 @@ THH:mm:ss.sss
         <li>does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</li>
       </ul>
 
-      <!-- es6num="25.4.5.1" -->
       <emu-clause id="sec-promise.prototype.catch">
         <h1>Promise.prototype.catch ( _onRejected_ )</h1>
         <p>When the `catch` method is called with argument _onRejected_, the following steps are taken:</p>
@@ -39487,7 +37899,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <!-- es6num="25.4.5.2" -->
       <emu-clause id="sec-promise.prototype.constructor">
         <h1>Promise.prototype.constructor</h1>
         <p>The initial value of `Promise.prototype.constructor` is the intrinsic object %Promise%.</p>
@@ -39551,7 +37962,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="25.4.5.3" -->
       <emu-clause id="sec-promise.prototype.then">
         <h1>Promise.prototype.then ( _onFulfilled_, _onRejected_ )</h1>
         <p>When the `then` method is called with arguments _onFulfilled_ and _onRejected_, the following steps are taken:</p>
@@ -39564,7 +37974,6 @@ THH:mm:ss.sss
         </emu-alg>
         <p>This function is the <dfn>%PromiseProto_then%</dfn> intrinsic object.</p>
 
-        <!-- es6num="25.4.5.3.1" -->
         <emu-clause id="sec-performpromisethen" aoid="PerformPromiseThen">
           <h1>PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_, _resultCapability_ )</h1>
           <p>The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. The result is _resultCapability_'s promise.</p>
@@ -39594,7 +38003,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <!-- es6num="25.4.5.4" -->
       <emu-clause id="sec-promise.prototype-@@tostringtag">
         <h1>Promise.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value `"Promise"`.</p>
@@ -39602,7 +38010,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="25.4.6" -->
     <emu-clause id="sec-properties-of-promise-instances">
       <h1>Properties of Promise Instances</h1>
       <p>Promise instances are ordinary objects that inherit properties from the Promise prototype object (the intrinsic, %PromisePrototype%). Promise instances are initially created with the internal slots described in <emu-xref href="#table-59"></emu-xref>.</p>
@@ -39792,11 +38199,9 @@ THH:mm:ss.sss
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="26" -->
 <emu-clause id="sec-reflection">
   <h1>Reflection</h1>
 
-  <!-- es6num="26.1" -->
   <emu-clause id="sec-reflect-object">
     <h1>The Reflect Object</h1>
     <p>The Reflect object:</p>
@@ -39810,7 +38215,6 @@ THH:mm:ss.sss
       <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     </ul>
 
-    <!-- es6num="26.1.1" -->
     <emu-clause id="sec-reflect.apply">
       <h1>Reflect.apply ( _target_, _thisArgument_, _argumentsList_ )</h1>
       <p>When the `apply` function is called with arguments _target_, _thisArgument_, and _argumentsList_, the following steps are taken:</p>
@@ -39822,7 +38226,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.2" -->
     <emu-clause id="sec-reflect.construct">
       <h1>Reflect.construct ( _target_, _argumentsList_ [ , _newTarget_ ] )</h1>
       <p>When the `construct` function is called with arguments _target_, _argumentsList_, and _newTarget_, the following steps are taken:</p>
@@ -39835,7 +38238,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.3" -->
     <emu-clause id="sec-reflect.defineproperty">
       <h1>Reflect.defineProperty ( _target_, _propertyKey_, _attributes_ )</h1>
       <p>When the `defineProperty` function is called with arguments _target_, _propertyKey_, and _attributes_, the following steps are taken:</p>
@@ -39847,7 +38249,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.4" -->
     <emu-clause id="sec-reflect.deleteproperty">
       <h1>Reflect.deleteProperty ( _target_, _propertyKey_ )</h1>
       <p>When the `deleteProperty` function is called with arguments _target_ and _propertyKey_, the following steps are taken:</p>
@@ -39858,7 +38259,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.6" -->
     <emu-clause id="sec-reflect.get">
       <h1>Reflect.get ( _target_, _propertyKey_ [ , _receiver_ ] )</h1>
       <p>When the `get` function is called with arguments _target_, _propertyKey_, and _receiver_, the following steps are taken:</p>
@@ -39871,7 +38271,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.7" -->
     <emu-clause id="sec-reflect.getownpropertydescriptor">
       <h1>Reflect.getOwnPropertyDescriptor ( _target_, _propertyKey_ )</h1>
       <p>When the `getOwnPropertyDescriptor` function is called with arguments _target_ and _propertyKey_, the following steps are taken:</p>
@@ -39883,7 +38282,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.8" -->
     <emu-clause id="sec-reflect.getprototypeof">
       <h1>Reflect.getPrototypeOf ( _target_ )</h1>
       <p>When the `getPrototypeOf` function is called with argument _target_, the following steps are taken:</p>
@@ -39893,7 +38291,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.9" -->
     <emu-clause id="sec-reflect.has">
       <h1>Reflect.has ( _target_, _propertyKey_ )</h1>
       <p>When the `has` function is called with arguments _target_ and _propertyKey_, the following steps are taken:</p>
@@ -39904,7 +38301,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.10" -->
     <emu-clause id="sec-reflect.isextensible">
       <h1>Reflect.isExtensible ( _target_ )</h1>
       <p>When the `isExtensible` function is called with argument _target_, the following steps are taken:</p>
@@ -39914,7 +38310,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.11" -->
     <emu-clause id="sec-reflect.ownkeys">
       <h1>Reflect.ownKeys ( _target_ )</h1>
       <p>When the `ownKeys` function is called with argument _target_, the following steps are taken:</p>
@@ -39925,7 +38320,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.12" -->
     <emu-clause id="sec-reflect.preventextensions">
       <h1>Reflect.preventExtensions ( _target_ )</h1>
       <p>When the `preventExtensions` function is called with argument _target_, the following steps are taken:</p>
@@ -39935,7 +38329,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.13" -->
     <emu-clause id="sec-reflect.set">
       <h1>Reflect.set ( _target_, _propertyKey_, _V_ [ , _receiver_ ] )</h1>
       <p>When the `set` function is called with arguments _target_, _V_, _propertyKey_, and _receiver_, the following steps are taken:</p>
@@ -39948,7 +38341,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <!-- es6num="26.1.14" -->
     <emu-clause id="sec-reflect.setprototypeof">
       <h1>Reflect.setPrototypeOf ( _target_, _proto_ )</h1>
       <p>When the `setPrototypeOf` function is called with arguments _target_ and _proto_, the following steps are taken:</p>
@@ -39960,11 +38352,9 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="26.2" -->
   <emu-clause id="sec-proxy-objects">
     <h1>Proxy Objects</h1>
 
-    <!-- es6num="26.2.1" -->
     <emu-clause id="sec-proxy-constructor">
       <h1>The Proxy Constructor</h1>
       <p>The Proxy constructor:</p>
@@ -39975,7 +38365,6 @@ THH:mm:ss.sss
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
       </ul>
 
-      <!-- es6num="26.2.1.1" -->
       <emu-clause id="sec-proxy-target-handler">
         <h1>Proxy ( _target_, _handler_ )</h1>
         <p>When `Proxy` is called with arguments _target_ and _handler_ performs the following steps:</p>
@@ -39986,7 +38375,6 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <!-- es6num="26.2.2" -->
     <emu-clause id="sec-properties-of-the-proxy-constructor">
       <h1>Properties of the Proxy Constructor</h1>
       <p>The Proxy constructor:</p>
@@ -39996,7 +38384,6 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <!-- es6num="26.2.2.1" -->
       <emu-clause id="sec-proxy.revocable">
         <h1>Proxy.revocable ( _target_, _handler_ )</h1>
         <p>The `Proxy.revocable` function is used to create a revocable Proxy object. When `Proxy.revocable` is called with arguments _target_ and _handler_, the following steps are taken:</p>
@@ -40011,7 +38398,6 @@ THH:mm:ss.sss
           1. Return _result_.
         </emu-alg>
 
-        <!-- es6num="26.2.2.1.1" -->
         <emu-clause id="sec-proxy-revocation-functions">
           <h1>Proxy Revocation Functions</h1>
           <p>A Proxy revocation function is an anonymous function that has the ability to invalidate a specific Proxy object.</p>
@@ -40032,13 +38418,11 @@ THH:mm:ss.sss
     </emu-clause>
   </emu-clause>
 
-  <!-- es6num="26.3" -->
   <emu-clause id="sec-module-namespace-objects">
     <h1>Module Namespace Objects</h1>
     <p>A Module Namespace Object is a module namespace exotic object that provides runtime property-based access to a module's exported bindings. There is no constructor function for Module Namespace Objects. Instead, such an object is created for each module that is imported by an |ImportDeclaration| that includes a |NameSpaceImport|.</p>
     <p>In addition to the properties specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref> each Module Namespace Object has the following own property:</p>
 
-    <!-- es6num="26.3.1" -->
     <emu-clause id="sec-@@tostringtag">
       <h1>@@toStringTag</h1>
       <p>The initial value of the @@toStringTag property is the String value `"Module"`.</p>
@@ -40675,11 +39059,9 @@ THH:mm:ss.sss
   </emu-clause>
 </emu-clause>
 
-<!-- es6num="A" -->
 <emu-annex id="sec-grammar-summary">
   <h1>Grammar Summary</h1>
 
-  <!-- es6num="A.1" -->
   <emu-annex id="sec-lexical-grammar">
     <h1>Lexical Grammar</h1>
     <emu-prodref name=SourceCharacter></emu-prodref>
@@ -40771,7 +39153,6 @@ THH:mm:ss.sss
     <emu-prodref name=TemplateCharacter></emu-prodref>
   </emu-annex>
 
-  <!-- es6num="A.2" -->
   <emu-annex id="sec-expressions">
     <h1>Expressions</h1>
     <emu-prodref name=IdentifierReference></emu-prodref>
@@ -40847,7 +39228,6 @@ THH:mm:ss.sss
     <emu-prodref name=Expression></emu-prodref>
   </emu-annex>
 
-  <!-- es6num="A.3" -->
   <emu-annex id="sec-statements">
     <h1>Statements</h1>
     <emu-prodref name=Statement></emu-prodref>
@@ -40900,7 +39280,6 @@ THH:mm:ss.sss
     <emu-prodref name=DebuggerStatement></emu-prodref>
   </emu-annex>
 
-  <!-- es6num="A.4" -->
   <emu-annex id="sec-functions-and-classes">
     <h1>Functions and Classes</h1>
     <emu-prodref name=FunctionDeclaration></emu-prodref>
@@ -40944,7 +39323,6 @@ THH:mm:ss.sss
     <emu-prodref name=ClassElement></emu-prodref>
   </emu-annex>
 
-  <!-- es6num="A.5" -->
   <emu-annex id="sec-scripts-and-modules">
     <h1>Scripts and Modules</h1>
     <emu-prodref name=Script></emu-prodref>
@@ -40969,7 +39347,6 @@ THH:mm:ss.sss
     <emu-prodref name=ExportSpecifier></emu-prodref>
   </emu-annex>
 
-  <!-- es6num="A.6" -->
   <emu-annex id="sec-number-conversions">
     <h1>Number Conversions</h1>
     <emu-prodref name=StringNumericLiteral></emu-prodref>
@@ -40988,7 +39365,6 @@ THH:mm:ss.sss
     <p>All grammar symbols not explicitly defined by the |StringNumericLiteral| grammar have the definitions used in the <emu-xref href="#sec-literals-numeric-literals">Lexical Grammar for numeric literals</emu-xref>.</p>
   </emu-annex>
 
-  <!-- es6num="A.7" -->
   <emu-annex id="sec-universal-resource-identifier-character-classes">
     <h1>Universal Resource Identifier Character Classes</h1>
     <emu-prodref name=uri></emu-prodref>
@@ -41001,7 +39377,6 @@ THH:mm:ss.sss
     <emu-prodref name=uriMark></emu-prodref>
   </emu-annex>
 
-  <!-- es6num="A.8" -->
   <emu-annex id="sec-regular-expressions">
     <h1>Regular Expressions</h1>
     <emu-prodref name=Pattern></emu-prodref>
@@ -41037,7 +39412,6 @@ THH:mm:ss.sss
   </emu-annex>
 </emu-annex>
 
-<!-- es6num="B" -->
 <emu-annex id="sec-additional-ecmascript-features-for-web-browsers" namespace=annexB normative>
   <h1>Additional ECMAScript Features for Web Browsers</h1>
   <p>The ECMAScript language syntax and semantics defined in this annex are required when the ECMAScript host is a web browser. The content of this annex is normative but optional if the ECMAScript host is not a web browser.</p>
@@ -41046,11 +39420,9 @@ THH:mm:ss.sss
     <p>These features are not considered part of the core ECMAScript language. Programmers should not use or assume the existence of these features and behaviours when writing new ECMAScript code. ECMAScript implementations are discouraged from implementing these features unless the implementation is part of a web browser or is required to run the same legacy ECMAScript code that web browsers encounter.</p>
   </emu-note>
 
-  <!-- es6num="B.1" -->
   <emu-annex id="sec-additional-syntax">
     <h1>Additional Syntax</h1>
 
-    <!-- es6num="B.1.1" -->
     <emu-annex id="sec-additional-syntax-numeric-literals">
       <h1>Numeric Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-numeric-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
@@ -41085,7 +39457,6 @@ THH:mm:ss.sss
           `8` `9`
       </emu-grammar>
 
-      <!-- es6num="B.1.1.1" -->
       <emu-annex id="sec-additional-syntax-numeric-literals-status-semantics">
       <h1>Static Semantics</h1>
       <ul>
@@ -41123,7 +39494,6 @@ THH:mm:ss.sss
       </emu-annex>
     </emu-annex>
 
-    <!-- es6num="B.1.2" -->
     <emu-annex id="sec-additional-syntax-string-literals">
       <h1>String Literals</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-literals-string-literals"></emu-xref> is extended as follows except that this extension is not allowed for strict mode code:</p>
@@ -41149,7 +39519,6 @@ THH:mm:ss.sss
       </emu-grammar>
       <p>This definition of |EscapeSequence| is not used in strict mode or when parsing |TemplateCharacter|.</p>
 
-      <!-- es6num="B.1.2.1" -->
       <emu-annex id="sec-additional-syntax-string-literals-static-semantics">
         <h1>Static Semantics</h1>
         <ul>
@@ -41196,7 +39565,6 @@ THH:mm:ss.sss
       </emu-annex>
     </emu-annex>
 
-    <!-- es6num="B.1.3" -->
     <emu-annex id="sec-html-like-comments">
       <h1>HTML-like Comments</h1>
       <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source code using the goal symbol |Module|:</p>
@@ -41250,7 +39618,6 @@ THH:mm:ss.sss
       <p>Similar to a |MultiLineComment| that contains a line terminator code point, a |SingleLineHTMLCloseComment| is considered to be a |LineTerminator| for purposes of parsing by the syntactic grammar.</p>
     </emu-annex>
 
-    <!-- es6num="B.1.4" -->
     <emu-annex id="sec-regular-expressions-patterns">
       <h1>Regular Expressions Patterns</h1>
       <p>The syntax of <emu-xref href="#sec-patterns"></emu-xref> is modified and extended as follows. These changes introduce ambiguities that are broken by the ordering of grammar productions and by contextual information. When parsing using the following grammar, each alternative is considered only if previous production alternatives do not match.</p>
@@ -41400,7 +39767,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.1.4.1" -->
       <emu-annex id="sec-regular-expression-patterns-semantics">
         <h1>Pattern Semantics</h1>
         <p>The semantics of <emu-xref href="#sec-pattern-semantics"></emu-xref> is extended as follows:</p>
@@ -41491,12 +39857,10 @@ THH:mm:ss.sss
     </emu-annex>
   </emu-annex>
 
-  <!-- es6num="B.2" -->
   <emu-annex id="sec-additional-built-in-properties">
     <h1>Additional Built-in Properties</h1>
     <p>When the ECMAScript host is a web browser the following additional properties of the standard built-in objects are defined.</p>
 
-    <!-- es6num="B.2.1" -->
     <emu-annex id="sec-additional-properties-of-the-global-object">
       <h1>Additional Properties of the Global Object</h1>
       <p>The entries in <emu-xref href="#table-60"></emu-xref> are added to <emu-xref href="#table-7"></emu-xref>.</p>
@@ -41540,7 +39904,6 @@ THH:mm:ss.sss
         </table>
       </emu-table>
 
-      <!-- es6num="B.2.1.1" -->
       <emu-annex id="sec-escape-string">
         <h1>escape ( _string_ )</h1>
         <p>The `escape` function is a property of the global object. It computes a new version of a String value in which certain code units have been replaced by a hexadecimal escape sequence.</p>
@@ -41574,7 +39937,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-annex>
 
-      <!-- es6num="B.2.1.2" -->
       <emu-annex id="sec-unescape-string">
         <h1>unescape ( _string_ )</h1>
         <p>The `unescape` function is a property of the global object. It computes a new version of a String value in which each escape sequence of the sort that might be introduced by the `escape` function is replaced with the code unit that it represents.</p>
@@ -41600,16 +39962,13 @@ THH:mm:ss.sss
       </emu-annex>
     </emu-annex>
 
-    <!-- es6num="B.2.2" -->
     <emu-annex id="sec-additional-properties-of-the-object.prototype-object">
       <h1>Additional Properties of the Object.prototype Object</h1>
 
-      <!-- es6num="B.2.2.1" -->
       <emu-annex id="sec-object.prototype.__proto__">
         <h1>Object.prototype.__proto__</h1>
         <p>Object.prototype.__proto__ is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
 
-        <!-- es6num="B.2.2.1.1" -->
         <emu-annex id="sec-get-object.prototype.__proto__">
           <h1>get Object.prototype.__proto__</h1>
           <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps:</p>
@@ -41619,7 +39978,6 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-annex>
 
-        <!-- es6num="B.2.2.1.2" -->
         <emu-annex id="sec-set-object.prototype.__proto__">
           <h1>set Object.prototype.__proto__</h1>
           <p>The value of the [[Set]] attribute is a built-in function that takes an argument _proto_. It performs the following steps:</p>
@@ -41693,11 +40051,9 @@ THH:mm:ss.sss
       </emu-annex>
     </emu-annex>
 
-    <!-- es6num="B.2.3" -->
     <emu-annex id="sec-additional-properties-of-the-string.prototype-object">
       <h1>Additional Properties of the String.prototype Object</h1>
 
-      <!-- es6num="B.2.3.1" -->
       <emu-annex id="sec-string.prototype.substr">
         <h1>String.prototype.substr ( _start_, _length_ )</h1>
         <p>The `substr` method takes two arguments, _start_ and _length_, and returns a substring of the result of converting the *this* object to a String, starting from index _start_ and running for _length_ code units (or through the end of the String if _length_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_sourceLength_+_start_</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object. The following steps are taken:</p>
@@ -41717,7 +40073,6 @@ THH:mm:ss.sss
         </emu-note>
       </emu-annex>
 
-      <!-- es6num="B.2.3.2" -->
       <emu-annex id="sec-string.prototype.anchor">
         <h1>String.prototype.anchor ( _name_ )</h1>
         <p>When the `anchor` method is called with argument _name_, the following steps are taken:</p>
@@ -41726,7 +40081,6 @@ THH:mm:ss.sss
           1. Return ? CreateHTML(_S_, `"a"`, `"name"`, _name_).
         </emu-alg>
 
-        <!-- es6num="B.2.3.2.1" -->
         <emu-annex id="sec-createhtml" aoid="CreateHTML">
           <h1>Runtime Semantics: CreateHTML ( _string_, _tag_, _attribute_, _value_ )</h1>
           <p>The abstract operation CreateHTML is called with arguments _string_, _tag_, _attribute_, and _value_. The arguments _tag_ and _attribute_ must be String values. The following steps are taken:</p>
@@ -41753,7 +40107,6 @@ THH:mm:ss.sss
         </emu-annex>
       </emu-annex>
 
-      <!-- es6num="B.2.3.3" -->
       <emu-annex id="sec-string.prototype.big">
         <h1>String.prototype.big ( )</h1>
         <p>When the `big` method is called with no arguments, the following steps are taken:</p>
@@ -41763,7 +40116,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.4" -->
       <emu-annex id="sec-string.prototype.blink">
         <h1>String.prototype.blink ( )</h1>
         <p>When the `blink` method is called with no arguments, the following steps are taken:</p>
@@ -41773,7 +40125,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.5" -->
       <emu-annex id="sec-string.prototype.bold">
         <h1>String.prototype.bold ( )</h1>
         <p>When the `bold` method is called with no arguments, the following steps are taken:</p>
@@ -41783,7 +40134,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.6" -->
       <emu-annex id="sec-string.prototype.fixed">
         <h1>String.prototype.fixed ( )</h1>
         <p>When the `fixed` method is called with no arguments, the following steps are taken:</p>
@@ -41793,7 +40143,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.7" -->
       <emu-annex id="sec-string.prototype.fontcolor">
         <h1>String.prototype.fontcolor ( _color_ )</h1>
         <p>When the `fontcolor` method is called with argument _color_, the following steps are taken:</p>
@@ -41803,7 +40152,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.8" -->
       <emu-annex id="sec-string.prototype.fontsize">
         <h1>String.prototype.fontsize ( _size_ )</h1>
         <p>When the `fontsize` method is called with argument _size_, the following steps are taken:</p>
@@ -41813,7 +40161,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.9" -->
       <emu-annex id="sec-string.prototype.italics">
         <h1>String.prototype.italics ( )</h1>
         <p>When the `italics` method is called with no arguments, the following steps are taken:</p>
@@ -41823,7 +40170,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.10" -->
       <emu-annex id="sec-string.prototype.link">
         <h1>String.prototype.link ( _url_ )</h1>
         <p>When the `link` method is called with argument _url_, the following steps are taken:</p>
@@ -41833,7 +40179,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.11" -->
       <emu-annex id="sec-string.prototype.small">
         <h1>String.prototype.small ( )</h1>
         <p>When the `small` method is called with no arguments, the following steps are taken:</p>
@@ -41843,7 +40188,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.12" -->
       <emu-annex id="sec-string.prototype.strike">
         <h1>String.prototype.strike ( )</h1>
         <p>When the `strike` method is called with no arguments, the following steps are taken:</p>
@@ -41853,7 +40197,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.13" -->
       <emu-annex id="sec-string.prototype.sub">
         <h1>String.prototype.sub ( )</h1>
         <p>When the `sub` method is called with no arguments, the following steps are taken:</p>
@@ -41863,7 +40206,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.3.14" -->
       <emu-annex id="sec-string.prototype.sup">
         <h1>String.prototype.sup ( )</h1>
         <p>When the `sup` method is called with no arguments, the following steps are taken:</p>
@@ -41874,11 +40216,9 @@ THH:mm:ss.sss
       </emu-annex>
     </emu-annex>
 
-    <!-- es6num="B.2.4" -->
     <emu-annex id="sec-additional-properties-of-the-date.prototype-object">
       <h1>Additional Properties of the Date.prototype Object</h1>
 
-      <!-- es6num="B.2.4.1" -->
       <emu-annex id="sec-date.prototype.getyear">
         <h1>Date.prototype.getYear ( )</h1>
         <emu-note>
@@ -41892,7 +40232,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.4.2" -->
       <emu-annex id="sec-date.prototype.setyear">
         <h1>Date.prototype.setYear ( _year_ )</h1>
         <emu-note>
@@ -41913,7 +40252,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
 
-      <!-- es6num="B.2.4.3" -->
       <emu-annex id="sec-date.prototype.togmtstring">
         <h1>Date.prototype.toGMTString ( )</h1>
         <emu-note>
@@ -41923,11 +40261,9 @@ THH:mm:ss.sss
       </emu-annex>
     </emu-annex>
 
-    <!-- es6num="B.2.5" -->
     <emu-annex id="sec-additional-properties-of-the-regexp.prototype-object">
       <h1>Additional Properties of the RegExp.prototype Object</h1>
 
-      <!-- es6num="B.2.5.1" -->
       <emu-annex id="sec-regexp.prototype.compile">
         <h1>RegExp.prototype.compile ( _pattern_, _flags_ )</h1>
         <p>When the `compile` method is called with arguments _pattern_ and _flags_, the following steps are taken:</p>
@@ -41951,11 +40287,9 @@ THH:mm:ss.sss
     </emu-annex>
   </emu-annex>
 
-  <!-- es6num="B.3" -->
   <emu-annex id="sec-other-additional-features">
     <h1>Other Additional Features</h1>
 
-    <!-- es6num="B.3.1" -->
     <emu-annex id="sec-__proto__-property-names-in-object-initializers">
       <h1>__proto__ Property Names in Object Initializers</h1>
       <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the Early Error rule is <b>not</b> applied. In addition, it is not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|.</p>
@@ -41995,7 +40329,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-annex>
 
-    <!-- es6num="B.3.2" -->
     <emu-annex id="sec-labelled-function-declarations">
       <h1>Labelled Function Declarations</h1>
       <p>Prior to ECMAScript 2015, the specification of |LabelledStatement| did not allow for the association of a statement label with a |FunctionDeclaration|. However, a labelled |FunctionDeclaration| was an allowable extension for non-strict code and most browser-hosted ECMAScript implementations supported that extension. In ECMAScript 2015, the grammar productions for |LabelledStatement| permits use of |FunctionDeclaration| as a |LabelledItem| but <emu-xref href="#sec-labelled-statements-static-semantics-early-errors"></emu-xref> includes an Early Error rule that produces a Syntax Error if that occurs. For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
@@ -42010,7 +40343,6 @@ THH:mm:ss.sss
       </emu-note>
     </emu-annex>
 
-    <!-- es6num="B.3.3" -->
     <emu-annex id="sec-block-level-function-declarations-web-legacy-compatibility-semantics">
       <h1>Block-Level Function Declarations Web Legacy Compatibility Semantics</h1>
       <p>Prior to ECMAScript 2015, the ECMAScript specification did not define the occurrence of a |FunctionDeclaration| as an element of a |Block| statement's |StatementList|. However, support for that form of |FunctionDeclaration| was an allowable extension and most browser-hosted ECMAScript implementations permitted them. Unfortunately, the semantics of such declarations differ among those implementations. Because of these semantic differences, existing web ECMAScript code that uses |Block| level function declarations is only portable among browser implementation if the usage only depends upon the semantic intersection of all of the browser implementations for such declarations. The following are the use cases that fall within that intersection semantics:</p>
@@ -42207,7 +40539,6 @@ THH:mm:ss.sss
       </emu-annex>
     </emu-annex>
 
-    <!-- es6num="B.3.4" -->
     <emu-annex id="sec-functiondeclarations-in-ifstatement-statement-clauses">
       <h1>FunctionDeclarations in IfStatement Statement Clauses</h1>
       <p>The following augments the |IfStatement| production in <emu-xref href="#sec-if-statement"></emu-xref>:</p>
@@ -42221,7 +40552,6 @@ THH:mm:ss.sss
       <p>This production only applies when parsing non-strict code. Code matching this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ?Await, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
     </emu-annex>
 
-    <!-- es6num="B.3.5" -->
     <emu-annex id="sec-variablestatements-in-catch-blocks">
       <h1>VariableStatements in Catch Blocks</h1>
       <p>The content of subclause <emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref> is replaced with the following:</p>
@@ -42252,7 +40582,6 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-annex>
 
-    <!-- es6num="B.3.6" -->
     <emu-annex id="sec-initializers-in-forin-statement-heads">
       <h1>Initializers in ForIn Statement Heads</h1>
       <p>The following augments the |IterationStatement| production in <emu-xref href="#sec-iteration-statements"></emu-xref>:</p>
@@ -42374,7 +40703,6 @@ THH:mm:ss.sss
   </emu-annex>
 </emu-annex>
 
-<!-- es6num="C" -->
 <emu-annex id="sec-strict-mode-of-ecmascript">
   <h1>The Strict Mode of ECMAScript</h1>
   <p><b>The strict mode restriction and exceptions</b></p>
@@ -42433,7 +40761,6 @@ THH:mm:ss.sss
   </ul>
 </emu-annex>
 
-<!-- es6num="D" -->
 <emu-annex id="sec-corrections-and-clarifications-in-ecmascript-2015-with-possible-compatibility-impact">
   <h1>Corrections and Clarifications in ECMAScript 2015 with Possible Compatibility Impact</h1>
   <p><emu-xref href="#sec-candeclareglobalvar"></emu-xref>-<emu-xref href="#sec-createglobalfunctionbinding"></emu-xref> Edition 5 and 5.1 used a property existence test to determine whether a global object property corresponding to a new global declaration already existed. ECMAScript 2015 uses an own property existence test. This corresponds to what has been most commonly implemented by web browsers.</p>
@@ -42447,7 +40774,6 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>, <emu-xref href="#sec-sortcompare"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0* was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-dependent. In practice, implementations call ToNumber.</p>
 </emu-annex>
 
-<!-- es6num="E" -->
 <emu-annex id="sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">
   <h1>Additions and Changes That Introduce Incompatibilities with Prior Editions</h1>
   <p><emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>: In ECMAScript 2015, ToNumber applied to a String value now recognizes and converts |BinaryIntegerLiteral| and |OctalIntegerLiteral| numeric strings. In previous editions such strings were converted to *NaN*.</p>
@@ -42495,7 +40821,6 @@ THH:mm:ss.sss
   <p>This specification is authored on <a href="https://github.com/tc39/ecma262">GitHub</a> in a plaintext source format called <a href="https://github.com/bterlson/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMAScript specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/domenic/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this specification are produced by printing the HTML rendering to a PDF.</p>
   <p>Prior editions of this specification were authored using Word&mdash;the Ecmarkup source text that formed the basis of this edition was produced by converting the ECMAScript 2015 Word document to Ecmarkup using an automated conversion tool.</p>
 </emu-annex>
-<!-- es6num="F" -->
 <emu-annex id="sec-bibliography">
   <h1>Bibliography</h1>
   <ol>


### PR DESCRIPTION
Since these comments don't actually get converted into anchors, they serve no purpose. Let's get rid of them.