### PR TITLE
Editorial: Simplify %AsyncFromSyncIteratorPrototype% methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36433,19 +36433,9 @@ THH:mm:ss.sss
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _invalidIteratorError_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
-            1. Let _nextResult_ be IteratorNext(_syncIteratorRecord_, _value_).
-            1. IfAbruptRejectPromise(_nextResult_, _promiseCapability_).
-            1. Let _nextDone_ be IteratorComplete(_nextResult_).
-            1. IfAbruptRejectPromise(_nextDone_, _promiseCapability_).
-            1. Let _nextValue_ be IteratorValue(_nextResult_).
-            1. IfAbruptRejectPromise(_nextValue_, _promiseCapability_).
-            1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
-            1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _nextValue_ &raquo;).
-            1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
-            1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, &laquo; [[Done]] &raquo;).
-            1. Set _onFulfilled_.[[Done]] to _nextDone_.
-            1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
-            1. Return _promiseCapability_.[[Promise]].
+            1. Let _result_ be IteratorNext(_syncIteratorRecord_, _value_).
+            1. IfAbruptRejectPromise(_result_, _promiseCapability_).
+            1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
           </emu-alg>
         </emu-clause>
 
@@ -36466,22 +36456,12 @@ THH:mm:ss.sss
               1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
-            1. Let _returnResult_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
-            1. IfAbruptRejectPromise(_returnResult_, _promiseCapability_).
-            1. If Type(_returnResult_) is not Object, then
+            1. Let _result_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
+            1. IfAbruptRejectPromise(_result_, _promiseCapability_).
+            1. If Type(_result_) is not Object, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
               1. Return _promiseCapability_.[[Promise]].
-            1. Let _returnDone_ be IteratorComplete(_returnResult_).
-            1. IfAbruptRejectPromise(_returnDone_, _promiseCapability_).
-            1. Let _returnValue_ be IteratorValue(_returnResult_).
-            1. IfAbruptRejectPromise(_returnValue_, _promiseCapability_).
-            1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
-            1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _returnValue_ &raquo;).
-            1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
-            1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, &laquo; [[Done]] &raquo;).
-            1. Set _onFulfilled_.[[Done]] to _returnDone_.
-            1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
-            1. Return _promiseCapability_.[[Promise]].
+            1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
           </emu-alg>
         </emu-clause>
 
@@ -36501,22 +36481,12 @@ THH:mm:ss.sss
             1. If _throw_ is *undefined*, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
-            1. Let _throwResult_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
-            1. IfAbruptRejectPromise(_throwResult_, _promiseCapability_).
-            1. If Type(_throwResult_) is not Object, then
+            1. Let _result_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
+            1. IfAbruptRejectPromise(_result_, _promiseCapability_).
+            1. If Type(_result_) is not Object, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
               1. Return _promiseCapability_.[[Promise]].
-            1. Let _throwDone_ be IteratorComplete(_throwResult_).
-            1. IfAbruptRejectPromise(_throwDone_, _promiseCapability_).
-            1. Let _throwValue_ be IteratorValue(_throwResult_).
-            1. IfAbruptRejectPromise(_throwValue_, _promiseCapability_).
-            1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
-            1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _throwValue_ &raquo;).
-            1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
-            1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, &laquo; [[Done]] &raquo;).
-            1. Set _onFulfilled_.[[Done]] to _throwDone_.
-            1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
-            1. Return _promiseCapability_.[[Promise]].
+            1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
           </emu-alg>
         </emu-clause>
 
@@ -36566,6 +36536,24 @@ THH:mm:ss.sss
             </tbody>
           </table>
         </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-async-from-sync-iterator-continuation" aoid="AsyncFromSyncIteratorContinuation">
+        <h1>AsyncFromSyncIteratorContinuation ( _result_, _promiseCapability_ )</h1>
+
+        <emu-alg>
+          1. Let _done_ be IteratorComplete(_result_).
+          1. IfAbruptRejectPromise(_done_, _promiseCapability_).
+          1. Let _value_ be IteratorValue(_result_).
+          1. IfAbruptRejectPromise(_value_, _promiseCapability_).
+          1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
+          1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _value_ &raquo;).
+          1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, &laquo; [[Done]] &raquo;).
+          1. Set _onFulfilled_.[[Done]] to _done_.
+          1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
+          1. Return _promiseCapability_.[[Promise]].
+        </emu-alg>
       </emu-clause>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
Extract common steps from the following clauses:
25.1.4.2.1 %AsyncFromSyncIteratorPrototype%.next
25.1.4.2.2 %AsyncFromSyncIteratorPrototype%.return
25.1.4.2.3 %AsyncFromSyncIteratorPrototype%.throw
into new primitive AsyncFromSyncIteratorContinuation.