### PR TITLE
Normative: Use GetMethod instead of GetV to get iterator `next`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4855,7 +4855,8 @@
           1. Otherwise, set _method_ to ? GetMethod(_obj_, @@iterator).
         1. Let _iterator_ be ? Call(_method_, _obj_).
         1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
-        1. Let _nextMethod_ be ? GetV(_iterator_, `"next"`).
+        1. Let _nextMethod_ be ? GetMethod(_iterator_, `"next"`).
+        1. If _nextMethod_ is *undefined*, throw a *TypeError* exception.
         1. Let _iteratorRecord_ be Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
         1. Return _iteratorRecord_.
       </emu-alg>


### PR DESCRIPTION
This is purely for consistency. Currently, only the first throws (tested in Node 10), but with this patch, the second would also throw:

```js
[] = {[Symbol.iterator]: () => ({get next() { throw "foo" }})};
[] = {[Symbol.iterator]: () => ({next: 0})};
```

In every other case, this has no effect since they all call IteratorNext before any other ECMAScript-visible behavior, and I feel this better aligns intuitively with what the spec implies.