### PR TITLE
Editorial: Fix return value logic for async arrow functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19825,8 +19825,11 @@
         CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parencover
 
       ConciseBody[In] :
-        [lookahead != `{` ] AssignmentExpression[?In, ~Yield, ~Await]
+        [lookahead != `{` ] ExpressionBody[?In, ~Await]
         `{` FunctionBody[~Yield, ~Await] `}`
+
+      ExpressionBody[In, Await] :
+        AssignmentExpression[?In, ~Yield, ?Await]
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
     <p>When the production
@@ -19909,7 +19912,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-containsusestrict">
       <h1>Static Semantics: ContainsUseStrict</h1>
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -19970,7 +19973,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallydeclarednames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -19979,7 +19982,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -19988,7 +19991,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -19997,7 +20000,7 @@
     <emu-clause id="sec-arrow-function-definitions-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -20030,12 +20033,10 @@
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
       <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
-      <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
-        1. Let _exprValue_ be ? GetValue(_exprRef_).
-        1. Return Completion { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
+        1. Return the result of evaluating |ExpressionBody|.
       </emu-alg>
     </emu-clause>
 
@@ -20063,6 +20064,12 @@
       <emu-note>
         <p>An |ArrowFunction| does not define local bindings for `arguments`, `super`, `this`, or `new.target`. Any reference to `arguments`, `super`, `this`, or `new.target` within an |ArrowFunction| must resolve to a binding in a lexically enclosing environment. Typically this will be the Function Environment of an immediately enclosing function. Even though an |ArrowFunction| may contain references to `super`, the function object created in step 3 is not made into a method by performing MakeMethod. An |ArrowFunction| that references `super` is always contained within a non-|ArrowFunction| and the necessary state to implement `super` is accessible via the _scope_ that is captured by the function object of the |ArrowFunction|.</p>
       </emu-note>
+      <emu-grammar>ExpressionBody : AssignmentExpression</emu-grammar>
+      <emu-alg>
+        1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
+        1. Let _exprValue_ be ? GetValue(_exprRef_).
+        1. Return Completion { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -21541,7 +21548,7 @@
         CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
 
       AsyncConciseBody[In] :
-        [lookahead != `{`] AssignmentExpression[?In, ~Yield, +Await]
+        [lookahead != `{`] ExpressionBody[?In, +Await]
         `{` AsyncFunctionBody `}`
 
       AsyncArrowBindingIdentifier[Yield] :
@@ -21683,7 +21690,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-LexicallyDeclaredNames">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
       <emu-grammar>
-        AsyncConciseBody : AssignmentExpression
+        AsyncConciseBody : ExpressionBody
       </emu-grammar>
       <emu-alg>
         1. Return a new empty List.
@@ -21693,7 +21700,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-LexicallyScopedDeclarations">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
       <emu-grammar>
-        AsyncConciseBody : AssignmentExpression
+        AsyncConciseBody : ExpressionBody
       </emu-grammar>
       <emu-alg>
         1. Return a new empty List.
@@ -21703,7 +21710,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-VarDeclaredNames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-grammar>
-        AsyncConciseBody : AssignmentExpression
+        AsyncConciseBody : ExpressionBody
       </emu-grammar>
       <emu-alg>
         1. Return a new empty List.
@@ -21713,7 +21720,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-VarScopedDeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-grammar>
-        AsyncConciseBody : AssignmentExpression
+        AsyncConciseBody : ExpressionBody
       </emu-grammar>
       <emu-alg>
         1. Return a new empty List.
@@ -21745,22 +21752,16 @@
       <h1>Runtime Semantics: EvaluateBody</h1>
       <p>With parameters _functionObject_ and List _argumentsList_.</p>
       <emu-grammar>
-        AsyncConciseBody : AssignmentExpression
+        AsyncConciseBody : ExpressionBody
       </emu-grammar>
       <emu-alg>
         1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
         1. Let _declResult_ be FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. If _declResult_ is not an abrupt completion, then
-          1. Perform ! AsyncFunctionStart(_promiseCapability_, |AssignmentExpression|).
+          1. Perform ! AsyncFunctionStart(_promiseCapability_, |ExpressionBody|).
         1. Else,
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _declResult_.[[Value]] &raquo;).
         1. Return Completion { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
-      </emu-alg>
-      <emu-grammar>
-        AsyncConciseBody : `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return the result of EvaluateBody of |AsyncFunctionBody| passing _functionObject_ and _argumentsList_ as the arguments.
       </emu-alg>
     </emu-clause>
 
@@ -21836,10 +21837,6 @@
 
       <emu-clause id="sec-statement-rules">
         <h1>Statement Rules</h1>
-        <emu-grammar>ConciseBody : AssignmentExpression</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |AssignmentExpression| with argument _call_.
-        </emu-alg>
         <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of |StatementList| with argument _call_.


### PR DESCRIPTION
Introduce a new production _ExpressionBody_ for both plain and async arrow functions, and allow correctly handling return value logic for both. Currently, _AsyncFunctionStart_ does not correctly handle the return value of async arrow functions correctly.