### PR TITLE
Editorial: Clarify internal slots during object creation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7396,7 +7396,7 @@
         1. If _functionKind_ is `"normal"`, let _needsConstruct_ be *true*.
         1. Else, let _needsConstruct_ be *false*.
         1. If _functionKind_ is `"non-constructor"`, set _functionKind_ to `"normal"`.
-        1. Let _F_ be a newly created ECMAScript function object with the internal slots listed in <emu-xref href="#table-27"></emu-xref>. All of those internal slots are initialized to *undefined*.
+        1. Let _F_ be a newly created ECMAScript function object with the internal slots listed in <emu-xref href="#table-27"></emu-xref>.
         1. Set _F_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
         1. Set _F_.[[Call]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
         1. If _needsConstruct_ is *true*, then
@@ -7732,7 +7732,7 @@
         1. If _realm_ is not present, set _realm_ to the current Realm Record.
         1. Assert: _realm_ is a Realm Record.
         1. If _prototype_ is not present, set _prototype_ to _realm_.[[Intrinsics]].[[%FunctionPrototype%]].
-        1. Let _func_ be a new built-in function object that when called performs the action described by _steps_. The new function object has internal slots whose names are the elements of _internalSlotsList_. The initial value of each of those internal slots is *undefined*.
+        1. Let _func_ be a new built-in function object that when called performs the action described by _steps_. The new function object has internal slots whose names are the elements of _internalSlotsList_.
         1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[Prototype]] to _prototype_.
         1. Set _func_.[[Extensible]] to *true*.
@@ -7834,7 +7834,7 @@
         <emu-alg>
           1. Assert: Type(_targetFunction_) is Object.
           1. Let _proto_ be ? _targetFunction_.[[GetPrototypeOf]]().
-          1. Let _obj_ be a newly created object.
+          1. Let _obj_ be a newly created bound function exotic object with the internal slots listed in <emu-xref href="#table-28"></emu-xref>.
           1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-bound-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
           1. If IsConstructor(_targetFunction_) is *true*, then
@@ -8022,7 +8022,7 @@
         <p>The abstract operation StringCreate with arguments _value_ and _prototype_ is used to specify the creation of new String exotic objects. It performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_value_) is String.
-          1. Let _S_ be a newly created String exotic object.
+          1. Let _S_ be a newly created String exotic object with a [[StringData]] internal slot.
           1. Set _S_.[[StringData]] to _value_.
           1. Set _S_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _S_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-string-exotic-objects-getownproperty-p"></emu-xref>.
@@ -8384,7 +8384,7 @@
         <p>The abstract operation IntegerIndexedObjectCreate with arguments _prototype_ and _internalSlotsList_ is used to specify the creation of new <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>. The argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. IntegerIndexedObjectCreate performs the following steps:</p>
         <emu-alg>
           1. Assert: _internalSlotsList_ contains the names [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]].
-          1. Let _A_ be a newly created object with an internal slot for each name in _internalSlotsList_.
+          1. Let _A_ be a newly created Integer-Indexed exotic object with an internal slot for each name in _internalSlotsList_.
           1. Set _A_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _A_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-getownproperty-p"></emu-xref>.
           1. Set _A_.[[HasProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-hasproperty-p"></emu-xref>.
@@ -8625,7 +8625,7 @@
           1. Assert: _module_ is a Module Record.
           1. Assert: _module_.[[Namespace]] is *undefined*.
           1. Assert: _exports_ is a List of String values.
-          1. Let _M_ be a newly created object.
+          1. Let _M_ be a newly created module namespace exotic object with the internal slots listed in <emu-xref href="#table-29"></emu-xref>.
           1. Set _M_'s essential internal methods to the definitions specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref>.
           1. Set _M_.[[Module]] to _module_.
           1. Let _sortedExports_ be a new List containing the same values as the list _exports_ where the values are ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
@@ -9273,7 +9273,7 @@
         1. If _target_ is a Proxy exotic object and _target_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
         1. If Type(_handler_) is not Object, throw a *TypeError* exception.
         1. If _handler_ is a Proxy exotic object and _handler_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
-        1. Let _P_ be a newly created object.
+        1. Let _P_ be a newly created Proxy exotic object with internal slots [[ProxyTarget]] and [[ProxyHandler]].
         1. Set _P_'s essential internal methods (except for [[Call]] and [[Construct]]) to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
         1. If IsCallable(_target_) is *true*, then
           1. Set _P_.[[Call]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.


### PR DESCRIPTION
- Do not redundantly set initial value, as "Unless specified otherwise, the initial value of an internal slot is the value **undefined**."
- Do explicitly state what the internal slots are when creating a new exotic object.