### PR TITLE
Editorial: fix a few variable names

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3309,12 +3309,12 @@
           1. Let _desc_ be a new Property Descriptor that initially has no fields.
           1. Let _hasEnumerable_ be ? HasProperty(_Obj_, `"enumerable"`).
           1. If _hasEnumerable_ is *true*, then
-            1. Let _enum_ be ToBoolean(? Get(_Obj_, `"enumerable"`)).
-            1. Set _desc_.[[Enumerable]] to _enum_.
+            1. Let _enumerable_ be ToBoolean(? Get(_Obj_, `"enumerable"`)).
+            1. Set _desc_.[[Enumerable]] to _enumerable_.
           1. Let _hasConfigurable_ be ? HasProperty(_Obj_, `"configurable"`).
           1. If _hasConfigurable_ is *true*, then
-            1. Let _conf_ be ToBoolean(? Get(_Obj_, `"configurable"`)).
-            1. Set _desc_.[[Configurable]] to _conf_.
+            1. Let _configurable_ be ToBoolean(? Get(_Obj_, `"configurable"`)).
+            1. Set _desc_.[[Configurable]] to _configurable_.
           1. Let _hasValue_ be ? HasProperty(_Obj_, `"value"`).
           1. If _hasValue_ is *true*, then
             1. Let _value_ be ? Get(_Obj_, `"value"`).
@@ -24161,14 +24161,14 @@
         </emu-alg>
 
         <emu-clause id="sec-getownpropertykeys" aoid="GetOwnPropertyKeys">
-          <h1>Runtime Semantics: GetOwnPropertyKeys ( _O_, _Type_ )</h1>
-          <p>The abstract operation GetOwnPropertyKeys is called with arguments _O_ and _Type_ where _O_ is an Object and _Type_ is one of the ECMAScript specification types String or Symbol. The following steps are taken:</p>
+          <h1>Runtime Semantics: GetOwnPropertyKeys ( _O_, _type_ )</h1>
+          <p>The abstract operation GetOwnPropertyKeys is called with arguments _O_ and _Type_ where _O_ is an Object and _type_ is one of the ECMAScript specification types String or Symbol. The following steps are taken:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(_O_).
             1. Let _keys_ be ? _obj_.[[OwnPropertyKeys]]().
             1. Let _nameList_ be a new empty List.
             1. For each element _nextKey_ of _keys_ in List order, do
-              1. If Type(_nextKey_) is _Type_, then
+              1. If Type(_nextKey_) is _type_, then
                 1. Append _nextKey_ as the last element of _nameList_.
             1. Return CreateArrayFromList(_nameList_).
           </emu-alg>


### PR DESCRIPTION
- `enum` was changed to `enumerable` because `enum` is a terrible thing to name a variable. (also changed `conf` to keep consistent)

- `Type` parameter changed to `type` because shadowing abstract op names is not fun