### PR TITLE
Editorial: Quote properties across the board.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -88,10 +88,10 @@
   <p>The fifth edition of ECMAScript (published as ECMA-262 5<sup>th</sup> edition) codified de facto interpretations of the language specification that have become common among browser implementations and added support for new features that had emerged since the publication of the third edition. Such features include accessor properties, reflective creation and inspection of objects, program control of property attributes, additional array manipulation functions, support for the JSON object encoding format, and a strict mode that provides enhanced error checking and program security. The fifth edition was adopted by the Ecma General Assembly of December 2009.</p>
   <p>The fifth edition was submitted to ISO/IEC JTC 1 for adoption under the fast-track procedure, and approved as international standard ISO/IEC 16262:2011. Edition 5.1 of the ECMAScript Standard incorporated minor corrections and is the same text as ISO/IEC 16262:2011. The 5.1 Edition was adopted by the Ecma General Assembly of June 2011.</p>
   <p>Focused development of the sixth edition started in 2009, as the fifth edition was being prepared for publication. However, this was preceded by significant experimentation and language enhancement design efforts dating to the publication of the third edition in 1999. In a very real sense, the completion of the sixth edition is the culmination of a fifteen year effort. The goals for this edition included providing better support for large applications, library creation, and for use of ECMAScript as a compilation target for other languages. Some of its major enhancements included modules, class declarations, lexical block scoping, iterators and generators, promises for asynchronous programming, destructuring patterns, and proper tail calls. The ECMAScript library of built-ins was expanded to support additional data abstractions including maps, sets, and arrays of binary numeric values as well as additional support for Unicode supplemental characters in strings and regular expressions. The built-ins were also made extensible via subclassing. The sixth edition provides the foundation for regular, incremental language and library enhancements. The sixth edition was adopted by the General Assembly of June 2015.</p>
-  <p>ECMAScript 2016 was the first ECMAScript edition released under Ecma TC39's new yearly release cadence and open development process. A plain-text source document was built from the ECMAScript 2015 source document to serve as the base for further development entirely on GitHub. Over the year of this standard's development, hundreds of pull requests and issues were filed representing thousands of bug fixes, editorial fixes and other improvements. Additionally, numerous software tools were developed to aid in this effort including Ecmarkup, Ecmarkdown, and Grammarkdown. ES2016 also included support for a new exponentiation operator and adds a new method to Array.prototype called `includes`.</p>
+  <p>ECMAScript 2016 was the first ECMAScript edition released under Ecma TC39's new yearly release cadence and open development process. A plain-text source document was built from the ECMAScript 2015 source document to serve as the base for further development entirely on GitHub. Over the year of this standard's development, hundreds of pull requests and issues were filed representing thousands of bug fixes, editorial fixes and other improvements. Additionally, numerous software tools were developed to aid in this effort including Ecmarkup, Ecmarkdown, and Grammarkdown. ES2016 also included support for a new exponentiation operator and adds a new method to `Array.prototype` called `includes`.</p>
   <p>ECMAScript 2017 introduced Async Functions, Shared Memory, and Atomics along with smaller language and library enhancements, bug fixes, and editorial updates. Async functions improve the asynchronous programming experience by providing syntax for promise-returning functions. Shared Memory and Atomics introduce a new memory model that allows multi-agent programs to communicate using atomic operations that ensure a well-defined execution order even on parallel CPUs. It also included new static methods on Object: `Object.values`, `Object.entries`, and `Object.getOwnPropertyDescriptors`.</p>
-  <p>ECMAScript 2018 introduced support for asynchronous iteration via the AsyncIterator protocol and async generators. It also included four new regular expression features: the dotAll flag, named capture groups, Unicode property escapes, and look-behind assertions. Lastly it included object rest and spread properties.</p>
-  <p>ECMAScript 2019 introduced a few new built-in functions: `flat` and `flatMap` on `Array.prototype` for flattening arrays, `Object.fromEntries` for directly turning the return value of `Object.entries` into a new Object, and `trimStart` and `trimEnd` on `String.prototype` as better-named alternatives to the widely implemented but non-standard `String.prototype.trimLeft` and `trimRight` built-ins. In addition, it included a few minor updates to syntax and semantics. Updated syntax included optional catch binding parameters and allowing U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) in string literals to align with JSON. Other updates included requiring that `Array.prototype.sort` be a stable sort, requiring that JSON.stringify return well-formed UTF-8 regardless of input, and clarifying `Function.prototype.toString` by requiring that it either return the corresponding original source text or a standard placeholder.</p>
+  <p>ECMAScript 2018 introduced support for asynchronous iteration via the AsyncIterator protocol and async generators. It also included four new regular expression features: the `dotAll` flag, named capture groups, Unicode property escapes, and look-behind assertions. Lastly it included object rest and spread properties.</p>
+  <p>ECMAScript 2019 introduced a few new built-in functions: `flat` and `flatMap` on `Array.prototype` for flattening arrays, `Object.fromEntries` for directly turning the return value of `Object.entries` into a new Object, and `trimStart` and `trimEnd` on `String.prototype` as better-named alternatives to the widely implemented but non-standard `String.prototype.trimLeft` and `trimRight` built-ins. In addition, it included a few minor updates to syntax and semantics. Updated syntax included optional catch binding parameters and allowing U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) in string literals to align with JSON. Other updates included requiring that `Array.prototype.sort` be a stable sort, requiring that `JSON.stringify` return well-formed UTF-8 regardless of input, and clarifying `Function.prototype.toString` by requiring that it either return the corresponding original source text or a standard placeholder.</p>
   <p>Dozens of individuals representing many organizations have made very significant contributions within Ecma TC39 to the development of this edition and to the prior editions. In addition, a vibrant community has emerged supporting TC39's ECMAScript efforts. This community has reviewed numerous drafts, filed thousands of bug reports, performed implementation experiments, contributed test suites, and educated the world-wide developer community about ECMAScript. Unfortunately, it is impossible to identify and acknowledge every person and organization who has contributed to this effort.</p>
   <p>
     Allen Wirfs-Brock<br>
@@ -168,7 +168,7 @@
       </emu-figure>
       <p>In a class-based object-oriented language, in general, state is carried by instances, methods are carried by classes, and inheritance is only of structure and behaviour. In ECMAScript, the state and methods are carried by objects, while structure, behaviour, and state are all inherited.</p>
       <p>All objects that do not directly contain a particular property that their prototype contains share that property and its value. Figure 1 illustrates this:</p>
-      <p><b>CF</b> is a constructor (and also an object). Five objects have been created by using `new` expressions: <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b>. Each of these objects contains properties named `q1` and `q2`. The dashed lines represent the implicit prototype relationship; so, for example, <b>cf<sub>3</sub></b>'s prototype is <b>CF<sub>p</sub></b>. The constructor, <b>CF</b>, has two properties itself, named `P1` and `P2`, which are not visible to <b>CF<sub>p</sub></b>, <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, or <b>cf<sub>5</sub></b>. The property named `CFP1` in <b>CF<sub>p</sub></b> is shared by <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> (but not by <b>CF</b>), as are any properties found in <b>CF<sub>p</sub></b>'s implicit prototype chain that are not named `q1`, `q2`, or `CFP1`. Notice that there is no implicit prototype link between <b>CF</b> and <b>CF<sub>p</sub></b>.</p>
+      <p><b>CF</b> is a constructor (and also an object). Five objects have been created by using `new` expressions: <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b>. Each of these objects contains properties named `"q1"` and `"q2"`. The dashed lines represent the implicit prototype relationship; so, for example, <b>cf<sub>3</sub></b>'s prototype is <b>CF<sub>p</sub></b>. The constructor, <b>CF</b>, has two properties itself, named `"P1"` and `"P2"`, which are not visible to <b>CF<sub>p</sub></b>, <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, or <b>cf<sub>5</sub></b>. The property named `"CFP1"` in <b>CF<sub>p</sub></b> is shared by <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> (but not by <b>CF</b>), as are any properties found in <b>CF<sub>p</sub></b>'s implicit prototype chain that are not named `"q1"`, `"q2"`, or `"CFP1"`. Notice that there is no implicit prototype link between <b>CF</b> and <b>CF<sub>p</sub></b>.</p>
       <p>Unlike most class-based object languages, properties can be added to objects dynamically by assigning values to them. That is, constructors are not required to name or assign values to all or any of the constructed object's properties. In the above diagram, one could add a new shared property for <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> by assigning a new value to the property in <b>CF<sub>p</sub></b>.</p>
       <p>Although ECMAScript objects are not inherently class-based, it is often convenient to define class-like abstractions based upon a common pattern of constructor functions, prototype objects, and methods. The ECMAScript built-in objects themselves follow such a class-like pattern. Beginning with ECMAScript 2015, the ECMAScript language includes syntactic class definitions that permit programmers to concisely define objects that conform to the same class-like abstraction pattern used by the built-in objects.</p>
     </emu-clause>
@@ -210,7 +210,7 @@
       <h1>constructor</h1>
       <p>function object that creates and initializes objects</p>
       <emu-note>
-        <p>The value of a constructor's `prototype` property is a prototype object that is used to implement inheritance and shared properties.</p>
+        <p>The value of a constructor's `"prototype"` property is a prototype object that is used to implement inheritance and shared properties.</p>
       </emu-note>
     </emu-clause>
 
@@ -218,7 +218,7 @@
       <h1>prototype</h1>
       <p>object that provides shared properties for other objects</p>
       <emu-note>
-        <p>When a constructor creates an object, that object implicitly references the constructor's `prototype` property for the purpose of resolving property references. The constructor's `prototype` property can be referenced by the program expression <code><var>constructor</var>.prototype</code>, and properties added to an object's prototype are shared, through inheritance, by all objects sharing the prototype. Alternatively, a new object may be created with an explicitly specified prototype by using the `Object.create` built-in function.</p>
+        <p>When a constructor creates an object, that object implicitly references the constructor's `"prototype"` property for the purpose of resolving property references. The constructor's `"prototype"` property can be referenced by the program expression <code><var>constructor</var>.prototype</code>, and properties added to an object's prototype are shared, through inheritance, by all objects sharing the prototype. Alternatively, a new object may be created with an explicitly specified prototype by using the `Object.create` built-in function.</p>
       </emu-note>
     </emu-clause>
 
@@ -2638,7 +2638,7 @@
                 `ArrayBuffer.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %ArrayBuffer%; i.e., %ArrayBuffer.prototype%
+                The initial value of the `"prototype"` data property of %ArrayBuffer%; i.e., %ArrayBuffer.prototype%
               </td>
             </tr>
             <tr>
@@ -2659,7 +2659,7 @@
                 `Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>); i.e., %Array.prototype%
+                The initial value of the `"prototype"` data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>); i.e., %Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2670,7 +2670,7 @@
                 `Array.prototype.entries`
               </td>
               <td>
-                The initial value of the `entries` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>); i.e., %Array.prototype.entries%
+                The initial value of the `"entries"` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>); i.e., %Array.prototype.entries%
               </td>
             </tr>
             <tr>
@@ -2681,7 +2681,7 @@
                 `Array.prototype.forEach`
               </td>
               <td>
-                The initial value of the `forEach` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>); i.e., %Array.prototype.forEach%
+                The initial value of the `"forEach"` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>); i.e., %Array.prototype.forEach%
               </td>
             </tr>
             <tr>
@@ -2692,7 +2692,7 @@
                 `Array.prototype.keys`
               </td>
               <td>
-                The initial value of the `keys` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>); i.e., %Array.prototype.keys%
+                The initial value of the `"keys"` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>); i.e., %Array.prototype.keys%
               </td>
             </tr>
             <tr>
@@ -2703,7 +2703,7 @@
                 `Array.prototype.values`
               </td>
               <td>
-                The initial value of the `values` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>); i.e., %Array.prototype.values%
+                The initial value of the `"values"` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>); i.e., %Array.prototype.values%
               </td>
             </tr>
             <tr>
@@ -2733,7 +2733,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` data property of %AsyncFunction%; i.e., %AsyncFunction.prototype%
+                The initial value of the `"prototype"` data property of %AsyncFunction%; i.e., %AsyncFunction.prototype%
               </td>
             </tr>
             <tr>
@@ -2743,7 +2743,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` property of %AsyncGeneratorFunction%; i.e., %AsyncGeneratorFunction.prototype%
+                The initial value of the `"prototype"` property of %AsyncGeneratorFunction%; i.e., %AsyncGeneratorFunction.prototype%
               </td>
             </tr>
             <tr>
@@ -2763,7 +2763,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` property of %AsyncGenerator%; i.e., %AsyncGenerator.prototype%
+                The initial value of the `"prototype"` property of %AsyncGenerator%; i.e., %AsyncGenerator.prototype%
               </td>
             </tr>
             <tr>
@@ -2839,7 +2839,7 @@
                 `Boolean.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>); i.e., %Boolean.prototype%
+                The initial value of the `"prototype"` data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>); i.e., %Boolean.prototype%
               </td>
             </tr>
             <tr>
@@ -2861,7 +2861,7 @@
                 `DataView.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %DataView%; i.e., %DataView.prototype%
+                The initial value of the `"prototype"` data property of %DataView%; i.e., %DataView.prototype%
               </td>
             </tr>
             <tr>
@@ -2883,7 +2883,7 @@
                 `Date.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Date%.; i.e., %Date.prototype%
+                The initial value of the `"prototype"` data property of %Date%.; i.e., %Date.prototype%
               </td>
             </tr>
             <tr>
@@ -2949,7 +2949,7 @@
                 `Error.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Error%; i.e., %Error.prototype%
+                The initial value of the `"prototype"` data property of %Error%; i.e., %Error.prototype%
               </td>
             </tr>
             <tr>
@@ -2982,7 +2982,7 @@
                 `EvalError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %EvalError%; i.e., %EvalError.prototype%
+                The initial value of the `"prototype"` data property of %EvalError%; i.e., %EvalError.prototype%
               </td>
             </tr>
             <tr>
@@ -3004,7 +3004,7 @@
                 `Float32Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Float32Array%; i.e., %Float32Array.prototype%
+                The initial value of the `"prototype"` data property of %Float32Array%; i.e., %Float32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3026,7 +3026,7 @@
                 `Float64Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Float64Array%; i.e., %Float64Array.prototype%
+                The initial value of the `"prototype"` data property of %Float64Array%; i.e., %Float64Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3048,7 +3048,7 @@
                 `Function.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Function%; i.e., %Function.prototype%
+                The initial value of the `"prototype"` data property of %Function%; i.e., %Function.prototype%
               </td>
             </tr>
             <tr>
@@ -3058,7 +3058,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` data property of %GeneratorFunction%
+                The initial value of the `"prototype"` data property of %GeneratorFunction%
               </td>
             </tr>
             <tr>
@@ -3078,7 +3078,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` data property of %Generator%; i.e., %Generator.prototype%
+                The initial value of the `"prototype"` data property of %Generator%; i.e., %Generator.prototype%
               </td>
             </tr>
             <tr>
@@ -3100,7 +3100,7 @@
                 `Int8Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Int8Array%; i.e., %Int8Array.prototype%
+                The initial value of the `"prototype"` data property of %Int8Array%; i.e., %Int8Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3122,7 +3122,7 @@
                 `Int16Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Int16Array%; i.e., %Int16Array.prototype%
+                The initial value of the `"prototype"` data property of %Int16Array%; i.e., %Int16Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3144,7 +3144,7 @@
                 `Int32Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Int32Array%; i.e., %Int32Array.prototype%
+                The initial value of the `"prototype"` data property of %Int32Array%; i.e., %Int32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3198,7 +3198,7 @@
                 `JSON.parse`
               </td>
               <td>
-                The initial value of the `parse` data property of %JSON%; i.e., %JSON.parse%
+                The initial value of the `"parse"` data property of %JSON%; i.e., %JSON.parse%
               </td>
             </tr>
             <tr>
@@ -3209,7 +3209,7 @@
                 `JSON.stringify`
               </td>
               <td>
-                The initial value of the `stringify` data property of %JSON%; i.e., %JSON.stringify%
+                The initial value of the `"stringify"` data property of %JSON%; i.e., %JSON.stringify%
               </td>
             </tr>
             <tr>
@@ -3241,7 +3241,7 @@
                 `Map.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Map%; i.e., %Map.prototype%
+                The initial value of the `"prototype"` data property of %Map%; i.e., %Map.prototype%
               </td>
             </tr>
             <tr>
@@ -3274,7 +3274,7 @@
                 `Number.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Number%; i.e., %Number.prototype%
+                The initial value of the `"prototype"` data property of %Number%; i.e., %Number.prototype%
               </td>
             </tr>
             <tr>
@@ -3296,7 +3296,7 @@
                 `Object.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>); i.e., %Object.prototype%
+                The initial value of the `"prototype"` data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>); i.e., %Object.prototype%
               </td>
             </tr>
             <tr>
@@ -3307,7 +3307,7 @@
                 `Object.prototype.toString`
               </td>
               <td>
-                The initial value of the `toString` data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>); i.e., %Object.prototype.toString%
+                The initial value of the `"toString"` data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>); i.e., %Object.prototype.toString%
               </td>
             </tr>
             <tr>
@@ -3318,7 +3318,7 @@
                 `Object.prototype.valueOf`
               </td>
               <td>
-                The initial value of the `valueOf` data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>); i.e., %Object.prototype.valueOf%
+                The initial value of the `"valueOf"` data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>); i.e., %Object.prototype.valueOf%
               </td>
             </tr>
             <tr>
@@ -3362,7 +3362,7 @@
                 `Promise.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Promise%; i.e., %Promise.prototype%
+                The initial value of the `"prototype"` data property of %Promise%; i.e., %Promise.prototype%
               </td>
             </tr>
             <tr>
@@ -3373,7 +3373,7 @@
                 `Promise.prototype.then`
               </td>
               <td>
-                The initial value of the `then` data property of %Promise.prototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>); i.e., %Promise.prototype.then%
+                The initial value of the `"then"` data property of %Promise.prototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>); i.e., %Promise.prototype.then%
               </td>
             </tr>
             <tr>
@@ -3384,7 +3384,7 @@
                 `Promise.all`
               </td>
               <td>
-                The initial value of the `all` data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>); i.e., %Promise.all%
+                The initial value of the `"all"` data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>); i.e., %Promise.all%
               </td>
             </tr>
             <tr>
@@ -3395,7 +3395,7 @@
                 `Promise.reject`
               </td>
               <td>
-                The initial value of the `reject` data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>); i.e., %Promise.reject%
+                The initial value of the `"reject"` data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>); i.e., %Promise.reject%
               </td>
             </tr>
             <tr>
@@ -3406,7 +3406,7 @@
                 `Promise.resolve`
               </td>
               <td>
-                The initial value of the `resolve` data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>); i.e., %Promise.resolve%
+                The initial value of the `"resolve"` data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>); i.e., %Promise.resolve%
               </td>
             </tr>
             <tr>
@@ -3439,7 +3439,7 @@
                 `RangeError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %RangeError%; i.e., %RangeError.prototype%
+                The initial value of the `"prototype"` data property of %RangeError%; i.e., %RangeError.prototype%
               </td>
             </tr>
             <tr>
@@ -3461,7 +3461,7 @@
                 `ReferenceError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %ReferenceError%; i.e., %ReferenceError.prototype%
+                The initial value of the `"prototype"` data property of %ReferenceError%; i.e., %ReferenceError.prototype%
               </td>
             </tr>
             <tr>
@@ -3494,7 +3494,7 @@
                 `RegExp.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %RegExp%; i.e., %RegExp.prototype%
+                The initial value of the `"prototype"` data property of %RegExp%; i.e., %RegExp.prototype%
               </td>
             </tr>
             <tr>
@@ -3536,7 +3536,7 @@
                 `Set.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Set%; i.e., %Set.prototype%
+                The initial value of the `"prototype"` data property of %Set%; i.e., %Set.prototype%
               </td>
             </tr>
             <tr>
@@ -3558,7 +3558,7 @@
                 `SharedArrayBuffer.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %SharedArrayBuffer%; i.e., %SharedArrayBuffer.prototype%
+                The initial value of the `"prototype"` data property of %SharedArrayBuffer%; i.e., %SharedArrayBuffer.prototype%
               </td>
             </tr>
             <tr>
@@ -3590,7 +3590,7 @@
                 `String.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %String%; i.e., %String.prototype%
+                The initial value of the `"prototype"` data property of %String%; i.e., %String.prototype%
               </td>
             </tr>
             <tr>
@@ -3612,7 +3612,7 @@
                 `Symbol.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>); i.e., %Symbol.prototype%
+                The initial value of the `"prototype"` data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>); i.e., %Symbol.prototype%
               </td>
             </tr>
             <tr>
@@ -3634,7 +3634,7 @@
                 `SyntaxError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %SyntaxError%; i.e., %SyntaxError.prototype%
+                The initial value of the `"prototype"` data property of %SyntaxError%; i.e., %SyntaxError.prototype%
               </td>
             </tr>
             <tr>
@@ -3664,7 +3664,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` data property of %TypedArray%; i.e., %TypedArray.prototype%
+                The initial value of the `"prototype"` data property of %TypedArray%; i.e., %TypedArray.prototype%
               </td>
             </tr>
             <tr>
@@ -3686,7 +3686,7 @@
                 `TypeError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %TypeError%; i.e., %TypeError.prototype%
+                The initial value of the `"prototype"` data property of %TypeError%; i.e., %TypeError.prototype%
               </td>
             </tr>
             <tr>
@@ -3708,7 +3708,7 @@
                 `Uint8Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Uint8Array%; i.e., %Uint8Array.prototype%
+                The initial value of the `"prototype"` data property of %Uint8Array%; i.e., %Uint8Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3730,7 +3730,7 @@
                 `Uint8ClampedArray.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Uint8ClampedArray%; i.e., %Uint8ClampedArray.prototype%
+                The initial value of the `"prototype"` data property of %Uint8ClampedArray%; i.e., %Uint8ClampedArray.prototype%
               </td>
             </tr>
             <tr>
@@ -3752,7 +3752,7 @@
                 `Uint16Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Uint16Array%; i.e., %Uint16Array.prototype%
+                The initial value of the `"prototype"` data property of %Uint16Array%; i.e., %Uint16Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3774,7 +3774,7 @@
                 `Uint32Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Uint32Array%; i.e., %Uint32Array.prototype%
+                The initial value of the `"prototype"` data property of %Uint32Array%; i.e., %Uint32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3796,7 +3796,7 @@
                 `URIError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %URIError%; i.e., %URIError.prototype%
+                The initial value of the `"prototype"` data property of %URIError%; i.e., %URIError.prototype%
               </td>
             </tr>
             <tr>
@@ -3818,7 +3818,7 @@
                 `WeakMap.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %WeakMap%; i.e., %WeakMap.prototype%
+                The initial value of the `"prototype"` data property of %WeakMap%; i.e., %WeakMap.prototype%
               </td>
             </tr>
             <tr>
@@ -3840,7 +3840,7 @@
                 `WeakSet.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %WeakSet%; i.e., %WeakSet.prototype%
+                The initial value of the `"prototype"` data property of %WeakSet%; i.e., %WeakSet.prototype%
               </td>
             </tr>
             </tbody>
@@ -6456,7 +6456,7 @@
                 `"lexical"` | `"initialized"` | `"uninitialized"`
               </td>
               <td>
-                If the value is `"lexical"`, this is an |ArrowFunction| and does not have a local this value.
+                If the value is `"lexical"`, this is an |ArrowFunction| and does not have a local *this* value.
               </td>
             </tr>
             <tr>
@@ -6893,7 +6893,7 @@
             1. Return *true*.
           </emu-alg>
           <emu-note>
-            <p>Properties may exist upon a global object that were directly created rather than being declared using a var or function declaration. A global lexical binding may not be created that has the same name as a non-configurable property of the global object. The global property `undefined` is an example of such a property.</p>
+            <p>Properties may exist upon a global object that were directly created rather than being declared using a var or function declaration. A global lexical binding may not be created that has the same name as a non-configurable property of the global object. The global property `"undefined"` is an example of such a property.</p>
           </emu-note>
         </emu-clause>
 
@@ -8181,7 +8181,7 @@
 
     <emu-clause id="sec-ordinarycreatefromconstructor" aoid="OrdinaryCreateFromConstructor">
       <h1>OrdinaryCreateFromConstructor ( _constructor_, _intrinsicDefaultProto_ [ , _internalSlotsList_ ] )</h1>
-      <p>The abstract operation OrdinaryCreateFromConstructor creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's `prototype` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. The optional _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
+      <p>The abstract operation OrdinaryCreateFromConstructor creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's `"prototype"` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. The optional _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Let _proto_ be ? GetPrototypeFromConstructor(_constructor_, _intrinsicDefaultProto_).
@@ -8191,7 +8191,7 @@
 
     <emu-clause id="sec-getprototypefromconstructor" aoid="GetPrototypeFromConstructor">
       <h1>GetPrototypeFromConstructor ( _constructor_, _intrinsicDefaultProto_ )</h1>
-      <p>The abstract operation GetPrototypeFromConstructor determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's `prototype` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. This abstract operation performs the following steps:</p>
+      <p>The abstract operation GetPrototypeFromConstructor determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's `"prototype"` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Assert: IsCallable(_constructor_) is *true*.
@@ -8573,7 +8573,7 @@
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: IsConstructor(_F_) is *true*.
-        1. Assert: _F_ is an extensible object that does not have a `prototype` own property.
+        1. Assert: _F_ is an extensible object that does not have a `"prototype"` own property.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then
           1. Set _prototype_ to ObjectCreate(%Object.prototype%).
@@ -8607,9 +8607,9 @@
 
     <emu-clause id="sec-setfunctionname" aoid="SetFunctionName">
       <h1>SetFunctionName ( _F_, _name_ [ , _prefix_ ] )</h1>
-      <p>The abstract operation SetFunctionName requires a Function argument _F_, a String or Symbol argument _name_ and optionally a String argument _prefix_. This operation adds a `name` property to _F_ by performing the following steps:</p>
+      <p>The abstract operation SetFunctionName requires a Function argument _F_, a String or Symbol argument _name_ and optionally a String argument _prefix_. This operation adds a `"name"` property to _F_ by performing the following steps:</p>
       <emu-alg>
-        1. Assert: _F_ is an extensible object that does not have a `name` own property.
+        1. Assert: _F_ is an extensible object that does not have a `"name"` own property.
         1. Assert: Type(_name_) is either Symbol or String.
         1. Assert: If _prefix_ is present, then Type(_prefix_) is String.
         1. If Type(_name_) is Symbol, then
@@ -8763,9 +8763,9 @@
     <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided function exotic objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
     <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such function exotic objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
     <p>Unless otherwise specified every built-in function object has the %Function.prototype% object as the initial value of its [[Prototype]] internal slot.</p>
-    <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value `"classConstructor"`.</p>
+    <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value *"classConstructor"*.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
-    <p>Built-in functions that are not constructors do not have a `prototype` property unless otherwise specified in the description of a particular function.</p>
+    <p>Built-in functions that are not constructors do not have a `"prototype"` property unless otherwise specified in the description of a particular function.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
 
     <emu-clause id="sec-built-in-function-objects-call-thisargument-argumentslist">
@@ -8995,7 +8995,7 @@
           1. Return ? Construct(_C_, &laquo; _length_ &raquo;).
         </emu-alg>
         <emu-note>
-          <p>If _originalArray_ was created using the standard built-in Array constructor for a realm that is not the realm of the running execution context, then a new Array is created using the realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behaviour for the Array.prototype methods that now are defined using ArraySpeciesCreate.</p>
+          <p>If _originalArray_ was created using the standard built-in Array constructor for a realm that is not the realm of the running execution context, then a new Array is created using the realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behaviour for the `Array.prototype` methods that now are defined using ArraySpeciesCreate.</p>
         </emu-note>
       </emu-clause>
 
@@ -14734,7 +14734,7 @@
 
     <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
       <h1>Runtime Semantics: InstanceofOperator ( _V_, _target_ )</h1>
-      <p>The abstract operation InstanceofOperator(_V_, _target_) implements the generic algorithm for determining if  ECMAScript value _V_ is an instance of object _target_ either by consulting _target_'s @@hasinstance method or, if absent, determining whether the value of _target_'s `prototype` property is present in _V_'s prototype chain. This abstract operation performs the following steps:</p>
+      <p>The abstract operation InstanceofOperator(_V_, _target_) implements the generic algorithm for determining if  ECMAScript value _V_ is an instance of object _target_ either by consulting _target_'s @@hasinstance method or, if absent, determining whether the value of _target_'s `"prototype"` property is present in _V_'s prototype chain. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _instOfHandler_ be ? GetMethod(_target_, @@hasInstance).
@@ -19513,7 +19513,7 @@
         <p>The |BindingIdentifier| in a |FunctionExpression| can be referenced from inside the |FunctionExpression|'s |FunctionBody| to allow the function to call itself recursively. However, unlike in a |FunctionDeclaration|, the |BindingIdentifier| in a |FunctionExpression| cannot be referenced from and does not affect the scope enclosing the |FunctionExpression|.</p>
       </emu-note>
       <emu-note>
-        <p>A `prototype` property is automatically created for every function defined using a |FunctionDeclaration| or |FunctionExpression|, to allow for the possibility that the function will be used as a constructor.</p>
+        <p>A `"prototype"` property is automatically created for every function defined using a |FunctionDeclaration| or |FunctionExpression|, to allow for the possibility that the function will be used as a constructor.</p>
       </emu-note>
       <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
@@ -23015,7 +23015,7 @@
                 String
               </td>
               <td>
-                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value `"*"` indicates that the import request is for the target module's namespace object.
+                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value *"*"* indicates that the import request is for the target module's namespace object.
               </td>
             </tr>
             <tr>
@@ -24428,7 +24428,7 @@
   <p>There are certain built-in objects available whenever an ECMAScript |Script| or |Module| begins execution. One, the global object, is part of the lexical environment of the executing program. Others are accessible as initial properties of the global object or indirectly as properties of accessible built-in objects.</p>
   <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
-  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;`this` value&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
+  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;*this* value&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>
   <emu-note>
     <p>Implementations that add additional capabilities to the set of built-in functions are encouraged to do so by adding new functions rather than adding new parameters to existing functions.</p>
@@ -24439,11 +24439,11 @@
   <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>).</p>
   <p>Every built-in function object, including constructors, has a `"length"` property whose value is an integer. Unless otherwise specified, this value is equal to the largest number of named arguments shown in the subclause headings for the function description. Optional parameters (which are indicated with brackets: `[` `]`) or rest parameters (which are shown using the form &laquo;...name&raquo;) are not included in the default argument count.</p>
   <emu-note>
-    <p>For example, the function object that is the initial value of the `map` property of the Array prototype object is described under the subclause heading &laquo;Array.prototype.map (callbackFn [ , thisArg])&raquo; which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the `"length"` property of that function object is 1.</p>
+    <p>For example, the function object that is the initial value of the `"map"` property of the Array prototype object is described under the subclause heading &laquo;Array.prototype.map (callbackFn [ , thisArg])&raquo; which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the `"length"` property of that function object is 1.</p>
   </emu-note>
   <p>Unless otherwise specified, the `"length"` property of a built-in function object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-  <p>Every built-in function object, including constructors, that is not identified as an anonymous function has a `name` property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. For functions that are specified as properties of objects, the name value is the property name string used to access the function. Functions that are specified as get or set accessor functions of built-in properties have `"get "` or `"set "` prepended to the property name string. The value of the `name` property is explicitly specified for each built-in functions whose property key is a Symbol value.</p>
-  <p>Unless otherwise specified, the `name` property of a built-in function object, if it exists, has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+  <p>Every built-in function object, including constructors, that is not identified as an anonymous function has a `"name"` property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. For functions that are specified as properties of objects, the name value is the property name string used to access the function. Functions that are specified as get or set accessor functions of built-in properties have `"get "` or `"set "` prepended to the property name string. The value of the `"name"` property is explicitly specified for each built-in functions whose property key is a Symbol value.</p>
+  <p>Unless otherwise specified, the `"name"` property of a built-in function object, if it exists, has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   <p>Every other data property described in clauses 18 through 26 and in Annex <emu-xref href="#sec-additional-built-in-properties"></emu-xref> has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* } unless otherwise specified.</p>
   <p>Every accessor property described in clauses 18 through 26 and in Annex <emu-xref href="#sec-additional-built-in-properties"></emu-xref> has the attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, *undefined*. If only a set accessor is described the get accessor is the default value, *undefined*.</p>
 </emu-clause>
@@ -24464,7 +24464,7 @@
 
     <emu-clause id="sec-globalthis">
       <h1>globalThis</h1>
-      <p>The initial value of the `globalThis` property of the global object in a Realm Record _realm_ is _realm_.[[GlobalEnv]]'s EnvironmentRecord's [[GlobalThisValue]].</p>
+      <p>The initial value of the `"globalThis"` property of the global object in a Realm Record _realm_ is _realm_.[[GlobalEnv]]'s EnvironmentRecord's [[GlobalThisValue]].</p>
       <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
 
@@ -25299,7 +25299,7 @@
       <p>The Object constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Object%</dfn>.</li>
-        <li>is the initial value of the `Object` property of the global object.</li>
+        <li>is the initial value of the `"Object"` property of the global object.</li>
         <li>creates a new ordinary object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition.</li>
@@ -25684,7 +25684,7 @@
         </emu-alg>
         <p>The optional parameters to this function are not used but are intended to correspond to the parameter pattern used by ECMA-402 `toLocaleString` functions. Implementations that do not include ECMA-402 support must not use those parameter positions for other purposes.</p>
         <emu-note>
-          <p>This function provides a generic `toLocaleString` implementation for objects that have no locale-specific `toString` behaviour. `Array`, `Number`, `Date`, and `Typed Arrays` provide their own locale-sensitive `toLocaleString` methods.</p>
+          <p>This function provides a generic `toLocaleString` implementation for objects that have no locale-specific `toString` behaviour. `Array`, `Number`, `Date`, and %TypedArray% provide their own locale-sensitive `toLocaleString` methods.</p>
         </emu-note>
         <emu-note>
           <p>ECMA-402 intentionally does not provide an alternative to this default implementation.</p>
@@ -25743,7 +25743,7 @@
       <p>The Function constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Function%</dfn>.</li>
-        <li>is the initial value of the `Function` property of the global object.</li>
+        <li>is the initial value of the `"Function"` property of the global object.</li>
         <li>creates and initializes a new function object when called as a function rather than as a constructor. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction`, `AsyncFunction`, and `AsyncGeneratorFunction` subclasses.</li>
       </ul>
@@ -25846,7 +25846,7 @@
             1. Return _F_.
           </emu-alg>
           <emu-note>
-            <p>A `prototype` property is created for every non-async function created using CreateDynamicFunction to provide for the possibility that the function will be used as a constructor.</p>
+            <p>A `"prototype"` property is created for every non-async function created using CreateDynamicFunction to provide for the possibility that the function will be used as a constructor.</p>
           </emu-note>
 
           <emu-table id="table-dynamic-function-sourcetext-prefixes" caption="Dynamic Function SourceText Prefixes">
@@ -25894,9 +25894,9 @@
         <li>accepts any arguments and returns *undefined* when invoked.</li>
         <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
-        <li>does not have a `prototype` property.</li>
+        <li>does not have a `"prototype"` property.</li>
         <li>has a `"length"` property whose value is 0.</li>
-        <li>has a `name` property whose value is the empty String.</li>
+        <li>has a `"name"` property whose value is the empty String.</li>
       </ul>
       <emu-note>
         <p>The Function prototype object is specified to be a function object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
@@ -25946,7 +25946,7 @@
           1. Return _F_.
         </emu-alg>
         <emu-note>
-          <p>Function objects created using `Function.prototype.bind` are exotic objects. They also do not have a `prototype` property.</p>
+          <p>Function objects created using `Function.prototype.bind` are exotic objects. They also do not have a `"prototype"` property.</p>
         </emu-note>
         <emu-note>
           <p>If _Target_ is an arrow function or a bound function then the _thisArg_ passed to this method will not be used by subsequent calls to _F_.</p>
@@ -25982,7 +25982,7 @@
         <p>When the `toString` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If _func_ is a <emu-xref href="#sec-bound-function-exotic-objects">Bound Function exotic object</emu-xref> or a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ is a <emu-xref href="#sec-well-known-intrinsic-objects">Well-known Intrinsic Object</emu-xref> and is not identified as an anonymous function, the portion of the returned String that would be matched by |PropertyName| must be the initial value of the `name` property of _func_.
+          1. If _func_ is a <emu-xref href="#sec-bound-function-exotic-objects">Bound Function exotic object</emu-xref> or a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ is a <emu-xref href="#sec-well-known-intrinsic-objects">Well-known Intrinsic Object</emu-xref> and is not identified as an anonymous function, the portion of the returned String that would be matched by |PropertyName| must be the initial value of the `"name"` property of _func_.
           1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and Type(_func_.[[SourceText]]) is String and ! HostHasSourceTextAvailable(_func_) is *true*, then return _func_.[[SourceText]].
           1. If Type(_func_) is Object and IsCallable(_func_) is *true*, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
           1. Throw a *TypeError* exception.
@@ -26001,7 +26001,7 @@
           1. Let _F_ be the *this* value.
           1. Return ? OrdinaryHasInstance(_F_, _V_).
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.hasInstance]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.hasInstance]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>This is the default implementation of `@@hasInstance` that most functions inherit. `@@hasInstance` is called by the `instanceof` operator to determine whether a value is an instance of a specific constructor. An expression such as</p>
@@ -26030,16 +26030,16 @@
 
       <emu-clause id="sec-function-instances-name">
         <h1>name</h1>
-        <p>The value of the `name` property is a String that is descriptive of the function. The name has no semantic significance but is typically a variable or property name that is used to refer to the function at its point of definition in ECMAScript code. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-        <p>Anonymous functions objects that do not have a contextual name associated with them by this specification do not have a `name` own property but inherit the `name` property of %Function.prototype%.</p>
+        <p>The value of the `"name"` property is a String that is descriptive of the function. The name has no semantic significance but is typically a variable or property name that is used to refer to the function at its point of definition in ECMAScript code. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>Anonymous functions objects that do not have a contextual name associated with them by this specification do not have a `"name"` own property but inherit the `"name"` property of %Function.prototype%.</p>
       </emu-clause>
 
       <emu-clause id="sec-function-instances-prototype">
         <h1>prototype</h1>
-        <p>Function instances that can be used as a constructor have a `prototype` property. Whenever such a Function instance is created another ordinary object is also created and is the initial value of the function's `prototype` property. Unless otherwise specified, the value of the `prototype` property is used to initialize the [[Prototype]] internal slot of the object created when that function is invoked as a constructor.</p>
+        <p>Function instances that can be used as a constructor have a `"prototype"` property. Whenever such a Function instance is created another ordinary object is also created and is the initial value of the function's `"prototype"` property. Unless otherwise specified, the value of the `"prototype"` property is used to initialize the [[Prototype]] internal slot of the object created when that function is invoked as a constructor.</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Function objects created using `Function.prototype.bind`, or by evaluating a |MethodDefinition| (that is not a |GeneratorMethod| or |AsyncGeneratorMethod|) or an |ArrowFunction| do not have a `prototype` property.</p>
+          <p>Function objects created using `Function.prototype.bind`, or by evaluating a |MethodDefinition| (that is not a |GeneratorMethod| or |AsyncGeneratorMethod|) or an |ArrowFunction| do not have a `"prototype"` property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -26059,7 +26059,7 @@
       <p>The Boolean constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Boolean%</dfn>.</li>
-        <li>is the initial value of the `Boolean` property of the global object.</li>
+        <li>is the initial value of the `"Boolean"` property of the global object.</li>
         <li>creates and initializes a new Boolean object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behaviour must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</li>
@@ -26150,7 +26150,7 @@
       <p>The Symbol constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Symbol%</dfn>.</li>
-        <li>is the initial value of the `Symbol` property of the global object.</li>
+        <li>is the initial value of the `"Symbol"` property of the global object.</li>
         <li>returns a new Symbol value when called as a function.</li>
         <li>is not intended to be used with the `new` operator.</li>
         <li>is not intended to be subclassed.</li>
@@ -26275,7 +26275,7 @@
 
       <emu-clause id="sec-symbol.matchall">
         <h1>Symbol.matchAll</h1>
-        <p>The initial value of *Symbol.matchAll* is the well-known symbol @@matchAll (<emu-xref href="#table-2"></emu-xref>).</p>
+        <p>The initial value of `Symbol.matchAll` is the well-known symbol @@matchAll (<emu-xref href="#table-2"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26399,13 +26399,13 @@
         <emu-alg>
           1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.toPrimitive]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.toPrimitive]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.prototype-@@tostringtag">
         <h1>Symbol.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"Symbol"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"Symbol"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -26425,7 +26425,7 @@
       <p>The Error constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Error%</dfn>.</li>
-        <li>is the initial value of the `Error` property of the global object.</li>
+        <li>is the initial value of the `"Error"` property of the global object.</li>
         <li>creates and initializes a new Error object when called as a function rather than as a constructor. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
       </ul>
@@ -26544,7 +26544,7 @@
 
     <emu-clause id="sec-nativeerror-object-structure">
       <h1>_NativeError_ Object Structure</h1>
-      <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the `name` property of the prototype object, and in the implementation-defined `message` property of the prototype object.</p>
+      <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the `"name"` property of the prototype object, and in the implementation-defined `"message"` property of the prototype object.</p>
       <p>For each error object, references to _NativeError_ in the definition should be replaced with the appropriate error object name from <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>.</p>
 
       <emu-clause id="sec-nativeerror-constructors">
@@ -26576,7 +26576,7 @@
         <p>Each _NativeError_ constructor:</p>
         <ul>
           <li>has a [[Prototype]] internal slot whose value is %Error%.</li>
-          <li>has a `name` property whose value is the String value `"<var>NativeError</var>"`.</li>
+          <li>has a `"name"` property whose value is the String value *"NativeError"*.</li>
           <li>has the following properties:</li>
         </ul>
 
@@ -26598,17 +26598,17 @@
 
         <emu-clause id="sec-nativeerror.prototype.constructor">
           <h1>_NativeError_.prototype.constructor</h1>
-          <p>The initial value of the `constructor` property of the prototype for a given _NativeError_ constructor is the corresponding intrinsic object %_NativeError_% (<emu-xref href="#sec-nativeerror-constructors"></emu-xref>).</p>
+          <p>The initial value of the `"constructor"` property of the prototype for a given _NativeError_ constructor is the corresponding intrinsic object %_NativeError_% (<emu-xref href="#sec-nativeerror-constructors"></emu-xref>).</p>
         </emu-clause>
 
         <emu-clause id="sec-nativeerror.prototype.message">
           <h1>_NativeError_.prototype.message</h1>
-          <p>The initial value of the `message` property of the prototype for a given _NativeError_ constructor is the empty String.</p>
+          <p>The initial value of the `"message"` property of the prototype for a given _NativeError_ constructor is the empty String.</p>
         </emu-clause>
 
         <emu-clause id="sec-nativeerror.prototype.name">
           <h1>_NativeError_.prototype.name</h1>
-          <p>The initial value of the `name` property of the prototype for a given _NativeError_ constructor is the String value consisting of the name of the constructor (the name used instead of _NativeError_).</p>
+          <p>The initial value of the `"name"` property of the prototype for a given _NativeError_ constructor is the String value consisting of the name of the constructor (the name used instead of _NativeError_).</p>
         </emu-clause>
       </emu-clause>
 
@@ -26631,7 +26631,7 @@
       <p>The Number constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Number%</dfn>.</li>
-        <li>is the initial value of the `Number` property of the global object.</li>
+        <li>is the initial value of the `"Number"` property of the global object.</li>
         <li>creates and initializes a new Number object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behaviour must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</li>
@@ -26661,7 +26661,7 @@
 
       <emu-clause id="sec-number.epsilon">
         <h1>Number.EPSILON</h1>
-        <p>The value of Number.EPSILON is the difference between 1 and the smallest value greater than 1 that is representable as a Number value, which is approximately 2.2204460492503130808472633361816 x 10<sup> - 16</sup>.</p>
+        <p>The value of `Number.EPSILON` is the difference between 1 and the smallest value greater than 1 that is representable as a Number value, which is approximately 2.2204460492503130808472633361816 x 10<sup> - 16</sup>.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26711,7 +26711,7 @@
         <emu-note>
           <p>The value of `Number.MAX_SAFE_INTEGER` is the largest integer n such that n and n + 1 are both exactly representable as a Number value.</p>
         </emu-note>
-        <p>The value of Number.MAX_SAFE_INTEGER is 9007199254740991 (2<sup>53</sup> - 1).</p>
+        <p>The value of `Number.MAX_SAFE_INTEGER` is 9007199254740991 (2<sup>53</sup> - 1).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26726,7 +26726,7 @@
         <emu-note>
           <p>The value of `Number.MIN_SAFE_INTEGER` is the smallest integer n such that n and n - 1 are both exactly representable as a Number value.</p>
         </emu-note>
-        <p>The value of Number.MIN_SAFE_INTEGER is -9007199254740991 (-(2<sup>53</sup> - 1)).</p>
+        <p>The value of `Number.MIN_SAFE_INTEGER` is -9007199254740991 (-(2<sup>53</sup> - 1)).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26745,23 +26745,23 @@
 
       <emu-clause id="sec-number.negative_infinity">
         <h1>Number.NEGATIVE_INFINITY</h1>
-        <p>The value of Number.NEGATIVE_INFINITY is *-&infin;*.</p>
+        <p>The value of `Number.NEGATIVE_INFINITY` is *-&infin;*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.parsefloat">
         <h1>Number.parseFloat ( _string_ )</h1>
-        <p>The value of the `Number.parseFloat` data property is the same built-in function object that is the value of the `parseFloat` property of the global object defined in <emu-xref href="#sec-parsefloat-string"></emu-xref>.</p>
+        <p>The value of the `Number.parseFloat` data property is the same built-in function object that is the value of the `"parseFloat"` property of the global object defined in <emu-xref href="#sec-parsefloat-string"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.parseint">
         <h1>Number.parseInt ( _string_, _radix_ )</h1>
-        <p>The value of the `Number.parseInt` data property is the same built-in function object that is the value of the `parseInt` property of the global object defined in <emu-xref href="#sec-parseint-string-radix"></emu-xref>.</p>
+        <p>The value of the `Number.parseInt` data property is the same built-in function object that is the value of the `"parseInt"` property of the global object defined in <emu-xref href="#sec-parseint-string-radix"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.positive_infinity">
         <h1>Number.POSITIVE_INFINITY</h1>
-        <p>The value of Number.POSITIVE_INFINITY is *+&infin;*.</p>
+        <p>The value of `Number.POSITIVE_INFINITY` is *+&infin;*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26975,7 +26975,7 @@
       <p>The BigInt constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%BigInt%</dfn>.</li>
-        <li>is the initial value of the `BigInt` property of the global object.</li>
+        <li>is the initial value of the `"BigInt"` property of the global object.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is not intended to be used with the `new` operator or to be subclassed. It may be used as the value of an `extends` clause of a class definition but a `super` call to the `BigInt` constructor will cause an exception.</li>
       </ul>
@@ -27091,7 +27091,7 @@
 
       <emu-clause id="sec-bigint.prototype-@@tostringtag">
         <h1>BigInt.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"BigInt"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"BigInt"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -27102,7 +27102,7 @@
     <p>The Math object:</p>
     <ul>
       <li>is the intrinsic object <dfn>%Math%</dfn>.</li>
-      <li>is the initial value of the `Math` property of the global object.</li>
+      <li>is the initial value of the `"Math"` property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>is not a function object.</li>
@@ -27175,7 +27175,7 @@
 
       <emu-clause id="sec-math-@@tostringtag">
         <h1>Math [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"Math"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"Math"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -27517,7 +27517,7 @@
           </li>
         </ul>
         <emu-note>
-          <p>The value of cosh(x) is the same as <i>(exp(x) + exp(-x)) / 2</i>.</p>
+          <p>The value of `Math.cosh(x)` is the same as the value of `(Math.exp(x) + Math.exp(-x)) / 2`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27881,7 +27881,7 @@
           </li>
         </ul>
         <emu-note>
-          <p>The value of sinh(x) is the same as <i>(exp(x) - exp(-x)) / 2</i>.</p>
+          <p>The value of `Math.sinh(x)` is the same as the value of `(Math.exp(x) - Math.exp(-x)) / 2`.</p>
         </emu-note>
       </emu-clause>
 
@@ -27947,7 +27947,7 @@
           </li>
         </ul>
         <emu-note>
-          <p>The value of tanh(x) is the same as <i>(exp(x) - exp(-x))/(exp(x) + exp(-x))</i>.</p>
+          <p>The value of `Math.tanh(x)` is the same as the value of `(Math.exp(x) - Math.exp(-x)) / (Math.exp(x) + Math.exp(-x))`.</p>
         </emu-note>
       </emu-clause>
 
@@ -28364,7 +28364,7 @@ THH:mm:ss.sss
       <p>The Date constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Date%</dfn>.</li>
-        <li>is the initial value of the `Date` property of the global object.</li>
+        <li>is the initial value of the `"Date"` property of the global object.</li>
         <li>creates and initializes a new Date object when called as a constructor.</li>
         <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
         <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
@@ -29321,14 +29321,14 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _hint_ is the String value `"string"` or the String value `"default"`, then
-            1. Let _tryFirst_ be `"string"`.
-          1. Else if _hint_ is the String value `"number"`, then
-            1. Let _tryFirst_ be `"number"`.
+          1. If _hint_ is the String value *"string"* or the String value *"default"*, then
+            1. Let _tryFirst_ be *"string"*.
+          1. Else if _hint_ is the String value *"number"*, then
+            1. Let _tryFirst_ be *"number"*.
           1. Else, throw a *TypeError* exception.
           1. Return ? OrdinaryToPrimitive(_O_, _tryFirst_).
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.toPrimitive]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.toPrimitive]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -29351,7 +29351,7 @@ THH:mm:ss.sss
       <p>The String constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%String%</dfn>.</li>
-        <li>is the initial value of the `String` property of the global object.</li>
+        <li>is the initial value of the `"String"` property of the global object.</li>
         <li>creates and initializes a new String object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behaviour must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</li>
@@ -30276,7 +30276,7 @@ THH:mm:ss.sss
           1. Let _S_ be ? ToString(_O_).
           1. Return CreateStringIterator(_S_).
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.iterator]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.iterator]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -30340,7 +30340,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-%stringiteratorprototype%-@@tostringtag">
           <h1>%StringIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value `"String Iterator"`.</p>
+          <p>The initial value of the @@toStringTag property is the String value *"String Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -31991,7 +31991,7 @@ THH:mm:ss.sss
       <p>The RegExp constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%RegExp%</dfn>.</li>
-        <li>is the initial value of the `RegExp` property of the global object.</li>
+        <li>is the initial value of the `"RegExp"` property of the global object.</li>
         <li>creates and initializes a new RegExp object when called as a function rather than as a constructor. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behaviour must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</li>
       </ul>
@@ -32105,7 +32105,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
+        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>RegExp prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -32122,7 +32122,7 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <emu-note>
-        <p>The RegExp prototype object does not have a `valueOf` property of its own; however, it inherits the `valueOf` property from the Object prototype object.</p>
+        <p>The RegExp prototype object does not have a `"valueOf"` property of its own; however, it inherits the `"valueOf"` property from the Object prototype object.</p>
       </emu-note>
 
       <emu-clause id="sec-regexp.prototype.constructor">
@@ -32156,7 +32156,7 @@ THH:mm:ss.sss
             1. Return ? RegExpBuiltinExec(_R_, _S_).
           </emu-alg>
           <emu-note>
-            <p>If a callable `exec` property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behaviour for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of `exec`.</p>
+            <p>If a callable `"exec"` property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behaviour for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of `"exec"`.</p>
           </emu-note>
         </emu-clause>
 
@@ -32340,7 +32340,7 @@ THH:mm:ss.sss
                   1. Perform ? Set(_rx_, `"lastIndex"`, _nextIndex_, *true*).
                 1. Set _n_ to _n_ + 1.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.match]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.match]"*.</p>
         <emu-note>
           <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behaviour of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
         </emu-note>
@@ -32365,7 +32365,7 @@ THH:mm:ss.sss
           1. Else, let _fullUnicode_ be *false*.
           1. Return ! CreateRegExpStringIterator(_matcher_, _S_, _global_, _fullUnicode_).
         </emu-alg>
-        <p>The value of the *name* property of this function is `"[Symbol.matchAll]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.matchAll]"*.</p>
 
         <emu-clause id="sec-createregexpstringiterator" aoid="CreateRegExpStringIterator">
           <h1>CreateRegExpStringIterator ( _R_, _S_, _global_, _fullUnicode_ )</h1>
@@ -32465,7 +32465,7 @@ THH:mm:ss.sss
           1. If _nextSourcePosition_ &ge; _lengthS_, return _accumulatedResult_.
           1. Return the string-concatenation of _accumulatedResult_ and the substring of _S_ consisting of the code units from _nextSourcePosition_ (inclusive) up through the final code unit of _S_ (inclusive).
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.replace]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.replace]"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-regexp.prototype-@@search">
@@ -32485,9 +32485,9 @@ THH:mm:ss.sss
           1. If _result_ is *null*, return -1.
           1. Return ? Get(_result_, `"index"`).
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.search]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.search]"*.</p>
         <emu-note>
-          <p>The `lastIndex` and `global` properties of this RegExp object are ignored when performing the search. The `lastIndex` property is left unchanged.</p>
+          <p>The `"lastIndex"` and `"global"` properties of this RegExp object are ignored when performing the search. The `"lastIndex"` property is left unchanged.</p>
         </emu-note>
       </emu-clause>
 
@@ -32571,9 +32571,9 @@ THH:mm:ss.sss
           1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
           1. Return _A_.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.split]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.split]"*.</p>
         <emu-note>
-          <p>The `@@split` method ignores the value of the `global` and `sticky` properties of this RegExp object.</p>
+          <p>The `@@split` method ignores the value of the `"global"` and `"sticky"` properties of this RegExp object.</p>
         </emu-note>
       </emu-clause>
 
@@ -32639,13 +32639,13 @@ THH:mm:ss.sss
       <h1>Properties of RegExp Instances</h1>
       <p>RegExp instances are ordinary objects that inherit properties from the RegExp prototype object. RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and [[OriginalFlags]]. The value of the [[RegExpMatcher]] internal slot is an implementation-dependent representation of the |Pattern| of the RegExp object.</p>
       <emu-note>
-        <p>Prior to ECMAScript 2015, `RegExp` instances were specified as having the own data properties `source`, `global`, `ignoreCase`, and `multiline`. Those properties are now specified as accessor properties of RegExp.prototype.</p>
+        <p>Prior to ECMAScript 2015, `RegExp` instances were specified as having the own data properties `"source"`, `"global"`, `"ignoreCase"`, and `"multiline"`. Those properties are now specified as accessor properties of `RegExp.prototype`.</p>
       </emu-note>
       <p>RegExp instances also have the following property:</p>
 
       <emu-clause id="sec-lastindex">
         <h1>lastIndex</h1>
-        <p>The value of the `lastIndex` property specifies the String index at which to start the next match. It is coerced to an integer when used (see <emu-xref href="#sec-regexpbuiltinexec"></emu-xref>). This property shall have the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <p>The value of the `"lastIndex"` property specifies the String index at which to start the next match. It is coerced to an integer when used (see <emu-xref href="#sec-regexpbuiltinexec"></emu-xref>). This property shall have the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
@@ -32695,7 +32695,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-%regexpstringiteratorprototype%-@@tostringtag">
           <h1>%RegExpStringIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value `"RegExp String Iterator"`.</p>
+          <p>The initial value of the @@toStringTag property is the String value *"RegExp String Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -32750,11 +32750,11 @@ THH:mm:ss.sss
       <p>The Array constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Array%</dfn>.</li>
-        <li>is the initial value of the `Array` property of the global object.</li>
+        <li>is the initial value of the `"Array"` property of the global object.</li>
         <li>creates and initializes a new Array exotic object when called as a constructor.</li>
         <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
         <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behaviour must include a `super` call to the `Array` constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their `this` value being an Array exotic object.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behaviour must include a `super` call to the `Array` constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
         <li>has a `"length"` property whose value is 1.</li>
       </ul>
 
@@ -32929,7 +32929,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
+        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>Array prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -33599,7 +33599,7 @@ THH:mm:ss.sss
           1. Return _accumulator_.
         </emu-alg>
         <emu-note>
-          <p>The `reduceRight` function is intentionally generic; it does not require that its this value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `reduceRight` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -34155,7 +34155,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-%arrayiteratorprototype%-@@tostringtag">
           <h1>%ArrayIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value `"Array Iterator"`.</p>
+          <p>The initial value of the @@toStringTag property is the String value *"Array Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -34467,7 +34467,7 @@ THH:mm:ss.sss
       <p>The %TypedArray% intrinsic object:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>has a `name` property whose value is `"TypedArray"`.</li>
+        <li>has a `"name"` property whose value is *"TypedArray"*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -34565,7 +34565,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
+        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>%TypedArray.prototype% methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -35104,7 +35104,7 @@ THH:mm:ss.sss
           1. Return _name_.
         </emu-alg>
         <p>This property has the attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-        <p>The initial value of the `name` property of this function is `"get [Symbol.toStringTag]"`.</p>
+        <p>The initial value of the `"name"` property of this function is *"get [Symbol.toStringTag]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -35327,13 +35327,13 @@ THH:mm:ss.sss
       <p>Each _TypedArray_ constructor:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %TypedArray%.</li>
-        <li>has a `name` property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-49"></emu-xref>.</li>
+        <li>has a `"name"` property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-49"></emu-xref>.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-typedarray.bytes_per_element">
         <h1>_TypedArray_.BYTES_PER_ELEMENT</h1>
-        <p>The value of _TypedArray_.BYTES_PER_ELEMENT is the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
+        <p>The value of _TypedArray_`.BYTES_PER_ELEMENT` is the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -35355,13 +35355,13 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-typedarray.prototype.bytes_per_element">
         <h1>_TypedArray_.prototype.BYTES_PER_ELEMENT</h1>
-        <p>The value of <code><var>TypedArray</var>.prototype.BYTES_PER_ELEMENT</code> is the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
+        <p>The value of _TypedArray_`.prototype.BYTES_PER_ELEMENT` is the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _TypedArray_.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-typedarray.prototype.constructor">
         <h1>_TypedArray_.prototype.constructor</h1>
-        <p>The initial value of a <code><var>TypedArray</var>.prototype.constructor</code> is the corresponding %_TypedArray_% intrinsic object.</p>
+        <p>The initial value of a _TypedArray_`.prototype.constructor` is the corresponding %TypedArray% intrinsic object.</p>
       </emu-clause>
     </emu-clause>
 
@@ -35385,7 +35385,7 @@ THH:mm:ss.sss
       <p>The Map constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Map%</dfn>.</li>
-        <li>is the initial value of the `Map` property of the global object.</li>
+        <li>is the initial value of the `"Map"` property of the global object.</li>
         <li>creates and initializes a new Map object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behaviour must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
@@ -35454,7 +35454,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
+        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>Methods that create derived collection objects should call @@species to determine the constructor to use to create the derived objects. Subclass constructor may over-ride @@species to change the default constructor assignment.</p>
         </emu-note>
@@ -35621,12 +35621,12 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype-@@iterator">
         <h1>Map.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is the same function object as the initial value of the `entries` property.</p>
+        <p>The initial value of the @@iterator property is the same function object as the initial value of the `"entries"` property.</p>
       </emu-clause>
 
       <emu-clause id="sec-map.prototype-@@tostringtag">
         <h1>Map.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"Map"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"Map"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -35695,7 +35695,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-%mapiteratorprototype%-@@tostringtag">
           <h1>%MapIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value `"Map Iterator"`.</p>
+          <p>The initial value of the @@toStringTag property is the String value *"Map Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -35755,7 +35755,7 @@ THH:mm:ss.sss
       <p>The Set constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Set%</dfn>.</li>
-        <li>is the initial value of the `Set` property of the global object.</li>
+        <li>is the initial value of the `"Set"` property of the global object.</li>
         <li>creates and initializes a new Set object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behaviour must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
@@ -35803,7 +35803,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
+        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>Methods that create derived collection objects should call @@species to determine the constructor to use to create the derived objects. Subclass constructor may over-ride @@species to change the default constructor assignment.</p>
         </emu-note>
@@ -35926,7 +35926,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.keys">
         <h1>Set.prototype.keys ( )</h1>
-        <p>The initial value of the `keys` property is the same function object as the initial value of the `values` property.</p>
+        <p>The initial value of the `"keys"` property is the same function object as the initial value of the `"values"` property.</p>
         <emu-note>
           <p>For iteration purposes, a Set appears similar to a Map where each entry has the same value for its key and value.</p>
         </emu-note>
@@ -35957,12 +35957,12 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype-@@iterator">
         <h1>Set.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is the same function object as the initial value of the `values` property.</p>
+        <p>The initial value of the @@iterator property is the same function object as the initial value of the `"values"` property.</p>
       </emu-clause>
 
       <emu-clause id="sec-set.prototype-@@tostringtag">
         <h1>Set.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"Set"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"Set"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -36028,7 +36028,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-%setiteratorprototype%-@@tostringtag">
           <h1>%SetIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value `"Set Iterator"`.</p>
+          <p>The initial value of the @@toStringTag property is the String value *"Set Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -36094,7 +36094,7 @@ THH:mm:ss.sss
       <p>The WeakMap constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%WeakMap%</dfn>.</li>
-        <li>is the initial value of the `WeakMap` property of the global object.</li>
+        <li>is the initial value of the `"WeakMap"` property of the global object.</li>
         <li>creates and initializes a new WeakMap object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behaviour must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
@@ -36215,7 +36215,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakmap.prototype-@@tostringtag">
         <h1>WeakMap.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"WeakMap"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"WeakMap"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -36240,7 +36240,7 @@ THH:mm:ss.sss
       <p>The WeakSet constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%WeakSet%</dfn>.</li>
-        <li>is the initial value of the `WeakSet` property of the global object.</li>
+        <li>is the initial value of the `"WeakSet"` property of the global object.</li>
         <li>creates and initializes a new WeakSet object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behaviour must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
@@ -36349,7 +36349,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakset.prototype-@@tostringtag">
         <h1>WeakSet.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"WeakSet"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"WeakSet"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -36580,7 +36580,7 @@ THH:mm:ss.sss
       <p>The ArrayBuffer constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%ArrayBuffer%</dfn>.</li>
-        <li>is the initial value of the `ArrayBuffer` property of the global object.</li>
+        <li>is the initial value of the `"ArrayBuffer"` property of the global object.</li>
         <li>creates and initializes a new ArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behaviour must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
@@ -36627,7 +36627,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
+        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>ArrayBuffer prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -36694,7 +36694,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-arraybuffer.prototype-@@tostringtag">
         <h1>ArrayBuffer.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"ArrayBuffer"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"ArrayBuffer"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -36745,7 +36745,7 @@ THH:mm:ss.sss
       <p>The SharedArrayBuffer constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%SharedArrayBuffer%</dfn>.</li>
-        <li>is the initial value of the `SharedArrayBuffer` property of the global object.</li>
+        <li>is the initial value of the `"SharedArrayBuffer"` property of the global object.</li>
         <li>creates and initializes a new SharedArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `SharedArrayBuffer` behaviour must include a `super` call to the `SharedArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
@@ -36786,7 +36786,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
+        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -36845,7 +36845,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-sharedarraybuffer.prototype.toString">
         <h1>SharedArrayBuffer.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"SharedArrayBuffer"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"SharedArrayBuffer"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -36912,7 +36912,7 @@ THH:mm:ss.sss
       <p>The DataView constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%DataView%</dfn>.</li>
-        <li>is the initial value of the `DataView` property of the global object.</li>
+        <li>is the initial value of the `"DataView"` property of the global object.</li>
         <li>creates and initializes a new DataView object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behaviour must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
@@ -37211,7 +37211,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype-@@tostringtag">
         <h1>DataView.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"DataView"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"DataView"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -37230,7 +37230,7 @@ THH:mm:ss.sss
     <p>The Atomics object:</p>
     <ul>
       <li>is the intrinsic object <dfn>%Atomics%</dfn>.</li>
-      <li>is the initial value of the `Atomics` property of the global object.</li>
+      <li>is the initial value of the `"Atomics"` property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
@@ -37485,7 +37485,7 @@ THH:mm:ss.sss
         1. Return *false*.
       </emu-alg>
       <emu-note>
-        <p>`Atomics.isLockFree`() is an optimization primitive. The intuition is that if the atomic step of an atomic primitive (`compareExchange`, `load`, `store`, `add`, `sub`, `and`, `or`, `xor`, or `exchange`) on a datum of size _n_ bytes will be performed without the calling agent acquiring a lock outside the _n_ bytes comprising the datum, then `Atomics.isLockFree`(_n_) will return *true*. High-performance algorithms will use Atomics.isLockFree to determine whether to use locks or atomic operations in critical sections. If an atomic primitive is not lock-free then it is often more efficient for an algorithm to provide its own locking.</p>
+        <p>`Atomics.isLockFree`() is an optimization primitive. The intuition is that if the atomic step of an atomic primitive (`compareExchange`, `load`, `store`, `add`, `sub`, `and`, `or`, `xor`, or `exchange`) on a datum of size _n_ bytes will be performed without the calling agent acquiring a lock outside the _n_ bytes comprising the datum, then `Atomics.isLockFree`(_n_) will return *true*. High-performance algorithms will use `Atomics.isLockFree` to determine whether to use locks or atomic operations in critical sections. If an atomic primitive is not lock-free then it is often more efficient for an algorithm to provide its own locking.</p>
         <p>`Atomics.isLockFree`(4) always returns *true* as that can be supported on all known relevant hardware. Being able to assume this will generally simplify programs.</p>
         <p>Regardless of the value of `Atomics.isLockFree`, all atomic operations are guaranteed to be atomic. For example, they will never have a visible operation take place in the middle of the operation (e.g., "tearing").</p>
       </emu-note>
@@ -37610,7 +37610,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics-@@tostringtag">
       <h1>Atomics [ @@toStringTag ]</h1>
-      <p>The initial value of the @@toStringTag property is the String value `"Atomics"`.</p>
+      <p>The initial value of the @@toStringTag property is the String value *"Atomics"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
   </emu-clause>
@@ -37620,7 +37620,7 @@ THH:mm:ss.sss
     <p>The JSON object:</p>
     <ul>
       <li>is the intrinsic object <dfn>%JSON%</dfn>.</li>
-      <li>is the initial value of the `JSON` property of the global object.</li>
+      <li>is the initial value of the `"JSON"` property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>contains two functions, `parse` and `stringify`, that are used to parse and construct JSON texts.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -37748,16 +37748,16 @@ THH:mm:ss.sss
         <p>Symbolic primitive values are rendered as follows:</p>
         <ul>
           <li>
-            The *null* value is rendered in JSON text as the String `null`.
+            The *null* value is rendered in JSON text as the String `"null"`.
           </li>
           <li>
             The *undefined* value is not rendered.
           </li>
           <li>
-            The *true* value is rendered in JSON text as the String `true`.
+            The *true* value is rendered in JSON text as the String `"true"`.
           </li>
           <li>
-            The *false* value is rendered in JSON text as the String `false`.
+            The *false* value is rendered in JSON text as the String `"false"`.
           </li>
         </ul>
       </emu-note>
@@ -37765,10 +37765,10 @@ THH:mm:ss.sss
         <p>String values are wrapped in QUOTATION MARK (`"`) code units. The code units `"` and `\\` are escaped with `\\` prefixes. Control characters code units are replaced with escape sequences `\\u`HHHH, or with the shorter forms, `\\b` (BACKSPACE), `\\f` (FORM FEED), `\\n` (LINE FEED), `\\r` (CARRIAGE RETURN), `\\t` (CHARACTER TABULATION).</p>
       </emu-note>
       <emu-note>
-        <p>Finite numbers are stringified as if by calling ToString(_number_). *NaN* and Infinity regardless of sign are represented as the String `null`.</p>
+        <p>Finite numbers are stringified as if by calling ToString(_number_). *NaN* and *Infinity* regardless of sign are represented as the String `"null"`.</p>
       </emu-note>
       <emu-note>
-        <p>Values that do not have a JSON representation (such as *undefined* and functions) do not produce a String. Instead they produce the *undefined* value. In arrays these values are represented as the String `null`. In objects an unrepresentable value causes the property to be excluded from stringification.</p>
+        <p>Values that do not have a JSON representation (such as *undefined* and functions) do not produce a String. Instead they produce the *undefined* value. In arrays these values are represented as the String `"null"`. In objects an unrepresentable value causes the property to be excluded from stringification.</p>
       </emu-note>
       <emu-note>
         <p>An object is rendered as U+007B (LEFT CURLY BRACKET) followed by zero or more properties, separated with a U+002C (COMMA), closed with a U+007D (RIGHT CURLY BRACKET). A property is a quoted String representing the key or property name, a U+003A (COLON), and then the stringified property value. An array is rendered as an opening U+005B (LEFT SQUARE BRACKET followed by zero or more values, separated with a U+002C (COMMA), closed with a U+005D (RIGHT SQUARE BRACKET).</p>
@@ -38015,7 +38015,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-json-@@tostringtag">
       <h1>JSON [ @@toStringTag ]</h1>
-      <p>The initial value of the @@toStringTag property is the String value `"JSON"`.</p>
+      <p>The initial value of the @@toStringTag property is the String value *"JSON"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
   </emu-clause>
@@ -38083,13 +38083,13 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `next`
+                `"next"`
               </td>
               <td>
                 A function that returns an <i>IteratorResult</i> object.
               </td>
               <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>Iterator</i> has returned an <i>IteratorResult</i> object whose `done` property is *true*, then all subsequent calls to the `next` method of that object should also return an <i>IteratorResult</i> object whose `done` property is *true*. However, this requirement is not enforced.
+                The returned object must conform to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>Iterator</i> has returned an <i>IteratorResult</i> object whose `"done"` property is *true*, then all subsequent calls to the `next` method of that object should also return an <i>IteratorResult</i> object whose `"done"` property is *true*. However, this requirement is not enforced.
               </td>
             </tr>
             </tbody>
@@ -38114,24 +38114,24 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `return`
+                `"return"`
               </td>
               <td>
                 A function that returns an <i>IteratorResult</i> object.
               </td>
               <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller does not intend to make any more `next` method calls to the <i>Iterator</i>. The returned <i>IteratorResult</i> object will typically have a `done` property whose value is *true*, and a `value` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.
+                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller does not intend to make any more `next` method calls to the <i>Iterator</i>. The returned <i>IteratorResult</i> object will typically have a `"done"` property whose value is *true*, and a `"value"` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.
               </td>
             </tr>
             <tr>
               <td>
-                `throw`
+                `"throw"`
               </td>
               <td>
                 A function that returns an <i>IteratorResult</i> object.
               </td>
               <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to `throw` the value passed as the argument. If the method does not `throw`, the returned <i>IteratorResult</i> object will typically have a `done` property whose value is *true*.
+                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to `throw` the value passed as the argument. If the method does not `throw`, the returned <i>IteratorResult</i> object will typically have a `"done"` property whose value is *true*.
               </td>
             </tr>
             </tbody>
@@ -38175,12 +38175,12 @@ THH:mm:ss.sss
               <th>Requirements</th>
             </tr>
             <tr>
-              <td>`next`</td>
+              <td>`"next"`</td>
               <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
               <td>
-                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose `done` property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose `done` property is *true*. However, this requirement is not enforced.</p>
+                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose `"done"` property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose `"done"` property is *true*. However, this requirement is not enforced.</p>
 
-                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
+                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `"value"` property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
               </td>
             </tr>
             </tbody>
@@ -38198,21 +38198,21 @@ THH:mm:ss.sss
               <th>Requirements</th>
             </tr>
             <tr>
-              <td>`return`</td>
+              <td>`"return"`</td>
               <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
               <td>
-                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a `done` property whose value is *true*, and a `value` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
+                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a `"done"` property whose value is *true*, and a `"value"` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
 
-                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). If the argument value is used in the typical manner, then if it is a rejected promise, a promise rejected with the same reason should be returned; if it is a fulfilled promise, then its fulfillment value should be used as the `value` property of the returned promise's <i>IteratorResult</i> object fulfillment value. However, these requirements are also not enforced.</p>
+                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `"value"` property whose value is not a promise (or "thenable"). If the argument value is used in the typical manner, then if it is a rejected promise, a promise rejected with the same reason should be returned; if it is a fulfilled promise, then its fulfillment value should be used as the `"value"` property of the returned promise's <i>IteratorResult</i> object fulfillment value. However, these requirements are also not enforced.</p>
               </td>
             </tr>
             <tr>
-              <td>`throw`</td>
+              <td>`"throw"`</td>
               <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
               <td>
                 <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to return a rejected promise which rejects with the value passed as the argument.</p>
 
-                <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a `done` property whose value is *true*. Additionally, it should have a `value` property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
+                <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a `"done"` property whose value is *true*. Additionally, it should have a `"value"` property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
               </td>
             </tr>
             </tbody>
@@ -38242,24 +38242,24 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `done`
+                `"done"`
               </td>
               <td>
                 Either *true* or *false*.
               </td>
               <td>
-                This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached `done` is *true*. If the end was not reached `done` is *false* and a value is available. If a `done` property (either own or inherited) does not exist, it is consider to have the value *false*.
+                This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached `"done"` is *true*. If the end was not reached `"done"` is *false* and a value is available. If a `"done"` property (either own or inherited) does not exist, it is consider to have the value *false*.
               </td>
             </tr>
             <tr>
               <td>
-                `value`
+                `"value"`
               </td>
               <td>
                 Any ECMAScript language value.
               </td>
               <td>
-                If done is *false*, this is the current iteration element value. If done is *true*, this is the return value of the iterator, if it supplied one. If the iterator does not have a return value, `value` is *undefined*. In that case, the `value` property may be absent from the conforming object if it does not inherit an explicit `value` property.
+                If done is *false*, this is the current iteration element value. If done is *true*, this is the return value of the iterator, if it supplied one. If the iterator does not have a return value, `"value"` is *undefined*. In that case, the `"value"` property may be absent from the conforming object if it does not inherit an explicit `"value"` property.
               </td>
             </tr>
             </tbody>
@@ -38276,7 +38276,7 @@ THH:mm:ss.sss
         <li>is an ordinary object.</li>
       </ul>
       <emu-note>
-        <p>All objects defined in this specification that implement the Iterator interface also inherit from %IteratorPrototype%. ECMAScript code may also define objects that inherit from %IteratorPrototype%.The %IteratorPrototype% object provides a place where additional methods that are applicable to all iterator objects may be added.</p>
+        <p>All objects defined in this specification that implement the Iterator interface also inherit from %IteratorPrototype%. ECMAScript code may also define objects that inherit from %IteratorPrototype%. The %IteratorPrototype% object provides a place where additional methods that are applicable to all iterator objects may be added.</p>
         <p>The following expression is one way that ECMAScript code can access the %IteratorPrototype% object:</p>
         <pre><code class="javascript">Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))</code></pre>
       </emu-note>
@@ -38287,7 +38287,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.iterator]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.iterator]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -38299,7 +38299,7 @@ THH:mm:ss.sss
         <li>is an ordinary object.</li>
       </ul>
       <emu-note>
-        <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%.The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
+        <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%. The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
       </emu-note>
 
       <emu-clause id="sec-asynciteratorprototype-asynciterator">
@@ -38308,7 +38308,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"[Symbol.asyncIterator]"`.</p>
+        <p>The value of the `"name"` property of this function is *"[Symbol.asyncIterator]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -38399,7 +38399,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-async-from-sync-iterator-value-unwrap-functions">
           <h1>Async-from-Sync Iterator Value Unwrap Functions</h1>
 
-          <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by AsyncFromSyncIteratorContinuation when processing the `value` property of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async-from-sync iterator value unwrap function has a [[Done]] internal slot.</p>
+          <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by AsyncFromSyncIteratorContinuation when processing the `"value"` property of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async-from-sync iterator value unwrap function has a [[Done]] internal slot.</p>
 
           <p>When an async-from-sync iterator value unwrap function is called with argument _value_, the following steps are taken:</p>
 
@@ -38496,7 +38496,7 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
-        <li>has a `name` property whose value is `"GeneratorFunction"`.</li>
+        <li>has a `"name"` property whose value is *"GeneratorFunction"*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -38518,7 +38518,7 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-56"></emu-xref>.</li>
-        <li>is the value of the `prototype` property of %GeneratorFunction%.</li>
+        <li>is the value of the `"prototype"` property of %GeneratorFunction%.</li>
         <li>is the intrinsic object <dfn>%Generator%</dfn> (see Figure 2).</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
@@ -38537,7 +38537,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction.prototype-@@tostringtag">
         <h1>GeneratorFunction.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"GeneratorFunction"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"GeneratorFunction"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -38554,15 +38554,15 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction-instances-name">
         <h1>name</h1>
-        <p>The specification for the `name` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to GeneratorFunction instances.</p>
+        <p>The specification for the `"name"` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to GeneratorFunction instances.</p>
       </emu-clause>
 
       <emu-clause id="sec-generatorfunction-instances-prototype">
         <h1>prototype</h1>
-        <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's `prototype` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
+        <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's `"prototype"` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's `prototype` property does not have a `constructor` property whose value is the GeneratorFunction instance.</p>
+          <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's `"prototype"` property does not have a `"constructor"` property whose value is the GeneratorFunction instance.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -38602,7 +38602,7 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
-        <li>has a `name` property whose value is `"AsyncGeneratorFunction"`.</li>
+        <li>has a `"name"` property whose value is *"AsyncGeneratorFunction"*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -38624,7 +38624,7 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
-        <li>is the value of the `prototype` property of %AsyncGeneratorFunction%.</li>
+        <li>is the value of the `"prototype"` property of %AsyncGeneratorFunction%.</li>
         <li>is %AsyncGenerator%.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
@@ -38643,7 +38643,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype-tostringtag">
         <h1>AsyncGeneratorFunction.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"AsyncGeneratorFunction"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"AsyncGeneratorFunction"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -38661,15 +38661,15 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-name">
         <h1>name</h1>
-        <p>The specification for the `name` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncGeneratorFunction instances.</p>
+        <p>The specification for the `"name"` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncGeneratorFunction instances.</p>
       </emu-clause>
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-prototype">
         <h1>prototype</h1>
-        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's `prototype` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator object when the generator function object is invoked using [[Call]].</p>
+        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's `"prototype"` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator object when the generator function object is invoked using [[Call]].</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Unlike function instances, the object that is the value of the an AsyncGeneratorFunction's `prototype` property does not have a `constructor` property whose value is the AsyncGeneratorFunction instance.</p>
+          <p>Unlike function instances, the object that is the value of the an AsyncGeneratorFunction's `"prototype"` property does not have a `"constructor"` property whose value is the AsyncGeneratorFunction instance.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -38678,14 +38678,14 @@ THH:mm:ss.sss
   <emu-clause id="sec-generator-objects">
     <h1>Generator Objects</h1>
     <p>A Generator object is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
-    <p>Generator instances directly inherit properties from the object that is the value of the `prototype` property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %Generator.prototype%.</p>
+    <p>Generator instances directly inherit properties from the object that is the value of the `"prototype"` property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %Generator.prototype%.</p>
 
     <emu-clause id="sec-properties-of-generator-prototype">
       <h1>Properties of the Generator Prototype Object</h1>
       <p>The Generator prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%GeneratorPrototype%</dfn>.</li>
-        <li>is the initial value of the `prototype` property of %Generator% (the GeneratorFunction.prototype).</li>
+        <li>is the initial value of the `"prototype"` property of %Generator% (the `GeneratorFunction.prototype`).</li>
         <li>is an ordinary object.</li>
         <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
@@ -38729,7 +38729,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generator.prototype-@@tostringtag">
         <h1>Generator.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"Generator"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"Generator"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -38888,14 +38888,14 @@ THH:mm:ss.sss
     <h1>AsyncGenerator Objects</h1>
     <p>An AsyncGenerator object is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
 
-    <p>AsyncGenerator instances directly inherit properties from the object that is the value of the `prototype` property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGenerator.prototype%.</p>
+    <p>AsyncGenerator instances directly inherit properties from the object that is the value of the `"prototype"` property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGenerator.prototype%.</p>
 
     <emu-clause id="sec-properties-of-asyncgenerator-prototype">
       <h1>Properties of the AsyncGenerator Prototype Object</h1>
       <p>The AsyncGenerator prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%AsyncGeneratorPrototype%</dfn>.</li>
-        <li>is the initial value of the `prototype` property of %AsyncGenerator% (the AsyncGeneratorFunction.prototype).</li>
+        <li>is the initial value of the `"prototype"` property of %AsyncGenerator% (the `AsyncGeneratorFunction.prototype`).</li>
         <li>is an ordinary object.</li>
         <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %AsyncIteratorPrototype%.</li>
@@ -38937,7 +38937,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgenerator-prototype-tostringtag">
         <h1>AsyncGenerator.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"AsyncGenerator"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"AsyncGenerator"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -39545,7 +39545,7 @@ THH:mm:ss.sss
       <p>The Promise constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Promise%</dfn>.</li>
-        <li>is the initial value of the `Promise` property of the global object.</li>
+        <li>is the initial value of the `"Promise"` property of the global object.</li>
         <li>creates and initializes a new Promise object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behaviour must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
@@ -39887,7 +39887,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
+        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>Promise prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -40027,7 +40027,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.prototype-@@tostringtag">
         <h1>Promise.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value `"Promise"`.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"Promise"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -40130,7 +40130,7 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
-        <li>has a `name` property whose value is `"AsyncFunction"`.</li>
+        <li>has a `"name"` property whose value is *"AsyncFunction"*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -40152,7 +40152,7 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</li>
-        <li>is the value of the `prototype` property of %AsyncFunction%.</li>
+        <li>is the value of the `"prototype"` property of %AsyncFunction%.</li>
         <li>is the intrinsic object <dfn>%AsyncFunctionPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
@@ -40168,7 +40168,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-async-function-prototype-properties-toStringTag">
         <h1>AsyncFunction.prototype [ @@toStringTag ]</h1>
 
-        <p>The initial value of the @@toStringTag property is the string value `"AsyncFunction"`.</p>
+        <p>The initial value of the @@toStringTag property is the string value *"AsyncFunction"*.</p>
 
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
@@ -40186,7 +40186,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-async-function-instances-name">
         <h1>name</h1>
-        <p>The specification for the `name` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncFunction instances.</p>
+        <p>The specification for the `"name"` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncFunction instances.</p>
       </emu-clause>
     </emu-clause>
 
@@ -40229,7 +40229,7 @@ THH:mm:ss.sss
     <p>The Reflect object:</p>
     <ul>
       <li>is the intrinsic object <dfn>%Reflect%</dfn>.</li>
-      <li>is the initial value of the `Reflect` property of the global object.</li>
+      <li>is the initial value of the `"Reflect"` property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>is not a function object.</li>
@@ -40382,7 +40382,7 @@ THH:mm:ss.sss
       <p>The Proxy constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Proxy%</dfn>.</li>
-        <li>is the initial value of the `Proxy` property of the global object.</li>
+        <li>is the initial value of the `"Proxy"` property of the global object.</li>
         <li>creates and initializes a new proxy exotic object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
       </ul>
@@ -40402,7 +40402,7 @@ THH:mm:ss.sss
       <p>The Proxy constructor:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>does not have a `prototype` property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
+        <li>does not have a `"prototype"` property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -40448,7 +40448,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-@@tostringtag">
       <h1>@@toStringTag</h1>
-      <p>The initial value of the @@toStringTag property is the String value `"Module"`.</p>
+      <p>The initial value of the @@toStringTag property is the String value *"Module"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
   </emu-clause>
@@ -42034,7 +42034,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-object.prototype.__proto__">
         <h1>Object.prototype.__proto__</h1>
-        <p>Object.prototype.__proto__ is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
+        <p>`Object.prototype.__proto__` is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
 
         <emu-annex id="sec-get-object.prototype.__proto__">
           <h1>get Object.prototype.__proto__</h1>
@@ -42285,17 +42285,17 @@ THH:mm:ss.sss
       <emu-annex id="String.prototype.trimleft">
         <h1>String.prototype.trimLeft ( )</h1>
         <emu-note>
-          <p>The property `trimStart` is preferred. The `trimLeft` property is provided principally for compatibility with old code. It is recommended that the `trimStart` property be used in new ECMAScript code.</p>
+          <p>The property `"trimStart"` is preferred. The `"trimLeft"` property is provided principally for compatibility with old code. It is recommended that the `"trimStart"` property be used in new ECMAScript code.</p>
         </emu-note>
-        <p>The initial value of the `trimLeft` property is the same function object as the initial value of the `String.prototype.trimStart` property.</p>
+        <p>The initial value of the `"trimLeft"` property is the same function object as the initial value of the `String.prototype.trimStart` property.</p>
       </emu-annex>
 
       <emu-annex id="String.prototype.trimright">
         <h1>String.prototype.trimRight ( )</h1>
         <emu-note>
-          <p>The property `trimEnd` is preferred. The `trimRight` property is provided principally for compatibility with old code. It is recommended that the `trimEnd` property be used in new ECMAScript code.</p>
+          <p>The property `"trimEnd"` is preferred. The `"trimRight"` property is provided principally for compatibility with old code. It is recommended that the `"trimEnd"` property be used in new ECMAScript code.</p>
         </emu-note>
-        <p>The initial value of the `trimRight` property is the same function object as the initial value of the `String.prototype.trimEnd` property.</p>
+        <p>The initial value of the `"trimRight"` property is the same function object as the initial value of the `String.prototype.trimEnd` property.</p>
       </emu-annex>
     </emu-annex>
 
@@ -42341,7 +42341,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-date.prototype.togmtstring">
         <h1>Date.prototype.toGMTString ( )</h1>
         <emu-note>
-          <p>The property `toUTCString` is preferred. The `toGMTString` property is provided principally for compatibility with old code. It is recommended that the `toUTCString` property be used in new ECMAScript code.</p>
+          <p>The property `"toUTCString"` is preferred. The `"toGMTString"` property is provided principally for compatibility with old code. It is recommended that the `"toUTCString"` property be used in new ECMAScript code.</p>
         </emu-note>
         <p>The function object that is the initial value of `Date.prototype.toGMTString` is the same function object that is the initial value of `Date.prototype.toUTCString`.</p>
       </emu-annex>
@@ -42401,7 +42401,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
-        1. If _propKey_ is the String value `"__proto__"` and if IsComputedPropertyKey(|PropertyName|) is *false*, then
+        1. If _propKey_ is the String value *"__proto__"* and if IsComputedPropertyKey(|PropertyName|) is *false*, then
           1. Let _isProtoSetter_ be *true*.
         1. Else,
           1. Let _isProtoSetter_ be *false*.
@@ -42828,7 +42828,7 @@ THH:mm:ss.sss
       Strict mode eval code cannot instantiate variables or functions in the variable environment of the caller to eval. Instead, a new variable environment is created and that environment is used for declaration binding instantiation for the eval code (<emu-xref href="#sec-eval-x"></emu-xref>).
     </li>
     <li>
-      If *this* is evaluated within strict mode code, then the *this* value is not coerced to an object. A *this* value of *undefined* or *null* is not converted to the global object and primitive values are not converted to wrapper objects. The *this* value passed via a function call (including calls made using `Function.prototype.apply` and `Function.prototype.call`) do not coerce the passed this value to an object (<emu-xref href="#sec-ordinarycallbindthis"></emu-xref>, <emu-xref href="#sec-function.prototype.apply"></emu-xref>, <emu-xref href="#sec-function.prototype.call"></emu-xref>).
+      If *this* is evaluated within strict mode code, then the *this* value is not coerced to an object. A *this* value of *undefined* or *null* is not converted to the global object and primitive values are not converted to wrapper objects. The *this* value passed via a function call (including calls made using `Function.prototype.apply` and `Function.prototype.call`) do not coerce the passed *this* value to an object (<emu-xref href="#sec-ordinarycallbindthis"></emu-xref>, <emu-xref href="#sec-function.prototype.apply"></emu-xref>, <emu-xref href="#sec-function.prototype.call"></emu-xref>).
     </li>
     <li>
       When a `delete` operator occurs within strict mode code, a *SyntaxError* is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name (<emu-xref href="#sec-delete-operator-static-semantics-early-errors"></emu-xref>).
@@ -42846,7 +42846,7 @@ THH:mm:ss.sss
       It is a *SyntaxError* if the same |BindingIdentifier| appears more than once in the |FormalParameters| of a strict function. An attempt to create such a function using a `Function`, `Generator`, or `AsyncFunction` constructor is a *SyntaxError* (<emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-createdynamicfunction"></emu-xref>).
     </li>
     <li>
-      An implementation may not extend, beyond that defined in this specification, the meanings within strict functions of properties named `caller` or `arguments` of function instances.
+      An implementation may not extend, beyond that defined in this specification, the meanings within strict functions of properties named `"caller"` or `"arguments"` of function instances.
     </li>
   </ul>
 </emu-annex>
@@ -42858,9 +42858,9 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0* or *-0* as the representation of a 0 time value. ECMAScript 2015 specifies that *+0* always returned. This means that for ECMAScript 2015 the time value of a Date object is never observably *-0* and methods that return time values never return *-0*.</p>
   <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a UTC offset representation is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as `"z"`.</p>
   <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
-  <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by Date.prototype.toString when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value is `"Invalid Date"`.</p>
-  <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the `source` property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `"/"`.</p>
-  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` is flag set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by one only if the pattern matched the empty string.</p>
+  <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>
+  <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the `"source"` property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `"/"`.</p>
+  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by one only if the pattern matched the empty string.</p>
   <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>, <emu-xref href="#sec-sortcompare"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0* was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-dependent. In practice, implementations call ToNumber.</p>
 </emu-annex>
 
@@ -42884,7 +42884,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-try-statement"></emu-xref>: In ECMAScript 2015, it is an early error for a |Catch| clause to contain a `var` declaration for the same |Identifier| that appears as the |Catch| clause parameter. In previous editions, such a variable declaration would be instantiated in the enclosing variable environment but the declaration's |Initializer| value would be assigned to the |Catch| parameter.</p>
   <p><emu-xref href="#sec-try-statement"></emu-xref>, <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref>: In ECMAScript 2015, a runtime *SyntaxError* is thrown if a |Catch| clause evaluates a non-strict direct `eval` whose eval code includes a `var` or `FunctionDeclaration` declaration that binds the same |Identifier| that appears as the |Catch| clause parameter.</p>
   <p><emu-xref href="#sec-try-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the completion value of a |TryStatement| is never the value ~empty~. If the |Block| part of a |TryStatement| evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined*. If the |Block| part of a |TryStatement| evaluates to a throw completion and it has a |Catch| part that evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined* if there is no |Finally| clause or if its |Finally| clause evaluates to an ~empty~ normal completion.</p>
-  <p><emu-xref href="#sec-method-definitions-runtime-semantics-propertydefinitionevaluation"></emu-xref> In ECMAScript 2015, the function objects that are created as the values of the [[Get]] or [[Set]] attribute of accessor properties in an |ObjectLiteral| are not constructor functions and they do not have a `prototype` own property. In the previous edition, they were constructors and had a `prototype` property.</p>
+  <p><emu-xref href="#sec-method-definitions-runtime-semantics-propertydefinitionevaluation"></emu-xref> In ECMAScript 2015, the function objects that are created as the values of the [[Get]] or [[Set]] attribute of accessor properties in an |ObjectLiteral| are not constructor functions and they do not have a `"prototype"` own property. In the previous edition, they were constructors and had a `"prototype"` property.</p>
   <p><emu-xref href="#sec-object.freeze"></emu-xref>: In ECMAScript 2015, if the argument to `Object.freeze` is not an object it is treated as if it was a non-extensible ordinary object with no own properties. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.getownpropertydescriptor"></emu-xref>: In ECMAScript 2015, if the argument to `Object.getOwnPropertyDescriptor` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.getownpropertynames"></emu-xref>: In ECMAScript 2015, if the argument to `Object.getOwnPropertyNames` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
@@ -42904,7 +42904,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-string.prototype.trim"></emu-xref> In ECMAScript 2015, the `String.prototype.trim` method is defined to recognize white space code points that may exists outside of the Unicode BMP. However, as of Unicode 7 no such code points are defined. In previous editions such code points would not have been recognized as white space.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref> In ECMAScript 2015, If the _pattern_ argument is a RegExp instance and the _flags_ argument is not *undefined*, a new RegExp instance is created just like _pattern_ except that _pattern_'s flags are replaced by the argument _flags_. In previous editions a *TypeError* exception was thrown when _pattern_ was a RegExp instance and _flags_ was not *undefined*.</p>
   <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, the RegExp prototype object is not a RegExp instance. In previous editions it was a RegExp instance whose pattern is the empty string.</p>
-  <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, `source`, `global`, `ignoreCase`, and `multiline` are accessor properties defined on the RegExp prototype object. In previous editions they were data properties defined on RegExp instances.</p>
+  <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, `"source"`, `"global"`, `"ignoreCase"`, and `"multiline"` are accessor properties defined on the RegExp prototype object. In previous editions they were data properties defined on RegExp instances.</p>
 </emu-annex>
 <emu-annex id="sec-colophon">
   <h1>Colophon</h1>


### PR DESCRIPTION
Follow-up to #1239.

On IRC, two ideas were raised as to a consistent, enforceable approach to quoting properties:

- @ljharb suggested always using quotes unless that property can also be considered an identifier (hence "`"prototype"` property" but "`Function` property of the global object" ).

- @jmdyck suggested using quotes just when referring to it _as_ a property (hence "`"Function"` property" but "`Function` constructor", "`"toString"` property" but "`toString` method").

Either approach is acceptable to me, but I am starting with the latter, as the diff is more conservative.

I've also included a few related commits which fix neighboring typos, add missing backticks (e.g. to Array.prototype in plaintext), and turn "value `foo`" into "value **foo**" where trivial. The last of these could be a separate PR if desired; I've included it here since it too was brought up in the last PR.