### PR TITLE
add Symbol.prototype.description getter

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25027,6 +25027,16 @@
         </emu-clause>
       </emu-clause>
 
+      <emu-clause id="sec-symbol.prototype.description">
+        <h1>get Symbol.prototype.description</h1>
+        <p>`Symbol.prototype.description` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <emu-alg>
+          1. Let _s_ be the *this* value.
+          1. Let _sym_ be ? thisSymbolValue(_s_).
+          1. Return _sym_.[[Description]].
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-symbol.prototype.valueof">
         <h1>Symbol.prototype.valueOf ( )</h1>
         <p>The following steps are taken:</p>


### PR DESCRIPTION
This integrates the stage 3 [symbol description proposal](https://github.com/tc39/proposal-Symbol-description) in preparation for stage 4.

As of this writing, there are [three compatible browser implementations](https://test262.report/browse/built-ins/Symbol/prototype/description).