### PR TITLE
Normative: Suppress GetMethod errors in IteratorClose

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6109,9 +6109,11 @@
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Assert: _completion_ is a Completion Record.
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
-        1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
-        1. If _return_ is *undefined*, return Completion(_completion_).
-        1. Let _innerResult_ be Call(_return_, _iterator_).
+        1. Let _innerResult_ be GetMethod(_iterator_, *"return"*).
+        1. If _innerResult_.[[Type]] is ~normal~, then
+          1. Let _return_ be _innerResult_.[[Value]].
+          1. If _return_ is *undefined*, return Completion(_completion_).
+          1. Set _innerResult_ to Call(_return_, _iterator_).
         1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
         1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
         1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.
@@ -6126,10 +6128,12 @@
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Assert: _completion_ is a Completion Record.
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
-        1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
-        1. If _return_ is *undefined*, return Completion(_completion_).
-        1. Let _innerResult_ be Call(_return_, _iterator_).
-        1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
+        1. Let _innerResult_ be GetMethod(_iterator_, *"return"*).
+        1. If _innerResult_.[[Type]] is ~normal~, then
+          1. Let _return_ be _innerResult_.[[Value]].
+          1. If _return_ is *undefined*, return Completion(_completion_).
+          1. Set _innerResult_ to Call(_return_, _iterator_).
+          1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
         1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
         1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
         1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.


### PR DESCRIPTION
Fixes #1398 

### Current behavior:

If the "return" property of an iterator is not callable, a TypeError will be thrown from `IteratorClose`, regardless of the completion provided as an argument.

### Proposed behavior:

If a "throw" completion is provided to `IteratorClose`, then it will rethrow that error even if the return property is not callable.

### Test case:

```js
let iter = {
  [Symbol.iterator]() { return this; },
  next() { return { value: 1, done: false }; },
  return: 0, // Not a function
};
try {
  for (let i of iter)
    throw 1; // Throw and trigger IteratorClose
} catch (e) {
  // Does this print "1" or "TypeError: 0 is not a function"?
  print(e);
}
```

### Current engine behavior:

```
eshost -e '(() => { try { for (let i of { [Symbol.iterator]() { return this }, next() { return { value: 1, done: false }; }, return: 0 }) throw 1; } catch (e) { print(e) } })()'

#### ch
1

#### jsc
1

#### v8
TypeError: The iterator's 'return' method is not callable

#### sm
TypeError: property 'return' of iterator is not callable

#### xs
1
```