### PR TITLE
Normative: Make non-writable prototype properties not prevent assigning to instance

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7016,7 +7016,6 @@
             1. Else,
               1. Set _ownDesc_ to the PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
           1. If IsDataDescriptor(_ownDesc_) is *true*, then
-            1. If _ownDesc_.[[Writable]] is *false*, return *false*.
             1. If Type(_Receiver_) is not Object, return *false*.
             1. Let _existingDescriptor_ be ? _Receiver_.[[GetOwnProperty]](_P_).
             1. If _existingDescriptor_ is not *undefined*, then


### PR DESCRIPTION
TC39 is discussing making inherited non-writable properties overridable with Set,
in #1307. We have not yet assessed the web compatibility of the change or written
tests, so this PR is not yet ready to merge, but this PR gives some concreteness
to how the specification may be done, to help move the discussion forward.

This patch implements the approach described in https://github.com/tc39/ecma262/pull/1307#issuecomment-422808140