### PR TITLE
Editorial: Trivial fix for header of Well-Known symbols table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -930,7 +930,7 @@
                 Specification Name
               </th>
               <th>
-                [[Description]]
+                Description
               </th>
               <th>
                 Value and Purpose


### PR DESCRIPTION
I found a table header has unnecessary `[[` and `]]` at https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type . Removed them.