### PR TITLE
Editorial: Consistency for the term "fully populated Property Descriptor"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2570,7 +2570,7 @@
             The normal return type is either Property Descriptor or Undefined.
           </li>
           <li>
-            If the Type of the return value is Property Descriptor, the return value must be a <emu-xref href="#sec-completepropertydescriptor">complete property descriptor</emu-xref>.
+            If the Type of the return value is Property Descriptor, the return value must be a fully populated Property Descriptor.
           </li>
           <li>
             If _P_ is described as a non-configurable, non-writable own data property, all future calls to [[GetOwnProperty]] ( _P_ ) must return Property Descriptor whose [[Value]] is SameValue as _P_'s [[Value]] attribute.
@@ -7441,7 +7441,7 @@
         1. Let _global_ be _realmRec_.[[GlobalObject]].
         1. For each property of the Global Object specified in clause <emu-xref href="#sec-global-object"></emu-xref>, do
           1. Let _name_ be the String value of the property name.
-          1. Let _desc_ be the fully populated data property descriptor for the property, containing the specified attributes for the property. For properties listed in <emu-xref href="#sec-function-properties-of-the-global-object"></emu-xref>, <emu-xref href="#sec-constructor-properties-of-the-global-object"></emu-xref>, or <emu-xref href="#sec-other-properties-of-the-global-object"></emu-xref> the value of the [[Value]] attribute is the corresponding intrinsic object from _realmRec_.
+          1. Let _desc_ be the fully populated data Property Descriptor for the property, containing the specified attributes for the property. For properties listed in <emu-xref href="#sec-function-properties-of-the-global-object"></emu-xref>, <emu-xref href="#sec-constructor-properties-of-the-global-object"></emu-xref>, or <emu-xref href="#sec-other-properties-of-the-global-object"></emu-xref> the value of the [[Value]] attribute is the corresponding intrinsic object from _realmRec_.
           1. Perform ? DefinePropertyOrThrow(_global_, _name_, _desc_).
         1. Return _global_.
       </emu-alg>


### PR DESCRIPTION
Previously a mixture of "complete property descriptor" and "fully populated property descriptor" was used. Change to use the defined "fully populated property descriptor" term.

Also capitalise "Property Descriptor" so that definition detection (hopefully) kicks in elsewhere, to be consistent with the rest of the spec.