### PR TITLE
Normative: Use GetValue to evaluate class heritage.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19731,9 +19731,9 @@
           1. Let _constructorParent_ be the intrinsic object %FunctionPrototype%.
         1. Else,
           1. Set the running execution context's LexicalEnvironment to _classScope_.
-          1. Let _superclass_ be the result of evaluating |ClassHeritage|.
+          1. Let _superclassRef_ be the result of evaluating |ClassHeritage|.
           1. Set the running execution context's LexicalEnvironment to _lex_.
-          1. ReturnIfAbrupt(_superclass_).
+          1. Let _superclass_ be ? GetValue(_superclassRef_).
           1. If _superclass_ is *null*, then
             1. Let _protoParent_ be *null*.
             1. Let _constructorParent_ be the intrinsic object %FunctionPrototype%.


### PR DESCRIPTION
It seems like all other cases of `"Let X be the result of evaluation SomeGrammar."` that actually use the value are followed by a call to `GetValue`, but this one is missing. I was talking through the spec with someone on StackOverflow and they noted that it was missing, and thing I realized #934 had been filed, so a PR seemed like the best next step to get the conversation going.

Fixes #934.