### PR TITLE
Normative: IsRegExp: make `Symbol.match` not be uniquely special

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4328,8 +4328,6 @@
       <p>The abstract operation IsRegExp with argument _argument_ performs the following steps:</p>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
-        1. Let _matcher_ be ? Get(_argument_, @@match).
-        1. If _matcher_ is not *undefined*, return ToBoolean(_matcher_).
         1. If _argument_ has a [[RegExpMatcher]] internal slot, return *true*.
         1. Return *false*.
       </emu-alg>
@@ -28074,7 +28072,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _isRegExp_ be ? IsRegExp(_searchString_).
+          1. Let _isRegExp_ be ! IsRegExp(_searchString_).
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _len_ be the length of _S_.
@@ -28103,7 +28101,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _isRegExp_ be ? IsRegExp(_searchString_).
+          1. Let _isRegExp_ be ! IsRegExp(_searchString_).
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _pos_ be ? ToInteger(_position_).
@@ -28583,7 +28581,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _isRegExp_ be ? IsRegExp(_searchString_).
+          1. Let _isRegExp_ be ! IsRegExp(_searchString_).
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _pos_ be ? ToInteger(_position_).
@@ -30442,7 +30440,7 @@ THH:mm:ss.sss
         <h1>RegExp ( _pattern_, _flags_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _patternIsRegExp_ be ? IsRegExp(_pattern_).
+          1. Let _patternIsRegExp_ be ! IsRegExp(_pattern_).
           1. If NewTarget is *undefined*, then
             1. Let _newTarget_ be the active function object.
             1. If _patternIsRegExp_ is *true* and _flags_ is *undefined*, then
@@ -30786,9 +30784,6 @@ THH:mm:ss.sss
                 1. Increment _n_.
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.match]"`.</p>
-        <emu-note>
-          <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behaviour of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.multiline">


### PR DESCRIPTION
Either `IsRegExp` should check all 4 (soon 5) of the regex symbols, or it should check none.

Currently this check is only used in 4 places: 3 String methods, to throw a TypeError to indicate that they only take a string and not a regex; and in the `RegExp` constructor to decide whether to extract `.constructor`/`.source`/`.flags`, or to naively stringify.

This will only impact objects that do not use `extends RegExp`/`super` to create a "RegExp-like" object.

Some examples of the current inconsistency:
```js
class MyRE extends RegExp {}

// similar results for startsWith and endsWith
'a'.includes({ [Symbol.split]: true, toString() { return 'a'; } }); // `true`
'a'.includes({ [Symbol.search]: true, toString() { return 'a'; } }); // `true`
'a'.includes({ [Symbol.replace]: true, toString() { return 'a'; } }); // `true`
'a'.includes({ [Symbol.match]: true, toString() { return 'a'; } }); // throws
'a'.includes(new MyRE('a', 'g')); // throws

new RegExp(/b/g); // `/b/g`
new RegExp(new MyRE('a', 'g')); // `/a/g`, a regular regex, not an instanceof MyRE
new RegExp({ [Symbol.split]: true, toString() { return 'a'; }, source: 'b', flags: 'g' });  // `/a/`
new RegExp({ [Symbol.search]: true, toString() { return 'a'; }, source: 'b', flags: 'g' });  // `/a/`
new RegExp({ [Symbol.replace]: true, toString() { return 'a'; }, source: 'b', flags: 'g' });  // `/a/`
new RegExp({ [Symbol.match]: true, toString() { return 'a'; }, source: 'b', flags: 'g' }); // `/b/g`
```

This PR changes the results for an object that defines `Symbol.match` so that they perform the same as an object defining any of the other regex-related well-known Symbols. It does not impact any operations with regex literals, instances of RegExp, or instances of any subclasses of RegExp.

This has a secondary benefit of making `IsRegExp` no longer an observable operation.

It is highly unlikely that there is code on the web relying on this behavior; we'd need to determine if that is the case before merging this.

After this PR, these would be the above results:
```js
class MyRE extends RegExp {}

// similar results for startsWith and endsWith
'a'.includes({ [Symbol.split]: true, toString() { return 'a'; } }); // `true`
'a'.includes({ [Symbol.search]: true, toString() { return 'a'; } }); // `true`
'a'.includes({ [Symbol.replace]: true, toString() { return 'a'; } }); // `true`
'a'.includes({ [Symbol.match]: true, toString() { return 'a'; } }); // `true`
'a'.includes(new MyRE('a', 'g')); // throws

new RegExp(/b/g); // `/b/g`
new RegExp(new MyRE('a', 'g')); // `/a/g`, a regular regex, not an instanceof MyRE
new RegExp({ [Symbol.split]: true, toString() { return 'a'; }, source: 'b', flags: 'g' });  // `/a/`
new RegExp({ [Symbol.search]: true, toString() { return 'a'; }, source: 'b', flags: 'g' });  // `/a/`
new RegExp({ [Symbol.replace]: true, toString() { return 'a'; }, source: 'b', flags: 'g' });  // `/a/`
new RegExp({ [Symbol.match]: true, toString() { return 'a'; }, source: 'b', flags: 'g' }); // `/a/`
```