### PR TITLE
Layering: Distinguish template literals to embedders

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7851,14 +7851,15 @@
       </emu-clause>
 
       <emu-clause id="sec-arraycreate" aoid="ArrayCreate">
-        <h1>ArrayCreate ( _length_ [ , _proto_ ] )</h1>
-        <p>The abstract operation ArrayCreate with argument _length_ (either 0 or a positive integer) and optional argument _proto_ is used to specify the creation of new Array exotic objects. It performs the following steps:</p>
+        <h1>ArrayCreate ( _length_ [ , _proto_ [ , _internalSlotsList_ ] ] )</h1>
+        <p>The abstract operation ArrayCreate with argument _length_ (either 0 or a positive integer), optional argument _proto_ is used to specify the creation of new Array exotic objects, and optional argument _internalSlotsList_ specifies a List of internal slot keys to create in the new Array. It performs the following steps:</p>
         <emu-alg>
           1. Assert: _length_ is an integer Number &ge; 0.
           1. If _length_ is *-0*, set _length_ to *+0*.
           1. If _length_ &gt; 2<sup>32</sup> - 1, throw a *RangeError* exception.
           1. If _proto_ is not present, set _proto_ to the intrinsic object %ArrayPrototype%.
-          1. Let _A_ be a newly created Array exotic object.
+          1. If _internalSlotsList_ is not present, set _internalSlotsList_ to a new empty List.
+          1. Let _A_ be a newly created Array exotic object with an internal slot for each name in _internalSlotsList_.
           1. Set _A_'s essential internal methods except for [[DefineOwnProperty]] to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _A_.[[Prototype]] to _proto_.
@@ -11978,7 +11979,7 @@
           1. Let _cookedStrings_ be TemplateStrings of _templateLiteral_ with argument *false*.
           1. Let _count_ be the number of elements in the List _cookedStrings_.
           1. Assert: _count_ &le; 2<sup>32</sup> - 1.
-          1. Let _template_ be ! ArrayCreate(_count_).
+          1. Let _template_ be ! ArrayCreate(_count_, %ArrayPrototype%, &laquo; [[TemplateLiteral]] &raquo;).
           1. Let _rawObj_ be ! ArrayCreate(_count_).
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _count_
@@ -12002,6 +12003,9 @@
         </emu-note>
         <emu-note>
           <p>Future editions of this specification may define additional non-enumerable properties of template objects.</p>
+        </emu-note>
+        <emu-note>
+          The [[TemplateLiteral]] internal slot is created on template objects in order to enable APIs in embedding environments to check whether an object is a template object. The value of the slot is typically *undefined*.
         </emu-note>
       </emu-clause>
 


### PR DESCRIPTION
This patch gives the frozen Arrays passed to tagged templates
a [[TemplateLiteral]] internal slot. Such a slot can be used
as a brand check to prove that the object came from a template
literal in the program. Combined with CSP [1] or similar
restrictions, this can prove that the Array came from a tagged
template literal in the provided original application code.
Such proof may be useful in JavaScript embeddings like the Web
in the Trusted Types proposal [2].

This patch does not introduce a JavaScript API to perform the check.
It has been suggested that this check should have certain integrity
properties. There are various ideas about introducing standard
library integrity properties in the get-originals [3] and
JS-Standard-Library [4] proposals. When these proposals are more
developed, they will show the way for how such a check API should
be introduced into JavaScript.

[1] https://w3c.github.io/webappsec-csp/
[2] https://github.com/WICG/trusted-types
[3] https://github.com/domenic/get-originals
[4] https://github.com/tc39/proposal-javascript-standard-library