### PR TITLE
Normative: Add missing GetValue() to TemplateLiteral evaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12041,8 +12041,8 @@
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateHead| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _sub_ be the result of evaluating |Expression|.
-          1. ReturnIfAbrupt(_sub_).
+          1. Let _subRef_ be the result of evaluating |Expression|.
+          1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _middle_ be ? ToString(_sub_).
           1. Let _tail_ be the result of evaluating |TemplateSpans|.
           1. ReturnIfAbrupt(_tail_).
@@ -12066,8 +12066,8 @@
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _sub_ be the result of evaluating |Expression|.
-          1. ReturnIfAbrupt(_sub_).
+          1. Let _subRef_ be the result of evaluating |Expression|.
+          1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _middle_ be ? ToString(_sub_).
           1. Return the sequence of code units consisting of the code units of _head_ followed by the elements of _middle_.
         </emu-alg>
@@ -12079,8 +12079,8 @@
           1. Let _rest_ be the result of evaluating |TemplateMiddleList|.
           1. ReturnIfAbrupt(_rest_).
           1. Let _middle_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _sub_ be the result of evaluating |Expression|.
-          1. ReturnIfAbrupt(_sub_).
+          1. Let _subRef_ be the result of evaluating |Expression|.
+          1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _last_ be ? ToString(_sub_).
           1. Return the sequence of code units consisting of the elements of _rest_ followed by the code units of _middle_ followed by the elements of _last_.
         </emu-alg>


### PR DESCRIPTION
As currently spec'd, it is an undefined behavior when an *Expression* that evaluates to a Reference is present in a *TemplateLiteral*, as the Reference value would be directly passed into ToString which expects an ECMAScript language value.

Fixes #935.

----

Quite similar to #1286.