### PR TITLE
Editorial: Convert @@ notation to intrinsics notation for well-known Symbols

### DIFF
--- a/img/figure-2.svg
+++ b/img/figure-2.svg
@@ -83,14 +83,14 @@
       </g>
     </g>
 
-    <g transform="translate(370,160)">
-      <rect class="class" x="0" y="0" width="160" height="30" />
-      <rect class="class" x="0" y="30" width="160" height="70" />
+    <g transform="translate(360,160)">
+      <rect class="class" x="0" y="0" width="180" height="30" />
+      <rect class="class" x="0" y="30" width="180" height="70" />
       <g transform="translate(0,4)">
-        <text x="80" y="16" text-anchor="middle">Function.prototype</text>
+        <text x="90" y="16" text-anchor="middle">Function.prototype</text>
       </g>
       <g transform="translate(4,32)">
-        <text x="0" y="16">@@hasInstance()</text>
+        <text x="0" y="16">%Symbol.hasInstance%()</text>
         <text x="0" y="32">apply()</text>
         <text x="0" y="48">bind()</text>
         <text x="0" y="64">call()</text>
@@ -104,7 +104,7 @@
         <text x="110" y="16" text-anchor="middle">%GeneratorFunction.prototype%</text>
       </g>
       <g transform="translate(4,32)">
-        <text x="0" y="16">@@toStringTag =</text>
+        <text x="0" y="16">%Symbol.toStringTag% =</text>
         <text x="16" y="32">"GeneratorFunction"</text>
       </g>
     </g>
@@ -127,26 +127,26 @@
       </g>
     </g>
 
-    <g transform="translate(720,120)">
-      <rect class="class" x="0" y="0" width="160" height="30" />
-      <rect class="class" x="0" y="30" width="160" height="30" />
+    <g transform="translate(680,120)">
+      <rect class="class" x="0" y="0" width="200" height="30" />
+      <rect class="class" x="0" y="30" width="200" height="30" />
       <g transform="translate(0,4)">
-        <text x="80" y="16" text-anchor="middle">%IteratorPrototype%</text>
+        <text x="100" y="16" text-anchor="middle">%IteratorPrototype%</text>
       </g>
       <g transform="translate(4,32)">
-        <text x="0" y="16">@@iterator() : object</text>
+        <text x="0" y="16">%Symbol.iterator%() : object</text>
       </g>
     </g>
 
-    <g transform="translate(670,300)">
-      <rect class="class" x="0" y="0" width="210" height="30" />
-      <rect class="class" x="0" y="30" width="210" height="24" />
-      <rect class="class" x="0" y="54" width="210" height="56" />
+    <g transform="translate(630,300)">
+      <rect class="class" x="0" y="0" width="250" height="30" />
+      <rect class="class" x="0" y="30" width="250" height="24" />
+      <rect class="class" x="0" y="54" width="250" height="56" />
       <g transform="translate(0,4)">
-        <text x="110" y="16" text-anchor="middle">%GeneratorPrototype%</text>
+        <text x="120" y="16" text-anchor="middle">%GeneratorPrototype%</text>
       </g>
       <g transform="translate(4,32)">
-        <text x="0" y="16">@@toStringTag = "Generator"</text>
+        <text x="0" y="16">%Symbol.toStringTag% = "Generator"</text>
       </g>
       <g transform="translate(4,56)">
         <text x="0" y="16">next() : object</text>
@@ -189,7 +189,7 @@
       </g>
     </g>
 
-    <g transform="translate(570,200)">
+    <g transform="translate(570,195)">
       <path class="note" d="M 0,0 V 80 H 220 V 10 h -10 10 l -10,-10 v 10 -10 z" />
       <g transform="translate(4,4)">
         <text x="0" y="16">%GeneratorFunction.prototype%</text>
@@ -242,12 +242,12 @@
       <path class="proto-slot-arrowend" d="M 0,0 L 9,5 L 0,10 z" />
     </marker>
 
-    <path class="proto-slot-arrow" d="M 450,160 V 120" />
-    <path class="proto-slot-arrow" d="M 450,300 V 260" />
-    <path class="proto-slot-arrow" d="M 450,440 V 370" />
+    <path class="proto-slot-arrow" d="M 450,160 V 120" /> <!-- between Object.prototype and Function.prototype -->
+    <path class="proto-slot-arrow" d="M 450,300 V 260" /> <!-- between Function.prototype and %GeneratorFunction.prototype% -->
+    <path class="proto-slot-arrow" d="M 450,440 V 370" /> <!-- below %GeneratorFunction.prototype% -->
 
-    <path class="proto-slot-arrow" d="M 100,200 V 175 H 370" />
-    <path class="proto-slot-arrow" d="M 100,300 V 260" />
+    <path class="proto-slot-arrow" d="M 100,200 V 175 H 360" /> <!-- between Function and Function.prototype -->
+    <path class="proto-slot-arrow" d="M 100,300 V 260" /> <!-- between Function and %GeneratorFunction% -->
 
     <path class="proto-slot-arrow" d="M 800,120 V 105 H 530" />
     <path class="proto-slot-arrow" d="M 800,300 V 180" />
@@ -272,8 +272,8 @@
     <text x="335" y="306" text-anchor="end">constructor</text>
     <text x="185" y="334">prototype</text>
 
-    <path class="prototype-constructor-arrow" d="M 560,315 H 670" />
-    <text x="665" y="306" text-anchor="end">constructor</text>
+    <path class="prototype-constructor-arrow" d="M 560,315 H 630" />
+    <text x="665" y="295" text-anchor="end">constructor</text>
     <text x="565" y="334">prototype</text>
 
     <path class="prototype-arrow" d="M 530,455 H 720" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "devDependencies": {
-        "ecmarkup": "^18.3.1",
+        "ecmarkup": "^19.0.0",
         "glob": "^7.1.6",
         "jsdom": "^15.0.0",
         "pagedjs": "^0.4.3",
@@ -1243,10 +1243,11 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.3.1.tgz",
-      "integrity": "sha512-ouyfwgVjtvyF9AdAQnI9krCWNE5srK90XGPym8vs6WPtjUso6Pq887DwAYBDbga9lrfwezWo5n8hGu9amYYu1g==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-19.0.0.tgz",
+      "integrity": "sha512-ncn5LXs46jPqcQSO/XdJCOOsdAvC8xT/Yebxted4qgpYWLisY4AEdOdZ4OXKgmPXGgWBqAgCSoV0obvEBEz8Hg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
   "author": "ECMA TC39",
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
-  "dependencies": {
-  },
   "devDependencies": {
-    "ecmarkup": "^18.3.1",
+    "ecmarkup": "^19.0.0",
     "glob": "^7.1.6",
     "jsdom": "^15.0.0",
     "pagedjs": "^0.4.3",

--- a/spec.html
+++ b/spec.html
@@ -1207,7 +1207,8 @@
       <emu-clause id="sec-well-known-symbols">
         <h1>Well-Known Symbols</h1>
         <p>Well-known symbols are built-in Symbol values that are explicitly referenced by algorithms of this specification. They are typically used as the keys of properties whose values serve as extension points of a specification algorithm. Unless otherwise specified, well-known symbols values are shared by all realms (<emu-xref href="#sec-code-realms"></emu-xref>).</p>
-        <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where “name” is one of the values listed in <emu-xref href="#table-well-known-symbols"></emu-xref>.</p>
+        <p>Within this specification a well-known symbol is referred to using the standard <emu-xref href="#sec-well-known-intrinsic-objects">intrinsic notation</emu-xref> where the intrinsic is one of the values listed in <emu-xref href="#table-well-known-symbols"></emu-xref>.</p>
+        <emu-note>Previous editions of this specification used a notation of the form @@name, where the current edition would use `%Symbol.name%`. In particular, the following names were used: @@asyncIterator, @@hasInstance, @@isConcatSpreadable, @@iterator, @@match, @@matchAll, @@replace, @@search, @@species, @@split, @@toPrimitive, @@toStringTag, and @@unscopables.</emu-note>
         <emu-table id="table-well-known-symbols" caption="Well-known Symbols" oldids="table-1">
           <table>
             <thead>
@@ -1225,7 +1226,7 @@
             </thead>
             <tr>
               <td>
-                <dfn>@@asyncIterator</dfn>
+                <dfn>%Symbol.asyncIterator%</dfn>
               </td>
               <td>
                 *"Symbol.asyncIterator"*
@@ -1236,7 +1237,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@hasInstance</dfn>
+                <dfn>%Symbol.hasInstance%</dfn>
               </td>
               <td>
                 *"Symbol.hasInstance"*
@@ -1247,7 +1248,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@isConcatSpreadable</dfn>
+                <dfn>%Symbol.isConcatSpreadable%</dfn>
               </td>
               <td>
                 *"Symbol.isConcatSpreadable"*
@@ -1258,7 +1259,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@iterator</dfn>
+                <dfn>%Symbol.iterator%</dfn>
               </td>
               <td>
                 *"Symbol.iterator"*
@@ -1269,7 +1270,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@match</dfn>
+                <dfn>%Symbol.match%</dfn>
               </td>
               <td>
                 *"Symbol.match"*
@@ -1280,7 +1281,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@matchAll</dfn>
+                <dfn>%Symbol.matchAll%</dfn>
               </td>
               <td>
                 *"Symbol.matchAll"*
@@ -1291,7 +1292,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@replace</dfn>
+                <dfn>%Symbol.replace%</dfn>
               </td>
               <td>
                 *"Symbol.replace"*
@@ -1302,7 +1303,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@search</dfn>
+                <dfn>%Symbol.search%</dfn>
               </td>
               <td>
                 *"Symbol.search"*
@@ -1313,7 +1314,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@species</dfn>
+                <dfn>%Symbol.species%</dfn>
               </td>
               <td>
                 *"Symbol.species"*
@@ -1324,7 +1325,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@split</dfn>
+                <dfn>%Symbol.split%</dfn>
               </td>
               <td>
                 *"Symbol.split"*
@@ -1335,7 +1336,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@toPrimitive</dfn>
+                <dfn>%Symbol.toPrimitive%</dfn>
               </td>
               <td>
                 *"Symbol.toPrimitive"*
@@ -1346,7 +1347,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@toStringTag</dfn>
+                <dfn>%Symbol.toStringTag%</dfn>
               </td>
               <td>
                 *"Symbol.toStringTag"*
@@ -1357,7 +1358,7 @@
             </tr>
             <tr>
               <td>
-                <dfn>@@unscopables</dfn>
+                <dfn>%Symbol.unscopables%</dfn>
               </td>
               <td>
                 *"Symbol.unscopables"*
@@ -4836,7 +4837,7 @@
       </dl>
       <emu-alg>
         1. If _input_ is an Object, then
-          1. Let _exoticToPrim_ be ? GetMethod(_input_, @@toPrimitive).
+          1. Let _exoticToPrim_ be ? GetMethod(_input_, %Symbol.toPrimitive%).
           1. If _exoticToPrim_ is not *undefined*, then
             1. If _preferredType_ is not present, then
               1. Let _hint_ be *"default"*.
@@ -4853,7 +4854,7 @@
         1. Return _input_.
       </emu-alg>
       <emu-note>
-        <p>When ToPrimitive is called without a hint, then it generally behaves as if the hint were ~number~. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Dates (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Dates treat the absence of a hint as if the hint were ~string~.</p>
+        <p>When ToPrimitive is called without a hint, then it generally behaves as if the hint were ~number~. However, objects may over-ride this behaviour by defining a %Symbol.toPrimitive% method. Of the objects defined in this specification only Dates (see <emu-xref href="#sec-date.prototype-%symbol.toprimitive%"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-%symbol.toprimitive%"></emu-xref>) over-ride the default ToPrimitive behaviour. Dates treat the absence of a hint as if the hint were ~string~.</p>
       </emu-note>
 
       <emu-clause id="sec-ordinarytoprimitive" type="abstract operation">
@@ -5819,7 +5820,7 @@
       </dl>
       <emu-alg>
         1. If _argument_ is not an Object, return *false*.
-        1. Let _matcher_ be ? Get(_argument_, @@match).
+        1. Let _matcher_ be ? Get(_argument_, %Symbol.match%).
         1. If _matcher_ is not *undefined*, return ToBoolean(_matcher_).
         1. If _argument_ has a [[RegExpMatcher]] internal slot, return *true*.
         1. Return *false*.
@@ -6499,13 +6500,13 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It is used to retrieve the constructor that should be used to create new objects that are derived from _O_. _defaultConstructor_ is the constructor to use if a constructor @@species property cannot be found starting from _O_.</dd>
+        <dd>It is used to retrieve the constructor that should be used to create new objects that are derived from _O_. _defaultConstructor_ is the constructor to use if a constructor %Symbol.species% property cannot be found starting from _O_.</dd>
       </dl>
       <emu-alg>
         1. Let _C_ be ? Get(_O_, *"constructor"*).
         1. If _C_ is *undefined*, return _defaultConstructor_.
         1. If _C_ is not an Object, throw a *TypeError* exception.
-        1. Let _S_ be ? Get(_C_, @@species).
+        1. Let _S_ be ? Get(_C_, %Symbol.species%).
         1. If _S_ is either *undefined* or *null*, return _defaultConstructor_.
         1. If IsConstructor(_S_) is *true*, return _S_.
         1. Throw a *TypeError* exception.
@@ -6917,14 +6918,14 @@
       </dl>
       <emu-alg>
         1. If _kind_ is ~async~, then
-          1. Let _method_ be ? GetMethod(_obj_, @@asyncIterator).
+          1. Let _method_ be ? GetMethod(_obj_, %Symbol.asyncIterator%).
           1. If _method_ is *undefined*, then
-            1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
+            1. Let _syncMethod_ be ? GetMethod(_obj_, %Symbol.iterator%).
             1. If _syncMethod_ is *undefined*, throw a *TypeError* exception.
             1. Let _syncIteratorRecord_ be ? GetIteratorFromMethod(_obj_, _syncMethod_).
             1. Return CreateAsyncFromSyncIterator(_syncIteratorRecord_).
         1. Else,
-          1. Let _method_ be ? GetMethod(_obj_, @@iterator).
+          1. Let _method_ be ? GetMethod(_obj_, %Symbol.iterator%).
         1. If _method_ is *undefined*, throw a *TypeError* exception.
         1. Return ? GetIteratorFromMethod(_obj_, _method_).
       </emu-alg>
@@ -10321,7 +10322,7 @@
             1. Let _foundBinding_ be ? HasProperty(_bindingObject_, _N_).
             1. If _foundBinding_ is *false*, return *false*.
             1. If _envRec_.[[IsWithEnvironment]] is *false*, return *true*.
-            1. Let _unscopables_ be ? Get(_bindingObject_, @@unscopables).
+            1. Let _unscopables_ be ? Get(_bindingObject_, %Symbol.unscopables%).
             1. If _unscopables_ is an Object, then
               1. Let _blocked_ be ToBoolean(? Get(_unscopables_, _N_)).
               1. If _blocked_ is *true*, return *false*.
@@ -14113,7 +14114,7 @@
             1. If _thisRealm_ and _realmC_ are not the same Realm Record, then
               1. If SameValue(_C_, _realmC_.[[Intrinsics]].[[%Array%]]) is *true*, set _C_ to *undefined*.
           1. If _C_ is an Object, then
-            1. Set _C_ to ? Get(_C_, @@species).
+            1. Set _C_ to ? Get(_C_, %Symbol.species%).
             1. If _C_ is *null*, set _C_ to *undefined*.
           1. If _C_ is *undefined*, return ? ArrayCreate(_length_).
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
@@ -14457,7 +14458,7 @@
             1. Let _val_ be _argumentsList_[_index_].
             1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(𝔽(_index_)), _val_).
             1. Set _index_ to _index_ + 1.
-          1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, %Symbol.iterator%, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _obj_.
         </emu-alg>
@@ -14505,7 +14506,7 @@
                 1. Let _p_ be MakeArgSetter(_name_, _env_).
                 1. Perform ! _map_.[[DefineOwnProperty]](! ToString(𝔽(_index_)), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
             1. Set _index_ to _index_ - 1.
-          1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, %Symbol.iterator%, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Value]]: _func_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Return _obj_.
         </emu-alg>
@@ -20237,18 +20238,18 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It implements the generic algorithm for determining if _V_ is an instance of _target_ either by consulting _target_'s @@hasInstance method or, if absent, determining whether the value of _target_'s *"prototype"* property is present in _V_'s prototype chain.</dd>
+        <dd>It implements the generic algorithm for determining if _V_ is an instance of _target_ either by consulting _target_'s %Symbol.hasInstance% method or, if absent, determining whether the value of _target_'s *"prototype"* property is present in _V_'s prototype chain.</dd>
       </dl>
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
-        1. Let _instOfHandler_ be ? GetMethod(_target_, @@hasInstance).
+        1. Let _instOfHandler_ be ? GetMethod(_target_, %Symbol.hasInstance%).
         1. If _instOfHandler_ is not *undefined*, then
           1. Return ToBoolean(? Call(_instOfHandler_, _target_, « _V_ »)).
         1. [id="step-instanceof-check-function"] If IsCallable(_target_) is *false*, throw a *TypeError* exception.
         1. [id="step-instanceof-fallback"] Return ? OrdinaryHasInstance(_target_, _V_).
       </emu-alg>
       <emu-note>
-        <p>Steps <emu-xref href="#step-instanceof-check-function"></emu-xref> and <emu-xref href="#step-instanceof-fallback"></emu-xref> provide compatibility with previous editions of ECMAScript that did not use a @@hasInstance method to define the `instanceof` operator semantics. If an object does not define or inherit @@hasInstance it uses the default `instanceof` semantics.</p>
+        <p>Steps <emu-xref href="#step-instanceof-check-function"></emu-xref> and <emu-xref href="#step-instanceof-fallback"></emu-xref> provide compatibility with previous editions of ECMAScript that did not use a %Symbol.hasInstance% method to define the `instanceof` operator semantics. If an object does not define or inherit %Symbol.hasInstance% it uses the default `instanceof` semantics.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -24905,7 +24906,7 @@
             1. If NewTarget is *undefined*, throw a *TypeError* exception.
             1. Let _F_ be the active function object.
             1. If _F_.[[ConstructorKind]] is ~derived~, then
-              1. NOTE: This branch behaves similarly to `constructor(...args) { super(...args); }`. The most notable distinction is that while the aforementioned ECMAScript source text observably calls the @@iterator method on `%Array.prototype%`, this function does not.
+              1. NOTE: This branch behaves similarly to `constructor(...args) { super(...args); }`. The most notable distinction is that while the aforementioned ECMAScript source text observably calls the %Symbol.iterator% method on `%Array.prototype%`, this function does not.
               1. Let _func_ be ! _F_.[[GetPrototypeOf]]().
               1. If IsConstructor(_func_) is *false*, throw a *TypeError* exception.
               1. Let _result_ be ? Construct(_func_, _args_, NewTarget).
@@ -30044,12 +30045,12 @@
           1. Else if _O_ has a [[DateValue]] internal slot, let _builtinTag_ be *"Date"*.
           1. Else if _O_ has a [[RegExpMatcher]] internal slot, let _builtinTag_ be *"RegExp"*.
           1. Else, let _builtinTag_ be *"Object"*.
-          1. Let _tag_ be ? Get(_O_, @@toStringTag).
+          1. Let _tag_ be ? Get(_O_, %Symbol.toStringTag%).
           1. If _tag_ is not a String, set _tag_ to _builtinTag_.
           1. Return the string-concatenation of *"[object "*, _tag_, and *"]"*.
         </emu-alg>
         <emu-note>
-          <p>Historically, this method was occasionally used to access the String value of the [[Class]] internal slot that was used in previous editions of this specification as a nominal type tag for various built-in objects. The above definition of `toString` preserves compatibility for legacy code that uses `toString` as a test for those specific kinds of built-in objects. It does not provide a reliable type testing mechanism for other kinds of built-in or program defined objects. In addition, programs can use @@toStringTag in ways that will invalidate the reliability of such legacy type tests.</p>
+          <p>Historically, this method was occasionally used to access the String value of the [[Class]] internal slot that was used in previous editions of this specification as a nominal type tag for various built-in objects. The above definition of `toString` preserves compatibility for legacy code that uses `toString` as a test for those specific kinds of built-in objects. It does not provide a reliable type testing mechanism for other kinds of built-in or program defined objects. In addition, programs can use %Symbol.toStringTag% in ways that will invalidate the reliability of such legacy type tests.</p>
         </emu-note>
       </emu-clause>
 
@@ -30412,8 +30413,8 @@
         </emu-grammar>
       </emu-clause>
 
-      <emu-clause id="sec-function.prototype-@@hasinstance">
-        <h1>Function.prototype [ @@hasInstance ] ( _V_ )</h1>
+      <emu-clause oldids="sec-function.prototype-@@hasinstance" id="sec-function.prototype-%symbol.hasinstance%">
+        <h1>Function.prototype [ %Symbol.hasInstance% ] ( _V_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _F_ be the *this* value.
@@ -30421,15 +30422,15 @@
         </emu-alg>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>This is the default implementation of `@@hasInstance` that most functions inherit. `@@hasInstance` is called by the `instanceof` operator to determine whether a value is an instance of a specific constructor. An expression such as</p>
+          <p>This is the default implementation of `%Symbol.hasInstance%` that most functions inherit. `%Symbol.hasInstance%` is called by the `instanceof` operator to determine whether a value is an instance of a specific constructor. An expression such as</p>
           <pre><code class="javascript">
             v instanceof F
           </code></pre>
           <p>evaluates as</p>
           <pre><code class="javascript">
-            F[@@hasInstance](v)
+            F[%Symbol.hasInstance%](v)
           </code></pre>
-          <p>A constructor function can control which objects are recognized as its instances by `instanceof` by exposing a different `@@hasInstance` method on the function.</p>
+          <p>A constructor function can control which objects are recognized as its instances by `instanceof` by exposing a different `%Symbol.hasInstance%` method on the function.</p>
         </emu-note>
         <p>This property is non-writable and non-configurable to prevent tampering that could be used to globally expose the target function of a bound function.</p>
         <p>The value of the *"name"* property of this method is *"[Symbol.hasInstance]"*.</p>
@@ -30616,7 +30617,7 @@
 
       <emu-clause id="sec-symbol.asynciterator">
         <h1>Symbol.asyncIterator</h1>
-        <p>The initial value of `Symbol.asyncIterator` is the well-known symbol @@asyncIterator (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.asyncIterator` is the well-known symbol %Symbol.asyncIterator% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -30676,19 +30677,19 @@
 
       <emu-clause id="sec-symbol.hasinstance">
         <h1>Symbol.hasInstance</h1>
-        <p>The initial value of `Symbol.hasInstance` is the well-known symbol @@hasInstance (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.hasInstance` is the well-known symbol %Symbol.hasInstance% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.isconcatspreadable">
         <h1>Symbol.isConcatSpreadable</h1>
-        <p>The initial value of `Symbol.isConcatSpreadable` is the well-known symbol @@isConcatSpreadable (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.isConcatSpreadable` is the well-known symbol %Symbol.isConcatSpreadable% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.iterator">
         <h1>Symbol.iterator</h1>
-        <p>The initial value of `Symbol.iterator` is the well-known symbol @@iterator (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.iterator` is the well-known symbol %Symbol.iterator% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -30703,13 +30704,13 @@
 
       <emu-clause id="sec-symbol.match">
         <h1>Symbol.match</h1>
-        <p>The initial value of `Symbol.match` is the well-known symbol @@match (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.match` is the well-known symbol %Symbol.match% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.matchall">
         <h1>Symbol.matchAll</h1>
-        <p>The initial value of `Symbol.matchAll` is the well-known symbol @@matchAll (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.matchAll` is the well-known symbol %Symbol.matchAll% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -30721,43 +30722,43 @@
 
       <emu-clause id="sec-symbol.replace">
         <h1>Symbol.replace</h1>
-        <p>The initial value of `Symbol.replace` is the well-known symbol @@replace (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.replace` is the well-known symbol %Symbol.replace% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.search">
         <h1>Symbol.search</h1>
-        <p>The initial value of `Symbol.search` is the well-known symbol @@search (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.search` is the well-known symbol %Symbol.search% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.species">
         <h1>Symbol.species</h1>
-        <p>The initial value of `Symbol.species` is the well-known symbol @@species (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.species` is the well-known symbol %Symbol.species% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.split">
         <h1>Symbol.split</h1>
-        <p>The initial value of `Symbol.split` is the well-known symbol @@split (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.split` is the well-known symbol %Symbol.split% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.toprimitive">
         <h1>Symbol.toPrimitive</h1>
-        <p>The initial value of `Symbol.toPrimitive` is the well-known symbol @@toPrimitive (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.toPrimitive` is the well-known symbol %Symbol.toPrimitive% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.tostringtag">
         <h1>Symbol.toStringTag</h1>
-        <p>The initial value of `Symbol.toStringTag` is the well-known symbol @@toStringTag (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.toStringTag` is the well-known symbol %Symbol.toStringTag% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.unscopables">
         <h1>Symbol.unscopables</h1>
-        <p>The initial value of `Symbol.unscopables` is the well-known symbol @@unscopables (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>The initial value of `Symbol.unscopables` is the well-known symbol %Symbol.unscopables% (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -30838,8 +30839,8 @@
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-symbol.prototype-@@toprimitive">
-        <h1>Symbol.prototype [ @@toPrimitive ] ( _hint_ )</h1>
+      <emu-clause oldids="sec-symbol.prototype-@@toprimitive" id="sec-symbol.prototype-%symbol.toprimitive%">
+        <h1>Symbol.prototype [ %Symbol.toPrimitive% ] ( _hint_ )</h1>
         <p>This method is called by ECMAScript language operators to convert a Symbol object to a primitive value.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
@@ -30852,9 +30853,9 @@
         <p>The value of the *"name"* property of this method is *"[Symbol.toPrimitive]"*.</p>
       </emu-clause>
 
-      <emu-clause id="sec-symbol.prototype-@@tostringtag">
-        <h1>Symbol.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"Symbol"*.</p>
+      <emu-clause oldids="sec-symbol.prototype-@@tostringtag" id="sec-symbol.prototype-%symbol.tostringtag%">
+        <h1>Symbol.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"Symbol"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -31707,9 +31708,9 @@
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-bigint.prototype-@@tostringtag">
-        <h1>BigInt.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"BigInt"*.</p>
+      <emu-clause oldids="sec-bigint.prototype-@@tostringtag" id="sec-bigint.prototype-%symbol.tostringtag%">
+        <h1>BigInt.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"BigInt"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -31796,9 +31797,9 @@
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-math-@@tostringtag">
-        <h1>Math [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"Math"*.</p>
+      <emu-clause oldids="sec-math-@@tostringtag" id="sec-math-%symbol.tostringtag%">
+        <h1>Math [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"Math"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -34367,8 +34368,8 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-date.prototype-@@toprimitive">
-        <h1>Date.prototype [ @@toPrimitive ] ( _hint_ )</h1>
+      <emu-clause oldids="sec-date.prototype-@@toprimitive" id="sec-date.prototype-%symbol.toprimitive%">
+        <h1>Date.prototype [ %Symbol.toPrimitive% ] ( _hint_ )</h1>
         <p>This method is called by ECMAScript language operators to convert a Date to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*. Dates are unique among built-in ECMAScript object in that they treat *"default"* as being equivalent to *"string"*, All other built-in ECMAScript objects treat *"default"* as being equivalent to *"number"*.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
@@ -34782,12 +34783,12 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _regexp_ is neither *undefined* nor *null*, then
-            1. Let _matcher_ be ? GetMethod(_regexp_, @@match).
+            1. Let _matcher_ be ? GetMethod(_regexp_, %Symbol.match%).
             1. If _matcher_ is not *undefined*, then
               1. Return ? Call(_matcher_, _regexp_, « _O_ »).
           1. Let _S_ be ? ToString(_O_).
           1. Let _rx_ be ? RegExpCreate(_regexp_, *undefined*).
-          1. Return ? Invoke(_rx_, @@match, « _S_ »).
+          1. Return ? Invoke(_rx_, %Symbol.match%, « _S_ »).
         </emu-alg>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -34807,12 +34808,12 @@ THH:mm:ss.sss
               1. Let _flags_ be ? Get(_regexp_, *"flags"*).
               1. Perform ? RequireObjectCoercible(_flags_).
               1. If ? ToString(_flags_) does not contain *"g"*, throw a *TypeError* exception.
-            1. Let _matcher_ be ? GetMethod(_regexp_, @@matchAll).
+            1. Let _matcher_ be ? GetMethod(_regexp_, %Symbol.matchAll%).
             1. If _matcher_ is not *undefined*, then
               1. Return ? Call(_matcher_, _regexp_, « _O_ »).
           1. Let _S_ be ? ToString(_O_).
           1. Let _rx_ be ? RegExpCreate(_regexp_, *"g"*).
-          1. Return ? Invoke(_rx_, @@matchAll, « _S_ »).
+          1. Return ? Invoke(_rx_, %Symbol.matchAll%, « _S_ »).
         </emu-alg>
         <emu-note>This method is intentionally generic, it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</emu-note>
         <emu-note>Similarly to `String.prototype.split`, `String.prototype.matchAll` is designed to typically act without mutating its inputs.</emu-note>
@@ -34943,7 +34944,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _searchValue_ is neither *undefined* nor *null*, then
-            1. Let _replacer_ be ? GetMethod(_searchValue_, @@replace).
+            1. Let _replacer_ be ? GetMethod(_searchValue_, %Symbol.replace%).
             1. If _replacer_ is not *undefined*, then
               1. Return ? Call(_replacer_, _searchValue_, « _O_, _replaceValue_ »).
           1. Let _string_ be ? ToString(_O_).
@@ -35004,7 +35005,7 @@ THH:mm:ss.sss
                 1. Let _matchLength_ be the length of _matched_.
                 1. Let _tailPos_ be _position_ + _matchLength_.
                 1. Let _refReplacement_ be the substring of _str_ from min(_tailPos_, _stringLength_).
-                1. NOTE: _tailPos_ can exceed _stringLength_ only if this abstract operation was invoked by a call to the intrinsic @@replace method of %RegExp.prototype% on an object whose *"exec"* property is not the intrinsic %RegExp.prototype.exec%.
+                1. NOTE: _tailPos_ can exceed _stringLength_ only if this abstract operation was invoked by a call to the intrinsic %Symbol.replace% method of %RegExp.prototype% on an object whose *"exec"* property is not the intrinsic %RegExp.prototype.exec%.
               1. Else if _templateRemainder_ starts with *"$"* followed by 1 or more decimal digits, then
                 1. If _templateRemainder_ starts with *"$"* followed by 2 or more decimal digits, let _digitCount_ be 2. Otherwise, let _digitCount_ be 1.
                 1. Let _digits_ be the substring of _templateRemainder_ from 1 to 1 + _digitCount_.
@@ -35061,7 +35062,7 @@ THH:mm:ss.sss
               1. Let _flags_ be ? Get(_searchValue_, *"flags"*).
               1. Perform ? RequireObjectCoercible(_flags_).
               1. If ? ToString(_flags_) does not contain *"g"*, throw a *TypeError* exception.
-            1. Let _replacer_ be ? GetMethod(_searchValue_, @@replace).
+            1. Let _replacer_ be ? GetMethod(_searchValue_, %Symbol.replace%).
             1. If _replacer_ is not *undefined*, then
               1. Return ? Call(_replacer_, _searchValue_, « _O_, _replaceValue_ »).
           1. Let _string_ be ? ToString(_O_).
@@ -35100,12 +35101,12 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _regexp_ is neither *undefined* nor *null*, then
-            1. Let _searcher_ be ? GetMethod(_regexp_, @@search).
+            1. Let _searcher_ be ? GetMethod(_regexp_, %Symbol.search%).
             1. If _searcher_ is not *undefined*, then
               1. Return ? Call(_searcher_, _regexp_, « _O_ »).
           1. Let _string_ be ? ToString(_O_).
           1. Let _rx_ be ? RegExpCreate(_regexp_, *undefined*).
-          1. Return ? Invoke(_rx_, @@search, « _string_ »).
+          1. Return ? Invoke(_rx_, %Symbol.search%, « _string_ »).
         </emu-alg>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -35138,12 +35139,12 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.split">
         <h1>String.prototype.split ( _separator_, _limit_ )</h1>
-        <p>This method returns an Array into which substrings of the result of converting this object to a String have been stored. The substrings are determined by searching from left to right for occurrences of _separator_; these occurrences are not part of any String in the returned array, but serve to divide up the String value. The value of _separator_ may be a String of any length or it may be an object, such as a RegExp, that has a @@split method.</p>
+        <p>This method returns an Array into which substrings of the result of converting this object to a String have been stored. The substrings are determined by searching from left to right for occurrences of _separator_; these occurrences are not part of any String in the returned array, but serve to divide up the String value. The value of _separator_ may be a String of any length or it may be an object, such as a RegExp, that has a %Symbol.split% method.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _separator_ is neither *undefined* nor *null*, then
-            1. Let _splitter_ be ? GetMethod(_separator_, @@split).
+            1. Let _splitter_ be ? GetMethod(_separator_, %Symbol.split%).
             1. If _splitter_ is not *undefined*, then
               1. Return ? Call(_splitter_, _separator_, « _O_, _limit_ »).
           1. Let _S_ be ? ToString(_O_).
@@ -35411,8 +35412,8 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-string.prototype-@@iterator" oldids="sec-createstringiterator,sec-properties-of-string-iterator-instances,table-46,table-internal-slots-of-string-iterator-instances">
-        <h1>String.prototype [ @@iterator ] ( )</h1>
+      <emu-clause id="sec-string.prototype-%symbol.iterator%" oldids="sec-string.prototype-@@iterator,sec-createstringiterator,sec-properties-of-string-iterator-instances,table-46,table-internal-slots-of-string-iterator-instances">
+        <h1>String.prototype [ %Symbol.iterator% ] ( )</h1>
         <p>This method returns an Iterator object (<emu-xref href="#sec-iterator-interface"></emu-xref>) that iterates over the code points of a String value, returning each code point as a String value.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
@@ -35467,9 +35468,9 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%stringiteratorprototype%-@@tostringtag">
-          <h1>%StringIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value *"String Iterator"*.</p>
+        <emu-clause oldids="sec-%stringiteratorprototype%-@@tostringtag" id="sec-%stringiteratorprototype%-%symbol.tostringtag%">
+          <h1>%StringIteratorPrototype% [ %Symbol.toStringTag% ]</h1>
+          <p>The initial value of the %Symbol.toStringTag% property is the String value *"String Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -37760,15 +37761,15 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-get-regexp-@@species">
-        <h1>get RegExp [ @@species ]</h1>
-        <p>`RegExp[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-get-regexp-@@species" id="sec-get-regexp-%symbol.species%">
+        <h1>get RegExp [ %Symbol.species% ]</h1>
+        <p>`RegExp[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>RegExp prototype methods normally use their *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>RegExp prototype methods normally use their *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its %Symbol.species% property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -37890,8 +37891,8 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-regexp.prototype-@@match">
-        <h1>RegExp.prototype [ @@match ] ( _string_ )</h1>
+      <emu-clause oldids="sec-regexp.prototype-@@match" id="sec-regexp.prototype-%symbol.match%">
+        <h1>RegExp.prototype [ %Symbol.match% ] ( _string_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _rx_ be the *this* value.
@@ -37921,12 +37922,12 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the *"name"* property of this method is *"[Symbol.match]"*.</p>
         <emu-note>
-          <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behaviour of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
+          <p>The %Symbol.match% property is used by the IsRegExp abstract operation to identify objects that have the basic behaviour of regular expressions. The absence of a %Symbol.match% property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-regexp-prototype-matchall">
-        <h1>RegExp.prototype [ @@matchAll ] ( _string_ )</h1>
+      <emu-clause oldids="sec-regexp-prototype-matchall" id="sec-regexp-prototype-%symbol.matchall%">
+        <h1>RegExp.prototype [ %Symbol.matchAll% ] ( _string_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -37956,8 +37957,8 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-regexp.prototype-@@replace">
-        <h1>RegExp.prototype [ @@replace ] ( _string_, _replaceValue_ )</h1>
+      <emu-clause oldids="sec-regexp.prototype-@@replace" id="sec-regexp.prototype-%symbol.replace%">
+        <h1>RegExp.prototype [ %Symbol.replace% ] ( _string_, _replaceValue_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _rx_ be the *this* value.
@@ -38027,8 +38028,8 @@ THH:mm:ss.sss
         <p>The value of the *"name"* property of this method is *"[Symbol.replace]"*.</p>
       </emu-clause>
 
-      <emu-clause id="sec-regexp.prototype-@@search">
-        <h1>RegExp.prototype [ @@search ] ( _string_ )</h1>
+      <emu-clause oldids="sec-regexp.prototype-@@search" id="sec-regexp.prototype-%symbol.search%">
+        <h1>RegExp.prototype [ %Symbol.search% ] ( _string_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _rx_ be the *this* value.
@@ -38088,8 +38089,8 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-regexp.prototype-@@split">
-        <h1>RegExp.prototype [ @@split ] ( _string_, _limit_ )</h1>
+      <emu-clause oldids="sec-regexp.prototype-@@split" id="sec-regexp.prototype-%symbol.split%">
+        <h1>RegExp.prototype [ %Symbol.split% ] ( _string_, _limit_ )</h1>
         <emu-note>
           <p>This method returns an Array into which substrings of the result of converting _string_ to a String have been stored. The substrings are determined by searching from left to right for matches of the *this* value regular expression; these occurrences are not part of any String in the returned array, but serve to divide up the String value.</p>
           <p>The *this* value may be an empty regular expression or a regular expression that can match an empty String. In this case, the regular expression does not match the empty <emu-not-ref>substring</emu-not-ref> at the beginning or end of the input String, nor does it match the empty <emu-not-ref>substring</emu-not-ref> at the end of the previous separator match. (For example, if the regular expression matches the empty String, the String is split up into individual code unit elements; the length of the result array equals the length of the String, and each <emu-not-ref>substring</emu-not-ref> contains one code unit.) Only the first match at a given index of the String is considered, even if backtracking could yield a non-empty <emu-not-ref>substring</emu-not-ref> match at that index. (For example, `/a*?/[Symbol.split]("ab")` evaluates to the array `["a", "b"]`, while `/a*/[Symbol.split]("ab")` evaluates to the array `["","b"]`.)</p>
@@ -38536,9 +38537,9 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%regexpstringiteratorprototype%-@@tostringtag">
-          <h1>%RegExpStringIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value *"RegExp String Iterator"*.</p>
+        <emu-clause oldids="sec-%regexpstringiteratorprototype%-@@tostringtag" id="sec-%regexpstringiteratorprototype%-%symbol.tostringtag%">
+          <h1>%RegExpStringIteratorPrototype% [ %Symbol.toStringTag% ]</h1>
+          <p>The initial value of the %Symbol.toStringTag% property is the String value *"RegExp String Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -38619,7 +38620,7 @@ THH:mm:ss.sss
           1. Else,
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
-          1. Let _usingIterator_ be ? GetMethod(_items_, @@iterator).
+          1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
             1. If IsConstructor(_C_) is *true*, then
               1. Let _A_ be ? Construct(_C_).
@@ -38708,15 +38709,15 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-get-array-@@species">
-        <h1>get Array [ @@species ]</h1>
-        <p>`Array[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-get-array-@@species" id="sec-get-array-%symbol.species%">
+        <h1>get Array [ %Symbol.species% ]</h1>
+        <p>`Array[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>Array prototype methods normally use their *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>Array prototype methods normally use their *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its %Symbol.species% property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -38798,7 +38799,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. If _O_ is not an Object, return *false*.
-            1. Let _spreadable_ be ? Get(_O_, @@isConcatSpreadable).
+            1. Let _spreadable_ be ? Get(_O_, %Symbol.isConcatSpreadable%).
             1. If _spreadable_ is not *undefined*, return ToBoolean(_spreadable_).
             1. Return ? IsArray(_O_).
           </emu-alg>
@@ -40001,14 +40002,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-array.prototype-@@iterator">
-        <h1>Array.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is %Array.prototype.values%, defined in <emu-xref href="#sec-array.prototype.values"></emu-xref>.</p>
+      <emu-clause oldids="sec-array.prototype-@@iterator" id="sec-array.prototype-%symbol.iterator%">
+        <h1>Array.prototype [ %Symbol.iterator% ] ( )</h1>
+        <p>The initial value of the %Symbol.iterator% property is %Array.prototype.values%, defined in <emu-xref href="#sec-array.prototype.values"></emu-xref>.</p>
       </emu-clause>
 
-      <emu-clause id="sec-array.prototype-@@unscopables">
-        <h1>Array.prototype [ @@unscopables ]</h1>
-        <p>The initial value of the @@unscopables data property is an object created by the following steps:</p>
+      <emu-clause oldids="sec-array.prototype-@@unscopables" id="sec-array.prototype-%symbol.unscopables%">
+        <h1>Array.prototype [ %Symbol.unscopables% ]</h1>
+        <p>The initial value of the %Symbol.unscopables% data property is an object created by the following steps:</p>
         <emu-alg>
           1. Let _unscopableList_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"at"*, *true*).
@@ -40112,9 +40113,9 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%arrayiteratorprototype%-@@tostringtag">
-          <h1>%ArrayIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value *"Array Iterator"*.</p>
+        <emu-clause oldids="sec-%arrayiteratorprototype%-@@tostringtag" id="sec-%arrayiteratorprototype%-%symbol.tostringtag%">
+          <h1>%ArrayIteratorPrototype% [ %Symbol.toStringTag% ]</h1>
+          <p>The initial value of the %Symbol.toStringTag% property is the String value *"Array Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -40386,7 +40387,7 @@ THH:mm:ss.sss
           1. Else,
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
-          1. Let _usingIterator_ be ? GetMethod(_source_, @@iterator).
+          1. Let _usingIterator_ be ? GetMethod(_source_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
             1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_source_, _usingIterator_)).
             1. Let _len_ be the number of elements in _values_.
@@ -40446,15 +40447,15 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-get-%typedarray%-@@species">
-        <h1>get %TypedArray% [ @@species ]</h1>
-        <p>%TypedArray%`[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-get-%typedarray%-@@species" id="sec-get-%typedarray%-%symbol.species%">
+        <h1>get %TypedArray% [ %Symbol.species% ]</h1>
+        <p>%TypedArray%`[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>%TypedArray.prototype% methods normally use their *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>%TypedArray.prototype% methods normally use their *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its %Symbol.species% property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -41311,14 +41312,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype-@@iterator">
-        <h1>%TypedArray%.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is %TypedArray.prototype.values%, defined in <emu-xref href="#sec-%typedarray%.prototype.values"></emu-xref>.</p>
+      <emu-clause oldids="sec-%typedarray%.prototype-@@iterator" id="sec-%typedarray%.prototype-%symbol.iterator%">
+        <h1>%TypedArray%.prototype [ %Symbol.iterator% ] ( )</h1>
+        <p>The initial value of the %Symbol.iterator% property is %TypedArray.prototype.values%, defined in <emu-xref href="#sec-%typedarray%.prototype.values"></emu-xref>.</p>
       </emu-clause>
 
-      <emu-clause id="sec-get-%typedarray%.prototype-@@tostringtag">
-        <h1>get %TypedArray%.prototype [ @@toStringTag ]</h1>
-        <p>%TypedArray%`.prototype[@@toStringTag]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-get-%typedarray%.prototype-@@tostringtag" id="sec-get-%typedarray%.prototype-%symbol.tostringtag%">
+        <h1>get %TypedArray%.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>%TypedArray%`.prototype[%Symbol.toStringTag%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, return *undefined*.
@@ -41344,7 +41345,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike ArraySpeciesCreate, which can create non-Array objects through the use of @@species, this operation enforces that the constructor function creates an actual TypedArray.</dd>
+          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike ArraySpeciesCreate, which can create non-Array objects through the use of %Symbol.species%, this operation enforces that the constructor function creates an actual TypedArray.</dd>
         </dl>
         <emu-alg>
           1. Let _defaultConstructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
@@ -41387,7 +41388,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike TypedArraySpeciesCreate, which can construct custom TypedArray subclasses through the use of @@species, this operation always uses one of the built-in TypedArray constructors.</dd>
+          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike TypedArraySpeciesCreate, which can construct custom TypedArray subclasses through the use of %Symbol.species%, this operation always uses one of the built-in TypedArray constructors.</dd>
         </dl>
         <emu-alg>
           1. Let _constructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
@@ -41505,7 +41506,7 @@ THH:mm:ss.sss
                 1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
               1. Else,
                 1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
-                1. Let _usingIterator_ be ? GetMethod(_firstArgument_, @@iterator).
+                1. Let _usingIterator_ be ? GetMethod(_firstArgument_, %Symbol.iterator%).
                 1. If _usingIterator_ is not *undefined*, then
                   1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
                   1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
@@ -41786,7 +41787,7 @@ THH:mm:ss.sss
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
-          <p>If the parameter _iterable_ is present, it is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
+          <p>If the parameter _iterable_ is present, it is expected to be an object that implements an %Symbol.iterator% method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
         </emu-note>
       </emu-clause>
 
@@ -41818,7 +41819,7 @@ THH:mm:ss.sss
             1. IfAbruptCloseIterator(_status_, _iteratorRecord_).
         </emu-alg>
         <emu-note>
-          <p>The parameter _iterable_ is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
+          <p>The parameter _iterable_ is expected to be an object that implements an %Symbol.iterator% method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -41856,15 +41857,15 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-get-map-@@species">
-        <h1>get Map [ @@species ]</h1>
-        <p>`Map[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-get-map-@@species" id="sec-get-map-%symbol.species%">
+        <h1>get Map [ %Symbol.species% ]</h1>
+        <p>`Map[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>Methods that create derived collection objects should call @@species to determine the constructor to use to create the derived objects. Subclass constructor may over-ride @@species to change the default constructor assignment.</p>
+          <p>Methods that create derived collection objects should call %Symbol.species% to determine the constructor to use to create the derived objects. Subclass constructor may over-ride %Symbol.species% to change the default constructor assignment.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -42029,14 +42030,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-map.prototype-@@iterator">
-        <h1>Map.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is %Map.prototype.entries%, defined in <emu-xref href="#sec-map.prototype.entries"></emu-xref>.</p>
+      <emu-clause oldids="sec-map.prototype-@@iterator" id="sec-map.prototype-%symbol.iterator%">
+        <h1>Map.prototype [ %Symbol.iterator% ] ( )</h1>
+        <p>The initial value of the %Symbol.iterator% property is %Map.prototype.entries%, defined in <emu-xref href="#sec-map.prototype.entries"></emu-xref>.</p>
       </emu-clause>
 
-      <emu-clause id="sec-map.prototype-@@tostringtag">
-        <h1>Map.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"Map"*.</p>
+      <emu-clause oldids="sec-map.prototype-@@tostringtag" id="sec-map.prototype-%symbol.tostringtag%">
+        <h1>Map.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"Map"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -42103,9 +42104,9 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%mapiteratorprototype%-@@tostringtag">
-          <h1>%MapIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value *"Map Iterator"*.</p>
+        <emu-clause oldids="sec-%mapiteratorprototype%-@@tostringtag" id="sec-%mapiteratorprototype%-%symbol.tostringtag%">
+          <h1>%MapIteratorPrototype% [ %Symbol.toStringTag% ]</h1>
+          <p>The initial value of the %Symbol.toStringTag% property is the String value *"Map Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -42308,15 +42309,15 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-get-set-@@species">
-        <h1>get Set [ @@species ]</h1>
-        <p>`Set[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-get-set-@@species" id="sec-get-set-%symbol.species%">
+        <h1>get Set [ %Symbol.species% ]</h1>
+        <p>`Set[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>Methods that create derived collection objects should call @@species to determine the constructor to use to create the derived objects. Subclass constructor may over-ride @@species to change the default constructor assignment.</p>
+          <p>Methods that create derived collection objects should call %Symbol.species% to determine the constructor to use to create the derived objects. Subclass constructor may over-ride %Symbol.species% to change the default constructor assignment.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -42661,14 +42662,14 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-set.prototype-@@iterator">
-        <h1>Set.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is %Set.prototype.values%, defined in <emu-xref href="#sec-set.prototype.values"></emu-xref>.</p>
+      <emu-clause oldids="sec-set.prototype-@@iterator" id="sec-set.prototype-%symbol.iterator%">
+        <h1>Set.prototype [ %Symbol.iterator% ] ( )</h1>
+        <p>The initial value of the %Symbol.iterator% property is %Set.prototype.values%, defined in <emu-xref href="#sec-set.prototype.values"></emu-xref>.</p>
       </emu-clause>
 
-      <emu-clause id="sec-set.prototype-@@tostringtag">
-        <h1>Set.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"Set"*.</p>
+      <emu-clause oldids="sec-set.prototype-@@tostringtag" id="sec-set.prototype-%symbol.tostringtag%">
+        <h1>Set.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"Set"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -42733,9 +42734,9 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%setiteratorprototype%-@@tostringtag">
-          <h1>%SetIteratorPrototype% [ @@toStringTag ]</h1>
-          <p>The initial value of the @@toStringTag property is the String value *"Set Iterator"*.</p>
+        <emu-clause oldids="sec-%setiteratorprototype%-@@tostringtag" id="sec-%setiteratorprototype%-%symbol.tostringtag%">
+          <h1>%SetIteratorPrototype% [ %Symbol.toStringTag% ]</h1>
+          <p>The initial value of the %Symbol.toStringTag% property is the String value *"Set Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -42777,7 +42778,7 @@ THH:mm:ss.sss
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
-          <p>If the parameter _iterable_ is present, it is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a WeakMap key and whose second element is the value to associate with that key.</p>
+          <p>If the parameter _iterable_ is present, it is expected to be an object that implements an %Symbol.iterator% method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a WeakMap key and whose second element is the value to associate with that key.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -42874,9 +42875,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-weakmap.prototype-@@tostringtag">
-        <h1>WeakMap.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"WeakMap"*.</p>
+      <emu-clause oldids="sec-weakmap.prototype-@@tostringtag" id="sec-weakmap.prototype-%symbol.tostringtag%">
+        <h1>WeakMap.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"WeakMap"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -43003,9 +43004,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-weakset.prototype-@@tostringtag">
-        <h1>WeakSet.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"WeakSet"*.</p>
+      <emu-clause oldids="sec-weakset.prototype-@@tostringtag" id="sec-weakset.prototype-%symbol.tostringtag%">
+        <h1>WeakSet.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"WeakSet"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -43557,15 +43558,15 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-get-arraybuffer-@@species">
-        <h1>get ArrayBuffer [ @@species ]</h1>
-        <p>`ArrayBuffer[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-get-arraybuffer-@@species" id="sec-get-arraybuffer-%symbol.species%">
+        <h1>get ArrayBuffer [ %Symbol.species% ]</h1>
+        <p>`ArrayBuffer[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p><emu-xref href="#sec-arraybuffer.prototype.slice" title></emu-xref> normally uses its *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour for the <emu-xref href="#sec-arraybuffer.prototype.slice" title></emu-xref> method by redefining its @@species property.</p>
+          <p><emu-xref href="#sec-arraybuffer.prototype.slice" title></emu-xref> normally uses its *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour for the <emu-xref href="#sec-arraybuffer.prototype.slice" title></emu-xref> method by redefining its %Symbol.species% property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -43714,9 +43715,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-arraybuffer.prototype-@@tostringtag">
-        <h1>ArrayBuffer.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"ArrayBuffer"*.</p>
+      <emu-clause oldids="sec-arraybuffer.prototype-@@tostringtag" id="sec-arraybuffer.prototype-%symbol.tostringtag%">
+        <h1>ArrayBuffer.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"ArrayBuffer"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -43883,9 +43884,9 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-sharedarraybuffer-@@species">
-        <h1>get SharedArrayBuffer [ @@species ]</h1>
-        <p>`SharedArrayBuffer[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-sharedarraybuffer-@@species" id="sec-sharedarraybuffer-%symbol.species%">
+        <h1>get SharedArrayBuffer [ %Symbol.species% ]</h1>
+        <p>`SharedArrayBuffer[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -44008,9 +44009,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause oldids="sec-sharedarraybuffer.prototype.toString" id="sec-sharedarraybuffer.prototype-@@tostringtag">
-        <h1>SharedArrayBuffer.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"SharedArrayBuffer"*.</p>
+      <emu-clause oldids="sec-sharedarraybuffer.prototype.toString,sec-sharedarraybuffer.prototype-@@tostringtag" id="sec-sharedarraybuffer.prototype-%symbol.tostringtag%">
+        <h1>SharedArrayBuffer.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"SharedArrayBuffer"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -44530,9 +44531,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-dataview.prototype-@@tostringtag">
-        <h1>DataView.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"DataView"*.</p>
+      <emu-clause oldids="sec-dataview.prototype-@@tostringtag" id="sec-dataview.prototype-%symbol.tostringtag%">
+        <h1>DataView.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"DataView"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -45344,9 +45345,9 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-atomics-@@tostringtag">
-      <h1>Atomics [ @@toStringTag ]</h1>
-      <p>The initial value of the @@toStringTag property is the String value *"Atomics"*.</p>
+    <emu-clause oldids="sec-atomics-@@tostringtag" id="sec-atomics-%symbol.tostringtag%">
+      <h1>Atomics [ %Symbol.toStringTag% ]</h1>
+      <p>The initial value of the %Symbol.toStringTag% property is the String value *"Atomics"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
   </emu-clause>
@@ -45842,9 +45843,9 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-json-@@tostringtag">
-      <h1>JSON [ @@toStringTag ]</h1>
-      <p>The initial value of the @@toStringTag property is the String value *"JSON"*.</p>
+    <emu-clause oldids="sec-json-@@tostringtag" id="sec-json-%symbol.tostringtag%">
+      <h1>JSON [ %Symbol.toStringTag% ]</h1>
+      <p>The initial value of the %Symbol.toStringTag% property is the String value *"JSON"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
   </emu-clause>
@@ -45954,9 +45955,9 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-weak-ref.prototype-@@tostringtag">
-        <h1>WeakRef.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"WeakRef"*.</p>
+      <emu-clause oldids="sec-weak-ref.prototype-@@tostringtag" id="sec-weak-ref.prototype-%symbol.tostringtag%">
+        <h1>WeakRef.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"WeakRef"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -46103,9 +46104,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-finalization-registry.prototype-@@tostringtag">
-        <h1>FinalizationRegistry.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"FinalizationRegistry"*.</p>
+      <emu-clause oldids="sec-finalization-registry.prototype-@@tostringtag" id="sec-finalization-registry.prototype-%symbol.tostringtag%">
+        <h1>FinalizationRegistry.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"FinalizationRegistry"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -46147,7 +46148,7 @@ THH:mm:ss.sss
             </thead>
             <tr>
               <td>
-                `@@iterator`
+                `%Symbol.iterator%`
               </td>
               <td>
                 a function that returns an <i>Iterator</i> object
@@ -46251,7 +46252,7 @@ THH:mm:ss.sss
               </tr>
             </thead>
             <tr>
-              <td>`@@asyncIterator`</td>
+              <td>`%Symbol.asyncIterator%`</td>
               <td>a function that returns an <i>AsyncIterator</i> object</td>
               <td>The returned object must conform to the <i>AsyncIterator</i> interface.</td>
             </tr>
@@ -46377,8 +46378,8 @@ THH:mm:ss.sss
         <pre><code class="javascript">Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))</code></pre>
       </emu-note>
 
-      <emu-clause id="sec-%iteratorprototype%-@@iterator">
-        <h1>%IteratorPrototype% [ @@iterator ] ( )</h1>
+      <emu-clause oldids="sec-%iteratorprototype%-@@iterator" id="sec-%iteratorprototype%-%symbol.iterator%">
+        <h1>%IteratorPrototype% [ %Symbol.iterator% ] ( )</h1>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -46398,8 +46399,8 @@ THH:mm:ss.sss
         <p>All objects defined in this specification that implement the AsyncIterator interface also inherit from %AsyncIteratorPrototype%. ECMAScript code may also define objects that inherit from %AsyncIteratorPrototype%. The %AsyncIteratorPrototype% object provides a place where additional methods that are applicable to all async iterator objects may be added.</p>
       </emu-note>
 
-      <emu-clause id="sec-asynciteratorprototype-asynciterator">
-        <h1>%AsyncIteratorPrototype% [ @@asyncIterator ] ( )</h1>
+      <emu-clause oldids="sec-asynciteratorprototype-asynciterator" id="sec-%asynciteratorprototype%-%symbol.asynciterator%">
+        <h1>%AsyncIteratorPrototype% [ %Symbol.asyncIterator% ] ( )</h1>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -47472,15 +47473,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-get-promise-@@species">
-        <h1>get Promise [ @@species ]</h1>
-        <p>`Promise[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause oldids="sec-get-promise-@@species" id="sec-get-promise-%symbol.species%">
+        <h1>get Promise [ %Symbol.species% ]</h1>
+        <p>`Promise[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>Promise prototype methods normally use their *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>Promise prototype methods normally use their *this* value's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its %Symbol.species% property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -47601,9 +47602,9 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-promise.prototype-@@tostringtag">
-        <h1>Promise.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"Promise"*.</p>
+      <emu-clause oldids="sec-promise.prototype-@@tostringtag" id="sec-promise.prototype-%symbol.tostringtag%">
+        <h1>Promise.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"Promise"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -47758,9 +47759,9 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-generatorfunction.prototype-@@tostringtag">
-        <h1>GeneratorFunction.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"GeneratorFunction"*.</p>
+      <emu-clause oldids="sec-generatorfunction.prototype-@@tostringtag" id="sec-generatorfunction.prototype-%symbol.tostringtag%">
+        <h1>GeneratorFunction.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"GeneratorFunction"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -47860,9 +47861,9 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorfunction-prototype-tostringtag">
-        <h1>AsyncGeneratorFunction.prototype [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"AsyncGeneratorFunction"*.</p>
+      <emu-clause oldids="sec-asyncgeneratorfunction-prototype-tostringtag" id="sec-asyncgeneratorfunction-prototype-%symbol.tostringtag%">
+        <h1>AsyncGeneratorFunction.prototype [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"AsyncGeneratorFunction"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -47943,9 +47944,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-generator.prototype-@@tostringtag">
-        <h1>%GeneratorPrototype% [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"Generator"*.</p>
+      <emu-clause oldids="sec-generator.prototype-@@tostringtag" id="sec-generator.prototype-%symbol.tostringtag%">
+        <h1>%GeneratorPrototype% [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"Generator"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -48296,9 +48297,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgenerator-prototype-tostringtag">
-        <h1>%AsyncGeneratorPrototype% [ @@toStringTag ]</h1>
-        <p>The initial value of the @@toStringTag property is the String value *"AsyncGenerator"*.</p>
+      <emu-clause oldids="sec-asyncgenerator-prototype-tostringtag" id="sec-asyncgenerator-prototype-%symbol.tostringtag%">
+        <h1>%AsyncGeneratorPrototype% [ %Symbol.toStringTag% ]</h1>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"AsyncGenerator"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -48719,10 +48720,10 @@ THH:mm:ss.sss
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
-      <emu-clause id="sec-async-function-prototype-properties-toStringTag">
-        <h1>AsyncFunction.prototype [ @@toStringTag ]</h1>
+      <emu-clause oldids="sec-async-function-prototype-properties-toStringTag" id="sec-async-function-prototype-%symbol.tostringtag%">
+        <h1>AsyncFunction.prototype [ %Symbol.toStringTag% ]</h1>
 
-        <p>The initial value of the @@toStringTag property is the String value *"AsyncFunction"*.</p>
+        <p>The initial value of the %Symbol.toStringTag% property is the String value *"AsyncFunction"*.</p>
 
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
@@ -48991,9 +48992,9 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-reflect-@@tostringtag">
-      <h1>Reflect [ @@toStringTag ]</h1>
-      <p>The initial value of the @@toStringTag property is the String value *"Reflect"*.</p>
+    <emu-clause oldids="sec-reflect-@@tostringtag" id="sec-reflect-%symbol.tostringtag%">
+      <h1>Reflect [ %Symbol.toStringTag% ]</h1>
+      <p>The initial value of the %Symbol.toStringTag% property is the String value *"Reflect"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
   </emu-clause>
@@ -49061,9 +49062,9 @@ THH:mm:ss.sss
     <p>A Module Namespace Object is a module namespace exotic object that provides runtime property-based access to a module's exported bindings. There is no constructor function for Module Namespace Objects. Instead, such an object is created for each module that is imported by an |ImportDeclaration| that contains a |NameSpaceImport|.</p>
     <p>In addition to the properties specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref> each Module Namespace Object has the following own property:</p>
 
-    <emu-clause id="sec-@@tostringtag">
-      <h1>@@toStringTag</h1>
-      <p>The initial value of the @@toStringTag property is the String value *"Module"*.</p>
+    <emu-clause oldids="sec-@@tostringtag" id="sec-%symbol.tostringtag%">
+      <h1>%Symbol.toStringTag%</h1>
+      <p>The initial value of the %Symbol.toStringTag% property is the String value *"Module"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
   </emu-clause>
@@ -51367,7 +51368,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when the time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the *"source"* property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `/`.</p>
-  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change, it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by 1 only if the pattern matched the empty String.</p>
+  <p><emu-xref href="#sec-regexp.prototype-%symbol.match%"></emu-xref>, <emu-xref href="#sec-regexp.prototype-%symbol.replace%"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change, it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by 1 only if the pattern matched the empty String.</p>
   <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0*<sub>𝔽</sub> was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-defined. In practice, implementations call ToNumber.</p>
 </emu-annex>
 


### PR DESCRIPTION
 - this avoids a conceptual conflict with decorators, when they land

Open to bikesheds; other alternatives I considered:
 - explicitly using intrinsics, ie, `%SymbolSpecies%`, and hardcoding that table, while removing the "well-known symbols table". This felt like it would lose some clarity around intrinsics vs well-known-symbols.
 - Using `%Symbol%species%` - this would require upstream support in ecmarkup, so i opted not to do it for now.
 - something else?