### PR TITLE
[Normative] Make Array.prototype.sort stable

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32009,7 +32009,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.sort">
         <h1>Array.prototype.sort ( _comparefn_ )</h1>
-        <p>The elements of this array are sorted. The sort is not necessarily stable (that is, elements that compare equal do not necessarily remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative value if _x_ &lt; _y_, zero if _x_ = _y_, or a positive value if _x_ &gt; _y_.</p>
+        <p>The elements of this array are sorted. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative value if _x_ &lt; _y_, zero if _x_ = _y_, or a positive value if _x_ &gt; _y_.</p>
         <p>Upon entry, the following steps are performed to initialize evaluation of the `sort` function:</p>
         <emu-alg>
           1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
@@ -33260,7 +33260,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.sort">
         <h1>%TypedArray%.prototype.sort ( _comparefn_ )</h1>
-        <p>%TypedArray%`.prototype.sort` is a distinct function that, except as described below, implements the same requirements as those of `Array.prototype.sort` as defined in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. The implementation of the %TypedArray%`.prototype.sort` specification may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. The only internal methods of the *this* object that the algorithm may call are [[Get]] and [[Set]].</p>
+        <p>%TypedArray%`.prototype.sort` is a distinct function that, except as described below, implements the same requirements as those of `Array.prototype.sort` as defined in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. Unlike `Array.prototype.sort`, %TypedArray%`.prototype.sort` is not necessarily stable (that is, elements that compare equal do not necessarily remain in their original order). The implementation of the %TypedArray%`.prototype.sort` specification may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. The only internal methods of the *this* object that the algorithm may call are [[Get]] and [[Set]].</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
         <p>Upon entry, the following steps are performed to initialize evaluation of the `sort` function. These steps are used instead of the entry steps in <emu-xref href="#sec-array.prototype.sort"></emu-xref>:</p>
         <emu-alg>


### PR DESCRIPTION
All major JavaScript engines now have a stable `Array.prototype.sort` implementation. Let’s update the spec accordingly.

References:
- https://v8.dev/blog/array-sort
- https://github.com/Microsoft/ChakraCore/commit/c565b12f0aada9fc188cea5eb5243699d27c56e6
- https://github.com/Moddable-OpenSource/moddable/commit/d3ee129350f6ae0043319b06c56b9828e8e256a6
- https://mathiasbynens.be/demo/sort-stability
- [September 2018 TC39 meeting presentation](https://docs.google.com/presentation/d/1mHvxDciqsAchhjepMZlU5fn1DBvglCXSjDWUEtsPGvI/edit)
- [November 2018 TC39 meeting presentation](https://docs.google.com/presentation/d/1Io53b2Bi3_N0_wguWoA9OKuPRpHch34EVbS1H8zISes/edit)