### PR TITLE
Editorial: create addIterableFromEntries abstract operation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33586,14 +33586,25 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%MapPrototype%"`, &laquo; [[MapData]] &raquo;).
           1. Set _map_.[[MapData]] to a new empty List.
-          1. If _iterable_ is not present, let _iterable_ be *undefined*.
-          1. If _iterable_ is either *undefined* or *null*, return _map_.
+          1. If _iterable_ is not present, or is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, `"set"`).
+          1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
+        </emu-alg>
+        <emu-note>
+          <p>If the parameter _iterable_ is present, it is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-add-entries-from-iterable" aoid="AddEntriesFromIterable">
+        <h1>AddEntriesFromIterable ( _target_, _iterable_, _adder_ )</h1>
+        <p>The abstract operation AddEntriesFromIterable accepts a _target_ object, an _iterable_ of entries, and an _adder_ function to be invoked, with _target_ as the receiver.</p>
+        <emu-alg>
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. Assert: _iterable_ is present, and is neither *undefined* nor *null*.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-            1. If _next_ is *false*, return _map_.
+            1. If _next_ is *false*, return _target_.
             1. Let _nextItem_ be ? IteratorValue(_next_).
             1. If Type(_nextItem_) is not Object, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
@@ -33602,11 +33613,11 @@ THH:mm:ss.sss
             1. If _k_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _k_).
             1. Let _v_ be Get(_nextItem_, `"1"`).
             1. If _v_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _v_).
-            1. Let _status_ be Call(_adder_, _map_, &laquo; _k_.[[Value]], _v_.[[Value]] &raquo;).
+            1. Let _status_ be Call(_adder_, _target_, &laquo; _k_.[[Value]], _v_.[[Value]] &raquo;).
             1. If _status_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _status_).
         </emu-alg>
         <emu-note>
-          <p>If the parameter _iterable_ is present, it is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
+          <p>The parameter _iterable_ is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -34299,24 +34310,9 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakMapPrototype%"`, &laquo; [[WeakMapData]] &raquo;).
           1. Set _map_.[[WeakMapData]] to a new empty List.
-          1. If _iterable_ is not present, let _iterable_ be *undefined*.
-          1. If _iterable_ is either *undefined* or *null*, return _map_.
+          1. If _iterable_ is not present, or is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, `"set"`).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
-          1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
-          1. Repeat,
-            1. Let _next_ be ? IteratorStep(_iterRecord_).
-            1. If _next_ is *false*, return _map_.
-            1. Let _nextItem_ be ? IteratorValue(_next_).
-            1. If Type(_nextItem_) is not Object, then
-              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-              1. Return ? IteratorClose(_iteratorRecord_, _error_).
-            1. Let _k_ be Get(_nextItem_, `"0"`).
-            1. If _k_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _k_).
-            1. Let _v_ be Get(_nextItem_, `"1"`).
-            1. If _v_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _v_).
-            1. Let _status_ be Call(_adder_, _map_, &laquo; _k_.[[Value]], _v_.[[Value]] &raquo;).
-            1. If _status_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _status_).
+          1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
           <p>If the parameter _iterable_ is present, it is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a WeakMap key and whose second element is the value to associate with that key.</p>


### PR DESCRIPTION
This consolidates some of the logic in the Map and WeakMap constructors, and also creates a convenient operation for https://github.com/tc39/proposal-object-from-entries/issues/11.