### PR TITLE
Normative: Add String.prototype.{trimStart/trimEnd} (+ trimLeft/trimRight)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28647,13 +28647,53 @@ THH:mm:ss.sss
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be ? RequireObjectCoercible(*this* value).
-          1. Let _S_ be ? ToString(_O_).
-          1. Let _T_ be the String value that is a copy of _S_ with both leading and trailing white space removed. The definition of white space is the union of |WhiteSpace| and |LineTerminator|. When determining whether a Unicode code point is in Unicode general category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;), code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.
-          1. Return _T_.
+          1. Let _S_ be *this* value.
+          1. Return ? TrimString(_S_, `"start+end"`).
         </emu-alg>
         <emu-note>
           <p>The `trim` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+        </emu-note>
+
+        <emu-clause id="sec-trimstring" aoid="TrimString">
+          <h1>Runtime Semantics: TrimString ( _string_, _where_ )</h1>
+          <p>The abstract operation TrimString is called with arguments _string_ and _where_, and interprets the String value _string_  as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps:</p>
+          <emu-alg>
+            1. Let _str_ be ? RequireObjectCoercible(_string_).
+            1. Let _S_ be ? ToString(_str_).
+            1. If _where_ is `"start"`, let _T_ be a String value that is a copy of _S_ with leading white space removed.
+            1. Else if _where_ is `"end"`, let _T_ be a String value that is a copy of _S_ with trailing white space removed.
+            1. Else,
+              1. Assert: _where_ is `"start+end"`.
+              1. Let _T_ be a String value that is a copy of _S_ with both leading and trailing white space removed.
+            1. Return _T_.
+          </emu-alg>
+          <p>The definition of white space is the union of |WhiteSpace| and |LineTerminator|. When determining whether a Unicode code point is in Unicode general category &ldquo;Zs&rdquo;, code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-string.prototype.trimend">
+        <h1>String.prototype.trimEnd ( )</h1>
+        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>The following steps are taken:</p>
+        <emu-alg>
+          1. Let _S_ be *this* value.
+          1. Return ? TrimString(_S_, `"end"`).
+        </emu-alg>
+        <emu-note>
+          <p>The `trimEnd` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-string.prototype.trimstart">
+        <h1>String.prototype.trimStart ( )</h1>
+        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>The following steps are taken:</p>
+        <emu-alg>
+          1. Let _S_ be *this* value.
+          1. Return ? TrimString(_S_, `"start"`).
+        </emu-alg>
+        <emu-note>
+          <p>The `trimStart` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -40243,6 +40283,22 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, `"sup"`, `""`, `""`).
         </emu-alg>
+      </emu-annex>
+
+      <emu-annex id="String.prototype.trimleft">
+          <h1>String.prototype.trimLeft ( )</h1>
+          <emu-note>
+            <p>The property `trimStart` is preferred. The `trimLeft` property is provided principally for compatibility with old code. It is recommended that the `trimStart` property be used in new ECMAScript code.</p>
+          </emu-note>
+          <p>The initial value of the `trimLeft` property is the same function object as the initial value of the `String.prototype.trimStart` property.</p>
+      </emu-annex>
+
+      <emu-annex id="String.prototype.trimright">
+          <h1>String.prototype.trimRight ( )</h1>
+          <emu-note>
+            <p>The property `trimEnd` is preferred. The `trimRight` property is provided principally for compatibility with old code. It is recommended that the `trimEnd` property be used in new ECMAScript code.</p>
+          </emu-note>
+          <p>The initial value of the `trimRight` property is the same function object as the initial value of the `String.prototype.trimEnd` property.</p>
       </emu-annex>
     </emu-annex>
 

--- a/spec.html
+++ b/spec.html
@@ -28667,7 +28667,7 @@ THH:mm:ss.sss
               1. Let _T_ be a String value that is a copy of _S_ with both leading and trailing white space removed.
             1. Return _T_.
           </emu-alg>
-          <p>The definition of white space is the union of |WhiteSpace| and |LineTerminator|. When determining whether a Unicode code point is in Unicode general category &ldquo;Zs&rdquo;, code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+          <p>The definition of white space is the union of |WhiteSpace| and |LineTerminator|. When determining whether a Unicode code point is in Unicode general category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;), code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         </emu-clause>
       </emu-clause>
 


### PR DESCRIPTION
This is a pull request for the **stage 3** proposal https://github.com/tc39/proposal-string-left-right-trim. The proposal is/was championed by @sebmarkbage. 

test262 tests: yes, https://github.com/tc39/test262/commit/5931e313fc1ed6d3eafb1a0be8c30f32cf8d41ac and others

## Rationale
ES5 standardized `String.prototype.trim`. All major engines have also implemented corresponding `trimLeft` and `trimRight` functions - without any standard specification.
For consistency with `padStart`/`padEnd` we propose `trimStart` and `trimEnd` and `trimLeft`/`trimRight` as aliases required for web compatibility.

## Review notes
I wasn't quite sure where to put TrimString, but this follows String.prototype.replace with GetSubstitution by putting it inline.