### PR TITLE
Editorial: Add explicit Return to Await

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3008,6 +3008,8 @@
           1. Perform ! PerformPromiseThen(_promiseCapability_.[[Promise]], _onFulfilled_, _onRejected_).
           1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _completion_, the following steps of the algorithm that invoked Await will be performed, with _completion_ available.
+          1. Return.
+          1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _asyncContext_.
         </emu-alg>
 
         <p>where all variables in the above steps, with the exception of _completion_, are ephemeral and visible only in the steps pertaining to Await.</p>


### PR DESCRIPTION
Prior to this commit there has always been an implicit "Return." step, after the previous step in Await "sucks up" all the remaining steps in the caller. This is visible in places such as AsyncFunctionStart, which asserts that Await returns "a normal completion with a value of **undefined**," due to the fact that a "return" without value implicitly returns **undefined**.

Left implicit, the implicit "return" behavior is at best counterintuitive and at worst misleading (on top of something as abstruse as execution context suspension), for implementors such as myself. In this commit, I took the step of making the return explicit. Alternatively, I could keep the "return" implicit, but add a textual note explaining that Await in fact returns an **undefined** value, independent of any returns done by the caller of the Await algorithm.