### PR TITLE
Editorial: Fix formatting of grammar productions ending in html entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "ecmarkup": "^3.16.0"
   },
   "devDependencies": {
-    "@alrra/travis-scripts": "^2.0.0"
+    "@alrra/travis-scripts": "^2.1.0"
   }
 }


### PR DESCRIPTION
A bug in grammarkdown (which is fixed in master and not yet released)
causes a newline after an html entity to get consumed, making
alternatives run together and look like a seqence of symbols.

This commit works around the bug by adding a trailing space after html
entities in grammar productions.

See https://github.com/rbuckton/grammarkdown/pull/29 for the proper fix
which has yet to be released.