### PR TITLE
Normative: Remove implementation-defined typeof behavior

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13051,15 +13051,7 @@
             </tr>
             <tr>
               <td>
-                Object (ordinary and does not implement [[Call]])
-              </td>
-              <td>
-                `"object"`
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Object (standard exotic and does not implement [[Call]])
+                Object (does not implement [[Call]])
               </td>
               <td>
                 `"object"`
@@ -13073,20 +13065,9 @@
                 `"function"`
               </td>
             </tr>
-            <tr>
-              <td>
-                Object (non-standard exotic and does not implement [[Call]])
-              </td>
-              <td>
-                Implementation-defined. Must not be `"undefined"`, `"boolean"`, `"function"`, `"number"`, `"symbol"`, or `"string"`.
-              </td>
-            </tr>
             </tbody>
           </table>
         </emu-table>
-        <emu-note>
-          <p>Implementations are discouraged from defining new `typeof` result values for non-standard exotic objects. If possible `"object"` should be used for such objects.</p>
-        </emu-note>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
Previously, the ECMAScript specification permitted non-callable
non-standard exotic objects to have implementation-defined typeof,
within certain limits. Although some ECMAScript implementations
may have taken advantage of this possibility historically, it's not
clear that anyone needs it anymore. Instead, other mechanisms can
be used by embedders to indicate aspects of objects.

Closes #1440