### PR TITLE
Normative: Fix [[OwnPropertyKeys]]() for String exotic objects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7958,9 +7958,9 @@
           1. Let _len_ be the length of _str_.
           1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
             1. Add ! ToString(_i_) as the last element of _keys_.
-          1. For each own property key _P_ of _O_ such that _P_ is an integer index and ToInteger(_P_) &ge; _len_, in ascending numeric index order, do
+          1. For each own property key _P_ of _O_ such that _P_ is an array index and ToInteger(_P_) &ge; _len_, in ascending numeric index order, do
             1. Add _P_ as the last element of _keys_.
-          1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an integer index, in ascending chronological order of property creation, do
+          1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an array index, in ascending chronological order of property creation, do
             1. Add _P_ as the last element of _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is Symbol, in ascending chronological order of property creation, do
             1. Add _P_ as the last element of _keys_.


### PR DESCRIPTION
All engines except Chakra agree on the following behavior:

    $ eshost -e 'x = new String(); x[2**32-2] = 1; x[2**32-1] = 1; x[2**53-1] = 1; x[2**53] = 1; Reflect.ownKeys(x)'
    #### Chakra
    4294967294,4294967295,9007199254740991,9007199254740992,length

    #### JavaScriptCore
    4294967294,length,4294967295,9007199254740991,9007199254740992

    #### V8 --harmony
    4294967294,length,4294967295,9007199254740991,9007199254740992

    #### V8
    4294967294,length,4294967295,9007199254740991,9007199254740992

    #### SpiderMonkey
    4294967294,length,4294967295,9007199254740991,9007199254740992

That is, they use array indices instead of integer indices in `[[OwnPropertyKeys]]()` for String exotic objects.

This patch makes the spec match the reality of the majority of implementations.