### PR TITLE
Normative: Prevent JSON.stringify from returning ill-formed Unicode strings

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35984,15 +35984,18 @@ THH:mm:ss.sss
       <emu-clause id="sec-quotejsonstring" aoid="QuoteJSONString">
         <h1>Runtime Semantics: QuoteJSONString ( _value_ )</h1>
         <p>The abstract operation QuoteJSONString with argument _value_ wraps a String value in QUOTATION MARK code units and escapes certain other code units within it.</p>
+        <p>This operation interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
-          1. For each code unit _C_ in _value_, do
-            1. If the numeric value of _C_ is listed in the Code Unit Value column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
+          1. Let _cpList_ be a List containing in order the code points of _value_ when interpreted as a sequence of UTF-16 encoded code points as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.
+          1. For each code point _C_ in _cpList_, do
+            1. If _C_ is listed in the Code Point column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
               1. Set _product_ to the string-concatenation of _product_ and the Escape Sequence for _C_ as specified in <emu-xref href="#table-json-single-character-escapes"></emu-xref>.
-            1. Else if _C_ has a numeric value less than 0x0020 (SPACE), then
-              1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_C_).
+            1. Else if _C_ has a numeric value less than 0x0020 (SPACE), or _C_ has the same numeric value as a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, then
+              1. Let _unit_ be a code unit whose numeric value is that of _C_.
+              1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_unit_).
             1. Else,
-              1. Set _product_ to the string-concatenation of _product_ and _C_.
+              1. Set _product_ to the string-concatenation of _product_ and the <emu-xref aoid="UTF16Encoding"></emu-xref> of _C_.
           1. Set _product_ to the string-concatenation of _product_ and the code unit 0x0022 (QUOTATION MARK).
           1. Return _product_.
         </emu-alg>
@@ -36001,7 +36004,7 @@ THH:mm:ss.sss
             <tbody>
             <tr>
               <th>
-                Code Unit Value
+                Code Point
               </th>
               <th>
                 Unicode Character Name
@@ -36012,7 +36015,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `0x0008`
+                U+0008
               </td>
               <td>
                 BACKSPACE
@@ -36023,7 +36026,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `0x0009`
+                U+0009
               </td>
               <td>
                 CHARACTER TABULATION
@@ -36034,7 +36037,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `0x000A`
+                U+000A
               </td>
               <td>
                 LINE FEED (LF)
@@ -36045,7 +36048,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `0x000C`
+                U+000C
               </td>
               <td>
                 FORM FEED (FF)
@@ -36056,7 +36059,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `0x000D`
+                U+000D
               </td>
               <td>
                 CARRIAGE RETURN (CR)
@@ -36067,7 +36070,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `0x0022`
+                U+0022
               </td>
               <td>
                 QUOTATION MARK
@@ -36078,7 +36081,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `0x005C`
+                U+005C
               </td>
               <td>
                 REVERSE SOLIDUS


### PR DESCRIPTION
This implements https://github.com/tc39/proposal-well-formed-stringify , currently at stage 3. [Tests](https://github.com/tc39/test262/pull/1787) have already been merged.
Fixes #944