### PR TITLE
Editorial: Fix typo in AsyncFunctionStart

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38266,9 +38266,9 @@ THH:mm:ss.sss
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. If _result_.[[Type]] is ~normal~, then
-              1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).
-            1. Else if _result_.[[Type]] is ~return~, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _result_.[[Value]] &raquo;).
+            1. Else if _result_.[[Type]] is ~return~, then
+              1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).
             1. Else,
               1. Assert: _result_.[[Type]] is ~throw~.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).


### PR DESCRIPTION
We want to use undefined for return, not normal.