### PR TITLE
fixes #1133: replace some uses of "idempotent" with alternative wording

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9634,7 +9634,7 @@
           1. Return ? _targetEnvRec_.GetBindingValue(_binding_.[[BindingName]], *true*).
         </emu-alg>
         <emu-note>
-          <p>ResolveExport is idempotent and side-effect free. An implementation might choose to pre-compute or cache the ResolveExport results for the [[Exports]] of each module namespace exotic object.</p>
+          <p>ResolveExport is side-effect free. Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result. An implementation might choose to pre-compute or cache the ResolveExport results for the [[Exports]] of each module namespace exotic object.</p>
         </emu-note>
       </emu-clause>
 
@@ -22533,7 +22533,7 @@
               </td>
               <td>
                 <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to *"\*namespace\*"*. Return *null* if the name cannot be resolved, or *"ambiguous"* if multiple bindings were found.</p>
-                <p>This operation must be idempotent if it completes normally. Each time it is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result.</p>
+                <p>Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result if it completes normally.</p>
               </td>
             </tr>
             <tr>
@@ -23572,7 +23572,7 @@
             If a Module Record corresponding to the pair _referencingScriptOrModule_, _specifier_ does not exist or cannot be created, an exception must be thrown.
           </li>
           <li>
-            This operation must be idempotent if it completes normally. Each time it is called with a specific _referencingScriptOrModule_, _specifier_ pair as arguments it must return the same Module Record instance.
+            Each time this operation is called with a specific _referencingScriptOrModule_, _specifier_ pair as arguments it must return the same Module Record instance if it completes normally.
           </li>
         </ul>
         <p>Multiple different _referencingScriptOrModule_, _specifier_ pairs may map to the same Module Record instance. The actual mapping semantic is implementation-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>


### PR DESCRIPTION
Fixes #1133. The other uses of "idempotent" (to mean "if applied to any of its own outputs, it behaves as the identity function") were left intact.