### PR TITLE
Editorial: reword usage of rest arguments in built-in functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23106,7 +23106,7 @@
   <p>There are certain built-in objects available whenever an ECMAScript |Script| or |Module| begins execution. One, the global object, is part of the lexical environment of the executing program. Others are accessible as initial properties of the global object or indirectly as properties of accessible built-in objects.</p>
   <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
-  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;`this` value&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
+  <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments, if not covered by rest arguments, are considered to be &ldquo;not present&rdquo; and may be identified in that manner by specification algorithms. In the description of a particular function, the terms &ldquo;`this` value&rdquo; and &ldquo;NewTarget&rdquo; have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>
   <emu-note>
     <p>Implementations that add additional capabilities to the set of built-in functions are encouraged to do so by adding new functions rather than adding new parameters to existing functions.</p>
@@ -24033,8 +24033,7 @@
         <p>The `assign` function is used to copy the values of all of the enumerable own properties from one or more source objects to a _target_ object. When the `assign` function is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _to_ be ? ToObject(_target_).
-          1. If only one argument was passed, return _to_.
-          1. Let _sources_ be the List of argument values starting with the second argument.
+          1. If _sources_ is empty, return _to_.
           1. For each element _nextSource_ of _sources_, in ascending index order, do
             1. If _nextSource_ is neither *undefined* nor *null*, then
               1. Let _from_ be ! ToObject(_nextSource_).
@@ -24585,7 +24584,6 @@
         <emu-alg>
           1. Let _Target_ be the *this* value.
           1. If IsCallable(_Target_) is *false*, throw a *TypeError* exception.
-          1. Let _args_ be a new (possibly empty) List consisting of all of the argument values provided after _thisArg_ in order.
           1. Let _F_ be ? BoundFunctionCreate(_Target_, _thisArg_, _args_).
           1. Let _targetHasLength_ be ? HasOwnProperty(_Target_, `"length"`).
           1. If _targetHasLength_ is *true*, then
@@ -24593,7 +24591,8 @@
             1. If Type(_targetLen_) is not Number, let _L_ be 0.
             1. Else,
               1. Set _targetLen_ to ! ToInteger(_targetLen_).
-              1. Let _L_ be the larger of 0 and the result of _targetLen_ minus the number of elements of _args_.
+              1. Let _D_ be the _targetLen_ minus the number of elements of _args_.
+              1. Let _L_ be max(0, _D_).
           1. Else, let _L_ be 0.
           1. Perform ! SetFunctionLength(_F_, _L_).
           1. Let _targetName_ be ? Get(_Target_, `"name"`).
@@ -24616,9 +24615,8 @@
           1. Let _func_ be the *this* value.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
           1. Let _argList_ be a new empty List.
-          1. If this method was called with more than one argument, then in left to right order, starting with the second argument, append each argument as the last element of _argList_.
           1. Perform PrepareForTailCall().
-          1. Return ? Call(_func_, _thisArg_, _argList_).
+          1. Return ? Call(_func_, _thisArg_, _args_).
         </emu-alg>
         <emu-note>
           <p>The _thisArg_ value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* _thisArg_ is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the _thisArg_ is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
@@ -26124,7 +26122,7 @@
       </emu-clause>
 
       <emu-clause id="sec-math.hypot">
-        <h1>Math.hypot ( _value1_, _value2_, ..._values_ )</h1>
+        <h1>Math.hypot ( ..._values_ )</h1>
         <p>`Math.hypot` returns an implementation-dependent approximation of the square root of the sum of squares of its arguments.</p>
         <ul>
           <li>
@@ -26142,6 +26140,7 @@
           <li>
             If all arguments are either *+0* or *-0*, the result is *+0*.
           </li>
+          <p>The `"length"` property of `Math.hypot` is 2.
         </ul>
         <emu-note>
           <p>Implementations should take care to avoid the loss of precision from overflows and underflows that are prone to occur in naive implementations when this function is called with two or more arguments.</p>
@@ -26257,7 +26256,7 @@
       </emu-clause>
 
       <emu-clause id="sec-math.max">
-        <h1>Math.max ( _value1_, _value2_, ..._values_ )</h1>
+        <h1>Math.max ( ..._values_ )</h1>
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the largest of the resulting values.</p>
         <ul>
           <li>
@@ -26270,10 +26269,11 @@
             The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0* is considered to be larger than *-0*.
           </li>
         </ul>
+        <p>The `"length"` property of the `Math.max` function is 2.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.min">
-        <h1>Math.min ( _value1_, _value2_, ..._values_ )</h1>
+        <h1>Math.min ( ..._values_ )</h1>
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the smallest of the resulting values.</p>
         <ul>
           <li>
@@ -26286,6 +26286,7 @@
             The comparison of values to determine the smallest value is done using the Abstract Relational Comparison algorithm except that *+0* is considered to be larger than *-0*.
           </li>
         </ul>
+        <p>The `"length"` property of the `Math.min` function is 2.
       </emu-clause>
 
       <emu-clause id="sec-math.pow">
@@ -27890,16 +27891,11 @@ THH:mm:ss.sss
         <h1>String.fromCharCode ( ..._codeUnits_ )</h1>
         <p>The `String.fromCharCode` function may be called with any number of arguments which form the rest parameter _codeUnits_. The following steps are taken:</p>
         <emu-alg>
-          1. Let _codeUnits_ be a List containing the arguments passed to this function.
-          1. Let _length_ be the number of elements in _codeUnits_.
           1. Let _elements_ be a new empty List.
-          1. Let _nextIndex_ be 0.
-          1. Repeat, while _nextIndex_ &lt; _length_
-            1. Let _next_ be _codeUnits_[_nextIndex_].
+          1. For each element _next_ of _codeUnits_, in ascending index order, do
             1. Let _nextCU_ be ? ToUint16(_next_).
             1. Append _nextCU_ to the end of _elements_.
-            1. Increase _nextIndex_ by 1.
-          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty string is returned.
+          1. Return the String value whose code units are, in order, the elements in the List _elements_. If the number of elements in _codeUnits_ is 0, the empty string is returned.
         </emu-alg>
         <p>The `"length"` property of the `fromCharCode` function is 1.</p>
       </emu-clause>
@@ -27908,18 +27904,13 @@ THH:mm:ss.sss
         <h1>String.fromCodePoint ( ..._codePoints_ )</h1>
         <p>The `String.fromCodePoint` function may be called with any number of arguments which form the rest parameter _codePoints_. The following steps are taken:</p>
         <emu-alg>
-          1. Let _codePoints_ be a List containing the arguments passed to this function.
-          1. Let _length_ be the number of elements in _codePoints_.
           1. Let _elements_ be a new empty List.
-          1. Let _nextIndex_ be 0.
-          1. Repeat, while _nextIndex_ &lt; _length_
-            1. Let _next_ be _codePoints_[_nextIndex_].
+          1. For each element _next_ of _codePoints_, ascending index order, do
             1. Let _nextCP_ be ? ToNumber(_next_).
             1. If SameValue(_nextCP_, ! ToInteger(_nextCP_)) is *false*, throw a *RangeError* exception.
             1. If _nextCP_ &lt; 0 or _nextCP_ &gt; 0x10FFFF, throw a *RangeError* exception.
             1. Append the elements of the UTF16Encoding of _nextCP_ to the end of _elements_.
-            1. Increase _nextIndex_ by 1.
-          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty string is returned.
+          1. Return the String value whose code units are, in order, the elements in the List _elements_. If the number of elements in _codePoints_ is 0, the empty string is returned.
         </emu-alg>
         <p>The `"length"` property of the `fromCodePoint` function is 1.</p>
       </emu-clause>
@@ -27934,7 +27925,6 @@ THH:mm:ss.sss
         <h1>String.raw ( _template_, ..._substitutions_ )</h1>
         <p>The `String.raw` function may be called with a variable number of arguments. The first argument is _template_ and the remainder of the arguments form the List _substitutions_. The following steps are taken:</p>
         <emu-alg>
-          1. Let _substitutions_ be a List consisting of all of the arguments passed to this function, starting with the second argument. If fewer than two arguments were passed, the List is empty.
           1. Let _numberOfSubstitutions_ be the number of elements in _substitutions_.
           1. Let _cooked_ be ? ToObject(_template_).
           1. Let _raw_ be ? ToObject(? Get(_cooked_, `"raw"`)).
@@ -28051,7 +28041,6 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _args_ be a List whose elements are the arguments passed to this function.
           1. Let _R_ be _S_.
           1. Repeat, while _args_ is not empty
             1. Remove the first element from _args_ and let _next_ be the value of that element.
@@ -31122,7 +31111,6 @@ THH:mm:ss.sss
           1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%ArrayPrototype%"`).
           1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
           1. Let _k_ be 0.
-          1. Let _items_ be a zero-origined List containing the argument items in order.
           1. Repeat, while _k_ &lt; _numberOfArgs_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _itemK_ be _items_[_k_].
@@ -31215,8 +31203,7 @@ THH:mm:ss.sss
         <h1>Array.of ( ..._items_ )</h1>
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
         <emu-alg>
-          1. Let _len_ be the actual number of arguments passed to this function.
-          1. Let _items_ be the List of arguments passed to this function.
+          1. Let _len_ be the length of _items_.
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *true*, then
             1. Let _A_ be ? Construct(_C_, &laquo; _len_ &raquo;).
@@ -31279,7 +31266,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _n_ be 0.
-          1. Let _items_ be a List whose first element is _O_ and whose subsequent elements are, in left to right order, the arguments that were passed to this function invocation.
+          1. Let _items_ be a List whose first element is _O_ and whose subsequent elements are the elements of _arguments_.
           1. Repeat, while _items_ is not empty
             1. Remove the first element from _items_ and let _E_ be the value of the element.
             1. Let _spreadable_ be ? IsConcatSpreadable(_E_).
@@ -31762,7 +31749,6 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
-          1. Let _items_ be a List whose elements are, in left to right order, the arguments that were passed to this function invocation.
           1. Let _argCount_ be the number of elements in _items_.
           1. If _len_ + _argCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
           1. Repeat, while _items_ is not empty
@@ -32164,7 +32150,6 @@ THH:mm:ss.sss
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_k_), _fromValue_).
             1. Increment _k_ by 1.
           1. Perform ? Set(_A_, `"length"`, _actualDeleteCount_, *true*).
-          1. Let _items_ be a List whose elements are, in left to right order, the portion of the actual argument list starting with the third argument. The list is empty if fewer than three arguments were passed.
           1. Let _itemCount_ be the number of elements in _items_.
           1. If _itemCount_ &lt; _actualDeleteCount_, then
             1. Set _k_ to _actualStart_.
@@ -32265,7 +32250,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
-          1. Let _argCount_ be the number of actual arguments.
+          1. Let _argCount_ be the number of elements in _items_.
           1. If _argCount_ &gt; 0, then
             1. If _len_ + _argCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
             1. Let _k_ be _len_.
@@ -32280,7 +32265,6 @@ THH:mm:ss.sss
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Decrease _k_ by 1.
             1. Let _j_ be 0.
-            1. Let _items_ be a List whose elements are, in left to right order, the arguments that were passed to this function invocation.
             1. Repeat, while _items_ is not empty
               1. Remove the first element from _items_ and let _E_ be the value of that element.
               1. Perform ? Set(_O_, ! ToString(_j_), _E_, *true*).
@@ -32778,7 +32762,7 @@ THH:mm:ss.sss
         <h1>%TypedArray%.of ( ..._items_ )</h1>
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
         <emu-alg>
-          1. Let _len_ be the actual number of arguments passed to this function.
+          1. Let _len_ be the number of elements in _items_.
           1. Let _items_ be the List of arguments passed to this function.
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.

--- a/spec.html
+++ b/spec.html
@@ -24614,7 +24614,6 @@
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
-          1. Let _argList_ be a new empty List.
           1. Perform PrepareForTailCall().
           1. Return ? Call(_func_, _thisArg_, _args_).
         </emu-alg>
@@ -27891,11 +27890,16 @@ THH:mm:ss.sss
         <h1>String.fromCharCode ( ..._codeUnits_ )</h1>
         <p>The `String.fromCharCode` function may be called with any number of arguments which form the rest parameter _codeUnits_. The following steps are taken:</p>
         <emu-alg>
+          1. Let _length_ be the number of elements in _codePoints_.
           1. Let _elements_ be a new empty List.
-          1. For each element _next_ of _codeUnits_, in ascending index order, do
+          1. Let _nextIndex_ be 0.
+          1. Repeat, while _nextIndex_ &lt; _length_
+            1. Let _next_ be _codeUnits_[_nextIndex_].
             1. Let _nextCU_ be ? ToUint16(_next_).
             1. Append _nextCU_ to the end of _elements_.
-          1. Return the String value whose code units are, in order, the elements in the List _elements_. If the number of elements in _codeUnits_ is 0, the empty string is returned.
+            1. Increase _nextIndex_ by 1.
+          1. Return the String value whose code units are, in order, the elements in the List _elements_.
+          1. NOTE: If the number of elements in _codeUnits_ is 0, the empty string is returned.
         </emu-alg>
         <p>The `"length"` property of the `fromCharCode` function is 1.</p>
       </emu-clause>
@@ -32763,7 +32767,6 @@ THH:mm:ss.sss
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _items_.
-          1. Let _items_ be the List of arguments passed to this function.
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
           1. Let _newObj_ be ? TypedArrayCreate(_C_, &laquo; _len_ &raquo;).


### PR DESCRIPTION
- Specify that arguments covered by rest args aren't filled by `undefined`
- Remove steps which duplicate the definitions of rest arguments in algorithm bodies
- Remove most usage (ignoring the horror in Array and Date) of "(actual) number of (actual) arguments"