### PR TITLE
Normative: Fix memory model so DRF-SC holds

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39037,8 +39037,12 @@ THH:mm:ss.sss
       <p>For a candidate execution _execution_, memory-order is a strict total order of all events in EventSet(_execution_) that satisfies the following.</p>
       <ul>
         <li>For each pair (_E_, _D_) in _execution_.[[HappensBefore]], (_E_, _D_) is in memory-order.</li>
-        <li>
-          <p>For each pair (_E_, _D_) in _execution_.[[SynchronizesWith]], (_E_, _D_) is in memory-order if there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _W_ in SharedDataBlockEventSet(_execution_) with equal range as _D_ such that _W_ is not _E_, and the pairs (_E_, _W_) and (_W_, _D_) are in memory-order.</p>
+        <li>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], if (_W_, _R_) is in memory-order, then there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ in SharedDataBlockEventSet(_execution_) such that _W_ is not _V_, the pairs (_W_, _V_) and (_V_, _R_) are in memory-order, and any of the following conditions are true.
+          <ul>
+            <li>The pair (_W_, _R_) is in _execution_.[[SynchronizesWith]] and _V_ and _R_ have equal ranges.</li>
+            <li>The pair (_V_, _R_) is in _execution_.[[HappensBefore]], _W_.[[Order]] is `"SeqCst"`, _V_.[[Order]] is `"SeqCst"`, and _W_ and _V_ have equal ranges.</li>
+            <li>The pair (_W_, _V_) is in _execution_.[[HappensBefore]], _V_.[[Order]] is `"SeqCst"`, _R_.[[Order]] is `"SeqCst"`, and _V_ and _R_ have equal ranges.</li>
+          </ul>
           <emu-note>
             <p>This clause additionally constrains `"SeqCst"` events on equal ranges.</p>
           </emu-note>

--- a/spec.html
+++ b/spec.html
@@ -38878,7 +38878,7 @@ THH:mm:ss.sss
       <h1>agent-order</h1>
       <p>For a candidate execution _execution_, _execution_.[[AgentOrder]] is a Relation on events that satisfies the following.</p>
       <ul>
-        <li>For each pair (_E_, _D_) in EventSet(_execution_), (_E_, _D_) is in _execution_.[[AgentOrder]] if there is some Agent Events Record _aer_ in _execution_.[[EventsRecords]] such that _E_ and _D_ are in _aer_.[[EventList]] and _E_ is before _D_ in List order of _aer_.[[EventList]].</li>
+        <li>For each pair (_E_, _D_) in EventSet(_execution_), (_E_, _D_) is in _execution_.[[AgentOrder]] if and only if there is some Agent Events Record _aer_ in _execution_.[[EventsRecords]] such that _E_ and _D_ are in _aer_.[[EventList]] and _E_ is before _D_ in List order of _aer_.[[EventList]].</li>
       </ul>
 
       <emu-note>
@@ -38902,9 +38902,9 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reads-from" aoid="reads-from">
       <h1>reads-from</h1>
-      <p>For a candidate execution _execution_, _execution_.[[ReadsFrom]] is the least Relation on events that satisfies the following.</p>
+      <p>For a candidate execution _execution_, _execution_.[[ReadsFrom]] is a Relation on events that satisfies the following.</p>
       <ul>
-        <li>For each pair (_R_, _W_) in SharedDataBlockEventSet(_execution_), (_R_, _W_) is in _execution_.[[ReadsFrom]] if _W_ is in _execution_.[[ReadsBytesFrom]](_R_).</li>
+        <li>For each pair (_R_, _W_) in SharedDataBlockEventSet(_execution_), (_R_, _W_) is in _execution_.[[ReadsFrom]] if and only if _W_ is in _execution_.[[ReadsBytesFrom]](_R_).</li>
       </ul>
     </emu-clause>
 
@@ -38929,7 +38929,7 @@ THH:mm:ss.sss
       <p>For a candidate execution _execution_, _execution_.[[SynchronizesWith]] is the least Relation on events that satisfies the following.</p>
       <ul>
         <li>
-          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if all the following are true.
+          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if all of the following are true.
           <ul>
             <li>_R_.[[Order]] is `"SeqCst"`.</li>
             <li>_W_.[[Order]] is `"SeqCst"` or `"Init"`.</li>


### PR DESCRIPTION
This corresponds to the weakest fix from #1354.

@conrad-watt @waldemarhorwat Please take a look. I retained the original clause's "no event" wording instead of the if-then wording.