### PR TITLE
Normative: add `Object.fromEntries`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24101,6 +24101,34 @@
         </emu-alg>
       </emu-clause>
 
+      <emu-clause id="sec-object.fromentries">
+        <h1>Object.fromEntries ( iterable )</h1>
+        <p>When the `fromEntries` method is called with argument _iterable_, the following steps are taken:</p>
+        <emu-alg>
+          1. Perform ? RequireObjectCoercible(_iterable_).
+          1. Let _obj_ be ObjectCreate(%ObjectPrototype%).
+          1. Assert: _obj_ is an extensible ordinary object with no own properties.
+          1. Let _stepsDefine_ be the algorithm steps defined in <emu-xref href="#sec-create-data-property-on-object-functions">CreateDataPropertyOnObject Functions</emu-xref>.
+          1. Let _adder_ be CreateBuiltinFunction(_stepsDefine_, &laquo; &raquo;).
+          1. Return ? AddEntriesFromIterable(_obj_, _iterable_, _adder_).
+        </emu-alg>
+        <emu-note>
+          The function created for _adder_ is never directly accessible to ECMAScript code.
+        </emu-note>
+
+        <emu-clause id="sec-create-data-property-on-object-functions">
+          <h1>CreateDataPropertyOnObject Functions</h1>
+          <p>A CreateDataPropertyOnObject function is an anonymous built-in function. When a CreateDataPropertyOnObject function is called with arguments _key_ and _value_, the following steps are taken:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. Assert: Type(_O_) is Object.
+            1. Assert: _O_ is an extensible ordinary object.
+            1. Let _propertyKey_ be ? ToPropertyKey(_key_).
+            1. Perform ! CreateDataPropertyOrThrow(_O_, _propertyKey_, _value_).
+          <emu-alg>
+        </emu-clause>
+      </emu-clause>
+
       <emu-clause id="sec-object.entries">
         <h1>Object.entries ( _O_ )</h1>
         <p>When the `entries` function is called with argument _O_, the following steps are taken:</p>


### PR DESCRIPTION
This PR adds `Object.fromEntries` to the spec.

It is currently stage 3; and still needs merged test262 tests, and consensus, to reach stage 4 and be merged here.

Closes https://github.com/tc39/proposal-object-from-entries/issues/21.