### PR TITLE
Editorial: Fix Completion handling for != and !==

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13793,6 +13793,7 @@
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be the result of performing Abstract Equality Comparison _rval_ == _lval_.
+        1. ReturnIfAbrupt(_r_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
@@ -13810,7 +13811,8 @@
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be the result of performing Strict Equality Comparison _rval_ === _lval_.
-        1. If _r_ is *true*, return *false*. Otherwise, return *true*.
+        1. Assert: _r_ is a normal completion.
+        1. If _r_.[[Value]] is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-note>
         <p>Given the above definition of equality:</p>


### PR DESCRIPTION
The Abstract Equality Comparison operation may return abrupt completions, but the Strict Equality Comparison operation should always return Boolean values. Indicate that.