### PR TITLE
Editorial: Correct and make readable for-in/of/await-of static semantics 

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17527,30 +17527,21 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-vardeclarednames">
         <h1>Static Semantics: VarDeclaredNames</h1>
         <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarDeclaredNames of |Statement|.
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be the BoundNames of |ForBinding|.
-          1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarDeclaredNames of |Statement|.
-        </emu-alg>
         <emu-grammar>
           IterationStatement :
+            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
+            `for` `(` ForDeclaration `in` Expression `)` Statement
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
             `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
         <emu-grammar>
           IterationStatement :
+            `for` `(` `var` ForBinding `in` Expression `)` Statement
             `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
         </emu-grammar>
@@ -17558,14 +17549,6 @@
           1. Let _names_ be the BoundNames of |ForBinding|.
           1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
           1. Return _names_.
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return the VarDeclaredNames of |Statement|.
         </emu-alg>
         <emu-note>
           <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
@@ -17575,33 +17558,21 @@
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations">
         <h1>Static Semantics: VarScopedDeclarations</h1>
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarScopedDeclarations of |Statement|.
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _declarations_ be a List containing |ForBinding|.
-          1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
-          1. Return _declarations_.
-        </emu-alg>
         <emu-grammar>
           IterationStatement :
+            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` ForDeclaration `in` Expression `)` Statement
-            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return the VarScopedDeclarations of |Statement|.
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement :
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
         <emu-grammar>
           IterationStatement :
+            `for` `(` `var` ForBinding `in` Expression `)` Statement
             `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
         </emu-grammar>
@@ -17609,14 +17580,6 @@
           1. Let _declarations_ be a List containing |ForBinding|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
         <emu-note>
           <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>

--- a/spec.html
+++ b/spec.html
@@ -17596,7 +17596,6 @@
         <emu-grammar>
           IterationStatement :
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.


### PR DESCRIPTION
First commit:

Currently, VarScopedDeclarations is defined for

    IterationStatement :
      `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement

in two different places with conflicting definitions. Remove the incorrect definition.

Second commit:

Coalesce children of `for`-`in`, `for`-`of`, and `for`-`await`-`of` statements with identical definitions for VarDeclaredNames and VarScopedDeclarations for better readability: instead of having six different algorithm blocks for each of VarDeclaredNames and VarScopedDeclarations now there are only two for each.