### PR TITLE
Editorial: Refactor GetExportedNames() and ResolveExport() calls

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8572,7 +8572,7 @@
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _m_ be _O_.[[Module]].
-          1. Let _binding_ be ! _m_.ResolveExport(_P_, &laquo; &raquo;).
+          1. Let _binding_ be ! _m_.ResolveExport(_P_).
           1. Assert: _binding_ is a ResolvedBinding Record.
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.
@@ -21571,7 +21571,7 @@
             </tr>
             <tr>
               <td>
-                GetExportedNames(_exportStarSet_)
+                GetExportedNames([_exportStarSet_])
               </td>
               <td>
                 Return a list of all names that are either directly or indirectly exported from this module.
@@ -21579,7 +21579,7 @@
             </tr>
             <tr>
               <td>
-                ResolveExport(_exportName_, _resolveSet_)
+                ResolveExport(_exportName_ [, _resolveSet_])
               </td>
               <td>
                 <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. Return *null* if the name cannot be resolved, or `"ambiguous"` if multiple bindings were found.</p>
@@ -22399,10 +22399,12 @@
         </emu-clause>
 
         <emu-clause id="sec-getexportednames">
-          <h1>GetExportedNames ( _exportStarSet_ ) Concrete Method</h1>
+          <h1>GetExportedNames ( [ _exportStarSet_ ] ) Concrete Method</h1>
           <p>The GetExportedNames concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
           <p>It performs the following steps:</p>
           <emu-alg>
+            1. If _exportStarSet_ is not present, let _exportStarSet_ be a new empty List.
+            1. Assert: _exportStarSet_ is a List of Source Text Module Records.
             1. Let _module_ be this Source Text Module Record.
             1. If _exportStarSet_ contains _module_, then
               1. Assert: We've reached the starting point of an `import *` circularity.
@@ -22430,7 +22432,7 @@
         </emu-clause>
 
         <emu-clause id="sec-resolveexport">
-          <h1>ResolveExport ( _exportName_, _resolveSet_ ) Concrete Method</h1>
+          <h1>ResolveExport ( _exportName_ [ , _resolveSet_ ] ) Concrete Method</h1>
           <p>The ResolveExport concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
 
           <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
@@ -22440,6 +22442,8 @@
           <p>This abstract method performs the following steps:</p>
 
           <emu-alg>
+            1. If _resolveSet_ is not present, let _resolveSet_ be a new empty List.
+            1. Assert: _resolveSet_ is a List of Record { [[Module]], [[ExportName]] }.
             1. Let _module_ be this Source Text Module Record.
             1. For each Record { [[Module]], [[ExportName]] } _r_ in _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
@@ -22484,7 +22488,7 @@
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
-              1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
+              1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]]).
               1. If _resolution_ is *null* or `"ambiguous"`, throw a *SyntaxError* exception.
               1. Assert: _resolution_ is a ResolvedBinding Record.
             1. Assert: All named exports from _module_ are resolvable.
@@ -22501,7 +22505,7 @@
                 1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                 1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
               1. Else,
-                1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
+                1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]]).
                 1. If _resolution_ is *null* or `"ambiguous"`, throw a *SyntaxError* exception.
                 1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
             1. Let _code_ be _module_.[[ECMAScriptCode]].
@@ -22584,10 +22588,10 @@
           1. Assert: _module_.[[Status]] is not `"uninstantiated"`.
           1. Let _namespace_ be _module_.[[Namespace]].
           1. If _namespace_ is *undefined*, then
-            1. Let _exportedNames_ be ? _module_.GetExportedNames(&laquo; &raquo;).
+            1. Let _exportedNames_ be ? _module_.GetExportedNames().
             1. Let _unambiguousNames_ be a new empty List.
             1. For each _name_ that is an element of _exportedNames_, do
-              1. Let _resolution_ be ? _module_.ResolveExport(_name_, &laquo; &raquo;).
+              1. Let _resolution_ be ? _module_.ResolveExport(_name_).
               1. If _resolution_ is a ResolvedBinding Record, append _name_ to _unambiguousNames_.
             1. Set _namespace_ to ModuleNamespaceCreate(_module_, _unambiguousNames_).
           1. Return _namespace_.


### PR DESCRIPTION
Allows GetExportedNames() to be called without `exportStarSet`, and
for ResolveExport() to be called without `resolveSet`.