### PR TITLE
Date.prototype.toString is not generic

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27502,7 +27502,7 @@ THH:mm:ss.sss
           <p>For any Date object `d` whose milliseconds amount is zero, the result of `Date.parse(d.toString())` is equal to `d.valueOf()`. See <emu-xref href="#sec-date.parse"></emu-xref>.</p>
         </emu-note>
         <emu-note>
-          <p>The `toString` function is intentionally generic; it does not require that its *this* value be a Date object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Date object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-timestring" aoid="TimeString">


### PR DESCRIPTION
Date.prototype.toString is not generic.
Fixes #1268

I've essentially copy-pasted the corresponding note in Number.prototype.toString.