### PR TITLE
Allow symbols as Weak{Map,Set} keys

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4285,6 +4285,19 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-isforgable" aoid="IsForgable">
+      <h1>IsForgable ( _argument_ )</h1>
+      <p>The abstract operation IsForgable determines if _argument_, which must be an ECMAScript language value, is forgable.</p>
+      <emu-alg>
+        1. If Type(_argument_) is Symbol then,
+          1. For each element _e_ of the GlobalSymbolRegistry List, do,
+            1. If SameValue(_e_.[[Symbol]], _argument_) is *true*, return *true*.
+          1. Return *false*.
+        1. If Type(_argument_) is Object, return *true*.
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-isinteger" aoid="IsInteger">
       <h1>IsInteger ( _argument_ )</h1>
       <p>The abstract operation IsInteger determines if _argument_ is a finite integer numeric value.</p>
@@ -34358,7 +34371,7 @@ THH:mm:ss.sss
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
-          1. If Type(_key_) is not Object, return *false*.
+          1. If IsForgable(_key_) is *true*, return *false*.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Key]] to ~empty~.
@@ -34379,7 +34392,7 @@ THH:mm:ss.sss
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
-          1. If Type(_key_) is not Object, return *undefined*.
+          1. If IsForgable(_key_) is *true*, return *undefined*.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
           1. Return *undefined*.
@@ -34394,7 +34407,7 @@ THH:mm:ss.sss
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
-          1. If Type(_key_) is not Object, return *false*.
+          1. If IsForgable(_key_) is *true*, return *false*.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return *true*.
           1. Return *false*.
@@ -34409,7 +34422,7 @@ THH:mm:ss.sss
           1. If Type(_M_) is not Object, throw a *TypeError* exception.
           1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
-          1. If Type(_key_) is not Object, throw a *TypeError* exception.
+          1. If IsForgable(_key_) is *true*, throw a *TypeError* exception.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Value]] to _value_.
@@ -34507,7 +34520,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
-          1. If Type(_value_) is not Object, throw a *TypeError* exception.
+          1. If IsForgable(_value_) is *true*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. For each _e_ that is an element of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
@@ -34529,7 +34542,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
-          1. If Type(_value_) is not Object, return *false*.
+          1. If IsForgable(_value_) is *true*, return *false*.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. For each _e_ that is an element of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
@@ -34550,7 +34563,7 @@ THH:mm:ss.sss
           1. If Type(_S_) is not Object, throw a *TypeError* exception.
           1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
-          1. If Type(_value_) is not Object, return *false*.
+          1. If IsForgable(_value_) is *true*, return *false*.
           1. For each _e_ that is an element of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, return *true*.
           1. Return *false*.


### PR DESCRIPTION
Fixes #1194

Right now this doesn't allow symbols from the global registry but that can change.


this replaces #1206 because my fork of ecma262 was deleted since then.... sorry for the churn.