### PR TITLE
Make non-writable prototype properties not prevent assigning to instance

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7021,7 +7021,7 @@
             1. Let _existingDescriptor_ be ? _Receiver_.[[GetOwnProperty]](_P_).
             1. If _existingDescriptor_ is not *undefined*, then
               1. If IsAccessorDescriptor(_existingDescriptor_) is *true*, return *false*.
-              1. If _existingDescriptor_.[[Writable]] is *false*, return *false*.
+              1. If _existingDescriptor_.[[Writable]] is *false* and _O_ is equal to _Receiver_, return *false*.
               1. Let _valueDesc_ be the PropertyDescriptor { [[Value]]: _V_ }.
               1. Return ? _Receiver_.[[DefineOwnProperty]](_P_, _valueDesc_).
             1. Else _Receiver_ does not currently have a property _P_,


### PR DESCRIPTION
The so called "override mistake" is a symptom of this.

Some slides: https://docs.google.com/presentation/d/17dji3YM5_LeMvdAD3Y3PQoXU1Mgm5e2yN_BraBSTkjo/edit