### PR TITLE
Normative: Reduce the number of ticks in async/await

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2990,22 +2990,21 @@
         <p>Algorithm steps that say</p>
 
         <emu-alg>
-          1. Let _completion_ be Await(_promise_).
+          1. Let _completion_ be Await(_value_).
         </emu-alg>
 
         <p>mean the same thing as:</p>
 
         <emu-alg>
           1. Let _asyncContext_ be the running execution context.
-          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _promise_ &raquo;).
+          1. Let _promise_ be ? PromiseResolve(&laquo; _value_ &raquo;).
           1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#await-fulfilled" title></emu-xref>.
           1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[AsyncContext]] &raquo;).
           1. Set _onFulfilled_.[[AsyncContext]] to _asyncContext_.
           1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#await-rejected" title></emu-xref>.
           1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[AsyncContext]] &raquo;).
           1. Set _onRejected_.[[AsyncContext]] to _asyncContext_.
-          1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_).
+          1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
           1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _completion_, the following steps of the algorithm that invoked Await will be performed, with _completion_ available.
           1. Return.
@@ -3018,14 +3017,14 @@
           <p>Await can be combined with the `?` and `!` prefixes, so that for example</p>
 
           <emu-alg>
-            1. Let _value_ be ? Await(_promise_).
+            1. Let _result_ be ? Await(_value_).
           </emu-alg>
 
           <p>means the same thing as:</p>
 
           <emu-alg>
-            1. Let _value_ be Await(_promise_).
-            1. ReturnIfAbrupt(_value_).
+            1. Let _result_ be Await(_value_).
+            1. ReturnIfAbrupt(_result_).
           </emu-alg>
         </emu-note>
 
@@ -36909,12 +36908,11 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_done_, _promiseCapability_).
           1. Let _value_ be IteratorValue(_result_).
           1. IfAbruptRejectPromise(_value_, _promiseCapability_).
-          1. Let _valueWrapperCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _value_ &raquo;).
+          1. Let _valueWrapper_ be ? PromiseResolve(&laquo; _value_ &raquo;).
           1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
           1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, &laquo; [[Done]] &raquo;).
           1. Set _onFulfilled_.[[Done]] to _done_.
-          1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
+          1. Perform ! PerformPromiseThen(_valueWrapper_, _onFulfilled_, *undefined*, _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
       </emu-clause>
@@ -37535,15 +37533,14 @@ THH:mm:ss.sss
             1. If _state_ is `"completed"`, then
               1. If _completion_.[[Type]] is ~return~, then
                 1. Set _generator_.[[AsyncGeneratorState]] to `"awaiting-return"`.
-                1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
+                1. Let _promise_ be ? PromiseResolve(&laquo; _completion_.[[Value]] &raquo;).
                 1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
                 1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Generator]] &raquo;).
                 1. Set _onFulfilled_.[[Generator]] to _generator_.
                 1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
                 1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Generator]] &raquo;).
                 1. Set _onRejected_.[[Generator]] to _generator_.
-                1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_).
+                1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
                 1. Return *undefined*.
               1. Else,
                 1. Assert: _completion_.[[Type]] is ~throw~.

--- a/spec.html
+++ b/spec.html
@@ -2997,7 +2997,7 @@
 
         <emu-alg>
           1. Let _asyncContext_ be the running execution context.
-          1. Let _promise_ be ? PromiseResolve(&laquo; _value_ &raquo;).
+          1. Let _promise_ be ? PromiseResolve(%Promise%, &laquo; _value_ &raquo;).
           1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#await-fulfilled" title></emu-xref>.
           1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[AsyncContext]] &raquo;).
           1. Set _onFulfilled_.[[AsyncContext]] to _asyncContext_.
@@ -36908,7 +36908,7 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_done_, _promiseCapability_).
           1. Let _value_ be IteratorValue(_result_).
           1. IfAbruptRejectPromise(_value_, _promiseCapability_).
-          1. Let _valueWrapper_ be ? PromiseResolve(&laquo; _value_ &raquo;).
+          1. Let _valueWrapper_ be ? PromiseResolve(%Promise%, &laquo; _value_ &raquo;).
           1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
           1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, &laquo; [[Done]] &raquo;).
           1. Set _onFulfilled_.[[Done]] to _done_.
@@ -37533,7 +37533,7 @@ THH:mm:ss.sss
             1. If _state_ is `"completed"`, then
               1. If _completion_.[[Type]] is ~return~, then
                 1. Set _generator_.[[AsyncGeneratorState]] to `"awaiting-return"`.
-                1. Let _promise_ be ? PromiseResolve(&laquo; _completion_.[[Value]] &raquo;).
+                1. Let _promise_ be ? PromiseResolve(%Promise%, &laquo; _completion_.[[Value]] &raquo;).
                 1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
                 1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Generator]] &raquo;).
                 1. Set _onFulfilled_.[[Generator]] to _generator_.

--- a/spec.html
+++ b/spec.html
@@ -36900,7 +36900,7 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-async-from-sync-iterator-continuation" aoid="AsyncFromSyncIteratorContinuation">
+      <emu-clause id="sec-asyncfromsynciteratorcontinuation" aoid="AsyncFromSyncIteratorContinuation">
         <h1>AsyncFromSyncIteratorContinuation ( _result_, _promiseCapability_ )</h1>
 
         <emu-alg>


### PR DESCRIPTION
JavaScript programmers may expect that the following
two programs are largely similar in terms of how they perform with
respect to the ECMAScript job queue (if inside of an async function):

promise.then(f);                f(await promise);

However, if `promise` is a built-in promise, then these two code fragments
will differ in the number of iterations through the job queue are taken: because
`await` always wraps a Promise with another Promise, there are three job
queue items enqueued and dequeued before calling `f` in the `await` example,
whereas there is just a single item for the `then` usage.

In discussions with JavaScript programmers, the number of job queue items
in the current semantics turns out to be surprising. For example, the difference
has become more visible in conjunction with new V8 features for Promise
visibility and debugging, which are sometimes used in Node.js.

This patch changes the semantics of await to reduce the number of
job queue turns that are taken in the common `await` Promise case by replacing
the unconditional wrapping with a call to PromiseResolve. Analogous changes
are made in async iterators.

The patch preserves key design goals of async/await:
- Job queue processing remains deterministic, including both ordering and the number of jobs enqueued (which is observable by interspersing other jobs)
- Userland Promise libraries with "then" methods ("foreign thenables") are usable within `await`, and trigger a turn of the job queue
- Non-Promises can be awaited, and this takes a turn of the native job queue (as do all usages of `await`)

Reducing the number of job queue turns also improves performance
on multiple highly optimized async/await implementations. In a draft
implementation of this proposal in V8 behind a flag [1]:
- The doxbee async/await performance benchmark [2] improved with 48%
- The fibonacci async/await performance benchmark [3] improved with 23%
- The Hapi throughput benchmark [4] improved with 50% (when async hooks are enabled) and with 20% (when async hooks are disabled)

[1] https://chromium-review.googlesource.com/c/v8/v8/+/1106977
[2] https://github.com/bmeurer/promise-performance-tests/blob/master/lib/doxbee-async.js
[3] https://github.com/bmeurer/promise-performance-tests/blob/master/lib/fibonacci-async.js
[4] https://github.com/fastify/benchmarks