### PR TITLE
Normative: Require at least four digits in string representations of negative years

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27839,8 +27839,9 @@ THH:mm:ss.sss
             1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _yv_ be YearFromTime(_tv_).
             1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be `"-"`.
-            1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number of at least four digits, padded to the left with zeroes if necessary.
-            1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _year_.
+            1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
+            1. Let _paddedYear_ be ! StringPad(_year_, 4, *"0"*, *"start"*).
+            1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
             <table>
@@ -28075,8 +28076,9 @@ THH:mm:ss.sss
           1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
           1. Let _yv_ be YearFromTime(_tv_).
           1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be `"-"`.
-          1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number of at least four digits, padded to the left with zeroes if necessary.
-          1. Return the string-concatenation of _weekday_, `","`, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _year_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
+          1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
+          1. Let _paddedYear_ be ! StringPad(_year_, 4, *"0"*, *"start"*).
+          1. Return the string-concatenation of _weekday_, `","`, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -28065,7 +28065,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toutcstring">
         <h1>Date.prototype.toUTCString ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>The `toUTCString` method returns a String value representing the instance in time corresponding to this time value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Date objects. It performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
@@ -41492,6 +41492,9 @@ THH:mm:ss.sss
     </li>
     <li>
       <i>RFC 3629 &ldquo;UTF-8, a transformation format of ISO 10646&rdquo;</i>, available at &lt;<a href="https://tools.ietf.org/html/rfc3629">https://tools.ietf.org/html/rfc3629</a>&gt;
+    </li>
+    <li>
+      <i>RFC 7231 &ldquo;Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content&rdquo;</i>, available at &lt;<a href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>&gt;
     </li>
   </ol>
 </emu-annex>

--- a/spec.html
+++ b/spec.html
@@ -27837,8 +27837,10 @@ THH:mm:ss.sss
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
             1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-            1. Let _year_ be the String representation of YearFromTime(_tv_), formatted as a decimal number of at least four digits, padded to the left with zeroes if necessary.
-            1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), and _year_.
+            1. Let _yv_ be YearFromTime(_tv_).
+            1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be `"-"`.
+            1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number of at least four digits, padded to the left with zeroes if necessary.
+            1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _year_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
             <table>
@@ -28071,8 +28073,10 @@ THH:mm:ss.sss
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
           1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-          1. Let _year_ be the String representation of YearFromTime(_tv_), formatted as a decimal number of at least four digits, padded to the left with zeroes if necessary.
-          1. Return the string-concatenation of _weekday_, `","`, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _year_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
+          1. Let _yv_ be YearFromTime(_tv_).
+          1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be `"-"`.
+          1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number of at least four digits, padded to the left with zeroes if necessary.
+          1. Return the string-concatenation of _weekday_, `","`, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _year_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
Fixes #1035