### PR TITLE
Editorial: add RequireInternalSlot abstract operation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7131,6 +7131,15 @@
         <p>If _constructor_ does not supply a [[Prototype]] value, the default value that is used is obtained from the realm of the _constructor_ function rather than from the running execution context.</p>
       </emu-note>
     </emu-clause>
+
+    <emu-clause id="sec-requireinternalslot" aoid="RequireInternalSlot">
+      <h1>RequireInternalSlot ( _O_, _internalSlot_ )</h1>
+      <p>The abstract operation RequireInternalSlot throws an exception unless _O_ is an Object and has the given internal slot.</p>
+      <emu-alg>
+        1. If Type(_O_) is not Object, throw a *TypeError* exception.
+        1. If _O_ does not have an _internalSlot_ internal slot, throw a *TypeError* exception.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-ecmascript-function-objects">
@@ -30873,8 +30882,7 @@ THH:mm:ss.sss
         <p>The String ToString(_string_) is searched for an occurrence of the regular expression pattern as follows:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
-          1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. If _R_ does not have a [[RegExpMatcher]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_R_, [[RegExpMatcher]]).
           1. Let _S_ be ? ToString(_string_).
           1. Return ? RegExpBuiltinExec(_R_, _S_).
         </emu-alg>
@@ -30890,7 +30898,7 @@ THH:mm:ss.sss
               1. Let _result_ be ? Call(_exec_, _R_, &laquo; _S_ &raquo;).
               1. If Type(_result_) is neither Object or Null, throw a *TypeError* exception.
               1. Return _result_.
-            1. If _R_ does not have a [[RegExpMatcher]] internal slot, throw a *TypeError* exception.
+              1. Perform ? RequireInternalSlot(_R_, [[RegExpMatcher]]).
             1. Return ? RegExpBuiltinExec(_R_, _S_).
           </emu-alg>
           <emu-note>
@@ -33181,8 +33189,7 @@ THH:mm:ss.sss
         <p>%TypedArray%`.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Return _buffer_.
@@ -33194,8 +33201,7 @@ THH:mm:ss.sss
         <p>%TypedArray%`.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
@@ -33209,8 +33215,7 @@ THH:mm:ss.sss
         <p>%TypedArray%`.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
@@ -33268,8 +33273,7 @@ THH:mm:ss.sss
           <h1>Runtime Semantics: ValidateTypedArray ( _O_ )</h1>
           <p>When called with argument _O_, the following steps are taken:</p>
           <emu-alg>
-            1. If Type(_O_) is not Object, throw a *TypeError* exception.
-            1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+            1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
             1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
             1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
@@ -33404,8 +33408,7 @@ THH:mm:ss.sss
         <p>%TypedArray%`.prototype.length` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
@@ -33467,8 +33470,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: _array_ is any ECMAScript language value other than an Object with a [[TypedArrayName]] internal slot. If it is such an Object, the definition in <emu-xref href="#sec-%typedarray%.prototype.set-typedarray-offset"></emu-xref> applies.
             1. Let _target_ be the *this* value.
-            1. If Type(_target_) is not Object, throw a *TypeError* exception.
-            1. If _target_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+            1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
             1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
             1. Let _targetOffset_ be ? ToInteger(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
@@ -33502,8 +33504,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: _typedArray_ has a [[TypedArrayName]] internal slot. If it does not, the definition in <emu-xref href="#sec-%typedarray%.prototype.set-array-offset"></emu-xref> applies.
             1. Let _target_ be the *this* value.
-            1. If Type(_target_) is not Object, throw a *TypeError* exception.
-            1. If _target_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+            1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
             1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
             1. Let _targetOffset_ be ? ToInteger(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
@@ -33642,8 +33643,7 @@ THH:mm:ss.sss
         <p>Returns a new _TypedArray_ object whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Let _srcLength_ be _O_.[[ArrayLength]].
@@ -34069,8 +34069,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. Set _p_.[[Key]] to ~empty~.
@@ -34092,8 +34091,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
@@ -34121,8 +34119,7 @@ THH:mm:ss.sss
         <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _entries_ be the List that is _M_.[[MapData]].
@@ -34144,8 +34141,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
@@ -34158,8 +34154,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return *true*.
@@ -34181,8 +34176,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
@@ -34200,8 +34194,7 @@ THH:mm:ss.sss
         <p>`Map.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Let _count_ be 0.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
@@ -34244,8 +34237,7 @@ THH:mm:ss.sss
         <h1>CreateMapIterator ( _map_, _kind_ )</h1>
         <p>Several methods of Map objects return Iterator objects. The abstract operation CreateMapIterator with arguments _map_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
         <emu-alg>
-          1. If Type(_map_) is not Object, throw a *TypeError* exception.
-          1. If _map_ does not have a [[MapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
           1. Let _iterator_ be ObjectCreate(%MapIteratorPrototype%, &laquo; [[Map]], [[MapNextIndex]], [[MapIterationKind]] &raquo;).
           1. Set _iterator_.[[Map]] to _map_.
           1. Set _iterator_.[[MapNextIndex]] to 0.
@@ -34426,8 +34418,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each _e_ that is an element of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
@@ -34443,8 +34434,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each _e_ that is an element of _entries_, do
             1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
@@ -34465,8 +34455,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each _e_ that is an element of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
@@ -34496,8 +34485,7 @@ THH:mm:ss.sss
         <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _entries_ be the List that is _S_.[[SetData]].
@@ -34521,8 +34509,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each _e_ that is an element of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, return *true*.
@@ -34543,8 +34530,7 @@ THH:mm:ss.sss
         <p>`Set.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Let _count_ be 0.
           1. For each _e_ that is an element of _entries_, do
@@ -34587,8 +34573,7 @@ THH:mm:ss.sss
         <h1>CreateSetIterator ( _set_, _kind_ )</h1>
         <p>Several methods of Set objects return Iterator objects. The abstract operation CreateSetIterator with arguments _set_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
         <emu-alg>
-          1. If Type(_set_) is not Object, throw a *TypeError* exception.
-          1. If _set_ does not have a [[SetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_set_, [[SetData]]).
           1. Let _iterator_ be ObjectCreate(%SetIteratorPrototype%, &laquo; [[IteratedSet]], [[SetNextIndex]], [[SetIterationKind]] &raquo;).
           1. Set _iterator_.[[IteratedSet]] to _set_.
           1. Set _iterator_.[[SetNextIndex]] to 0.
@@ -34760,8 +34745,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
@@ -34781,8 +34765,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *undefined*.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
@@ -34796,8 +34779,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
@@ -34811,8 +34793,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. If Type(_M_) is not Object, throw a *TypeError* exception.
-          1. If _M_ does not have a [[WeakMapData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, throw a *TypeError* exception.
           1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
@@ -34910,8 +34891,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
           1. If Type(_value_) is not Object, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. For each _e_ that is an element of _entries_, do
@@ -34932,8 +34912,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
           1. If Type(_value_) is not Object, return *false*.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. For each _e_ that is an element of _entries_, do
@@ -34952,8 +34931,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. If Type(_S_) is not Object, throw a *TypeError* exception.
-          1. If _S_ does not have a [[WeakSetData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. If Type(_value_) is not Object, return *false*.
           1. For each _e_ that is an element of _entries_, do
@@ -35226,8 +35204,7 @@ THH:mm:ss.sss
         <p>`ArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _length_ be _O_.[[ArrayBufferByteLength]].
@@ -35245,8 +35222,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
@@ -35257,7 +35233,7 @@ THH:mm:ss.sss
           1. Let _newLen_ be max(_final_ - _first_, 0).
           1. Let _ctor_ be ? SpeciesConstructor(_O_, %ArrayBuffer%).
           1. Let _new_ be ? Construct(_ctor_, &laquo; _newLen_ &raquo;).
-          1. If _new_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If SameValue(_new_, _O_) is *true*, throw a *TypeError* exception.
@@ -35384,8 +35360,7 @@ THH:mm:ss.sss
         <p>`SharedArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
           1. Let _length_ be _O_.[[ArrayBufferByteLength]].
           1. Return _length_.
@@ -35402,8 +35377,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
           1. Let _relativeStart_ be ? ToInteger(_start_).
@@ -35413,7 +35387,7 @@ THH:mm:ss.sss
           1. Let _newLen_ be max(_final_ - _first_, 0).
           1. Let _ctor_ be ? SpeciesConstructor(_O_, %SharedArrayBuffer%).
           1. Let _new_ be ? Construct(_ctor_, &laquo; _newLen_ &raquo;).
-          1. If _new_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *false*, throw a *TypeError* exception.
           1. If _new_.[[ArrayBufferData]] and _O_.[[ArrayBufferData]] are the same Shared Data Block values, throw a *TypeError* exception.
           1. If _new_.[[ArrayBufferByteLength]] &lt; _newLen_, throw a *TypeError* exception.
@@ -35451,8 +35425,7 @@ THH:mm:ss.sss
         <h1>GetViewValue ( _view_, _requestIndex_, _isLittleEndian_, _type_ )</h1>
         <p>The abstract operation GetViewValue with arguments _view_, _requestIndex_, _isLittleEndian_, and _type_ is used by functions on DataView instances to retrieve values from the view's buffer. It performs the following steps:</p>
         <emu-alg>
-          1. If Type(_view_) is not Object, throw a *TypeError* exception.
-          1. If _view_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
@@ -35471,8 +35444,7 @@ THH:mm:ss.sss
         <h1>SetViewValue ( _view_, _requestIndex_, _isLittleEndian_, _type_, _value_ )</h1>
         <p>The abstract operation SetViewValue with arguments _view_, _requestIndex_, _isLittleEndian_, _type_, and _value_ is used by functions on DataView instances to store values into the view's buffer. It performs the following steps:</p>
         <emu-alg>
-          1. If Type(_view_) is not Object, throw a *TypeError* exception.
-          1. If _view_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. Let _numberValue_ be ? ToNumber(_value_).
@@ -35505,8 +35477,7 @@ THH:mm:ss.sss
         <p>When the `DataView` function is called with at least one argument _buffer_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If Type(_buffer_) is not Object, throw a *TypeError* exception.
-          1. If _buffer_ does not have an [[ArrayBufferData]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_buffer_, [[ArrayBufferData]]).
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
@@ -35556,8 +35527,7 @@ THH:mm:ss.sss
         <p>`DataView.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Return _buffer_.
@@ -35569,8 +35539,7 @@ THH:mm:ss.sss
         <p>`DataView.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
@@ -35584,8 +35553,7 @@ THH:mm:ss.sss
         <p>`DataView.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _O_ does not have a [[DataView]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
@@ -35795,8 +35763,7 @@ THH:mm:ss.sss
         <p>The abstract operation ValidateSharedIntegerTypedArray takes one argument _typedArray_ and an optional Boolean _onlyInt32_. It performs the following steps:</p>
         <emu-alg>
           1. If _onlyInt32_ is not present, set _onlyInt32_ to *false*.
-          1. If Type(_typedArray_) is not Object, throw a *TypeError* exception.
-          1. If _typedArray_ does not have a [[TypedArrayName]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_typedArray_, [[TypedArrayName]]).
           1. Let _typeName_ be _typedArray_.[[TypedArrayName]].
           1. If _onlyInt32_ is *true*, then
             1. If _typeName_ is not `"Int32Array"`, throw a *TypeError* exception.
@@ -37337,8 +37304,7 @@ THH:mm:ss.sss
         <h1>GeneratorValidate ( _generator_ )</h1>
         <p>The abstract operation GeneratorValidate with argument _generator_ performs the following steps:</p>
         <emu-alg>
-          1. If Type(_generator_) is not Object, throw a *TypeError* exception.
-          1. If _generator_ does not have a [[GeneratorState]] internal slot, throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_generator_, [[GeneratorState]]).
           1. Assert: _generator_ also has a [[GeneratorContext]] internal slot.
           1. Let _state_ be _generator_.[[GeneratorState]].
           1. If _state_ is `"executing"`, throw a *TypeError* exception.


### PR DESCRIPTION
To me, this seems like a nice way to DRY up a common operation - asserting that a value is an Object with a given internal slot.

What are your thoughts on this? Is this too much indirection, or does this reduction in spec lines make it easier to read?

It was a pretty quick change, mostly a single regex operation, so I'm happy to close it if we don't think this is an improvement.