### PR TITLE
Allow hosts to reuse an existing Realm Intrinsics record

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6163,7 +6163,7 @@
       <p>The abstract operation CreateRealm with no arguments performs the following steps:</p>
       <emu-alg>
         1. Let _realmRec_ be a new Realm Record.
-        1. Perform CreateIntrinsics(_realmRec_).
+        1. If the host requires use of an existing Realm Record's intrinsics to serve as _realmRec_'s intrinsics, let _realmRec_.[[Intrinsics]] be assigned in an implementation-defined manner to an existing Realm Record's intrinsics record. Otherwise, perform CreateIntrinsics(_realmRec_).
         1. Set _realmRec_.[[GlobalObject]] to *undefined*.
         1. Set _realmRec_.[[GlobalEnv]] to *undefined*.
         1. Set _realmRec_.[[TemplateMap]] to a new empty List.


### PR DESCRIPTION
This PR builds upon previous talks we have had about Realms and Frozen Realms in JS. After having several discussions in meetings about these topics, it seems like there is still division on the direction that could be taken regarding Realms. While working and attend both the Frozen Realms calls and Node.js Security WG issues, it seems like investigation into this area would be good for Node.js to get a better view of what it would be like to use Realms.

This allows a host to reuse an existing Realm's Intrinsics while exposing a different set of globals. This PR would enable hosts to create Realms with the same set of intrinsics such as Frozen Realms and Compartments that have been talked about in the past. This is intended only to be exposed at the host level and not be a required behavior for hosts not wishing to expose the behavior. Node.js has a specific interest in allowing this at the host level while investigating security policies of modules and the ability to run code in isolated spaces. This PR may be built upon after further investigation, but it intended to be minimal while that investigation continues.

Prior to this PR hosts are already able to supply their own global object and global this value; this PR expands the options of what a host may supply to include intrinsics from another existing realm. If there is need for having modified intrinsics such as having differing values for `Function` or `Function.prototype.constructor`, I feel that can be addressed in a separate PR.

We could refactor Realm creation a bit to make the whole process much more centralized and easier to read, but I left the PR as minimal as possible for now to allow easier reading and expression of the host determining this choice. If it is desirable to refactor the Realm creation text, we can do so hopefully separately from this PR, but it seems like it should be done sometime given some odd wording while reading things.