### PR TITLE
Editorial: add ‘!’ to CreateDataPropertyOrThrow calls in PropertyDefinitionEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11767,7 +11767,8 @@
           1. Let _exprValue_ be the result of evaluating |IdentifierReference|.
           1. Let _propValue_ be ? GetValue(_exprValue_).
           1. Assert: _enumerable_ is *true*.
-          1. Return CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
+          1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
+          1. Return ! CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
         </emu-alg>
         <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -11779,7 +11780,8 @@
             1. Let _hasNameProperty_ be ? HasOwnProperty(_propValue_, `"name"`).
             1. If _hasNameProperty_ is *false*, perform SetFunctionName(_propValue_, _propKey_).
           1. Assert: _enumerable_ is *true*.
-          1. Return CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
+          1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
+          1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
         </emu-alg>
         <emu-note>
           <p>An alternative semantics for this production is given in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref>.</p>
@@ -40467,7 +40469,8 @@ THH:mm:ss.sss
           1. Let _hasNameProperty_ be ? HasOwnProperty(_propValue_, `"name"`).
           1. If _hasNameProperty_ is *false*, perform SetFunctionName(_propValue_, _propKey_).
         1. Assert: _enumerable_ is *true*.
-        1. Return CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
+        1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
+        1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
       </emu-alg>
     </emu-annex>
 


### PR DESCRIPTION
…because they never return an abrupt completion from that particular code path.

This came up this morning while chatting with @bmeurer and @gsathya. 

https://tc39.github.io/ecma262/#sec-object-initializer-runtime-semantics-propertydefinitionevaluation