### PR TITLE
Normative: allow ArraySpeciesCreate to create non-arrays

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7868,14 +7868,13 @@
 
       <emu-clause id="sec-arrayspeciescreate" aoid="ArraySpeciesCreate">
         <h1>ArraySpeciesCreate ( _originalArray_, _length_ )</h1>
-        <p>The abstract operation ArraySpeciesCreate with arguments _originalArray_ and _length_ is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_. It performs the following steps:</p>
+        <p>The abstract operation ArraySpeciesCreate with arguments _originalArray_ and _length_ is used to specify the creation of a new object using a constructor function that is derived from _originalArray_, with special behavior when _originalArray_ is an ordinary array. It performs the following steps:</p>
         <emu-alg>
           1. Assert: _length_ is an integer Number &ge; 0.
           1. If _length_ is *-0*, set _length_ to *+0*.
           1. Let _isArray_ be ? IsArray(_originalArray_).
-          1. If _isArray_ is *false*, return ? ArrayCreate(_length_).
           1. Let _C_ be ? Get(_originalArray_, `"constructor"`).
-          1. If IsConstructor(_C_) is *true*, then
+          1. If _isArray_ is *true* and IsConstructor(_C_) is *true*, then
             1. Let _thisRealm_ be the current Realm Record.
             1. Let _realmC_ be ? GetFunctionRealm(_C_).
             1. If _thisRealm_ and _realmC_ are not the same Realm Record, then


### PR DESCRIPTION
Summary: this PR modifies the methods `Array.prototype.{concat, filter, map, slice, splice}` such that they return an instance of the same class<sup>1</sup> as the object on which they are invoked even if that object is not an array, rather than, as currently, only in the case that the object is an array (that is, was created by `Array` or a subclass thereof). 

<sup>1</sup> to be precise, of the class given by `original.constructor[Symbol.species]`, if it exists

---

`Array.prototype.map` and similar methods which create new arrays defer to `Symbol.species` to determine the constructor for the resulting object. However, unlike other usages of `Symbol.species` such as `RegExp.prototype[Symbol.split]`, the array prototype methods will only use `Symbol.species` when the object on which the method is invoked is an actual array. (I believe this may have been an oversight introduced in ES6 when specifying the magic cross-realm behavior of `Array.prototype.map` and friends.)

This means that in the following code
```js
class KindaArray { // NB: not extending `Array`, possibly because it needs to extend some other thing
  static get [Symbol.species]() {
    console.log('reached'); // not reached
    return KindaArray;
  }

  get map() {
    return [].map;
  }
}

let x = new KindaArray;
x[0] = 'foo';
x.length = 1;

let y = x.map(t => t + 'bar');
y instanceof KindaArray
```
the last line evaluates to `false`. Since Array prototype methods are explicitly intended to be usable on things which are not arrays, and `Symbol.species` is explicitly intended to allow methods which create new instances to return instances of the same class as the original instance rather the class on which the method was originally defined, this is surprising to me. The current behavior also seems not particularly useful. This is especially so because a proxy for an array is treated as an array for the purposes of these algorithms, and such a proxy might not behave like an array in any way.

This PR changes the behavior of the above code so that `reached` is printed and the last line evaluates to `true`.

Note that this change is observable even in code which does not explicitly reference `Symbol.species`: currently `Array.prototype.map.call(new Uint8Array([0,1,2]), x => x + 1)` returns an Array; with this change it would return a `Uint8Array`, just like `Uint8Array.prototype.map.call(new Uint8Array([0,1,2]), x => x + 1)`.

In practice, I don't expect this to affect much if any existing code. That people might be relying on the behavior in the previous paragraph is my only real worry, and I'm hopeful that's not the case. There might also be a slight performance regression when applying these methods to array-likes, as in the fairly common pattern of `[].slice.call(arguments, 0)`, since these will need to do two additional lookups (to resolve `arguments.constructor[Symbol.species]` to `undefined`).

See [twitter discussion](https://twitter.com/awbjs/status/1029927157668044801). Also see #1178.

cc @tabatkins @allenwb
