### PR TITLE
Editorial: Correct variable terminology

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4055,7 +4055,7 @@
           1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _asyncContext_.
         </emu-alg>
 
-        <p>where all variables in the above steps, with the exception of _completion_, are ephemeral and visible only in the steps pertaining to Await.</p>
+        <p>where all aliases in the above steps, with the exception of _completion_, are ephemeral and visible only in the steps pertaining to Await.</p>
 
         <emu-note>
           <p>Await can be combined with the `?` and `!` prefixes, so that for example</p>
@@ -31300,7 +31300,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-notation">
         <h1>Notation</h1>
-        <p>The descriptions below use the following variables:</p>
+        <p>The descriptions below use the following aliases:</p>
         <ul>
           <li>
             _Input_ is a List consisting of all of the characters, in order, of the String being matched by the regular expression pattern. Each character is either a code unit or a code point, depending upon the kind of pattern involved. The notation _Input_[_n_] means the _n_<sup>th</sup> character of _Input_, where _n_ can range between 0 (inclusive) and _InputLength_ (exclusive).
@@ -31353,7 +31353,7 @@ THH:mm:ss.sss
             1. Assert: Type(_str_) is String.
             1. Assert: ! IsNonNegativeInteger(_index_) is *true* and _index_ &le; the length of _str_.
             1. If _Unicode_ is *true*, let _Input_ be a List consisting of the sequence of code points of ! UTF16DecodeString(_str_). Otherwise, let _Input_ be a List consisting of the sequence of code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
-            1. Let _InputLength_ be the number of characters contained in _Input_. This variable will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.
+            1. Let _InputLength_ be the number of characters contained in _Input_. This alias will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.
             1. Let _listIndex_ be the index into _Input_ of the character that was obtained from element _index_ of _str_.
             1. Let _c_ be a new Continuation with parameters (_y_) that captures nothing and performs the following steps when called:
               1. Assert: _y_ is a State.


### PR DESCRIPTION
The spec "variables" are not variables, but aliases as defined in [5.2 Algorithm Conventions](https://tc39.github.io/ecma262/#sec-algorithm-conventions).