### PR TITLE
Fix indentation of the "Valid Chosen Reads" and "Coherent Reads"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39335,7 +39335,7 @@ THH:mm:ss.sss
             1. Return *false*.
           1. If _chosenValue_[_i_] is not equal to _readValue_[_i_] for any integer value _i_ in the range 0 through _chosenLen_, exclusive, then
             1. Return *false*.
-          1. Return *true*.
+        1. Return *true*.
       </emu-alg>
     </emu-clause>
 
@@ -39352,7 +39352,7 @@ THH:mm:ss.sss
             1. If there is a WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ that has _byteLocation_ in its range such that the pairs (_W_, _V_) and (_V_, _R_) are in _execution_.[[HappensBefore]], then
               1. Return *false*.
             1. Increment _byteLocation_ by 1.
-          1. Return *true*.
+        1. Return *true*.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
The current indentation mistakenly means that the two constraints are **true** if the *first* event is valid, instead of if *all* events are valid.