### PR TITLE
Editorial: Fix SubstitutionTemplate ArgumentListEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13420,15 +13420,20 @@
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
           1. Return a List containing the one element which is _siteObj_.
         </emu-alg>
-        <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-grammar>TemplateLiteral : SubstitutionTemplate</emu-grammar>
         <emu-alg>
           1. Let _templateLiteral_ be this |TemplateLiteral|.
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
+          1. Let _remaining_ be ? ArgumentListEvaluation of |SubstitutionTemplate|.
+          1. Return a List whose first element is _siteObj_ and whose subsequent elements are the elements of _remaining_, in order.
+        </emu-alg>
+        <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-alg>
           1. Let _firstSubRef_ be the result of evaluating |Expression|.
           1. Let _firstSub_ be ? GetValue(_firstSubRef_).
           1. Let _restSub_ be ? SubstitutionEvaluation of |TemplateSpans|.
           1. Assert: _restSub_ is a List.
-          1. Return a List whose first element is _siteObj_, whose second elements is _firstSub_, and whose subsequent elements are the elements of _restSub_, in order. _restSub_ may contain no elements.
+          1. Return a List whose first element is _firstSub_ and whose subsequent elements are the elements of _restSub_, in order. _restSub_ may contain no elements.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
Previously it was referencing an undeclared _TemplateLiteral_.