### PR TITLE
Editorial: remove example for global object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23067,7 +23067,7 @@
     <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
     <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     <li>has a [[Prototype]] internal slot whose value is implementation-dependent.</li>
-    <li>may have host defined properties in addition to the properties defined in this specification. This may include a property whose value is the global object itself; for example, in the HTML document object model the `window` property of the global object is the global object itself.</li>
+    <li>may have host defined properties in addition to the properties defined in this specification. This may include a property whose value is the global object itself.</li>
   </ul>
 
   <emu-clause id="sec-value-properties-of-the-global-object">


### PR DESCRIPTION
Remove the example in the fifth bullet point in the description for the
global object, because it isn't true anymore (window never returns the
global object).

Fixes: https://github.com/tc39/ecma262/issues/1200

/cc @ljharb @littledan 