### PR TITLE
Editorial: Update date-time format language

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26954,7 +26954,7 @@
       <emu-clause id="sec-date-time-string-format">
         <h1>Date Time String Format</h1>
         <p>ECMAScript defines a string interchange format for date-times based upon a simplification of the ISO 8601 calendar date extended format. The format is as follows: `YYYY-MM-DDTHH:mm:ss.sssZ`</p>
-        <p>Where the fields are as follows:</p>
+        <p>Where the elements are as follows:</p>
         <figure>
           <table class="lightweight-table">
             <tbody>
@@ -26963,7 +26963,7 @@
                 `YYYY`
               </td>
               <td>
-                is the decimal digits of the year 0000 to 9999 in the proleptic Gregorian calendar.
+                is the year in the proleptic Gregorian calendar as four decimal digits from 0000 to 9999, or as an <emu-xref href="#sec-expanded-years">expanded year</emu-xref> of `"+"` or `"-"` followed by six decimal digits.
               </td>
             </tr>
             <tr>
@@ -26979,7 +26979,7 @@
                 `MM`
               </td>
               <td>
-                is the month of the year from 01 (January) to 12 (December).
+                is the month of the year as two decimal digits from 01 (January) to 12 (December).
               </td>
             </tr>
             <tr>
@@ -26987,7 +26987,7 @@
                 `DD`
               </td>
               <td>
-                is the day of the month from 01 to 31.
+                is the day of the month as two decimal digits from 01 to 31.
               </td>
             </tr>
             <tr>
@@ -27051,7 +27051,7 @@
                 `Z`
               </td>
               <td>
-                is the time zone offset specified as `"Z"` (for UTC) or either `"+"` or `"-"` followed by a time expression `HH:mm`
+                is the UTC offset representation specified as `"Z"` (for UTC with no offset) or an offset of either `"+"` or `"-"` followed by a time expression `HH:mm` (indicating local time ahead of or behind UTC, respectively)
               </td>
             </tr>
             </tbody>
@@ -27063,14 +27063,13 @@ YYYY
 YYYY-MM
 YYYY-MM-DD
         </pre>
-        <p>It also includes &ldquo;date-time&rdquo; forms that consist of one of the above date-only forms immediately followed by one of the following time forms with an optional time zone offset appended:</p>
+        <p>It also includes &ldquo;date-time&rdquo; forms that consist of one of the above date-only forms immediately followed by one of the following time forms with an optional UTC offset representation appended:</p>
         <pre>
 THH:mm
 THH:mm:ss
 THH:mm:ss.sss
         </pre>
-        <p>All numbers must be base 10. If the `MM` or `DD` fields are absent `"01"` is used as the value. If the `HH`, `mm`, or `ss` fields are absent `"00"` is used as the value and the value of an absent `sss` field is `"000"`. When the time zone offset is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time.</p>
-        <p>A string containing out-of-bounds or nonconforming fields is not a valid instance of this format.</p>
+        <p>A string containing out-of-bounds or nonconforming elements is not a valid instance of this format.</p>
         <emu-note>
           <p>As every day both starts and ends with midnight, the two notations `00:00` and `24:00` are available to distinguish the two midnights that can be associated with one date. This means that the following two notations refer to exactly the same point in time: `1995-02-04T24:00` and `1995-02-05T00:00`. This interpretation of the latter form as "end of a calendar day" is consistent with ISO 8601, even though that specification reserves it for describing time intervals and does not permit it within representations of single points in time.</p>
         </emu-note>
@@ -27223,7 +27222,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.parse">
         <h1>Date.parse ( _string_ )</h1>
-        <p>The `parse` function applies the ToString operator to its argument. If ToString results in an abrupt completion the Completion Record is immediately returned. Otherwise, `parse` interprets the resulting String as a date and time; it returns a Number, the UTC time value corresponding to the date and time. The String may be interpreted as a local time, a UTC time, or a time in some other time zone, depending on the contents of the String. The function first attempts to parse the String according to the format described in Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>), including expanded years. If the String does not conform to that format the function may fall back to any implementation-specific heuristics or implementation-specific date formats. Strings that are unrecognizable or contain out-of-bounds format field values shall cause `Date.parse` to return *NaN*.</p>
+        <p>The `parse` function applies the ToString operator to its argument. If ToString results in an abrupt completion the Completion Record is immediately returned. Otherwise, `parse` interprets the resulting String as a date and time; it returns a Number, the UTC time value corresponding to the date and time. The String may be interpreted as a local time, a UTC time, or a time in some other time zone, depending on the contents of the String. The function first attempts to parse the String according to the format described in Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>), including expanded years. If the String does not conform to that format the function may fall back to any implementation-specific heuristics or implementation-specific date formats. Strings that are unrecognizable or contain out-of-bounds format element values shall cause `Date.parse` to return *NaN*.</p>
+        <p>If the String conforms to the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, substitute values take the place of absent format elements. When the `MM` or `DD` elements are absent, `"01"` is used. When the `HH`, `mm`, or `ss` elements are absent, `"00"` is used. When the `sss` element is absent, `"000"` is used. When the UTC offset representation is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time.</p>
         <p>If `x` is any Date object whose milliseconds amount is zero within a particular implementation of ECMAScript, then all of the following expressions should produce the same numeric value in that implementation, if all the properties referenced have their initial values:</p>
         <pre><code class="javascript">
           x.valueOf()
@@ -27745,7 +27745,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toisostring">
         <h1>Date.prototype.toISOString ( )</h1>
-        <p>This function returns a String value representing the instance in time corresponding to this time value. The format of the String is the Date Time string format defined in <emu-xref href="#sec-date-time-string-format"></emu-xref>. All fields are present in the String. The time zone is always UTC, denoted by the suffix Z. If this time value is not a finite Number or if the year is not a value that can be represented in that format (if necessary using expanded year format), a *RangeError* exception is thrown.</p>
+        <p>If this time value is not a finite Number or if it corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, this function throws a *RangeError* exception. Otherwise, it returns a String representation of this time value in that format on the UTC time scale, including all format elements and the UTC offset representation `"Z"`. </p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tojson">
@@ -41276,7 +41276,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-candeclareglobalvar"></emu-xref>-<emu-xref href="#sec-createglobalfunctionbinding"></emu-xref> Edition 5 and 5.1 used a property existence test to determine whether a global object property corresponding to a new global declaration already existed. ECMAScript 2015 uses an own property existence test. This corresponds to what has been most commonly implemented by web browsers.</p>
   <p><emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>: The 5<sup>th</sup> Edition moved the capture of the current array length prior to the integer conversion of the array index or new length value. However, the captured length value could become invalid if the conversion process has the side-effect of changing the array length. ECMAScript 2015 specifies that the current array length must be captured after the possible occurrence of such side-effects.</p>
   <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0* or *-0* as the representation of a 0 time value. ECMAScript 2015 specifies that *+0* always returned. This means that for ECMAScript 2015 the time value of a Date object is never observably *-0* and methods that return time values never return *-0*.</p>
-  <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a time zone offset is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as `"z"`.</p>
+  <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a UTC offset representation is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as `"z"`.</p>
   <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by Date.prototype.toString when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value is `"Invalid Date"`.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the `source` property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `"/"`.</p>


### PR DESCRIPTION
* Use ISO 8601 vocabulary
* Move interpretation of absent date time elements into Date.parse