### PR TITLE
Normative: Use array indices instead of integer indices in OrdinaryOwnPropertyKeys

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7052,9 +7052,9 @@
 
         <emu-alg>
           1. Let _keys_ be a new empty List.
-          1. For each own property key _P_ of _O_ that is an integer index, in ascending numeric index order, do
+          1. For each own property key _P_ of _O_ that is an array index, in ascending numeric index order, do
             1. Add _P_ as the last element of _keys_.
-          1. For each own property key _P_ of _O_ that is a String but is not an integer index, in ascending chronological order of property creation, do
+          1. For each own property key _P_ of _O_ that is a String but is not an array index, in ascending chronological order of property creation, do
             1. Add _P_ as the last element of _keys_.
           1. For each own property key _P_ of _O_ that is a Symbol, in ascending chronological order of property creation, do
             1. Add _P_ as the last element of _keys_.


### PR DESCRIPTION
All major JavaScript engines agree on the following behavior:

    $ eshost -e 'Reflect.ownKeys({ a: 1, [Number.MAX_SAFE_INTEGER]: 1, 42: 1, [2**32-1]: 1, [2**32-2]: 1 })'

    #### Chakra
    42,4294967294,a,9007199254740991,4294967295

    #### V8 --harmony
    42,4294967294,a,9007199254740991,4294967295

    #### V8
    42,4294967294,a,9007199254740991,4294967295

    #### JavaScriptCore
    42,4294967294,a,9007199254740991,4294967295

    #### SpiderMonkey
    42,4294967294,a,9007199254740991,4294967295

That is, the order is:

- array indices, in ascending numeric index order
- strings that are not array indices, in ascending chronological creation order
- symbols, in ascending chronological creation order

This patch makes the spec for `OrdinaryOwnPropertyKeys` match Web reality.