### PR TITLE
Editorial: fix assertion in IteratorBindingInitialization

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18386,7 +18386,7 @@
         1. Let _currentContext_ be the running execution context.
         1. Let _originalEnv_ be the VariableEnvironment of _currentContext_.
         1. Assert: The VariableEnvironment and LexicalEnvironment of _currentContext_ are the same.
-        1. Assert: _environment_ and _originalEnv_ are the same.
+        1. Assert: If _environment_ is not *undefined*, then _environment_ and _originalEnv_ are the same.
         1. Let _paramVarEnv_ be NewDeclarativeEnvironment(_originalEnv_).
         1. Set the VariableEnvironment of _currentContext_ to _paramVarEnv_.
         1. Set the LexicalEnvironment of _currentContext_ to _paramVarEnv_.
@@ -18404,7 +18404,7 @@
         1. Let _currentContext_ be the running execution context.
         1. Let _originalEnv_ be the VariableEnvironment of _currentContext_.
         1. Assert: The VariableEnvironment and LexicalEnvironment of _currentContext_ are the same.
-        1. Assert: _environment_ and _originalEnv_ are the same.
+        1. Assert: If _environment_ is not *undefined*, then _environment_ and _originalEnv_ are the same.
         1. Let _paramVarEnv_ be NewDeclarativeEnvironment(_originalEnv_).
         1. Set the VariableEnvironment of _currentContext_ to _paramVarEnv_.
         1. Set the LexicalEnvironment of _currentContext_ to _paramVarEnv_.


### PR DESCRIPTION
`environment` will be `undefined` if the formal parameters contain duplicates