### PR TITLE
Editorial: define and use improved intrinsics notation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1704,7 +1704,7 @@
       <emu-clause id="sec-well-known-intrinsic-objects">
         <h1>Well-Known Intrinsic Objects</h1>
         <p>Well-known intrinsics are built-in objects that are explicitly referenced by the algorithms of this specification and which usually have realm-specific identities. Unless otherwise specified each intrinsic object actually corresponds to a set of similar objects, one per realm.</p>
-        <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-7"></emu-xref>.</p>
+        <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. A reference such as %name.a.b% means, as if the "b" property of the "a" property of the intrinsic object %name% was accessed prior to any ECMAScript code being evaluated. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-7"></emu-xref>.</p>
         <emu-table id="table-7" caption="Well-Known Intrinsic Objects">
           <table>
             <tbody>
@@ -1749,7 +1749,7 @@
                 `ArrayBuffer.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %ArrayBuffer%.
+                The initial value of the `prototype` data property of %ArrayBuffer%; i.e., %ArrayBuffer.prototype%
               </td>
             </tr>
             <tr>
@@ -1759,7 +1759,7 @@
               <td>
               </td>
               <td>
-                The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"></emu-xref>)
+                The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"></emu-xref>); i.e., %ArrayIterator.prototype%
               </td>
             </tr>
             <tr>
@@ -1770,7 +1770,7 @@
                 `Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>)
+                The initial value of the `prototype` data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>); i.e., %Array.prototype%
               </td>
             </tr>
             <tr>
@@ -1781,7 +1781,7 @@
                 `Array.prototype.entries`
               </td>
               <td>
-                The initial value of the `entries` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>)
+                The initial value of the `entries` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>); i.e., %Array.prototype.entries%
               </td>
             </tr>
             <tr>
@@ -1792,7 +1792,7 @@
                 `Array.prototype.forEach`
               </td>
               <td>
-                The initial value of the `forEach` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>)
+                The initial value of the `forEach` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>); i.e., %Array.prototype.forEach%
               </td>
             </tr>
             <tr>
@@ -1803,7 +1803,7 @@
                 `Array.prototype.keys`
               </td>
               <td>
-                The initial value of the `keys` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>)
+                The initial value of the `keys` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>); i.e., %Array.prototype.keys%
               </td>
             </tr>
             <tr>
@@ -1814,7 +1814,7 @@
                 `Array.prototype.values`
               </td>
               <td>
-                The initial value of the `values` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>)
+                The initial value of the `values` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>); i.e., %Array.prototype.values%
               </td>
             </tr>
             <tr>
@@ -1844,7 +1844,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` data property of %AsyncFunction%
+                The initial value of the `prototype` data property of %AsyncFunction%; i.e., %AsyncFunction.prototype%
               </td>
             </tr>
             <tr>
@@ -1854,7 +1854,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` property of %AsyncGeneratorFunction%
+                The initial value of the `prototype` property of %AsyncGeneratorFunction%; i.e., %AsyncGeneratorFunction.prototype%
               </td>
             </tr>
             <tr>
@@ -1874,7 +1874,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` property of %AsyncGenerator%
+                The initial value of the `prototype` property of %AsyncGenerator%; i.e., %AsyncGenerator.prototype%
               </td>
             </tr>
             <tr>
@@ -1917,7 +1917,7 @@
                 `Boolean.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>)
+                The initial value of the `prototype` data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>); i.e., %Boolean.prototype%
               </td>
             </tr>
             <tr>
@@ -1939,7 +1939,7 @@
                 `DataView.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %DataView%
+                The initial value of the `prototype` data property of %DataView%; i.e., %DataView.prototype%
               </td>
             </tr>
             <tr>
@@ -1961,7 +1961,7 @@
                 `Date.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Date%.
+                The initial value of the `prototype` data property of %Date%.; i.e., %Date.prototype%
               </td>
             </tr>
             <tr>
@@ -2027,7 +2027,7 @@
                 `Error.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Error%
+                The initial value of the `prototype` data property of %Error%; i.e., %Error.prototype%
               </td>
             </tr>
             <tr>
@@ -2060,7 +2060,7 @@
                 `EvalError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %EvalError%
+                The initial value of the `prototype` data property of %EvalError%; i.e., %EvalError.prototype%
               </td>
             </tr>
             <tr>
@@ -2082,7 +2082,7 @@
                 `Float32Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Float32Array%
+                The initial value of the `prototype` data property of %Float32Array%; i.e., %Float32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2104,7 +2104,7 @@
                 `Float64Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Float64Array%
+                The initial value of the `prototype` data property of %Float64Array%; i.e., %Float64Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2126,7 +2126,7 @@
                 `Function.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Function%
+                The initial value of the `prototype` data property of %Function%; i.e., %Function.prototype%
               </td>
             </tr>
             <tr>
@@ -2156,7 +2156,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` data property of %Generator%
+                The initial value of the `prototype` data property of %Generator%; i.e., %Generator.prototype%
               </td>
             </tr>
             <tr>
@@ -2178,7 +2178,7 @@
                 `Int8Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Int8Array%
+                The initial value of the `prototype` data property of %Int8Array%; i.e., %Int8Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2200,7 +2200,7 @@
                 `Int16Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Int16Array%
+                The initial value of the `prototype` data property of %Int16Array%; i.e., %Int16Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2222,7 +2222,7 @@
                 `Int32Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Int32Array%
+                The initial value of the `prototype` data property of %Int32Array%; i.e., %Int32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2276,7 +2276,7 @@
                 `JSON.parse`
               </td>
               <td>
-                The initial value of the `parse` data property of %JSON%
+                The initial value of the `parse` data property of %JSON%; i.e., %JSON.parse%
               </td>
             </tr>
             <tr>
@@ -2287,7 +2287,7 @@
                 `JSON.stringify`
               </td>
               <td>
-                The initial value of the `stringify` data property of %JSON%
+                The initial value of the `stringify` data property of %JSON%; i.e., %JSON.stringify%
               </td>
             </tr>
             <tr>
@@ -2319,7 +2319,7 @@
                 `Map.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Map%
+                The initial value of the `prototype` data property of %Map%; i.e., %Map.prototype%
               </td>
             </tr>
             <tr>
@@ -2352,7 +2352,7 @@
                 `Number.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Number%
+                The initial value of the `prototype` data property of %Number%; i.e., %Number.prototype%
               </td>
             </tr>
             <tr>
@@ -2374,7 +2374,7 @@
                 `Object.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>)
+                The initial value of the `prototype` data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>); i.e., %Object.prototype%
               </td>
             </tr>
             <tr>
@@ -2385,7 +2385,7 @@
                 `Object.prototype.toString`
               </td>
               <td>
-                The initial value of the `toString` data property of %ObjectPrototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>)
+                The initial value of the `toString` data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>); i.e., %Object.prototype.toString%
               </td>
             </tr>
             <tr>
@@ -2396,7 +2396,7 @@
                 `Object.prototype.valueOf`
               </td>
               <td>
-                The initial value of the `valueOf` data property of %ObjectPrototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>)
+                The initial value of the `valueOf` data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>); i.e., %Object.prototype.valueOf%
               </td>
             </tr>
             <tr>
@@ -2440,7 +2440,7 @@
                 `Promise.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Promise%
+                The initial value of the `prototype` data property of %Promise%; i.e., %Promise.prototype%
               </td>
             </tr>
             <tr>
@@ -2451,7 +2451,7 @@
                 `Promise.prototype.then`
               </td>
               <td>
-                The initial value of the `then` data property of %PromisePrototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>)
+                The initial value of the `then` data property of %Promise.prototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>); i.e., %Promise.prototype.then%
               </td>
             </tr>
             <tr>
@@ -2462,7 +2462,7 @@
                 `Promise.all`
               </td>
               <td>
-                The initial value of the `all` data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>)
+                The initial value of the `all` data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>); i.e., %Promise.all%
               </td>
             </tr>
             <tr>
@@ -2473,7 +2473,7 @@
                 `Promise.reject`
               </td>
               <td>
-                The initial value of the `reject` data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>)
+                The initial value of the `reject` data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>); i.e., %Promise.reject%
               </td>
             </tr>
             <tr>
@@ -2484,7 +2484,7 @@
                 `Promise.resolve`
               </td>
               <td>
-                The initial value of the `resolve` data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>)
+                The initial value of the `resolve` data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>); i.e., %Promise.resolve%
               </td>
             </tr>
             <tr>
@@ -2517,7 +2517,7 @@
                 `RangeError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %RangeError%
+                The initial value of the `prototype` data property of %RangeError%; i.e., %RangeError.prototype%
               </td>
             </tr>
             <tr>
@@ -2539,7 +2539,7 @@
                 `ReferenceError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %ReferenceError%
+                The initial value of the `prototype` data property of %ReferenceError%; i.e., %ReferenceError.prototype%
               </td>
             </tr>
             <tr>
@@ -2572,7 +2572,7 @@
                 `RegExp.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %RegExp%
+                The initial value of the `prototype` data property of %RegExp%; i.e., %RegExp.prototype%
               </td>
             </tr>
             <tr>
@@ -2614,7 +2614,7 @@
                 `Set.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Set%
+                The initial value of the `prototype` data property of %Set%; i.e., %Set.prototype%
               </td>
             </tr>
             <tr>
@@ -2636,7 +2636,7 @@
                 `SharedArrayBuffer.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %SharedArrayBuffer%
+                The initial value of the `prototype` data property of %SharedArrayBuffer%; i.e., %SharedArrayBuffer.prototype%
               </td>
             </tr>
             <tr>
@@ -2668,7 +2668,7 @@
                 `String.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %String%
+                The initial value of the `prototype` data property of %String%; i.e., %String.prototype%
               </td>
             </tr>
             <tr>
@@ -2690,7 +2690,7 @@
                 `Symbol.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>)
+                The initial value of the `prototype` data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>); i.e., %Symbol.prototype%
               </td>
             </tr>
             <tr>
@@ -2712,7 +2712,7 @@
                 `SyntaxError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %SyntaxError%
+                The initial value of the `prototype` data property of %SyntaxError%; i.e., %SyntaxError.prototype%
               </td>
             </tr>
             <tr>
@@ -2742,7 +2742,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `prototype` data property of %TypedArray%
+                The initial value of the `prototype` data property of %TypedArray%; i.e., %TypedArray.prototype%
               </td>
             </tr>
             <tr>
@@ -2764,7 +2764,7 @@
                 `TypeError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %TypeError%
+                The initial value of the `prototype` data property of %TypeError%; i.e., %TypeError.prototype%
               </td>
             </tr>
             <tr>
@@ -2786,7 +2786,7 @@
                 `Uint8Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Uint8Array%
+                The initial value of the `prototype` data property of %Uint8Array%; i.e., %Uint8Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2808,7 +2808,7 @@
                 `Uint8ClampedArray.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Uint8ClampedArray%
+                The initial value of the `prototype` data property of %Uint8ClampedArray%; i.e., %Uint8ClampedArray.prototype%
               </td>
             </tr>
             <tr>
@@ -2830,7 +2830,7 @@
                 `Uint16Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Uint16Array%
+                The initial value of the `prototype` data property of %Uint16Array%; i.e., %Uint16Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2852,7 +2852,7 @@
                 `Uint32Array.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %Uint32Array%
+                The initial value of the `prototype` data property of %Uint32Array%; i.e., %Uint32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2874,7 +2874,7 @@
                 `URIError.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %URIError%
+                The initial value of the `prototype` data property of %URIError%; i.e., %URIError.prototype%
               </td>
             </tr>
             <tr>
@@ -2896,7 +2896,7 @@
                 `WeakMap.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %WeakMap%
+                The initial value of the `prototype` data property of %WeakMap%; i.e., %WeakMap.prototype%
               </td>
             </tr>
             <tr>
@@ -2918,7 +2918,7 @@
                 `WeakSet.prototype`
               </td>
               <td>
-                The initial value of the `prototype` data property of %WeakSet%
+                The initial value of the `prototype` data property of %WeakSet%; i.e., %WeakSet.prototype%
               </td>
             </tr>
             </tbody>
@@ -3332,7 +3332,7 @@
         <p>When the abstract operation FromPropertyDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *undefined*.
-          1. Let _obj_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _obj_ be ObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. If _Desc_ has a [[Value]] field, then
             1. Perform CreateDataProperty(_obj_, `"value"`, _Desc_.[[Value]]).
@@ -5016,7 +5016,7 @@
       <p>The abstract operation CreateIterResultObject with arguments _value_ and _done_ creates an object that supports the IteratorResult interface by performing the following steps:</p>
       <emu-alg>
         1. Assert: Type(_done_) is Boolean.
-        1. Let _obj_ be ObjectCreate(%ObjectPrototype%).
+        1. Let _obj_ be ObjectCreate(%Object.prototype%).
         1. Perform CreateDataProperty(_obj_, `"value"`, _value_).
         1. Perform CreateDataProperty(_obj_, `"done"`, _done_).
         1. Return _obj_.
@@ -6249,13 +6249,13 @@
         1. Let _intrinsics_ be a new Record.
         1. Set _realmRec_.[[Intrinsics]] to _intrinsics_.
         1. Let _objProto_ be ObjectCreate(*null*).
-        1. Set _intrinsics_.[[%ObjectPrototype%]] to _objProto_.
+        1. Set _intrinsics_.[[%Object.prototype%]] to _objProto_.
         1. Let _throwerSteps_ be the algorithm steps specified in <emu-xref href="#sec-%throwtypeerror%"></emu-xref> for the %ThrowTypeError% function.
         1. Let _thrower_ be ! CreateBuiltinFunction(_throwerSteps_, &laquo; &raquo;, _realmRec_, *null*).
         1. Set _intrinsics_.[[%ThrowTypeError%]] to _thrower_.
         1. Let _noSteps_ be an empty sequence of algorithm steps.
         1. Let _funcProto_ be ! CreateBuiltinFunction(_noSteps_, &laquo; &raquo;, _realmRec_, _objProto_).
-        1. Set _intrinsics_.[[%FunctionPrototype%]] to _funcProto_.
+        1. Set _intrinsics_.[[%Function.prototype%]] to _funcProto_.
         1. Call _thrower_.[[SetPrototypeOf]](_funcProto_).
         1. Perform AddRestrictedFunctionProperties(_funcProto_, _realmRec_).
         1. Set fields of _intrinsics_ with the values listed in <emu-xref href="#table-7"></emu-xref> that have not already been handled above. The field names are the names listed in column one of the table. The value of each field is a new object value fully and recursively populated with property values as defined by the specification of each object in clauses 18-26. All object property values are newly created object values. All values that are built-in function objects are created by performing CreateBuiltinFunction(&lt;steps&gt;, &lt;slots&gt;, _realmRec_, &lt;prototype&gt;) where &lt;steps&gt; is the definition of that function provided by this specification, &lt;slots&gt; is a list of the names, if any, of the function's specified internal slots, and &lt;prototype&gt; is the specified value of the function's [[Prototype]] internal slot. The creation of the intrinsics and their properties must be ordered to avoid any dependencies upon objects that have not yet been created.
@@ -6269,7 +6269,7 @@
       <emu-alg>
         1. If _globalObj_ is *undefined*, then
           1. Let _intrinsics_ be _realmRec_.[[Intrinsics]].
-          1. Set _globalObj_ to ObjectCreate(_intrinsics_.[[%ObjectPrototype%]]).
+          1. Set _globalObj_ to ObjectCreate(_intrinsics_.[[%Object.prototype%]]).
         1. Assert: Type(_globalObj_) is Object.
         1. If _thisValue_ is *undefined*, set _thisValue_ to _globalObj_.
         1. Set _realmRec_.[[GlobalObject]] to _globalObj_.
@@ -7436,7 +7436,7 @@
         1. Let _callerContext_ be the running execution context.
         1. Let _kind_ be _F_.[[ConstructorKind]].
         1. If _kind_ is `"base"`, then
-          1. Let _thisArgument_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%ObjectPrototype%"`).
+          1. Let _thisArgument_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Object.prototype%"`).
         1. Let _calleeContext_ be PrepareForOrdinaryCall(_F_, _newTarget_).
         1. Assert: _calleeContext_ is now the running execution context.
         1. If _kind_ is `"base"`, perform OrdinaryCallBindThis(_F_, _calleeContext_, _thisArgument_).
@@ -7500,7 +7500,7 @@
       <p>The abstract operation FunctionCreate requires the arguments: _kind_ which is one of (Normal, Method, Arrow), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, and optionally, an object _prototype_. FunctionCreate performs the following steps:</p>
       <emu-alg>
         1. If _prototype_ is not present, then
-          1. Set _prototype_ to the intrinsic object %FunctionPrototype%.
+          1. Set _prototype_ to %Function.prototype%.
         1. If _kind_ is not ~Normal~, let _allocKind_ be `"non-constructor"`.
         1. Else, let _allocKind_ be `"normal"`.
         1. Let _F_ be FunctionAllocate(_prototype_, _allocKind_).
@@ -7512,7 +7512,7 @@
       <h1>GeneratorFunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_ )</h1>
       <p>The abstract operation GeneratorFunctionCreate requires the arguments: _kind_ which is one of (Normal, Method), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. GeneratorFunctionCreate performs the following steps:</p>
       <emu-alg>
-        1. Let _functionPrototype_ be the intrinsic object %Generator%.
+        1. Let _functionPrototype_ be %Generator%.
         1. Let _F_ be FunctionAllocate(_functionPrototype_, `"generator"`).
         1. Return FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
@@ -7522,7 +7522,7 @@
       <h1>AsyncGeneratorFunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_ )</h1>
       <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. AsyncGeneratorFunctionCreate performs the following steps:</p>
       <emu-alg>
-        1. Let _functionPrototype_ be the intrinsic object %AsyncGenerator%.
+        1. Let _functionPrototype_ be %AsyncGenerator%.
         1. Let _F_ be ! FunctionAllocate(_functionPrototype_, `"generator"`).
         1. Return ! FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
@@ -7532,7 +7532,7 @@
       <h1>AsyncFunctionCreate ( _kind_, _parameters_, _body_, _Scope_ )</h1>
       <p>The abstract operation AsyncFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~, ~Arrow~), a parameter list Parse Node specified by _parameters_, a body Parse Node specified by _body_, a Lexical Environment specified by _Scope_. AsyncFunctionCreate performs the following steps:</p>
       <emu-alg>
-        1. Let _functionPrototype_ be the intrinsic object %AsyncFunctionPrototype%.
+        1. Let _functionPrototype_ be %AsyncFunction.prototype%.
         2. Let _F_ be ! FunctionAllocate(_functionPrototype_, `"async"`).
         3. Return ! FunctionInitialize(_F_, _kind_, _parameters_, _body_, _Scope_).
       </emu-alg>
@@ -7568,7 +7568,7 @@
         1. Assert: _F_ is an extensible object that does not have a `prototype` own property.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then
-          1. Set _prototype_ to ObjectCreate(%ObjectPrototype%).
+          1. Set _prototype_ to ObjectCreate(%Object.prototype%).
           1. Perform ! DefinePropertyOrThrow(_prototype_, `"constructor"`, PropertyDescriptor { [[Value]]: _F_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Perform ! DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return NormalCompletion(*undefined*).
@@ -7754,7 +7754,7 @@
     <h1>Built-in Function Objects</h1>
     <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided function exotic objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
     <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such function exotic objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
-    <p>Unless otherwise specified every built-in function object has the %FunctionPrototype% object as the initial value of its [[Prototype]] internal slot.</p>
+    <p>Unless otherwise specified every built-in function object has the %Function.prototype% object as the initial value of its [[Prototype]] internal slot.</p>
     <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value `"classConstructor"`.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
     <p>Built-in functions that are not constructors do not have a `prototype` property unless otherwise specified in the description of a particular function.</p>
@@ -7797,7 +7797,7 @@
         1. Assert: _steps_ is either a set of algorithm steps or other definition of a function's behaviour provided in this specification.
         1. If _realm_ is not present, set _realm_ to the current Realm Record.
         1. Assert: _realm_ is a Realm Record.
-        1. If _prototype_ is not present, set _prototype_ to _realm_.[[Intrinsics]].[[%FunctionPrototype%]].
+        1. If _prototype_ is not present, set _prototype_ to _realm_.[[Intrinsics]].[[%Function.prototype%]].
         1. Let _func_ be a new built-in function object that when called performs the action described by _steps_. The new function object has internal slots whose names are the elements of _internalSlotsList_.
         1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[Prototype]] to _prototype_.
@@ -7954,7 +7954,7 @@
           1. Assert: _length_ is an integer Number &ge; 0.
           1. If _length_ is *-0*, set _length_ to *+0*.
           1. If _length_ &gt; 2<sup>32</sup> - 1, throw a *RangeError* exception.
-          1. If _proto_ is not present, set _proto_ to the intrinsic object %ArrayPrototype%.
+          1. If _proto_ is not present, set _proto_ to %Array.prototype%.
           1. Let _A_ be a newly created Array exotic object.
           1. Set _A_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
@@ -8234,7 +8234,7 @@
         <p>The abstract operation CreateUnmappedArgumentsObject called with an argument _argumentsList_ performs the following steps:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _argumentsList_.
-          1. Let _obj_ be ObjectCreate(%ObjectPrototype%, &laquo; [[ParameterMap]] &raquo;).
+          1. Let _obj_ be ObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
           1. Set _obj_.[[ParameterMap]] to *undefined*.
           1. Perform DefinePropertyOrThrow(_obj_, `"length"`, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _index_ be 0.
@@ -8242,7 +8242,7 @@
             1. Let _val_ be _argumentsList_[_index_].
             1. Perform CreateDataProperty(_obj_, ! ToString(_index_), _val_).
             1. Set _index_ to _index_ + 1.
-          1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %ArrayProto_values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, `"callee"`, PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _obj_.
         </emu-alg>
@@ -8261,7 +8261,7 @@
           1. Set _obj_.[[Get]] as specified in <emu-xref href="#sec-arguments-exotic-objects-get-p-receiver"></emu-xref>.
           1. Set _obj_.[[Set]] as specified in <emu-xref href="#sec-arguments-exotic-objects-set-p-v-receiver"></emu-xref>.
           1. Set _obj_.[[Delete]] as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
-          1. Set _obj_.[[Prototype]] to %ObjectPrototype%.
+          1. Set _obj_.[[Prototype]] to %Object.prototype%.
           1. Set _obj_.[[Extensible]] to *true*.
           1. Let _map_ be ObjectCreate(*null*).
           1. Set _obj_.[[ParameterMap]] to _map_.
@@ -8284,7 +8284,7 @@
                 1. Let _p_ be MakeArgSetter(_name_, _env_).
                 1. Perform _map_.[[DefineOwnProperty]](! ToString(_index_), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
             1. Set _index_ to _index_ - 1.
-          1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %ArrayProto_values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, `"callee"`, PropertyDescriptor { [[Value]]: _func_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Return _obj_.
         </emu-alg>
@@ -11836,7 +11836,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ObjectLiteral : `{` `}`</emu-grammar>
         <emu-alg>
-          1. Return ObjectCreate(%ObjectPrototype%).
+          1. Return ObjectCreate(%Object.prototype%).
         </emu-alg>
         <emu-grammar>
           ObjectLiteral :
@@ -11844,7 +11844,7 @@
             `{` PropertyDefinitionList `,` `}`
         </emu-grammar>
         <emu-alg>
-          1. Let _obj_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _obj_ be ObjectCreate(%Object.prototype%).
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_ and *true*.
           1. Return _obj_.
         </emu-alg>
@@ -14435,7 +14435,7 @@
         <emu-alg>
           1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
           1. ReturnIfAbrupt(_lref_).
-          1. Let _restObj_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _restObj_ be ObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
           1. Return PutValue(_lref_, _restObj_).
         </emu-alg>
@@ -15700,7 +15700,7 @@
         <emu-grammar>BindingRestProperty : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
-          1. Let _restObj_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _restObj_ be ObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
           1. If _environment_ is *undefined*, return PutValue(_lhs_, _restObj_).
           1. Return InitializeReferencedBinding(_lhs_, _restObj_).
@@ -18981,7 +18981,7 @@
           1. Let _prototype_ be _functionPrototype_.
         1. Else,
           1. Let _kind_ be ~Method~.
-          1. Let _prototype_ be the intrinsic object %FunctionPrototype%.
+          1. Let _prototype_ be %Function.prototype%.
         1. Let _closure_ be FunctionCreate(_kind_, |UniqueFormalParameters|, |FunctionBody|, _scope_, _prototype_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Set _closure_.[[SourceText]] to the source text matched by |MethodDefinition|.
@@ -19914,8 +19914,8 @@
         1. If _classBinding_ is not *undefined*, then
           1. Perform _classScopeEnvRec_.CreateImmutableBinding(_classBinding_, *true*).
         1. If |ClassHeritage_opt| is not present, then
-          1. Let _protoParent_ be the intrinsic object %ObjectPrototype%.
-          1. Let _constructorParent_ be the intrinsic object %FunctionPrototype%.
+          1. Let _protoParent_ be %Object.prototype%.
+          1. Let _constructorParent_ be %Function.prototype%.
         1. Else,
           1. Set the running execution context's LexicalEnvironment to _classScope_.
           1. Let _superclassRef_ be the result of evaluating |ClassHeritage|.
@@ -19923,7 +19923,7 @@
           1. Let _superclass_ be ? GetValue(_superclassRef_).
           1. If _superclass_ is *null*, then
             1. Let _protoParent_ be *null*.
-            1. Let _constructorParent_ be the intrinsic object %FunctionPrototype%.
+            1. Let _constructorParent_ be %Function.prototype%.
           1. Else if IsConstructor(_superclass_) is *false*, throw a *TypeError* exception.
           1. Else,
             1. Let _protoParent_ be ? Get(_superclass_, `"prototype"`).
@@ -24333,8 +24333,8 @@
         <p>When the `Object` function is called with optional argument _value_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is neither *undefined* nor the active function, then
-            1. Return ? OrdinaryCreateFromConstructor(NewTarget, `"%ObjectPrototype%"`).
-          1. If _value_ is *null*, *undefined* or not supplied, return ObjectCreate(%ObjectPrototype%).
+            1. Return ? OrdinaryCreateFromConstructor(NewTarget, `"%Object.prototype%"`).
+          1. If _value_ is *null*, *undefined* or not supplied, return ObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
         <p>The `"length"` property of the `Object` constructor function is 1.</p>
@@ -24345,7 +24345,7 @@
       <h1>Properties of the Object Constructor</h1>
       <p>The Object constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has a `"length"` property.</li>
         <li>has the following additional properties:</li>
       </ul>
@@ -24451,7 +24451,7 @@
         <p>When the `fromEntries` method is called with argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_iterable_).
-          1. Let _obj_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _obj_ be ObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. Let _stepsDefine_ be the algorithm steps defined in <emu-xref href="#sec-create-data-property-on-object-functions" title></emu-xref>.
           1. Let _adder_ be ! CreateBuiltinFunction(_stepsDefine_, &laquo; &raquo;).
@@ -24492,7 +24492,7 @@
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _ownKeys_ be ? _obj_.[[OwnPropertyKeys]]().
-          1. Let _descriptors_ be ! ObjectCreate(%ObjectPrototype%).
+          1. Let _descriptors_ be ! ObjectCreate(%Object.prototype%).
           1. For each element _key_ of _ownKeys_ in List order, do
             1. Let _desc_ be ? _obj_.[[GetOwnProperty]](_key_).
             1. Let _descriptor_ be ! FromPropertyDescriptor(_desc_).
@@ -24598,7 +24598,7 @@
 
       <emu-clause id="sec-object.prototype">
         <h1>Object.prototype</h1>
-        <p>The initial value of `Object.prototype` is the intrinsic object %ObjectPrototype%.</p>
+        <p>The initial value of `Object.prototype` is %Object.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -24641,14 +24641,14 @@
       <h1>Properties of the Object Prototype Object</h1>
       <p>The Object prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%ObjectPrototype%</dfn>.</li>
+        <li>is the intrinsic object <dfn>%Object.prototype%</dfn>.</li>
         <li>is an immutable prototype exotic object.</li>
         <li>has a [[Prototype]] internal slot whose value is *null*.</li>
       </ul>
 
       <emu-clause id="sec-object.prototype.constructor">
         <h1>Object.prototype.constructor</h1>
-        <p>The initial value of `Object.prototype.constructor` is the intrinsic object %Object%.</p>
+        <p>The initial value of `Object.prototype.constructor` is %Object%.</p>
       </emu-clause>
 
       <emu-clause id="sec-object.prototype.hasownproperty">
@@ -24802,7 +24802,7 @@
             1. If _kind_ is `"normal"`, then
               1. Let _goal_ be the grammar symbol |FunctionBody[~Yield, ~Await]|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, ~Await]|.
-              1. Let _fallbackProto_ be `"%FunctionPrototype%"`.
+              1. Let _fallbackProto_ be `"%Function.prototype%"`.
             1. Else if _kind_ is `"generator"`, then
               1. Let _goal_ be the grammar symbol |GeneratorBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, ~Await]|.
@@ -24810,7 +24810,7 @@
             1. Else if _kind_ is `"async"`, then
               1. Let _goal_ be the grammar symbol |AsyncFunctionBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, +Await]|.
-              1. Let _fallbackProto_ be `"%AsyncFunctionPrototype%"`.
+              1. Let _fallbackProto_ be `"%AsyncFunction.prototype%"`.
             1. Else,
               1. Assert: _kind_ is `"async generator"`.
               1. Let _goal_ be the grammar symbol |AsyncGeneratorBody|.
@@ -24892,7 +24892,7 @@
       <p>The Function constructor:</p>
       <ul>
         <li>is itself a built-in function object.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -24903,7 +24903,7 @@
 
       <emu-clause id="sec-function.prototype">
         <h1>Function.prototype</h1>
-        <p>The value of `Function.prototype` is %FunctionPrototype%, the intrinsic Function prototype object.</p>
+        <p>The value of `Function.prototype` is %Function.prototype%, the intrinsic Function prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -24912,11 +24912,11 @@
       <h1>Properties of the Function Prototype Object</h1>
       <p>The Function prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%FunctionPrototype%</dfn>.</li>
+        <li>is <dfn>%Function.prototype%</dfn>.</li>
         <li>is itself a built-in function object.</li>
         <li>accepts any arguments and returns *undefined* when invoked.</li>
         <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>does not have a `prototype` property.</li>
         <li>has a `"length"` property whose value is 0.</li>
         <li>has a `name` property whose value is the empty String.</li>
@@ -24997,7 +24997,7 @@
 
       <emu-clause id="sec-function.prototype.constructor">
         <h1>Function.prototype.constructor</h1>
-        <p>The initial value of `Function.prototype.constructor` is the intrinsic object %Function%.</p>
+        <p>The initial value of `Function.prototype.constructor` is %Function%.</p>
       </emu-clause>
 
       <emu-clause id="sec-function.prototype.tostring">
@@ -25054,7 +25054,7 @@
       <emu-clause id="sec-function-instances-name">
         <h1>name</h1>
         <p>The value of the `name` property is a String that is descriptive of the function. The name has no semantic significance but is typically a variable or property name that is used to refer to the function at its point of definition in ECMAScript code. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-        <p>Anonymous functions objects that do not have a contextual name associated with them by this specification do not have a `name` own property but inherit the `name` property of %FunctionPrototype%.</p>
+        <p>Anonymous functions objects that do not have a contextual name associated with them by this specification do not have a `name` own property but inherit the `name` property of %Function.prototype%.</p>
       </emu-clause>
 
       <emu-clause id="sec-function-instances-prototype">
@@ -25094,7 +25094,7 @@
         <emu-alg>
           1. Let _b_ be ! ToBoolean(_value_).
           1. If NewTarget is *undefined*, return _b_.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%BooleanPrototype%"`, &laquo; [[BooleanData]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Boolean.prototype%"`, &laquo; [[BooleanData]] &raquo;).
           1. Set _O_.[[BooleanData]] to _b_.
           1. Return _O_.
         </emu-alg>
@@ -25105,13 +25105,13 @@
       <h1>Properties of the Boolean Constructor</h1>
       <p>The Boolean constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-boolean.prototype">
         <h1>Boolean.prototype</h1>
-        <p>The initial value of `Boolean.prototype` is the intrinsic object %BooleanPrototype%.</p>
+        <p>The initial value of `Boolean.prototype` is %Boolean.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -25123,7 +25123,7 @@
         <li>is the intrinsic object <dfn>%BooleanPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
 
       <p>The abstract operation <dfn id="sec-thisbooleanvalue" aoid="thisBooleanValue">thisBooleanValue</dfn>(_value_) performs the following steps:</p>
@@ -25138,7 +25138,7 @@
 
       <emu-clause id="sec-boolean.prototype.constructor">
         <h1>Boolean.prototype.constructor</h1>
-        <p>The initial value of `Boolean.prototype.constructor` is the intrinsic object %Boolean%.</p>
+        <p>The initial value of `Boolean.prototype.constructor` is %Boolean%.</p>
       </emu-clause>
 
       <emu-clause id="sec-boolean.prototype.tostring">
@@ -25196,7 +25196,7 @@
       <h1>Properties of the Symbol Constructor</h1>
       <p>The Symbol constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -25304,7 +25304,7 @@
 
       <emu-clause id="sec-symbol.prototype">
         <h1>Symbol.prototype</h1>
-        <p>The initial value of `Symbol.prototype` is the intrinsic object %SymbolPrototype%.</p>
+        <p>The initial value of `Symbol.prototype` is %Symbol.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -25358,7 +25358,7 @@
         <li>is the intrinsic object <dfn>%SymbolPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a Symbol instance and does not have a [[SymbolData]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
 
       <p>The abstract operation <dfn id="sec-thissymbolvalue" aoid="thisSymbolValue">thisSymbolValue</dfn>(_value_) performs the following steps:</p>
@@ -25373,7 +25373,7 @@
 
       <emu-clause id="sec-symbol.prototype.constructor">
         <h1>Symbol.prototype.constructor</h1>
-        <p>The initial value of `Symbol.prototype.constructor` is the intrinsic object %Symbol%.</p>
+        <p>The initial value of `Symbol.prototype.constructor` is %Symbol%.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.prototype.description">
@@ -25458,7 +25458,7 @@
         <p>When the `Error` function is called with argument _message_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%ErrorPrototype%"`, &laquo; [[ErrorData]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Error.prototype%"`, &laquo; [[ErrorData]] &raquo;).
           1. If _message_ is not *undefined*, then
             1. Let _msg_ be ? ToString(_message_).
             1. Let _msgDesc_ be the PropertyDescriptor { [[Value]]: _msg_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
@@ -25472,13 +25472,13 @@
       <h1>Properties of the Error Constructor</h1>
       <p>The Error constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-error.prototype">
         <h1>Error.prototype</h1>
-        <p>The initial value of `Error.prototype` is the intrinsic object %ErrorPrototype%.</p>
+        <p>The initial value of `Error.prototype` is %Error.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -25490,12 +25490,12 @@
         <li>is the intrinsic object <dfn>%ErrorPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
 
       <emu-clause id="sec-error.prototype.constructor">
         <h1>Error.prototype.constructor</h1>
-        <p>The initial value of `Error.prototype.constructor` is the intrinsic object %Error%.</p>
+        <p>The initial value of `Error.prototype.constructor` is %Error%.</p>
       </emu-clause>
 
       <emu-clause id="sec-error.prototype.message">
@@ -25583,14 +25583,14 @@
           <p>When a _NativeError_ function is called with argument _message_, the following steps are taken:</p>
           <emu-alg>
             1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>Prototype%"</code>, &laquo; [[ErrorData]] &raquo;).
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%NativeErrorPrototype%"</code>, &laquo; [[ErrorData]] &raquo;).
             1. If _message_ is not *undefined*, then
               1. Let _msg_ be ? ToString(_message_).
               1. Let _msgDesc_ be the PropertyDescriptor { [[Value]]: _msg_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
               1. Perform ! DefinePropertyOrThrow(_O_, `"message"`, _msgDesc_).
             1. Return _O_.
           </emu-alg>
-          <p>The actual value of the string passed in step 2 is either `"%EvalErrorPrototype%"`, `"%RangeErrorPrototype%"`, `"%ReferenceErrorPrototype%"`, `"%SyntaxErrorPrototype%"`, `"%TypeErrorPrototype%"`, or `"%URIErrorPrototype%"` corresponding to which _NativeError_ constructor is being defined.</p>
+          <p>The actual value of the string passed in step 2 is either `"%EvalError.prototype%"`, `"%RangeError.prototype%"`, `"%ReferenceError.prototype%"`, `"%SyntaxError.prototype%"`, `"%TypeError.prototype%"`, or `"%URIError.prototype%"` corresponding to which _NativeError_ constructor is being defined.</p>
         </emu-clause>
       </emu-clause>
 
@@ -25598,7 +25598,7 @@
         <h1>Properties of the _NativeError_ Constructors</h1>
         <p>Each _NativeError_ constructor:</p>
         <ul>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Error%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %Error%.</li>
           <li>has a `name` property whose value is the String value `"<var>NativeError</var>"`.</li>
           <li>has the following properties:</li>
         </ul>
@@ -25616,7 +25616,7 @@
         <ul>
           <li>is an ordinary object.</li>
           <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ErrorPrototype%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %Error.prototype%.</li>
         </ul>
 
         <emu-clause id="sec-nativeerror.prototype.constructor">
@@ -25667,7 +25667,7 @@
           1. If no arguments were passed to this function invocation, let _n_ be *+0*.
           1. Else, let _n_ be ? ToNumber(_value_).
           1. If NewTarget is *undefined*, return _n_.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%NumberPrototype%"`, &laquo; [[NumberData]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Number.prototype%"`, &laquo; [[NumberData]] &raquo;).
           1. Set _O_.[[NumberData]] to _n_.
           1. Return _O_.
         </emu-alg>
@@ -25678,7 +25678,7 @@
       <h1>Properties of the Number Constructor</h1>
       <p>The Number constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -25790,7 +25790,7 @@
 
       <emu-clause id="sec-number.prototype">
         <h1>Number.prototype</h1>
-        <p>The initial value of `Number.prototype` is the intrinsic object %NumberPrototype%.</p>
+        <p>The initial value of `Number.prototype` is %Number.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -25802,7 +25802,7 @@
         <li>is the intrinsic object <dfn>%NumberPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
       <p>The abstract operation <dfn id="sec-thisnumbervalue" aoid="thisNumberValue">thisNumberValue</dfn>(_value_) performs the following steps:</p>
@@ -25818,7 +25818,7 @@
 
       <emu-clause id="sec-number.prototype.constructor">
         <h1>Number.prototype.constructor</h1>
-        <p>The initial value of `Number.prototype.constructor` is the intrinsic object %Number%.</p>
+        <p>The initial value of `Number.prototype.constructor` is %Number%.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.prototype.toexponential">
@@ -25998,7 +25998,7 @@
       <li>is the intrinsic object <dfn>%Math%</dfn>.</li>
       <li>is the initial value of the `Math` property of the global object.</li>
       <li>is an ordinary object.</li>
-      <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>is not a function object.</li>
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
       <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
@@ -27284,7 +27284,7 @@ THH:mm:ss.sss
               1. Let _yi_ be ! ToInteger(_y_).
               1. If 0 &le; _yi_ &le; 99, let _yr_ be 1900 + _yi_; otherwise, let _yr_ be _y_.
             1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DatePrototype%"`, &laquo; [[DateValue]] &raquo;).
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Date.prototype%"`, &laquo; [[DateValue]] &raquo;).
             1. Set _O_.[[DateValue]] to TimeClip(UTC(_finalDate_)).
             1. Return _O_.
         </emu-alg>
@@ -27310,7 +27310,7 @@ THH:mm:ss.sss
                 1. Let _tv_ be the result of parsing _v_ as a date, in exactly the same manner as for the `parse` method (<emu-xref href="#sec-date.parse"></emu-xref>).
               1. Else,
                 1. Let _tv_ be ? ToNumber(_v_).
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DatePrototype%"`, &laquo; [[DateValue]] &raquo;).
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Date.prototype%"`, &laquo; [[DateValue]] &raquo;).
             1. Set _O_.[[DateValue]] to TimeClip(_tv_).
             1. Return _O_.
         </emu-alg>
@@ -27327,7 +27327,7 @@ THH:mm:ss.sss
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
             1. Return ToDateString(_now_).
           1. Else,
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DatePrototype%"`, &laquo; [[DateValue]] &raquo;).
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Date.prototype%"`, &laquo; [[DateValue]] &raquo;).
             1. Set _O_.[[DateValue]] to the time value (UTC) identifying the current time.
             1. Return _O_.
         </emu-alg>
@@ -27338,7 +27338,7 @@ THH:mm:ss.sss
       <h1>Properties of the Date Constructor</h1>
       <p>The Date constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -27367,7 +27367,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype">
         <h1>Date.prototype</h1>
-        <p>The initial value of `Date.prototype` is the intrinsic object %DatePrototype%.</p>
+        <p>The initial value of `Date.prototype` is %Date.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -27402,7 +27402,7 @@ THH:mm:ss.sss
         <li>is the intrinsic object <dfn>%DatePrototype%</dfn>.</li>
         <li>is itself an ordinary object.</li>
         <li>is not a Date instance and does not have a [[DateValue]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly defined otherwise, the methods of the Date prototype object defined below are not generic and the *this* value passed to them must be an object that has a [[DateValue]] internal slot that has been initialized to a time value.</p>
       <p>The abstract operation <dfn id="sec-thistimevalue" aoid="thisTimeValue">thisTimeValue</dfn>(_value_) performs the following steps:</p>
@@ -27415,7 +27415,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.constructor">
         <h1>Date.prototype.constructor</h1>
-        <p>The initial value of `Date.prototype.constructor` is the intrinsic object %Date%.</p>
+        <p>The initial value of `Date.prototype.constructor` is %Date%.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.getdate">
@@ -28255,7 +28255,7 @@ THH:mm:ss.sss
             1. If NewTarget is *undefined* and Type(_value_) is Symbol, return SymbolDescriptiveString(_value_).
             1. Let _s_ be ? ToString(_value_).
           1. If NewTarget is *undefined*, return _s_.
-          1. Return ! StringCreate(_s_, ? GetPrototypeFromConstructor(NewTarget, `"%StringPrototype%"`)).
+          1. Return ! StringCreate(_s_, ? GetPrototypeFromConstructor(NewTarget, `"%String.prototype%"`)).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -28264,7 +28264,7 @@ THH:mm:ss.sss
       <h1>Properties of the String Constructor</h1>
       <p>The String constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -28308,7 +28308,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype">
         <h1>String.prototype</h1>
-        <p>The initial value of `String.prototype` is the intrinsic object %StringPrototype%.</p>
+        <p>The initial value of `String.prototype` is %String.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -28350,7 +28350,7 @@ THH:mm:ss.sss
         <li>is a String exotic object and has the internal methods specified for such objects.</li>
         <li>has a [[StringData]] internal slot whose value is the empty String.</li>
         <li>has a `"length"` property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
       <p>The abstract operation <dfn id="sec-thisstringvalue" aoid="thisStringValue">thisStringValue</dfn>(_value_) performs the following steps:</p>
@@ -28447,7 +28447,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.constructor">
         <h1>String.prototype.constructor</h1>
-        <p>The initial value of `String.prototype.constructor` is the intrinsic object %String%.</p>
+        <p>The initial value of `String.prototype.constructor` is %String%.</p>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.endswith">
@@ -29198,7 +29198,7 @@ THH:mm:ss.sss
         <ul>
           <li>has properties that are inherited by all String Iterator Objects.</li>
           <li>is an ordinary object.</li>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
           <li>has the following properties:</li>
         </ul>
 
@@ -30918,7 +30918,7 @@ THH:mm:ss.sss
           <h1>Runtime Semantics: RegExpAlloc ( _newTarget_ )</h1>
           <p>When the abstract operation RegExpAlloc with argument _newTarget_ is called, the following steps are taken:</p>
           <emu-alg>
-            1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%RegExpPrototype%"`, &laquo; [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] &raquo;).
+            1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%RegExp.prototype%"`, &laquo; [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] &raquo;).
             1. Perform ! DefinePropertyOrThrow(_obj_, `"lastIndex"`, PropertyDescriptor { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Return _obj_.
           </emu-alg>
@@ -30973,13 +30973,13 @@ THH:mm:ss.sss
       <h1>Properties of the RegExp Constructor</h1>
       <p>The RegExp constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-regexp.prototype">
         <h1>RegExp.prototype</h1>
-        <p>The initial value of `RegExp.prototype` is the intrinsic object %RegExpPrototype%.</p>
+        <p>The initial value of `RegExp.prototype` is %RegExp.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -31003,7 +31003,7 @@ THH:mm:ss.sss
         <li>is the intrinsic object <dfn>%RegExpPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a RegExp instance and does not have a [[RegExpMatcher]] internal slot or any of the other internal slots of RegExp instance objects.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <emu-note>
         <p>The RegExp prototype object does not have a `valueOf` property of its own; however, it inherits the `valueOf` property from the Object prototype object.</p>
@@ -31011,7 +31011,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp.prototype.constructor">
         <h1>RegExp.prototype.constructor</h1>
-        <p>The initial value of `RegExp.prototype.constructor` is the intrinsic object %RegExp%.</p>
+        <p>The initial value of `RegExp.prototype.constructor` is %RegExp%.</p>
       </emu-clause>
 
       <emu-clause id="sec-regexp.prototype.exec">
@@ -31133,7 +31133,7 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
-            1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
+            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit 0x0073 (LATIN SMALL LETTER S), return *true*.
@@ -31171,7 +31171,7 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
-            1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
+            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit 0x0067 (LATIN SMALL LETTER G), return *true*.
@@ -31186,7 +31186,7 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
-            1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
+            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit 0x0069 (LATIN SMALL LETTER I), return *true*.
@@ -31278,7 +31278,7 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
-            1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
+            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit 0x006D (LATIN SMALL LETTER M), return *true*.
@@ -31383,7 +31383,7 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalSource]] internal slot, then
-            1. If SameValue(_R_, %RegExpPrototype%) is *true*, return `"(?:)"`.
+            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return `"(?:)"`.
             1. Otherwise, throw a *TypeError* exception.
           1. Assert: _R_ has an [[OriginalFlags]] internal slot.
           1. Let _src_ be _R_.[[OriginalSource]].
@@ -31469,7 +31469,7 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
-            1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
+            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit 0x0079 (LATIN SMALL LETTER Y), return *true*.
@@ -31511,7 +31511,7 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalFlags]] internal slot, then
-            1. If SameValue(_R_, %RegExpPrototype%) is *true*, return *undefined*.
+            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *undefined*.
             1. Otherwise, throw a *TypeError* exception.
           1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains the code unit 0x0075 (LATIN SMALL LETTER U), return *true*.
@@ -31650,7 +31650,7 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ = 0.
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%ArrayPrototype%"`).
+          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%Array.prototype%"`).
           1. Return ! ArrayCreate(0, _proto_).
         </emu-alg>
       </emu-clause>
@@ -31662,7 +31662,7 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ = 1.
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%ArrayPrototype%"`).
+          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%Array.prototype%"`).
           1. Let _array_ be ! ArrayCreate(0, _proto_).
           1. If Type(_len_) is not Number, then
             1. Let _defineStatus_ be CreateDataProperty(_array_, `"0"`, _len_).
@@ -31684,7 +31684,7 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ &ge; 2.
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%ArrayPrototype%"`).
+          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%Array.prototype%"`).
           1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
           1. Let _k_ be 0.
           1. Let _items_ be a zero-origined List containing the argument items in order.
@@ -31704,7 +31704,7 @@ THH:mm:ss.sss
       <h1>Properties of the Array Constructor</h1>
       <p>The Array constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -31830,7 +31830,7 @@ THH:mm:ss.sss
         <li>is the intrinsic object <dfn>%ArrayPrototype%</dfn>.</li>
         <li>is an Array exotic object and has the internal methods specified for such objects.</li>
         <li>has a `"length"` property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <emu-note>
         <p>The Array prototype object is specified to be an Array exotic object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
@@ -31890,7 +31890,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.constructor">
         <h1>Array.prototype.constructor</h1>
-        <p>The initial value of `Array.prototype.constructor` is the intrinsic object %Array%.</p>
+        <p>The initial value of `Array.prototype.constructor` is %Array%.</p>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.copywithin">
@@ -32882,7 +32882,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _func_ be ? Get(_array_, `"join"`).
-          1. If IsCallable(_func_) is *false*, set _func_ to the intrinsic function %ObjProto_toString%.
+          1. If IsCallable(_func_) is *false*, set _func_ to the intrinsic function %Object.prototype.toString%.
           1. Return ? Call(_func_, _array_).
         </emu-alg>
         <emu-note>
@@ -33007,7 +33007,7 @@ THH:mm:ss.sss
         <ul>
           <li>has properties that are inherited by all Array Iterator Objects.</li>
           <li>is an ordinary object.</li>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
           <li>has the following properties:</li>
         </ul>
 
@@ -33316,7 +33316,7 @@ THH:mm:ss.sss
       <h1>Properties of the %TypedArray% Intrinsic Object</h1>
       <p>The %TypedArray% intrinsic object:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has a `name` property whose value is `"TypedArray"`.</li>
         <li>has the following properties:</li>
       </ul>
@@ -33426,7 +33426,7 @@ THH:mm:ss.sss
       <h1>Properties of the %TypedArrayPrototype% Object</h1>
       <p>The <dfn>%TypedArrayPrototype%</dfn> object:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</li>
       </ul>
@@ -33971,7 +33971,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>, 0).
+          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%TypedArrayPrototype%"</code>, 0).
         </emu-alg>
       </emu-clause>
 
@@ -33984,7 +33984,7 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _elementLength_ be ? ToIndex(_length_).
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>, _elementLength_).
+          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%TypedArrayPrototype%"</code>, _elementLength_).
         </emu-alg>
 
         <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
@@ -34033,7 +34033,7 @@ THH:mm:ss.sss
           1. Assert: Type(_typedArray_) is Object and _typedArray_ has a [[TypedArrayName]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
+          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%TypedArrayPrototype%"</code>).
           1. Let _srcArray_ be _typedArray_.
           1. Let _srcData_ be _srcArray_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
@@ -34079,7 +34079,7 @@ THH:mm:ss.sss
           1. Assert: Type(_object_) is Object and _object_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
+          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%TypedArrayPrototype%"</code>).
           1. Let _usingIterator_ be ? GetMethod(_object_, @@iterator).
           1. If _usingIterator_ is not *undefined*, then
             1. Let _values_ be ? IterableToList(_object_, _usingIterator_).
@@ -34115,7 +34115,7 @@ THH:mm:ss.sss
           1. Assert: Type(_buffer_) is Object and _buffer_ has an [[ArrayBufferData]] internal slot.
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-49"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>Prototype%"</code>).
+          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%TypedArrayPrototype%"</code>).
           1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
@@ -34166,7 +34166,7 @@ THH:mm:ss.sss
       <h1>Properties of the _TypedArray_ Constructors</h1>
       <p>Each _TypedArray_ constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %TypedArray%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %TypedArray%.</li>
         <li>has a `name` property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-49"></emu-xref>.</li>
         <li>has the following properties:</li>
       </ul>
@@ -34188,7 +34188,7 @@ THH:mm:ss.sss
       <h1>Properties of the _TypedArray_ Prototype Objects</h1>
       <p>Each _TypedArray_ prototype object:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %TypedArrayPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %TypedArray.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</li>
       </ul>
@@ -34236,7 +34236,7 @@ THH:mm:ss.sss
         <p>When the `Map` function is called with optional argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%MapPrototype%"`, &laquo; [[MapData]] &raquo;).
+          1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Map.prototype%"`, &laquo; [[MapData]] &raquo;).
           1. Set _map_.[[MapData]] to a new empty List.
           1. If _iterable_ is not present, or is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, `"set"`).
@@ -34278,13 +34278,13 @@ THH:mm:ss.sss
       <h1>Properties of the Map Constructor</h1>
       <p>The Map constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-map.prototype">
         <h1>Map.prototype</h1>
-        <p>The initial value of `Map.prototype` is the intrinsic object %MapPrototype%.</p>
+        <p>The initial value of `Map.prototype` is %Map.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -34306,7 +34306,7 @@ THH:mm:ss.sss
       <p>The Map prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%MapPrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[MapData]] internal slot.</li>
       </ul>
@@ -34330,7 +34330,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.constructor">
         <h1>Map.prototype.constructor</h1>
-        <p>The initial value of `Map.prototype.constructor` is the intrinsic object %Map%.</p>
+        <p>The initial value of `Map.prototype.constructor` is %Map%.</p>
       </emu-clause>
 
       <emu-clause id="sec-map.prototype.delete">
@@ -34499,7 +34499,7 @@ THH:mm:ss.sss
         <ul>
           <li>has properties that are inherited by all Map Iterator Objects.</li>
           <li>is an ordinary object.</li>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
           <li>has the following properties:</li>
         </ul>
 
@@ -34606,7 +34606,7 @@ THH:mm:ss.sss
         <p>When the `Set` function is called with optional argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%SetPrototype%"`, &laquo; [[SetData]] &raquo;).
+          1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Set.prototype%"`, &laquo; [[SetData]] &raquo;).
           1. Set _set_.[[SetData]] to a new empty List.
           1. If _iterable_ is not present, set _iterable_ to *undefined*.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
@@ -34627,7 +34627,7 @@ THH:mm:ss.sss
       <h1>Properties of the Set Constructor</h1>
       <p>The Set constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -34655,7 +34655,7 @@ THH:mm:ss.sss
       <p>The Set prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%SetPrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[SetData]] internal slot.</li>
       </ul>
@@ -34694,7 +34694,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.constructor">
         <h1>Set.prototype.constructor</h1>
-        <p>The initial value of `Set.prototype.constructor` is the intrinsic object %Set%.</p>
+        <p>The initial value of `Set.prototype.constructor` is %Set%.</p>
       </emu-clause>
 
       <emu-clause id="sec-set.prototype.delete">
@@ -34835,7 +34835,7 @@ THH:mm:ss.sss
         <ul>
           <li>has properties that are inherited by all Set Iterator Objects.</li>
           <li>is an ordinary object.</li>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
           <li>has the following properties:</li>
         </ul>
 
@@ -34945,7 +34945,7 @@ THH:mm:ss.sss
         <p>When the `WeakMap` function is called with optional argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakMapPrototype%"`, &laquo; [[WeakMapData]] &raquo;).
+          1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakMap.prototype%"`, &laquo; [[WeakMapData]] &raquo;).
           1. Set _map_.[[WeakMapData]] to a new empty List.
           1. If _iterable_ is not present, or is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, `"set"`).
@@ -34961,13 +34961,13 @@ THH:mm:ss.sss
       <h1>Properties of the WeakMap Constructor</h1>
       <p>The WeakMap constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-weakmap.prototype">
         <h1>WeakMap.prototype</h1>
-        <p>The initial value of `WeakMap.prototype` is the intrinsic object %WeakMapPrototype%.</p>
+        <p>The initial value of `WeakMap.prototype` is %WeakMap.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -34977,14 +34977,14 @@ THH:mm:ss.sss
       <p>The WeakMap prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%WeakMapPrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[WeakMapData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-weakmap.prototype.constructor">
         <h1>WeakMap.prototype.constructor</h1>
-        <p>The initial value of `WeakMap.prototype.constructor` is the intrinsic object %WeakMap%.</p>
+        <p>The initial value of `WeakMap.prototype.constructor` is %WeakMap%.</p>
       </emu-clause>
 
       <emu-clause id="sec-weakmap.prototype.delete">
@@ -35091,7 +35091,7 @@ THH:mm:ss.sss
         <p>When the `WeakSet` function is called with optional argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakSetPrototype%"`, &laquo; [[WeakSetData]] &raquo;).
+          1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakSet.prototype%"`, &laquo; [[WeakSetData]] &raquo;).
           1. Set _set_.[[WeakSetData]] to a new empty List.
           1. If _iterable_ is not present, set _iterable_ to *undefined*.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
@@ -35112,7 +35112,7 @@ THH:mm:ss.sss
       <h1>Properties of the WeakSet Constructor</h1>
       <p>The WeakSet constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -35128,7 +35128,7 @@ THH:mm:ss.sss
       <p>The WeakSet prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%WeakSetPrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[WeakSetData]] internal slot.</li>
       </ul>
@@ -35214,7 +35214,7 @@ THH:mm:ss.sss
         <h1>AllocateArrayBuffer ( _constructor_, _byteLength_ )</h1>
         <p>The abstract operation AllocateArrayBuffer with arguments _constructor_ and _byteLength_ is used to create an ArrayBuffer object. It performs the following steps:</p>
         <emu-alg>
-          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, `"%ArrayBufferPrototype%"`, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] &raquo;).
+          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, `"%ArrayBuffer.prototype%"`, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] &raquo;).
           1. Assert: _byteLength_ is an integer value &ge; 0.
           1. Let _block_ be ? CreateByteDataBlock(_byteLength_).
           1. Set _obj_.[[ArrayBufferData]] to _block_.
@@ -35403,7 +35403,7 @@ THH:mm:ss.sss
       <h1>Properties of the ArrayBuffer Constructor</h1>
       <p>The ArrayBuffer constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -35419,7 +35419,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-arraybuffer.prototype">
         <h1>ArrayBuffer.prototype</h1>
-        <p>The initial value of `ArrayBuffer.prototype` is the intrinsic object %ArrayBufferPrototype%.</p>
+        <p>The initial value of `ArrayBuffer.prototype` is %ArrayBuffer.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -35441,7 +35441,7 @@ THH:mm:ss.sss
       <p>The ArrayBuffer prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%ArrayBufferPrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
       </ul>
@@ -35461,7 +35461,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-arraybuffer.prototype.constructor">
         <h1>ArrayBuffer.prototype.constructor</h1>
-        <p>The initial value of `ArrayBuffer.prototype.constructor` is the intrinsic object %ArrayBuffer%.</p>
+        <p>The initial value of `ArrayBuffer.prototype.constructor` is %ArrayBuffer%.</p>
       </emu-clause>
 
       <emu-clause id="sec-arraybuffer.prototype.slice">
@@ -35519,7 +35519,7 @@ THH:mm:ss.sss
         <h1>AllocateSharedArrayBuffer ( _constructor_, _byteLength_ )</h1>
         <p>The abstract operation AllocateSharedArrayBuffer with arguments _constructor_ and _byteLength_ is used to create a SharedArrayBuffer object. It performs the following steps:</p>
         <emu-alg>
-          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, `"%SharedArrayBufferPrototype%"`, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
+          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, `"%SharedArrayBuffer.prototype%"`, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
           1. Assert: _byteLength_ is a nonnegative integer.
           1. Let _block_ be ? CreateSharedByteDataBlock(_byteLength_).
           1. Set _obj_.[[ArrayBufferData]] to _block_.
@@ -35572,13 +35572,13 @@ THH:mm:ss.sss
       <h1>Properties of the SharedArrayBuffer Constructor</h1>
       <p>The SharedArrayBuffer constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-sharedarraybuffer.prototype">
         <h1>SharedArrayBuffer.prototype</h1>
-        <p>The initial value of `SharedArrayBuffer.prototype` is the intrinsic object %SharedArrayBufferPrototype%.</p>
+        <p>The initial value of `SharedArrayBuffer.prototype` is %SharedArrayBuffer.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -35597,7 +35597,7 @@ THH:mm:ss.sss
       <p>The SharedArrayBuffer prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%SharedArrayBufferPrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
       </ul>
@@ -35616,7 +35616,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-sharedarraybuffer.prototype.constructor">
         <h1>SharedArrayBuffer.prototype.constructor</h1>
-        <p>The initial value of `SharedArrayBuffer.prototype.constructor` is the intrinsic object %SharedArrayBuffer%.</p>
+        <p>The initial value of `SharedArrayBuffer.prototype.constructor` is %SharedArrayBuffer%.</p>
       </emu-clause>
 
       <emu-clause id="sec-sharedarraybuffer.prototype.slice">
@@ -35734,7 +35734,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _viewByteLength_ be ? ToIndex(_byteLength_).
             1. If _offset_ + _viewByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DataViewPrototype%"`, &laquo; [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DataView.prototype%"`, &laquo; [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] &raquo;).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
           1. Set _O_.[[ByteLength]] to _viewByteLength_.
@@ -35748,13 +35748,13 @@ THH:mm:ss.sss
       <h1>Properties of the DataView Constructor</h1>
       <p>The DataView constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-dataview.prototype">
         <h1>DataView.prototype</h1>
-        <p>The initial value of `DataView.prototype` is the intrinsic object %DataViewPrototype%.</p>
+        <p>The initial value of `DataView.prototype` is %DataView.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -35764,7 +35764,7 @@ THH:mm:ss.sss
       <p>The DataView prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%DataViewPrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</li>
       </ul>
@@ -35811,7 +35811,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.constructor">
         <h1>DataView.prototype.constructor</h1>
-        <p>The initial value of `DataView.prototype.constructor` is the intrinsic object %DataView%.</p>
+        <p>The initial value of `DataView.prototype.constructor` is %DataView%.</p>
       </emu-clause>
 
       <emu-clause id="sec-dataview.prototype.getfloat32">
@@ -35993,7 +35993,7 @@ THH:mm:ss.sss
       <li>is the intrinsic object <dfn>%Atomics%</dfn>.</li>
       <li>is the initial value of the `Atomics` property of the global object.</li>
       <li>is an ordinary object.</li>
-      <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
       <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     </ul>
@@ -36363,7 +36363,7 @@ THH:mm:ss.sss
       <li>is the initial value of the `JSON` property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>contains two functions, `parse` and `stringify`, that are used to parse and construct JSON texts.</li>
-      <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
       <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     </ul>
@@ -36381,7 +36381,7 @@ THH:mm:ss.sss
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then
-          1. Let _root_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _root_ be ObjectCreate(%Object.prototype%).
           1. Let _rootName_ be the empty String.
           1. Let _status_ be CreateDataProperty(_root_, _rootName_, _unfiltered_).
           1. Assert: _status_ is *true*.
@@ -36472,7 +36472,7 @@ THH:mm:ss.sss
           1. If the length of _space_ is 10 or less, let _gap_ be _space_; otherwise let _gap_ be the String value consisting of the first 10 code units of _space_.
         1. Else,
           1. Let _gap_ be the empty String.
-        1. Let _wrapper_ be ObjectCreate(%ObjectPrototype%).
+        1. Let _wrapper_ be ObjectCreate(%Object.prototype%).
         1. Let _status_ be CreateDataProperty(_wrapper_, the empty String, _value_).
         1. Assert: _status_ is *true*.
         1. Return ? SerializeJSONProperty(the empty String, _wrapper_).
@@ -37011,7 +37011,7 @@ THH:mm:ss.sss
       <h1>The %IteratorPrototype% Object</h1>
       <p>The <dfn>%IteratorPrototype%</dfn> object:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
       </ul>
       <emu-note>
@@ -37034,7 +37034,7 @@ THH:mm:ss.sss
       <h1>The %AsyncIteratorPrototype% Object</h1>
       <p>The <dfn>%AsyncIteratorPrototype%</dfn> object:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
       </ul>
       <emu-note>
@@ -37073,7 +37073,7 @@ THH:mm:ss.sss
         <ul>
           <li>has properties that are inherited by all Async-from-Sync Iterator Objects.</li>
           <li>is an ordinary object.</li>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %AsyncIteratorPrototype%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %AsyncIterator.prototype%.</li>
           <li>has the following properties:</li>
         </ul>
 
@@ -37234,7 +37234,7 @@ THH:mm:ss.sss
       <p>The GeneratorFunction constructor:</p>
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
         <li>has a `name` property whose value is `"GeneratorFunction"`.</li>
         <li>has the following properties:</li>
       </ul>
@@ -37246,7 +37246,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction.prototype">
         <h1>GeneratorFunction.prototype</h1>
-        <p>The initial value of `GeneratorFunction.prototype` is the intrinsic object %Generator%.</p>
+        <p>The initial value of `GeneratorFunction.prototype` is %Generator%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -37257,14 +37257,14 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-56"></emu-xref>.</li>
-        <li>is the value of the `prototype` property of the intrinsic object %GeneratorFunction%.</li>
+        <li>is the value of the `prototype` property of %GeneratorFunction%.</li>
         <li>is the intrinsic object <dfn>%Generator%</dfn> (see Figure 2).</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
       <emu-clause id="sec-generatorfunction.prototype.constructor">
         <h1>GeneratorFunction.prototype.constructor</h1>
-        <p>The initial value of `GeneratorFunction.prototype.constructor` is the intrinsic object %GeneratorFunction%.</p>
+        <p>The initial value of `GeneratorFunction.prototype.constructor` is %GeneratorFunction%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -37340,7 +37340,7 @@ THH:mm:ss.sss
       <p>The AsyncGeneratorFunction constructor:</p>
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
         <li>has a `name` property whose value is `"AsyncGeneratorFunction"`.</li>
         <li>has the following properties:</li>
       </ul>
@@ -37363,14 +37363,14 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
-        <li>is the value of the `prototype` property of the intrinsic object %AsyncGeneratorFunction%.</li>
-        <li>is the intrinsic object %AsyncGenerator%.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>is the value of the `prototype` property of %AsyncGeneratorFunction%.</li>
+        <li>is %AsyncGenerator%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype-constructor">
         <h1>AsyncGeneratorFunction.prototype.constructor</h1>
-        <p>The initial value of `AsyncGeneratorFunction.prototype.constructor` is the intrinsic object %AsyncGeneratorFunction%.</p>
+        <p>The initial value of `AsyncGeneratorFunction.prototype.constructor` is %AsyncGeneratorFunction%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -37424,16 +37424,16 @@ THH:mm:ss.sss
       <p>The Generator prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%GeneratorPrototype%</dfn>.</li>
-        <li>is the initial value of the `prototype` property of the intrinsic object %Generator% (the GeneratorFunction.prototype).</li>
+        <li>is the initial value of the `prototype` property of %Generator% (the GeneratorFunction.prototype).</li>
         <li>is an ordinary object.</li>
         <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
         <li>has properties that are indirectly inherited by all Generator instances.</li>
       </ul>
 
       <emu-clause id="sec-generator.prototype.constructor">
         <h1>Generator.prototype.constructor</h1>
-        <p>The initial value of `Generator.prototype.constructor` is the intrinsic object %Generator%.</p>
+        <p>The initial value of `Generator.prototype.constructor` is %Generator%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -37634,16 +37634,16 @@ THH:mm:ss.sss
       <p>The AsyncGenerator prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%AsyncGeneratorPrototype%</dfn>.</li>
-        <li>is the initial value of the `prototype` property of the intrinsic object %AsyncGenerator% (the AsyncGeneratorFunction.prototype).</li>
+        <li>is the initial value of the `prototype` property of %AsyncGenerator% (the AsyncGeneratorFunction.prototype).</li>
         <li>is an ordinary object.</li>
         <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %AsyncIteratorPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %AsyncIterator.prototype%.</li>
         <li>has properties that are indirectly inherited by all AsyncGenerator instances.</li>
       </ul>
 
       <emu-clause id="sec-asyncgenerator-prototype-constructor">
         <h1>AsyncGenerator.prototype.constructor</h1>
-        <p>The initial value of `AsyncGenerator.prototype.constructor` is the intrinsic object %AsyncGenerator%.</p>
+        <p>The initial value of `AsyncGenerator.prototype.constructor` is %AsyncGenerator%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -38296,7 +38296,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
-          1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%PromisePrototype%"`, &laquo; [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] &raquo;).
+          1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Promise.prototype%"`, &laquo; [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] &raquo;).
           1. Set _promise_.[[PromiseState]] to `"pending"`.
           1. Set _promise_.[[PromiseFulfillReactions]] to a new empty List.
           1. Set _promise_.[[PromiseRejectReactions]] to a new empty List.
@@ -38320,7 +38320,7 @@ THH:mm:ss.sss
       <h1>Properties of the Promise Constructor</h1>
       <p>The Promise constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -38409,7 +38409,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.prototype">
         <h1>Promise.prototype</h1>
-        <p>The initial value of `Promise.prototype` is the intrinsic object %PromisePrototype%.</p>
+        <p>The initial value of `Promise.prototype` is %Promise.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -38519,7 +38519,7 @@ THH:mm:ss.sss
       <p>The Promise prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%PromisePrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</li>
       </ul>
@@ -38535,7 +38535,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.prototype.constructor">
         <h1>Promise.prototype.constructor</h1>
-        <p>The initial value of `Promise.prototype.constructor` is the intrinsic object %Promise%.</p>
+        <p>The initial value of `Promise.prototype.constructor` is %Promise%.</p>
       </emu-clause>
 
       <emu-clause id="sec-promise.prototype.finally">
@@ -38749,7 +38749,7 @@ THH:mm:ss.sss
       <p>The AsyncFunction constructor:</p>
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Function%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
         <li>has a `name` property whose value is `"AsyncFunction"`.</li>
         <li>has the following properties:</li>
       </ul>
@@ -38761,7 +38761,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-async-function-constructor-prototype">
         <h1>AsyncFunction.prototype</h1>
-        <p>The initial value of `AsyncFunction.prototype` is the intrinsic object %AsyncFunctionPrototype%.</p>
+        <p>The initial value of `AsyncFunction.prototype` is %AsyncFunction.prototype%.</p>
 
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
@@ -38772,15 +38772,15 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</li>
-        <li>is the value of the `prototype` property of the intrinsic object %AsyncFunction%.</li>
-        <li>is the intrinsic object <dfn>%AsyncFunctionPrototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>is the value of the `prototype` property of %AsyncFunction%.</li>
+        <li>is the intrinsic object <dfn>%AsyncFunction.prototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
       <emu-clause id="sec-async-function-prototype-properties-constructor">
         <h1>AsyncFunction.prototype.constructor</h1>
 
-        <p>The initial value of `AsyncFunction.prototype.constructor` is the intrinsic object %AsyncFunction%</p>
+        <p>The initial value of `AsyncFunction.prototype.constructor` is %AsyncFunction%</p>
 
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
@@ -38851,7 +38851,7 @@ THH:mm:ss.sss
       <li>is the intrinsic object <dfn>%Reflect%</dfn>.</li>
       <li>is the initial value of the `Reflect` property of the global object.</li>
       <li>is an ordinary object.</li>
-      <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ObjectPrototype%.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>is not a function object.</li>
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
       <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
@@ -39021,7 +39021,7 @@ THH:mm:ss.sss
       <h1>Properties of the Proxy Constructor</h1>
       <p>The Proxy constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %FunctionPrototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>does not have a `prototype` property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
         <li>has the following properties:</li>
       </ul>
@@ -39034,7 +39034,7 @@ THH:mm:ss.sss
           1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-proxy-revocation-functions" title></emu-xref>.
           1. Let _revoker_ be ! CreateBuiltinFunction(_steps_, &laquo; [[RevocableProxy]] &raquo;).
           1. Set _revoker_.[[RevocableProxy]] to _p_.
-          1. Let _result_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _result_ be ObjectCreate(%Object.prototype%).
           1. Perform CreateDataProperty(_result_, `"proxy"`, _p_).
           1. Perform CreateDataProperty(_result_, `"revoke"`, _revoker_).
           1. Return _result_.
@@ -41523,7 +41523,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-object.keys"></emu-xref>: In ECMAScript 2015, if the argument to `Object.keys` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.preventextensions"></emu-xref>: In ECMAScript 2015, if the argument to `Object.preventExtensions` is not an object it is treated as if it was a non-extensible ordinary object with no own properties. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.seal"></emu-xref>: In ECMAScript 2015, if the argument to `Object.seal` is not an object it is treated as if it was a non-extensible ordinary object with no own properties. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
-  <p><emu-xref href="#sec-function.prototype.bind"></emu-xref>: In ECMAScript 2015, the [[Prototype]] internal slot of a bound function is set to the [[GetPrototypeOf]] value of its target function. In the previous edition, [[Prototype]] was always set to %FunctionPrototype%.</p>
+  <p><emu-xref href="#sec-function.prototype.bind"></emu-xref>: In ECMAScript 2015, the [[Prototype]] internal slot of a bound function is set to the [[GetPrototypeOf]] value of its target function. In the previous edition, [[Prototype]] was always set to %Function.prototype%.</p>
   <p><emu-xref href="#sec-function-instances-length"></emu-xref>: In ECMAScript 2015, the `"length"` property of function instances is configurable. In previous editions it was non-configurable.</p>
   <p><emu-xref href="#sec-properties-of-the-nativeerror-constructors"></emu-xref>: In ECMAScript 2015, the [[Prototype]] internal slot of a _NativeError_ constructor is the Error constructor. In previous editions it was the Function prototype object.</p>
   <p><emu-xref href="#sec-properties-of-the-date-prototype-object"></emu-xref> In ECMAScript 2015, the Date prototype object is not a Date instance. In previous editions it was a Date instance whose TimeValue was *NaN*.</p>


### PR DESCRIPTION
Per editors' group discussion, separating this out from #1314.

The intention here is to prevent unbounded future growth of the intrinsics table, while also making intrinsic references slightly more readable/intuitive by making them more closely mirror the JS you'd use to access them (in an unmodified realm).

This ideally would be coupled with a change in ecmarkup to auto-link intrinsic syntax to the value in question, for even easier consumption.

Closes #1377. Closes #1105.