### PR TITLE
Editorial: Treat not present parameters as `undefined`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25239,7 +25239,7 @@
         <emu-alg>
           1. If NewTarget is neither *undefined* nor the active function, then
             1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
-          1. If _value_ is *null*, *undefined* or not supplied, return ObjectCreate(%Object.prototype%).
+          1. If _value_ is *undefined* or *null*, return ObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
         <p>The *"length"* property of the `Object` constructor function is 1.</p>
@@ -26568,8 +26568,8 @@
         <h1>Number ( _value_ )</h1>
         <p>When `Number` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
-          1. If no arguments were passed to this function invocation, let _n_ be *+0*.
-          1. Else, let _n_ be ? ToNumber(_value_).
+          1. If _value_ is present, let _n_ be ? ToNumber(_value_).
+          1. Else, let _n_ be *+0*.
           1. If NewTarget is *undefined*, return _n_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Number.prototype%"*, &laquo; [[NumberData]] &raquo;).
           1. Set _O_.[[NumberData]] to _n_.
@@ -26865,13 +26865,12 @@
       <emu-clause id="sec-number.prototype.tostring">
         <h1>Number.prototype.toString ( [ _radix_ ] )</h1>
         <emu-note>
-          <p>The optional _radix_ should be an integer value in the inclusive range 2 to 36. If _radix_ is not present or is *undefined* the Number 10 is used as the value of _radix_.</p>
+          <p>The optional _radix_ should be an integer value in the inclusive range 2 to 36. If _radix_ is *undefined* the Number 10 is used as the value of _radix_.</p>
         </emu-note>
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
-          1. If _radix_ is not present, let _radixNumber_ be 10.
-          1. Else if _radix_ is *undefined*, let _radixNumber_ be 10.
+          1. If _radix_ is *undefined*, let _radixNumber_ be 10.
           1. Else, let _radixNumber_ be ? ToInteger(_radix_).
           1. If _radixNumber_ &lt; 2 or _radixNumber_ &gt; 36, throw a *RangeError* exception.
           1. If _radixNumber_ = 10, return ! ToString(_x_).
@@ -29287,7 +29286,7 @@ THH:mm:ss.sss
         <h1>String ( _value_ )</h1>
         <p>When `String` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
-          1. If no arguments were passed to this function invocation, let _s_ be *""*.
+          1. If _value_ is not present, let _s_ be the empty String.
           1. Else,
             1. If NewTarget is *undefined* and Type(_value_) is Symbol, return SymbolDescriptiveString(_value_).
             1. Let _s_ be ? ToString(_value_).
@@ -29661,8 +29660,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. If _form_ is not present or _form_ is *undefined*, set _form_ to *"NFC"*.
-          1. Let _f_ be ? ToString(_form_).
+          1. If _form_ is *undefined*, let _f_ be *"NFC"*.
+          1. Else, let _f_ be ? ToString(_form_).
           1. If _f_ is not one of *"NFC"*, *"NFD"*, *"NFKC"*, or *"NFKD"*, throw a *RangeError* exception.
           1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="https://unicode.org/reports/tr15/">https://unicode.org/reports/tr15/</a>.
           1. Return _ns_.
@@ -32747,7 +32746,6 @@ THH:mm:ss.sss
           1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
           1. Else,
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
-            1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_items_, @@iterator).
           1. If _usingIterator_ is not *undefined*, then
@@ -32768,7 +32766,7 @@ THH:mm:ss.sss
                 1. Return _A_.
               1. Let _nextValue_ be ? IteratorValue(_next_).
               1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be Call(_mapfn_, _T_, &laquo; _nextValue_, _k_ &raquo;).
+                1. Let _mappedValue_ be Call(_mapfn_, _thisArg_, &laquo; _nextValue_, _k_ &raquo;).
                 1. If _mappedValue_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _mappedValue_).
                 1. Set _mappedValue_ to _mappedValue_.[[Value]].
               1. Else, let _mappedValue_ be _nextValue_.
@@ -32787,7 +32785,7 @@ THH:mm:ss.sss
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. If _mapping_ is *true*, then
-              1. Let _mappedValue_ be ? Call(_mapfn_, _T_, &laquo; _kValue_, _k_ &raquo;).
+              1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, _k_ &raquo;).
             1. Else, let _mappedValue_ be _kValue_.
             1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
             1. Set _k_ to _k_ + 1.
@@ -32991,14 +32989,13 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _testResult_ is *false*, return *false*.
             1. Set _k_ to _k_ + 1.
           1. Return *true*.
@@ -33047,7 +33044,6 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
@@ -33056,7 +33052,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _selected_ is *true*, then
                 1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_to_), _kValue_).
                 1. Set _to_ to _to_ + 1.
@@ -33083,12 +33079,11 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
             1. If _testResult_ is *true*, return _kValue_.
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
@@ -33112,12 +33107,11 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
             1. If _testResult_ is *true*, return _k_.
             1. Set _k_ to _k_ + 1.
           1. Return -1.
@@ -33202,14 +33196,13 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Perform ? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;).
+              1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;).
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
         </emu-alg>
@@ -33370,7 +33363,6 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
@@ -33378,7 +33370,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _mappedValue_ be ? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;).
+              1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;).
               1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
             1. Set _k_ to _k_ + 1.
           1. Return _A_.
@@ -33645,14 +33637,13 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _testResult_ is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -34395,11 +34386,10 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
-          1. If _mapfn_ is present and _mapfn_ is not *undefined*, then
+          1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
+          1. Else,
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
-          1. Else, let _mapping_ be *false*.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _usingIterator_ be ? GetMethod(_source_, @@iterator).
           1. If _usingIterator_ is not *undefined*, then
             1. Let _values_ be ? IterableToList(_source_, _usingIterator_).
@@ -34410,7 +34400,7 @@ THH:mm:ss.sss
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
               1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be ? Call(_mapfn_, _T_, &laquo; _kValue_, _k_ &raquo;).
+                1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, _k_ &raquo;).
               1. Else, let _mappedValue_ be _kValue_.
               1. Perform ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
               1. Set _k_ to _k_ + 1.
@@ -34425,7 +34415,7 @@ THH:mm:ss.sss
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. If _mapping_ is *true*, then
-              1. Let _mappedValue_ be ? Call(_mapfn_, _T_, &laquo; _kValue_, _k_ &raquo;).
+              1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, _k_ &raquo;).
             1. Else, let _mappedValue_ be _kValue_.
             1. Perform ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
             1. Set _k_ to _k_ + 1.
@@ -34645,14 +34635,13 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _kept_ be a new empty List.
           1. Let _k_ be 0.
           1. Let _captured_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
             1. If _selected_ is *true*, then
               1. Append _kValue_ to the end of _kept_.
               1. Set _captured_ to _captured_ + 1.
@@ -34743,13 +34732,12 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _len_ &raquo;).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _mappedValue_ be ? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;).
+            1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;).
             1. Perform ? Set(_A_, _Pk_, _mappedValue_, *true*).
             1. Set _k_ to _k_ + 1.
           1. Return _A_.
@@ -35194,11 +35182,11 @@ THH:mm:ss.sss
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
           1. Let _offset_ be ? ToIndex(_byteOffset_).
           1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
-          1. If _length_ is present and _length_ is not *undefined*, then
+          1. If _length_ is not *undefined*, then
             1. Let _newLength_ be ? ToIndex(_length_).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
-          1. If _length_ is either not present or *undefined*, then
+          1. If _length_ is *undefined*, then
             1. If _bufferByteLength_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
             1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
             1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
@@ -35316,7 +35304,7 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Map.prototype%"*, &laquo; [[MapData]] &raquo;).
           1. Set _map_.[[MapData]] to a new empty List.
-          1. If _iterable_ is not present, or is either *undefined* or *null*, return _map_.
+          1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
@@ -35446,11 +35434,10 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _e_ that is an element of _entries_, in original key insertion order, do
             1. If _e_.[[Key]] is not ~empty~, then
-              1. Perform ? Call(_callbackfn_, _T_, &laquo; _e_.[[Value]], _e_.[[Key]], _M_ &raquo;).
+              1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _e_.[[Value]], _e_.[[Key]], _M_ &raquo;).
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
@@ -35686,7 +35673,6 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Set.prototype%"*, &laquo; [[SetData]] &raquo;).
           1. Set _set_.[[SetData]] to a new empty List.
-          1. If _iterable_ is not present, set _iterable_ to *undefined*.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
@@ -35812,11 +35798,10 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each _e_ that is an element of _entries_, in original insertion order, do
             1. If _e_ is not ~empty~, then
-              1. Perform ? Call(_callbackfn_, _T_, &laquo; _e_, _e_, _S_ &raquo;).
+              1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _e_, _e_, _S_ &raquo;).
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
@@ -36025,7 +36010,7 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakMap.prototype%"*, &laquo; [[WeakMapData]] &raquo;).
           1. Set _map_.[[WeakMapData]] to a new empty List.
-          1. If _iterable_ is not present, or is either *undefined* or *null*, return _map_.
+          1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
@@ -36171,7 +36156,6 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakSet.prototype%"*, &laquo; [[WeakSetData]] &raquo;).
           1. Set _set_.[[WeakSetData]] to a new empty List.
-          1. If _iterable_ is not present, set _iterable_ to *undefined*.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
@@ -36846,7 +36830,7 @@ THH:mm:ss.sss
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
           1. If _offset_ &gt; _bufferByteLength_, throw a *RangeError* exception.
-          1. If _byteLength_ is either not present or *undefined*, then
+          1. If _byteLength_ is *undefined*, then
             1. Let _viewByteLength_ be _bufferByteLength_ - _offset_.
           1. Else,
             1. Let _viewByteLength_ be ? ToIndex(_byteLength_).


### PR DESCRIPTION
Using missing parameters directly eliminates extra steps, resulting in more descriptive variable names and increased visibility for functions where "X is (not) present" is absolutely required. ES6+ era algorithms already do treat missing parameters as `undefined` and use them directly.