### PR TITLE
Editorial: Explain why *_SAFE_INTEGER magnitude is not a power of two

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30946,6 +30946,9 @@
 
       <emu-clause id="sec-number.issafeinteger">
         <h1>Number.isSafeInteger ( _number_ )</h1>
+        <emu-note>
+          <p>An integer _n_ is considered "<dfn id="safe-integer">safe</dfn>" if and only if the Number value for _n_ is not the Number value for any other integer.</p>
+        </emu-note>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If IsIntegralNumber(_number_) is *true*, then
@@ -30957,7 +30960,7 @@
       <emu-clause id="sec-number.max_safe_integer">
         <h1>Number.MAX_SAFE_INTEGER</h1>
         <emu-note>
-          <p>The value of `Number.MAX_SAFE_INTEGER` is the largest integral Number n such that ℝ(n) and ℝ(n) + 1 are both exactly representable as a Number value.</p>
+          <p>Due to rounding behaviour necessitated by precision limitations of IEEE 754-2019, the Number value for every integer greater than `Number.MAX_SAFE_INTEGER` is shared with at least one other integer. Such large-magnitude integers are therefore not <emu-xref href="#safe-integer">safe</emu-xref>, and are not guaranteed to be exactly representable as Number values or even to be distinguishable from each other. For example, both `9007199254740992` and `9007199254740993` evaluate to the Number value *9007199254740992*<sub>𝔽</sub>.</p>
         </emu-note>
         <p>The value of `Number.MAX_SAFE_INTEGER` is *9007199254740991*<sub>𝔽</sub> (𝔽(2<sup>53</sup> - 1)).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
@@ -30972,7 +30975,7 @@
       <emu-clause id="sec-number.min_safe_integer">
         <h1>Number.MIN_SAFE_INTEGER</h1>
         <emu-note>
-          <p>The value of `Number.MIN_SAFE_INTEGER` is the smallest integral Number n such that ℝ(n) and ℝ(n) - 1 are both exactly representable as a Number value.</p>
+          <p>Due to rounding behaviour necessitated by precision limitations of IEEE 754-2019, the Number value for every integer less than `Number.MIN_SAFE_INTEGER` is shared with at least one other integer. Such large-magnitude integers are therefore not <emu-xref href="#safe-integer">safe</emu-xref>, and are not guaranteed to be exactly representable as Number values or even to be distinguishable from each other. For example, both `-9007199254740992` and `-9007199254740993` evaluate to the Number value *-9007199254740992*<sub>𝔽</sub>.</p>
         </emu-note>
         <p>The value of `Number.MIN_SAFE_INTEGER` is *-9007199254740991*<sub>𝔽</sub> (𝔽(-(2<sup>53</sup> - 1))).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>


### PR DESCRIPTION
The current text for MAX_SAFE_INTEGER and MIN_SAFE_INTEGER is somewhat indirect, resulting in repeated confusion and re-explanation of what those values signify and why they should not have magnitude 2<sup>53</sup> (i.e., failing to indicate the relevance of "n + 1" and "n - 1"). It also comes up in other contexts, cf. https://github.com/httpwg/http-extensions/issues/737#issuecomment-452189033 .

This PR attempts to remedy the issue with both prose and simple code examples of collision at 2<sup>53</sup>.