### PR TITLE
Normative: LeftHandSideExpression -> UnaryExpression in Static Semantics: Early Errors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12708,7 +12708,7 @@
           It is an early Reference Error if AssignmentTargetType of |UnaryExpression| is ~invalid~.
         </li>
         <li>
-          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is ~strict~.
+          It is an early Syntax Error if AssignmentTargetType of |UnaryExpression| is ~strict~.
         </li>
       </ul>
     </emu-clause>


### PR DESCRIPTION
Fixes this spec bug: 

![image](https://user-images.githubusercontent.com/27985/50171053-5c2d6a00-02bf-11e9-8d97-243c1a9e1e40.png)
