### PR TITLE
Editorial: Fence non-terminal token for NotCodePoint/CodePoint.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10639,10 +10639,10 @@
           `u` `{` CodePoint [lookahead &lt;! HexDigit] [lookahead != `}`]
 
         NotCodePoint ::
-          HexDigits [> but only if MV of HexDigits &gt; 0x10FFFF ]
+          HexDigits [> but only if MV of |HexDigits| &gt; 0x10FFFF ]
 
         CodePoint ::
-          HexDigits [> but only if MV of HexDigits &le; 0x10FFFF ]
+          HexDigits [> but only if MV of |HexDigits| &le; 0x10FFFF ]
       </emu-grammar>
       <p>A conforming implementation must not use the extended definition of |EscapeSequence| described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref> when parsing a |TemplateCharacter|.</p>
       <emu-note>


### PR DESCRIPTION
According to [grammarkdown reference](https://github.com/rbuckton/grammarkdown#assertions), prose assertions referencing a non-terminal should fence the non-terminal reference with `|` chars.