### PR TITLE
Allow variable declaration within IfStatement conditions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15793,8 +15793,8 @@
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       IfStatement[Yield, Await, Return] :
-        `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` Statement[?Yield, ?Await, ?Return]
-        `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+        `if` `(` Statement[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` Statement[?Yield, ?Await, ?Return]
+        `if` `(` Statement[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     </emu-grammar>
     <p>Each `else` for which the choice of associated `if` is ambiguous shall be associated with the nearest possible `if` that would otherwise have no corresponding `else`.</p>
 
@@ -15802,8 +15802,8 @@
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
         IfStatement :
-          `if` `(` Expression `)` Statement `else` Statement
-          `if` `(` Expression `)` Statement
+          `if` `(` Statement `)` Statement `else` Statement
+          `if` `(` Statement `)` Statement
       </emu-grammar>
       <ul>
         <li>
@@ -15819,13 +15819,13 @@
       <h1>Static Semantics: ContainsDuplicateLabels</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasDuplicate_ be ContainsDuplicateLabels of the first |Statement| with argument _labelSet_.
         1. If _hasDuplicate_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of the second |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -15835,13 +15835,13 @@
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |Statement| with argument _labelSet_.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of the second |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
@@ -15851,13 +15851,13 @@
       <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
       <p>With parameters _iterationSet_ and _labelSet_.</p>
       <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         1. If _hasUndefinedLabels_ is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of the second |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -15866,13 +15866,13 @@
     <emu-clause id="sec-if-statement-static-semantics-vardeclarednames">
       <h1>Static Semantics: VarDeclaredNames</h1>
       <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _names_ be VarDeclaredNames of the first |Statement|.
         1. Append to _names_ the elements of the VarDeclaredNames of the second |Statement|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
@@ -15881,13 +15881,13 @@
     <emu-clause id="sec-if-statement-static-semantics-varscopeddeclarations">
       <h1>Static Semantics: VarScopedDeclarations</h1>
       <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of the first |Statement|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of the second |Statement|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
@@ -15895,7 +15895,7 @@
 
     <emu-clause id="sec-if-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
@@ -15905,7 +15905,7 @@
           1. Let _stmtCompletion_ be the result of evaluating the second |Statement|.
         1. Return Completion(UpdateEmpty(_stmtCompletion_, *undefined*)).
       </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Statement `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
@@ -20445,14 +20445,14 @@
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+        <emu-grammar>IfStatement : `if` `(` Statement `)` Statement `else` Statement</emu-grammar>
         <emu-alg>
           1. Let _has_ be HasCallInTailPosition of the first |Statement| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. Return HasCallInTailPosition of the second |Statement| with argument _call_.
         </emu-alg>
         <emu-grammar>
-          IfStatement : `if` `(` Expression `)` Statement
+          IfStatement : `if` `(` Statement `)` Statement
 
           IterationStatement :
             `do` Statement `while` `(` Expression `)` `;`
@@ -40680,10 +40680,10 @@ THH:mm:ss.sss
       <p>The following augments the |IfStatement| production in <emu-xref href="#sec-if-statement"></emu-xref>:</p>
       <emu-grammar type="definition">
         IfStatement[Yield, Await, Return] :
-          `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` Statement[?Yield, ?Await, ?Return]
-          `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
-          `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
-          `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default]
+          `if` `(` Statement[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` Statement[?Yield, ?Await, ?Return]
+          `if` `(` Statement[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
+          `if` `(` Statement[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
+          `if` `(` Statement[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default]
       </emu-grammar>
       <p>This production only applies when parsing non-strict code. Code matching this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ?Await, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
     </emu-annex>


### PR DESCRIPTION
In languages such as C and Perl, it is possible to declare a variable within the `Condition` of an If statement:

```
if (const paramKey = this.link.queryParamKey) {
    console.log(paramKey);
}
```

I recognize the fact that my modifications to `spec.html` are insufficient and likely incorrect.