### PR TITLE
Editorial: Simplify tables removing end tags (tr, th, and td) and tbody

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -924,10 +924,12 @@
         <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where &ldquo;name&rdquo; is one of the values listed in <emu-xref href="#table-1"></emu-xref>.</p>
         <emu-table id="table-1" caption="Well-known Symbols">
           <table>
-            <tr>
-              <th>Specification Name
-              <th>[[Description]]
-              <th>Value and Purpose
+            <thead>
+              <tr>
+                <th>Specification Name
+                <th>[[Description]]
+                <th>Value and Purpose
+            </thead>
             <tr>
               <td>@@asyncIterator
               <td>`"Symbol.asyncIterator"`
@@ -1028,10 +1030,12 @@
         <p>Attributes are used in this specification to define and explain the state of Object properties. A data property associates a key value with the attributes listed in <emu-xref href="#table-2"></emu-xref>.</p>
         <emu-table id="table-2" caption="Attributes of a Data Property">
           <table>
-            <tr>
-              <th>Attribute Name
-              <th>Value Domain
-              <th>Description
+            <thead>
+              <tr>
+                <th>Attribute Name
+                <th>Value Domain
+                <th>Description
+            </thead>
             <tr>
               <td>[[Value]]
               <td>Any ECMAScript language type
@@ -1053,10 +1057,12 @@
         <p>An accessor property associates a key value with the attributes listed in <emu-xref href="#table-3"></emu-xref>.</p>
         <emu-table id="table-3" caption="Attributes of an Accessor Property">
           <table>
-            <tr>
-              <th>Attribute Name
-              <th>Value Domain
-              <th>Description
+            <thead>
+              <tr>
+                <th>Attribute Name
+                <th>Value Domain
+                <th>Description
+            </thead>
             <tr>
               <td>[[Get]]
               <td>Object | Undefined
@@ -1078,9 +1084,11 @@
         <p>If the initial values of a property's attributes are not explicitly specified by this specification, the default value defined in <emu-xref href="#table-4"></emu-xref> is used.</p>
         <emu-table id="table-4" caption="Default Attribute Values">
           <table>
-            <tr>
-              <th>Attribute Name
-              <th>Default Value
+            <thead>
+              <tr>
+                <th>Attribute Name
+                <th>Default Value
+            </thead>
             <tr>
               <td>[[Value]]
               <td>*undefined*
@@ -1113,10 +1121,12 @@
         <p>The &ldquo;Signature&rdquo; column of <emu-xref href="#table-5"></emu-xref> and other similar tables describes the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names. If a parameter name is the same as an ECMAScript type name then the name describes the required type of the parameter value. If an internal method explicitly returns a value, its parameter list is followed by the symbol &ldquo;&rarr;&rdquo; and the type name of the returned value. The type names used in signatures refer to the types defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> augmented by the following additional names. &ldquo;<em>any</em>&rdquo; means the value may be any ECMAScript language type. An internal method implicitly returns a Completion Record. In addition to its parameters, an internal method always has access to the object that is the target of the method invocation.</p>
         <emu-table id="table-5" caption="Essential Internal Methods">
           <table>
-            <tr>
-              <th>Internal Method
-              <th>Signature
-              <th>Description
+            <thead>
+              <tr>
+                <th>Internal Method
+                <th>Signature
+                <th>Description
+            </thead>
             <tr>
               <td>[[GetPrototypeOf]]
               <td>( ) <b>&rarr;</b> Object | Null
@@ -1166,10 +1176,12 @@
         <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.</p>
         <emu-table id="table-6" caption="Additional Essential Internal Methods of Function Objects">
           <table>
-            <tr>
-              <th>Internal Method
-              <th>Signature
-              <th>Description
+            <thead>
+              <tr>
+                <th>Internal Method
+                <th>Signature
+                <th>Description
+            </thead>
             <tr>
               <td>[[Call]]
               <td>(<em>any</em>, a List of <em>any</em>) <b>&rarr;</b> <em>any</em>
@@ -1357,10 +1369,12 @@
         <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-7"></emu-xref>.</p>
         <emu-table id="table-7" caption="Well-Known Intrinsic Objects">
           <table>
-            <tr>
-              <th>Intrinsic Name
-              <th>Global Name
-              <th>ECMAScript Language Association
+            <thead>
+              <tr>
+                <th>Intrinsic Name
+                <th>Global Name
+                <th>ECMAScript Language Association
+            </thead>
             <tr>
               <td>%Array%
               <td>`Array`
@@ -1860,10 +1874,12 @@
       <p>Values of the Completion type are Record values whose fields are defined as by <emu-xref href="#table-8"></emu-xref>. Such values are referred to as <dfn>Completion Record</dfn>s.</p>
       <emu-table id="table-8" caption="Completion Record Fields">
         <table>
-          <tr>
-            <th>Field Name
-            <th>Value
-            <th>Meaning
+          <thead>
+            <tr>
+              <th>Field Name
+              <th>Value
+              <th>Meaning
+          </thead>
           <tr>
             <td>[[Type]]
             <td>One of ~normal~, ~break~, ~continue~, ~return~, or ~throw~
@@ -2386,9 +2402,11 @@
       <p>The abstract operation ToBoolean converts _argument_ to a value of type Boolean according to <emu-xref href="#table-10"></emu-xref>:</p>
       <emu-table id="table-10" caption="ToBoolean Conversions">
         <table>
-          <tr>
-            <th>Argument Type
-            <th>Result
+          <thead>
+            <tr>
+              <th>Argument Type
+              <th>Result
+          </thead>
           <tr>
             <td>Undefined
             <td>Return *false*.
@@ -2419,9 +2437,11 @@
       <p>The abstract operation ToNumber converts _argument_ to a value of type Number according to <emu-xref href="#table-11"></emu-xref>:</p>
       <emu-table id="table-11" caption="ToNumber Conversions">
         <table>
-          <tr>
-            <th>Argument Type
-            <th>Result
+          <thead>
+            <tr>
+              <th>Argument Type
+              <th>Result
+          </thead>
           <tr>
             <td>Undefined
             <td>Return *NaN*.
@@ -2733,9 +2753,11 @@
       <p>The abstract operation ToString converts _argument_ to a value of type String according to <emu-xref href="#table-12"></emu-xref>:</p>
       <emu-table id="table-12" caption="ToString Conversions">
         <table>
-          <tr>
-            <th>Argument Type
-            <th>Result
+          <thead>
+            <tr>
+              <th>Argument Type
+              <th>Result
+          </thead>
           <tr>
             <td>Undefined
             <td>Return `"undefined"`.
@@ -2836,9 +2858,11 @@
       <p>The abstract operation ToObject converts _argument_ to a value of type Object according to <emu-xref href="#table-13"></emu-xref>:</p>
       <emu-table id="table-13" caption="ToObject Conversions">
         <table>
-          <tr>
-            <th>Argument Type
-            <th>Result
+          <thead>
+            <tr>
+              <th>Argument Type
+              <th>Result
+          </thead>
           <tr>
             <td>Undefined
             <td>Throw a *TypeError* exception.
@@ -2922,9 +2946,11 @@
       <p>The abstract operation RequireObjectCoercible throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-14"></emu-xref>:</p>
       <emu-table id="table-14" caption="RequireObjectCoercible Results">
         <table>
-          <tr>
-            <th>Argument Type
-            <th>Result
+          <thead>
+            <tr>
+              <th>Argument Type
+              <th>Result
+          </thead>
           <tr>
             <td>Undefined
             <td>Throw a *TypeError* exception.
@@ -3697,9 +3723,11 @@
       <p>For specification purposes Environment Record values are values of the Record specification type and can be thought of as existing in a simple object-oriented hierarchy where Environment Record is an abstract class with three concrete subclasses, declarative Environment Record, object Environment Record, and global Environment Record. Function Environment Records and module Environment Records are subclasses of declarative Environment Record. The abstract class includes the abstract specification methods defined in <emu-xref href="#table-15"></emu-xref>. These abstract methods have distinct concrete algorithms for each of the concrete subclasses.</p>
       <emu-table id="table-15" caption="Abstract Methods of Environment Records">
         <table>
-          <tr>
-            <th>Method
-            <th>Purpose
+          <thead>
+            <tr>
+              <th>Method
+              <th>Purpose
+          </thead>
           <tr>
             <td>HasBinding(N)
             <td>Determine if an Environment Record has a binding for the String value _N_. Return *true* if it does and *false* if it does not.
@@ -3975,10 +4003,12 @@
         <p>Function Environment Records have the additional state fields listed in <emu-xref href="#table-16"></emu-xref>.</p>
         <emu-table id="table-16" caption="Additional Fields of Function Environment Records">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[ThisValue]]
               <td>Any
@@ -4004,9 +4034,11 @@
         <p>Function Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and share the same specifications for all of those methods except for HasThisBinding and HasSuperBinding. In addition, function Environment Records support the methods listed in <emu-xref href="#table-17"></emu-xref>:</p>
         <emu-table id="table-17" caption="Additional Methods of Function Environment Records">
           <table>
-            <tr>
-              <th>Method
-              <th>Purpose
+            <thead>
+              <tr>
+                <th>Method
+                <th>Purpose
+            </thead>
             <tr>
               <td>BindThisValue(V)
               <td>Set the [[ThisValue]] and record that it has been initialized.
@@ -4079,10 +4111,12 @@
         <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-18"></emu-xref> and the additional methods listed in <emu-xref href="#table-19"></emu-xref>.</p>
         <emu-table id="table-18" caption="Additional Fields of Global Environment Records">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[ObjectRecord]]
               <td>Object Environment Record
@@ -4103,9 +4137,11 @@
         </emu-table>
         <emu-table id="table-19" caption="Additional Methods of Global Environment Records">
           <table>
-            <tr>
-              <th>Method
-              <th>Purpose
+            <thead>
+              <tr>
+                <th>Method
+                <th>Purpose
+            </thead>
             <tr>
               <td>GetThisBinding()
               <td>Return the value of this Environment Record's `this` binding.
@@ -4376,9 +4412,11 @@
         <p>Module Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and share the same specifications for all of those methods except for GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding. In addition, module Environment Records support the methods listed in <emu-xref href="#table-20"></emu-xref>:</p>
         <emu-table id="table-20" caption="Additional Methods of Module Environment Records">
           <table>
-            <tr>
-              <th>Method
-              <th>Purpose
+            <thead>
+              <tr>
+                <th>Method
+                <th>Purpose
+            </thead>
             <tr>
               <td>CreateImportBinding(N, M, N2)
               <td>Create an immutable indirect binding in a module Environment Record. The String value _N_ is the text of the bound name. _M_ is a Module Record, and _N2_ is a binding that exists in M's module Environment Record.
@@ -4553,10 +4591,12 @@
     <p>A realm is represented in this specification as a <dfn id="realm-record">Realm Record</dfn> with the fields specified in <emu-xref href="#table-21"></emu-xref>:</p>
     <emu-table id="table-21" caption="Realm Record Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+      <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[Intrinsics]]
           <td>Record whose field names are intrinsic keys and whose values are objects
@@ -4653,9 +4693,11 @@
     <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-22"></emu-xref>.</p>
     <emu-table id="table-22" caption="State Components for All Execution Contexts">
       <table>
-        <tr>
-          <th>Component
-          <th>Purpose
+        <thead>
+          <tr>
+            <th>Component
+            <th>Purpose
+        </thead>
         <tr>
           <td>code evaluation state
           <td>Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
@@ -4675,9 +4717,11 @@
     <p>Execution contexts for ECMAScript code have the additional state components listed in <emu-xref href="#table-23"></emu-xref>.</p>
     <emu-table id="table-23" caption="Additional State Components for ECMAScript Code Execution Contexts">
       <table>
-        <tr>
-          <th>Component
-          <th>Purpose
+        <thead>
+          <tr>
+            <th>Component
+            <th>Purpose
+        </thead>
         <tr>
           <td>LexicalEnvironment
           <td>Identifies the Lexical Environment used to resolve identifier references made by code within this execution context.
@@ -4690,9 +4734,11 @@
     <p>Execution contexts representing the evaluation of generator objects have the additional state components listed in <emu-xref href="#table-24"></emu-xref>.</p>
     <emu-table id="table-24" caption="Additional State Components for Generator Execution Contexts">
       <table>
-        <tr>
-          <th>Component
-          <th>Purpose
+        <thead>
+          <tr>
+            <th>Component
+            <th>Purpose
+        </thead>
         <tr>
           <td>Generator
           <td>The GeneratorObject that this execution context is evaluating.
@@ -4781,10 +4827,12 @@
     <p>Execution of a Job can be initiated only when there is no running execution context and the execution context stack is empty. A PendingJob is a request for the future execution of a Job. A PendingJob is an internal Record whose fields are specified in <emu-xref href="#table-25"></emu-xref>. Once execution of a Job is initiated, the Job always executes to completion. No other Job may be initiated until the currently running Job completes. However, the currently running Job or external events may cause the enqueuing of additional PendingJobs that may be initiated sometime after completion of the currently running Job.</p>
     <emu-table id="table-25" caption="PendingJob Record Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+        <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[Job]]
           <td>The name of a Job abstract operation
@@ -4811,9 +4859,11 @@
     <p>Each agent has its own set of named Job Queues.  All references to a named job queue in this specification denote the named job queue of the surrounding agent.</p>
     <emu-table id="table-26" caption="Required Job Queues">
       <table>
-        <tr>
-          <th>Name
-          <th>Purpose
+        <thead>
+          <tr>
+            <th>Name
+            <th>Purpose
+        </thead>
         <tr>
           <td>ScriptJobs
           <td>Jobs that validate and evaluate ECMAScript |Script| and |Module| source text. See clauses 10 and 15.
@@ -4904,10 +4954,12 @@
     <p>While an agent's executing thread executes the jobs in the agent's job queues, the agent is the <dfn id="surrounding-agent">surrounding agent</dfn> for the code in those jobs.  The code uses the surrounding agent to access the specification level execution objects held within the agent: the running execution context, the execution context stack, the named job queues, and the Agent Record's fields.</p>
     <emu-table id="table-agent-record" caption="Agent Record Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+        <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[LittleEndian]]
           <td>Boolean
@@ -5426,10 +5478,12 @@
     <p>ECMAScript function objects have the additional internal slots listed in <emu-xref href="#table-27"></emu-xref>.</p>
     <emu-table id="table-27" caption="Internal Slots of ECMAScript Function Objects">
       <table>
-        <tr>
-          <th>Internal Slot
-          <th>Type
-          <th>Description
+        <thead>
+          <tr>
+            <th>Internal Slot
+            <th>Type
+            <th>Description
+        </thead>
         <tr>
           <td>[[Environment]]
           <td>Lexical Environment
@@ -5941,10 +5995,12 @@
       <p>Bound function objects do not have the internal slots of ECMAScript function objects defined in <emu-xref href="#table-27"></emu-xref>. Instead they have the internal slots defined in <emu-xref href="#table-28"></emu-xref>.</p>
       <emu-table id="table-28" caption="Internal Slots of Bound Function Exotic Objects">
         <table>
-          <tr>
-            <th>Internal Slot
-            <th>Type
-            <th>Description
+          <thead>
+            <tr>
+              <th>Internal Slot
+              <th>Type
+              <th>Description
+          </thead>
           <tr>
             <td>[[BoundTargetFunction]]
             <td>Callable Object
@@ -6607,10 +6663,12 @@
       <p>Module namespace objects have the internal slots defined in <emu-xref href="#table-29"></emu-xref>.</p>
       <emu-table id="table-29" caption="Internal Slots of Module Namespace Exotic Objects">
         <table>
-          <tr>
-            <th>Internal Slot
-            <th>Type
-            <th>Description
+          <thead>
+            <tr>
+              <th>Internal Slot
+              <th>Type
+              <th>Description
+          </thead>
           <tr>
             <td>[[Module]]
             <td>Module Record
@@ -6797,9 +6855,11 @@
     <p>A proxy object is an exotic object whose essential internal methods are partially implemented using ECMAScript code. Every proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's <em>handler object</em>, or *null*. Methods (see <emu-xref href="#table-30"></emu-xref>) of a handler object may be used to augment the implementation for one or more of the proxy object's internal methods. Every proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the *null* value. This object is called the proxy's <em>target object</em>.</p>
     <emu-table id="table-30" caption="Proxy Handler Methods">
       <table>
-        <tr>
-          <th>Internal Method
-          <th>Handler Method
+        <thead>
+          <tr>
+            <th>Internal Method
+            <th>Handler Method
+        </thead>
         <tr>
           <td>[[GetPrototypeOf]]
           <td>`getPrototypeOf`
@@ -7496,11 +7556,13 @@
     <p>The special treatment of certain format-control characters outside of comments, string literals, and regular expression literals is summarized in <emu-xref href="#table-31"></emu-xref>.</p>
     <emu-table id="table-31" caption="Format-Control Code Point Usage">
       <table>
-        <tr>
-          <th>Code Point
-          <th>Name
-          <th>Abbreviation
-          <th>Usage
+        <thead>
+          <tr>
+            <th>Code Point
+            <th>Name
+            <th>Abbreviation
+            <th>Usage
+        </thead>
         <tr>
           <td>`U+200C`
           <td>ZERO WIDTH NON-JOINER
@@ -7526,10 +7588,12 @@
     <p>The ECMAScript white space code points are listed in <emu-xref href="#table-32"></emu-xref>.</p>
     <emu-table id="table-32" caption="White Space Code Points">
       <table>
-        <tr>
-          <th>Code Point
-          <th>Name
-          <th>Abbreviation
+        <thead>
+          <tr>
+            <th>Code Point
+            <th>Name
+            <th>Abbreviation
+        </thead>
         <tr>
           <td>`U+0009`
           <td>CHARACTER TABULATION
@@ -7585,10 +7649,12 @@
     <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-33"></emu-xref>.</p>
     <emu-table id="table-33" caption="Line Terminator Code Points">
       <table>
-        <tr>
-          <th>Code Point
-          <th>Unicode Name
-          <th>Abbreviation
+        <thead>
+          <tr>
+            <th>Code Point
+            <th>Unicode Name
+            <th>Abbreviation
+        </thead>
         <tr>
           <td>`U+000A`
           <td>LINE FEED (LF)
@@ -8295,11 +8361,13 @@
         </ul>
         <emu-table id="table-34" caption="String Single Character Escape Sequences">
           <table>
-            <tr>
-              <th>Escape Sequence
-              <th>Code Unit Value
-              <th>Unicode Character Name
-              <th>Symbol
+            <thead>
+              <tr>
+                <th>Escape Sequence
+                <th>Code Unit Value
+                <th>Unicode Character Name
+                <th>Symbol
+            </thead>
             <tr>
               <td>`\\b`
               <td>`0x0008`
@@ -10821,9 +10889,11 @@
         </emu-alg>
         <emu-table id="table-35" caption="typeof Operator Results">
           <table>
-            <tr>
-              <th>Type of _val_
-              <th>Result
+            <thead>
+              <tr>
+                <th>Type of _val_
+                <th>Result
+            </thead>
             <tr>
               <td>Undefined
               <td>`"undefined"`
@@ -18696,10 +18766,12 @@
 
       <emu-table id="table-script-records" caption="Script Record Fields">
         <table>
-          <tr>
-            <th>Field Name
-            <th>Value Type
-            <th>Meaning
+          <thead>
+            <tr>
+              <th>Field Name
+              <th>Value Type
+              <th>Meaning
+          </thead>
           <tr>
             <td>[[Realm]]
             <td>Realm Record | *undefined*
@@ -19199,10 +19271,12 @@
         <p>Module Record defines the fields listed in <emu-xref href="#table-36"></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-37"></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
         <emu-table id="table-36" caption="Module Record Fields">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value Type
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value Type
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[Realm]]
               <td>Realm Record | *undefined*
@@ -19223,9 +19297,11 @@
         </emu-table>
         <emu-table id="table-37" caption="Abstract Methods of Module Records">
           <table>
-            <tr>
-              <th>Method
-              <th>Purpose
+            <thead>
+              <tr>
+                <th>Method
+                <th>Purpose
+            </thead>
             <tr>
               <td>GetExportedNames(_exportStarSet_)
               <td>Return a list of all names that are either directly or indirectly exported from this module.
@@ -19257,10 +19333,12 @@
 
         <emu-table id="table-38" caption="Additional Fields of Source Text Module Records">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value Type
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value Type
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[ECMAScriptCode]]
               <td>a Parse Node
@@ -19306,10 +19384,12 @@
         <p>An <dfn id="importentry-record">ImportEntry Record</dfn> is a Record that digests information about a single declarative import. Each ImportEntry Record has the fields defined in <emu-xref href="#table-39"></emu-xref>:</p>
         <emu-table id="table-39" caption="ImportEntry Record Fields">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value Type
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value Type
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[ModuleRequest]]
               <td>String
@@ -19328,11 +19408,13 @@
           <p><emu-xref href="#table-40"></emu-xref> gives examples of ImportEntry records fields used to represent the syntactic import forms:</p>
           <emu-table id="table-40" caption="Import Forms Mappings to ImportEntry Records" informative>
             <table>
-              <tr>
-                <th>Import Statement Form
-                <th>[[ModuleRequest]]
-                <th>[[ImportName]]
-                <th>[[LocalName]]
+              <thead>
+                <tr>
+                  <th>Import Statement Form
+                  <th>[[ModuleRequest]]
+                  <th>[[ImportName]]
+                  <th>[[LocalName]]
+              </thead>
               <tr>
                 <td>`import v from "mod";`
                 <td>`"mod"`
@@ -19362,10 +19444,12 @@
         <p>An <dfn id="exportentry-record">ExportEntry Record</dfn> is a Record that digests information about a single declarative export. Each ExportEntry Record has the fields defined in <emu-xref href="#table-41"></emu-xref>:</p>
         <emu-table id="table-41" caption="ExportEntry Record Fields">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value Type
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value Type
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[ExportName]]
               <td>String | null
@@ -19388,12 +19472,14 @@
           <p><emu-xref href="#table-42"></emu-xref> gives examples of the ExportEntry record fields used to represent the syntactic export forms:</p>
           <emu-table id="table-42" caption="Export Forms Mappings to ExportEntry Records" informative>
             <table>
-              <tr>
-                <th>Export Statement Form
-                <th>[[ExportName]]
-                <th>[[ModuleRequest]]
-                <th>[[ImportName]]
-                <th>[[LocalName]]
+              <thead>
+                <tr>
+                  <th>Export Statement Form
+                  <th>[[ExportName]]
+                  <th>[[ModuleRequest]]
+                  <th>[[ImportName]]
+                  <th>[[LocalName]]
+              </thead>
               <tr>
                 <td>`export var v;`
                 <td>`"v"`
@@ -21045,13 +21131,15 @@
             <p>In UTF-8, characters are encoded using sequences of 1 to 6 octets. The only octet of a sequence of one has the higher-order bit set to 0, the remaining 7 bits being used to encode the character value. In a sequence of n octets, n &gt; 1, the initial octet has the n higher-order bits set to 1, followed by a bit set to 0. The remaining bits of that octet contain bits from the value of the character to be encoded. The following octets all have the higher-order bit set to 1 and the following bit set to 0, leaving 6 bits in each to contain bits from the character to be encoded. The possible UTF-8 encodings of ECMAScript characters are specified in <emu-xref href="#table-43"></emu-xref>.</p>
             <emu-table id="table-43" caption="UTF-8 Encodings" informative>
               <table>
-                <tr>
-                  <th>Code Unit Value
-                  <th>Representation
-                  <th>1<sup>st</sup> Octet
-                  <th>2<sup>nd</sup> Octet
-                  <th>3<sup>rd</sup> Octet
-                  <th>4<sup>th</sup> Octet
+                <thead>
+                  <tr>
+                    <th>Code Unit Value
+                    <th>Representation
+                    <th>1<sup>st</sup> Octet
+                    <th>2<sup>nd</sup> Octet
+                    <th>3<sup>rd</sup> Octet
+                    <th>4<sup>th</sup> Octet
+                </thead>
                 <tr>
                   <td>`0x0000 - 0x007F`
                   <td><code>00000000 0<i>zzzzzzz</i></code>
@@ -22246,10 +22334,12 @@
         <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-44"></emu-xref>.</p>
         <emu-table id="table-44" caption="GlobalSymbolRegistry Record Fields">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value
-              <th>Usage
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value
+                <th>Usage
+            </thead>
             <tr>
               <td>[[Key]]
               <td>A String
@@ -24942,9 +25032,11 @@ THH:mm:ss.sss
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
             <table>
-              <tr>
-                <th>Number
-                <th>Name
+              <thead>
+                <tr>
+                  <th>Number
+                  <th>Name
+              </thead>
               <tr>
                 <td>0
                 <td>`"Sun"`
@@ -24970,9 +25062,11 @@ THH:mm:ss.sss
           </emu-table>
           <emu-table id="sec-todatestring-month-names" caption="Names of months of the year">
             <table>
-              <tr>
-                <th>Number
-                <th>Name
+              <thead>
+                <tr>
+                  <th>Number
+                  <th>Name
+              </thead>
               <tr>
                 <td>0
                 <td>`"Jan"`
@@ -25603,10 +25697,12 @@ THH:mm:ss.sss
           </emu-alg>
           <emu-table id="table-45" caption="Replacement Text Symbol Substitutions">
             <table>
-              <tr>
-                <th>Code units
-                <th>Unicode Characters
-                <th>Replacement text
+              <thead>
+                <tr>
+                  <th>Code units
+                  <th>Unicode Characters
+                  <th>Replacement text
+              </thead>
               <tr>
                 <td>0x0024, 0x0024
                 <td>`$$`
@@ -25998,9 +26094,11 @@ THH:mm:ss.sss
         <p>String Iterator instances are ordinary objects that inherit properties from the %StringIteratorPrototype% intrinsic object. String Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-46"></emu-xref>.</p>
         <emu-table id="table-46" caption="Internal Slots of String Iterator Instances">
           <table>
-            <tr>
-              <th>Internal Slot
-              <th>Description
+            <thead>
+              <tr>
+                <th>Internal Slot
+                <th>Description
+            </thead>
             <tr>
               <td>[[IteratedString]]
               <td>The String value whose code units are being iterated.
@@ -26373,12 +26471,14 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-table id="table-47" caption="ControlEscape Code Point Values">
           <table>
-            <tr>
-              <th>ControlEscape
-              <th>Code Point Value
-              <th>Code Point
-              <th>Unicode Name
-              <th>Symbol
+            <thead>
+              <tr>
+                <th>ControlEscape
+                <th>Code Point Value
+                <th>Code Point
+                <th>Unicode Name
+                <th>Symbol
+            </thead>
             <tr>
               <td>`t`
               <td>9
@@ -29524,9 +29624,11 @@ THH:mm:ss.sss
         <p>Array Iterator instances are ordinary objects that inherit properties from the %ArrayIteratorPrototype% intrinsic object. Array Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-48"></emu-xref>.</p>
         <emu-table id="table-48" caption="Internal Slots of Array Iterator Instances">
           <table>
-            <tr>
-              <th>Internal Slot
-              <th>Description
+            <thead>
+              <tr>
+                <th>Internal Slot
+                <th>Description
+            </thead>
             <tr>
               <td>[[IteratedObject]]
               <td>The object whose array elements are being iterated.
@@ -29547,13 +29649,15 @@ THH:mm:ss.sss
     <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). Each element of a _TypedArray_ instance has the same underlying binary scalar data type. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-49"></emu-xref>, for each of the nine supported element types. Each constructor in <emu-xref href="#table-49"></emu-xref> has a corresponding distinct prototype object.</p>
     <emu-table id="table-49" caption="The TypedArray Constructors">
       <table>
-        <tr>
-          <th>Constructor Name and Intrinsic
-          <th>Element Type
-          <th>Element Size
-          <th>Conversion Operation
-          <th>Description
-          <th>Equivalent C Type
+        <thead>
+          <tr>
+            <th>Constructor Name and Intrinsic
+            <th>Element Type
+            <th>Element Size
+            <th>Conversion Operation
+            <th>Description
+            <th>Equivalent C Type
+        </thead>
         <tr>
           <td>
             Int8Array
@@ -30919,9 +31023,11 @@ THH:mm:ss.sss
         <p>Map Iterator instances are ordinary objects that inherit properties from the %MapIteratorPrototype% intrinsic object. Map Iterator instances are initially created with the internal slots described in <emu-xref href="#table-50"></emu-xref>.</p>
         <emu-table id="table-50" caption="Internal Slots of Map Iterator Instances">
           <table>
-            <tr>
-              <th>Internal Slot
-              <th>Description
+            <thead>
+              <tr>
+                <th>Internal Slot
+                <th>Description
+            </thead>
             <tr>
               <td>[[Map]]
               <td>The Map object that is being iterated.
@@ -31237,9 +31343,11 @@ THH:mm:ss.sss
         <p>Set Iterator instances are ordinary objects that inherit properties from the %SetIteratorPrototype% intrinsic object. Set Iterator instances are initially created with the internal slots specified in <emu-xref href="#table-51"></emu-xref>.</p>
         <emu-table id="table-51" caption="Internal Slots of Set Iterator Instances">
           <table>
-            <tr>
-              <th>Internal Slot
-              <th>Description
+            <thead>
+              <tr>
+                <th>Internal Slot
+                <th>Description
+            </thead>
             <tr>
               <td>[[IteratedSet]]
               <td>The Set object that is being iterated.
@@ -32919,10 +33027,12 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-table id="table-json-single-character-escapes" caption="JSON Single Character Escape Sequences">
           <table>
-            <tr>
-              <th>Code Unit Value
-              <th>Unicode Character Name
-              <th>Escape Sequence
+            <thead>
+              <tr>
+                <th>Code Unit Value
+                <th>Unicode Character Name
+                <th>Escape Sequence
+            </thead>
             <tr>
               <td>`0x0008`
               <td>BACKSPACE
@@ -33067,10 +33177,12 @@ THH:mm:ss.sss
         <p>The <i>Iterable</i> interface includes the property described in <emu-xref href="#table-52"></emu-xref>:</p>
         <emu-table id="table-52" caption="<i>Iterable</i> Interface Required Properties">
           <table>
-            <tr>
-              <th>Property
-              <th>Value
-              <th>Requirements
+            <thead>
+              <tr>
+                <th>Property
+                <th>Value
+                <th>Requirements
+            </thead>
             <tr>
               <td>`@@iterator`
               <td>A function that returns an <i>Iterator</i> object.
@@ -33084,10 +33196,12 @@ THH:mm:ss.sss
         <p>An object that implements the <i>Iterator</i> interface must include the property in <emu-xref href="#table-53"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-54"></emu-xref>.</p>
         <emu-table id="table-53" caption="<i>Iterator</i> Interface Required Properties">
           <table>
-            <tr>
-              <th>Property
-              <th>Value
-              <th>Requirements
+            <thead>
+              <tr>
+                <th>Property
+                <th>Value
+                <th>Requirements
+            </thead>
             <tr>
               <td>`next`
               <td>A function that returns an <i>IteratorResult</i> object.
@@ -33099,10 +33213,12 @@ THH:mm:ss.sss
         </emu-note>
         <emu-table id="table-54" caption="<i>Iterator</i> Interface Optional Properties">
           <table>
-            <tr>
-              <th>Property
-              <th>Value
-              <th>Requirements
+            <thead>
+              <tr>
+                <th>Property
+                <th>Value
+                <th>Requirements
+            </thead>
             <tr>
               <td>`return`
               <td>A function that returns an <i>IteratorResult</i> object.
@@ -33123,10 +33239,12 @@ THH:mm:ss.sss
         <p>The <i>AsyncIterable</i> interface includes the properties described in <emu-xref href="#table-async-iterable"></emu-xref>:</p>
         <emu-table id="table-async-iterable" caption="<i>AsyncIterable</i> Interface Required Properties">
           <table>
-            <tr>
-              <th>Property
-              <th>Value
-              <th>Requirements
+            <thead>
+              <tr>
+                <th>Property
+                <th>Value
+                <th>Requirements
+            </thead>
             <tr>
               <td>`@@asyncIterator`
               <td>A function that returns an <i>AsyncIterator</i> object.
@@ -33140,10 +33258,12 @@ THH:mm:ss.sss
         <p>An object that implements the <i>AsyncIterator</i> interface must include the properties in <emu-xref href="#table-async-iterator-required"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-async-iterator-optional"></emu-xref>.</p>
         <emu-table id="table-async-iterator-required" caption="<i>AsyncIterator</i> Interface Required Properties">
           <table>
-            <tr>
-              <th>Property
-              <th>Value
-              <th>Requirements
+            <thead>
+              <tr>
+                <th>Property
+                <th>Value
+                <th>Requirements
+            </thead>
             <tr>
               <td>`next`
               <td>A function that returns a promise for an <i>IteratorResult</i> object.
@@ -33157,10 +33277,12 @@ THH:mm:ss.sss
         </emu-note>
         <emu-table id="table-async-iterator-optional" caption="<i>AsyncIterator</i> Interface Optional Properties">
           <table>
-            <tr>
-              <th>Property
-              <th>Value
-              <th>Requirements
+            <thead>
+              <tr>
+                <th>Property
+                <th>Value
+                <th>Requirements
+            </thead>
             <tr>
               <td>`return`
               <td>A function that returns a promise for an <i>IteratorResult</i> object.
@@ -33185,10 +33307,12 @@ THH:mm:ss.sss
         <p>The <i>IteratorResult</i> interface includes the properties listed in <emu-xref href="#table-55"></emu-xref>:</p>
         <emu-table id="table-55" caption="<i>IteratorResult</i> Interface Properties">
           <table>
-            <tr>
-              <th>Property
-              <th>Value
-              <th>Requirements
+            <thead>
+              <tr>
+                <th>Property
+                <th>Value
+                <th>Requirements
+            </thead>
             <tr>
               <td>`done`
               <td>Either *true* or *false*.
@@ -33362,9 +33486,11 @@ THH:mm:ss.sss
         <p>Async-from-Sync Iterator instances are ordinary objects that inherit properties from the %AsyncFromSyncIteratorPrototype% intrinsic object. Async-from-Sync Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-async-from-sync-iterator-internal-slots"></emu-xref>.</p>
         <emu-table id="table-async-from-sync-iterator-internal-slots" caption="Internal Slots of Async-from-Sync Iterator Instances">
           <table>
-            <tr>
-              <th>Internal Slot
-              <th>Description
+            <thead>
+              <tr>
+                <th>Internal Slot
+                <th>Description
+            </thead>
             <tr>
               <td>[[SyncIteratorRecord]]
               <td>A Record, of the type returned by GetIterator, representing the original synchronous iterator which is being adapted.
@@ -33672,9 +33798,11 @@ THH:mm:ss.sss
       <p>Generator instances are initially created with the internal slots described in <emu-xref href="#table-56"></emu-xref>.</p>
       <emu-table id="table-56" caption="Internal Slots of Generator Instances">
         <table>
-          <tr>
-            <th>Internal Slot
-            <th>Description
+          <thead>
+            <tr>
+              <th>Internal Slot
+              <th>Description
+          </thead>
           <tr>
             <td>[[GeneratorState]]
             <td>The current execution state of the generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, and `"completed"`.
@@ -33865,9 +33993,11 @@ THH:mm:ss.sss
       <p>AsyncGenerator instances are initially created with the internal slots described below:</p>
       <emu-table id="table-internal-slots-of-asyncgenerator-instances" caption="Internal Slots of AsyncGenerator Instances">
         <table>
-          <tr>
-            <th>Internal Slot
-            <th>Description
+          <thead>
+            <tr>
+              <th>Internal Slot
+              <th>Description
+          </thead>
           <tr>
             <td>[[AsyncGeneratorState]]
             <td>The current execution state of the async generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, `"awaiting-return"`, and `"completed"`.
@@ -33889,10 +34019,12 @@ THH:mm:ss.sss
         <p>They have the following fields:</p>
         <emu-table caption="AsyncGeneratorRequest Record Fields">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[Completion]]
               <td>A Completion record
@@ -34109,10 +34241,12 @@ THH:mm:ss.sss
         <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-57"></emu-xref>.</p>
         <emu-table id="table-57" caption="PromiseCapability Record Fields">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[Promise]]
               <td>An object
@@ -34150,10 +34284,12 @@ THH:mm:ss.sss
         <p>PromiseReaction records have the fields listed in <emu-xref href="#table-58"></emu-xref>.</p>
         <emu-table id="table-58" caption="PromiseReaction Record Fields">
           <table>
-            <tr>
-              <th>Field Name
-              <th>Value
-              <th>Meaning
+            <thead>
+              <tr>
+                <th>Field Name
+                <th>Value
+                <th>Meaning
+            </thead>
             <tr>
               <td>[[Capability]]
               <td>A PromiseCapability Record, or *undefined*
@@ -34764,9 +34900,11 @@ THH:mm:ss.sss
       <p>Promise instances are ordinary objects that inherit properties from the Promise prototype object (the intrinsic, %PromisePrototype%). Promise instances are initially created with the internal slots described in <emu-xref href="#table-59"></emu-xref>.</p>
       <emu-table id="table-59" caption="Internal Slots of Promise Instances">
         <table>
-          <tr>
-            <th>Internal Slot
-            <th>Description
+          <thead>
+            <tr>
+              <th>Internal Slot
+              <th>Description
+          </thead>
           <tr>
             <td>[[PromiseState]]
             <td>A String value that governs how a promise will react to incoming calls to its `then` method. The possible values are: `"pending"`, `"fulfilled"`, and `"rejected"`.
@@ -35168,10 +35306,12 @@ THH:mm:ss.sss
 
     <emu-table id="table-readsharedmemory-fields" caption="ReadSharedMemory Event Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+        <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[Order]]
           <td>`"SeqCst"` or `"Unordered"`
@@ -35197,10 +35337,12 @@ THH:mm:ss.sss
 
     <emu-table id="table-writesharedmemory-fields" caption="WriteSharedMemory Event Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+        <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[Order]]
           <td>`"SeqCst"`, `"Unordered"`, or `"Init"`
@@ -35230,10 +35372,12 @@ THH:mm:ss.sss
 
     <emu-table id="table-rmwsharedmemory-fields" caption="ReadModifyWriteSharedMemory Event Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+        <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[Order]]
           <td>`"SeqCst"`
@@ -35280,10 +35424,12 @@ THH:mm:ss.sss
     <p>An <dfn>Agent Events Record</dfn> is a Record with the following fields.</p>
     <emu-table id="table-agent-events-records" caption="Agent Events Record Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+        <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[AgentSignifier]]
           <td>A value that admits equality testing
@@ -35305,10 +35451,12 @@ THH:mm:ss.sss
     <p>A <dfn>Chosen Value Record</dfn> is a Record with the following fields.</p>
     <emu-table id="table-chosen-value-records" caption="Chosen Value Record Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+        <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[Event]]
           <td>A Shared Data Block event
@@ -35326,10 +35474,12 @@ THH:mm:ss.sss
     <p>A <dfn>candidate execution</dfn> of the evaluation of an agent cluster is a Record with the following fields.</p>
     <emu-table id="table-candidate-execution-records" caption="Candidate Execution Record Fields">
       <table>
-        <tr>
-          <th>Field Name
-          <th>Value
-          <th>Meaning
+        <thead>
+          <tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
+        </thead>
         <tr>
           <td>[[EventsRecords]]
           <td>A List of Agent Events Records.
@@ -36582,10 +36732,12 @@ THH:mm:ss.sss
       <p>The entries in <emu-xref href="#table-60"></emu-xref> are added to <emu-xref href="#table-7"></emu-xref>.</p>
       <emu-table id="table-60" caption="Additional Well-known Intrinsic Objects">
         <table>
-          <tr>
-            <th>Intrinsic Name
-            <th>Global Name
-            <th>ECMAScript Language Association
+          <thead>
+            <tr>
+              <th>Intrinsic Name
+              <th>Global Name
+              <th>ECMAScript Language Association
+          </thead>
           <tr>
             <td>%escape%
             <td>`escape`
@@ -37378,9 +37530,11 @@ THH:mm:ss.sss
             Additional <emu-xref href="#sec-typeof-operator">`typeof`</emu-xref> Operator Results
           </emu-caption>
           <table>
-            <tr>
-              <th>Type of _val_
-              <th>Result
+            <thead>
+              <tr>
+                <th>Type of _val_
+                <th>Result
+            </thead>
             <tr>
               <td>Object (has an [[IsHTMLDDA]] internal slot)
               <td>`"undefined"`

--- a/spec.html
+++ b/spec.html
@@ -924,151 +924,58 @@
         <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where &ldquo;name&rdquo; is one of the values listed in <emu-xref href="#table-1"></emu-xref>.</p>
         <emu-table id="table-1" caption="Well-known Symbols">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Specification Name
-              </th>
-              <th>
-                [[Description]]
-              </th>
-              <th>
-                Value and Purpose
-              </th>
-            </tr>
+              <th>Specification Name
+              <th>[[Description]]
+              <th>Value and Purpose
             <tr>
-              <td>
-                @@asyncIterator
-              </td>
-              <td>
-                `"Symbol.asyncIterator"`
-              </td>
-              <td>
-                A method that returns the default AsyncIterator for an object. Called by the semantics of the `for`-`await`-`of` statement.
-              </td>
-            </tr>
+              <td>@@asyncIterator
+              <td>`"Symbol.asyncIterator"`
+              <td>A method that returns the default AsyncIterator for an object. Called by the semantics of the `for`-`await`-`of` statement.
             <tr>
-              <td>
-                @@hasInstance
-              </td>
-              <td>
-                `"Symbol.hasInstance"`
-              </td>
-              <td>
-                A method that determines if a constructor object recognizes an object as one of the constructor's instances. Called by the semantics of the `instanceof` operator.
-              </td>
-            </tr>
+              <td>@@hasInstance
+              <td>`"Symbol.hasInstance"`
+              <td>A method that determines if a constructor object recognizes an object as one of the constructor's instances. Called by the semantics of the `instanceof` operator.
             <tr>
-              <td>
-                @@isConcatSpreadable
-              </td>
-              <td>
-                `"Symbol.isConcatSpreadable"`
-              </td>
-              <td>
-                A Boolean valued property that if true indicates that an object should be flattened to its array elements by <emu-xref href="#sec-array.prototype.concat">`Array.prototype.concat`</emu-xref>.
-              </td>
-            </tr>
+              <td>@@isConcatSpreadable
+              <td>`"Symbol.isConcatSpreadable"`
+              <td>A Boolean valued property that if true indicates that an object should be flattened to its array elements by <emu-xref href="#sec-array.prototype.concat">`Array.prototype.concat`</emu-xref>.
             <tr>
-              <td>
-                @@iterator
-              </td>
-              <td>
-                `"Symbol.iterator"`
-              </td>
-              <td>
-                A method that returns the default Iterator for an object. Called by the semantics of the for-of statement.
-              </td>
-            </tr>
+              <td>@@iterator
+              <td>`"Symbol.iterator"`
+              <td>A method that returns the default Iterator for an object. Called by the semantics of the for-of statement.
             <tr>
-              <td>
-                @@match
-              </td>
-              <td>
-                `"Symbol.match"`
-              </td>
-              <td>
-                A regular expression method that matches the regular expression against a string. Called by the <emu-xref href="#sec-string.prototype.match">`String.prototype.match`</emu-xref> method.
-              </td>
-            </tr>
+              <td>@@match
+              <td>`"Symbol.match"`
+              <td>A regular expression method that matches the regular expression against a string. Called by the <emu-xref href="#sec-string.prototype.match">`String.prototype.match`</emu-xref> method.
             <tr>
-              <td>
-                @@replace
-              </td>
-              <td>
-                `"Symbol.replace"`
-              </td>
-              <td>
-                A regular expression method that replaces matched substrings of a string. Called by the <emu-xref href="#sec-string.prototype.replace">`String.prototype.replace`</emu-xref> method.
-              </td>
-            </tr>
+              <td>@@replace
+              <td>`"Symbol.replace"`
+              <td>A regular expression method that replaces matched substrings of a string. Called by the <emu-xref href="#sec-string.prototype.replace">`String.prototype.replace`</emu-xref> method.
             <tr>
-              <td>
-                @@search
-              </td>
-              <td>
-                `"Symbol.search"`
-              </td>
-              <td>
-                A regular expression method that returns the index within a string that matches the regular expression. Called by the <emu-xref href="#sec-string.prototype.search">`String.prototype.search`</emu-xref> method.
-              </td>
-            </tr>
+              <td>@@search
+              <td>`"Symbol.search"`
+              <td>A regular expression method that returns the index within a string that matches the regular expression. Called by the <emu-xref href="#sec-string.prototype.search">`String.prototype.search`</emu-xref> method.
             <tr>
-              <td>
-                @@species
-              </td>
-              <td>
-                `"Symbol.species"`
-              </td>
-              <td>
-                A function valued property that is the constructor function that is used to create derived objects.
-              </td>
-            </tr>
+              <td>@@species
+              <td>`"Symbol.species"`
+              <td>A function valued property that is the constructor function that is used to create derived objects.
             <tr>
-              <td>
-                @@split
-              </td>
-              <td>
-                `"Symbol.split"`
-              </td>
-              <td>
-                A regular expression method that splits a string at the indices that match the regular expression. Called by the <emu-xref href="#sec-string.prototype.split">`String.prototype.split`</emu-xref> method.
-              </td>
-            </tr>
+              <td>@@split
+              <td>`"Symbol.split"`
+              <td>A regular expression method that splits a string at the indices that match the regular expression. Called by the <emu-xref href="#sec-string.prototype.split">`String.prototype.split`</emu-xref> method.
             <tr>
-              <td>
-                @@toPrimitive
-              </td>
-              <td>
-                `"Symbol.toPrimitive"`
-              </td>
-              <td>
-                A method that converts an object to a corresponding primitive value. Called by the ToPrimitive abstract operation.
-              </td>
-            </tr>
+              <td>@@toPrimitive
+              <td>`"Symbol.toPrimitive"`
+              <td>A method that converts an object to a corresponding primitive value. Called by the ToPrimitive abstract operation.
             <tr>
-              <td>
-                @@toStringTag
-              </td>
-              <td>
-                `"Symbol.toStringTag"`
-              </td>
-              <td>
-                A String valued property that is used in the creation of the default string description of an object. Accessed by the built-in method <emu-xref href="#sec-object.prototype.tostring">`Object.prototype.toString`</emu-xref>.
-              </td>
-            </tr>
+              <td>@@toStringTag
+              <td>`"Symbol.toStringTag"`
+              <td>A String valued property that is used in the creation of the default string description of an object. Accessed by the built-in method <emu-xref href="#sec-object.prototype.tostring">`Object.prototype.toString`</emu-xref>.
             <tr>
-              <td>
-                @@unscopables
-              </td>
-              <td>
-                `"Symbol.unscopables"`
-              </td>
-              <td>
-                An object valued property whose own and inherited property names are property names that are excluded from the `with` environment bindings of the associated object.
-              </td>
-            </tr>
-            </tbody>
+              <td>@@unscopables
+              <td>`"Symbol.unscopables"`
+              <td>An object valued property whose own and inherited property names are property names that are excluded from the `with` environment bindings of the associated object.
           </table>
         </emu-table>
       </emu-clause>
@@ -1121,188 +1028,77 @@
         <p>Attributes are used in this specification to define and explain the state of Object properties. A data property associates a key value with the attributes listed in <emu-xref href="#table-2"></emu-xref>.</p>
         <emu-table id="table-2" caption="Attributes of a Data Property">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Attribute Name
-              </th>
-              <th>
-                Value Domain
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <th>Attribute Name
+              <th>Value Domain
+              <th>Description
             <tr>
-              <td>
-                [[Value]]
-              </td>
-              <td>
-                Any ECMAScript language type
-              </td>
-              <td>
-                The value retrieved by a get access of the property.
-              </td>
-            </tr>
+              <td>[[Value]]
+              <td>Any ECMAScript language type
+              <td>The value retrieved by a get access of the property.
             <tr>
-              <td>
-                [[Writable]]
-              </td>
-              <td>
-                Boolean
-              </td>
-              <td>
-                If *false*, attempts by ECMAScript code to change the property's [[Value]] attribute using [[Set]] will not succeed.
-              </td>
-            </tr>
+              <td>[[Writable]]
+              <td>Boolean
+              <td>If *false*, attempts by ECMAScript code to change the property's [[Value]] attribute using [[Set]] will not succeed.
             <tr>
-              <td>
-                [[Enumerable]]
-              </td>
-              <td>
-                Boolean
-              </td>
-              <td>
-                If *true*, the property will be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
-              </td>
-            </tr>
+              <td>[[Enumerable]]
+              <td>Boolean
+              <td>If *true*, the property will be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
             <tr>
-              <td>
-                [[Configurable]]
-              </td>
-              <td>
-                Boolean
-              </td>
-              <td>
-                If *false*, attempts to delete the property, change the property to be an accessor property, or change its attributes (other than [[Value]], or changing [[Writable]] to *false*) will fail.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[Configurable]]
+              <td>Boolean
+              <td>If *false*, attempts to delete the property, change the property to be an accessor property, or change its attributes (other than [[Value]], or changing [[Writable]] to *false*) will fail.
           </table>
         </emu-table>
         <p>An accessor property associates a key value with the attributes listed in <emu-xref href="#table-3"></emu-xref>.</p>
         <emu-table id="table-3" caption="Attributes of an Accessor Property">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Attribute Name
-              </th>
-              <th>
-                Value Domain
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <th>Attribute Name
+              <th>Value Domain
+              <th>Description
             <tr>
-              <td>
-                [[Get]]
-              </td>
-              <td>
-                Object | Undefined
-              </td>
-              <td>
-                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-6"></emu-xref>) is called with an empty arguments list to retrieve the property value each time a get access of the property is performed.
-              </td>
-            </tr>
+              <td>[[Get]]
+              <td>Object | Undefined
+              <td>If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-6"></emu-xref>) is called with an empty arguments list to retrieve the property value each time a get access of the property is performed.
             <tr>
-              <td>
-                [[Set]]
-              </td>
-              <td>
-                Object | Undefined
-              </td>
-              <td>
-                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-6"></emu-xref>) is called with an arguments list containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
-              </td>
-            </tr>
+              <td>[[Set]]
+              <td>Object | Undefined
+              <td>If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-6"></emu-xref>) is called with an arguments list containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
             <tr>
-              <td>
-                [[Enumerable]]
-              </td>
-              <td>
-                Boolean
-              </td>
-              <td>
-                If *true*, the property is to be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
-              </td>
-            </tr>
+              <td>[[Enumerable]]
+              <td>Boolean
+              <td>If *true*, the property is to be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
             <tr>
-              <td>
-                [[Configurable]]
-              </td>
-              <td>
-                Boolean
-              </td>
-              <td>
-                If *false*, attempts to delete the property, change the property to be a data property, or change its attributes will fail.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[Configurable]]
+              <td>Boolean
+              <td>If *false*, attempts to delete the property, change the property to be a data property, or change its attributes will fail.
           </table>
         </emu-table>
         <p>If the initial values of a property's attributes are not explicitly specified by this specification, the default value defined in <emu-xref href="#table-4"></emu-xref> is used.</p>
         <emu-table id="table-4" caption="Default Attribute Values">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Attribute Name
-              </th>
-              <th>
-                Default Value
-              </th>
-            </tr>
+              <th>Attribute Name
+              <th>Default Value
             <tr>
-              <td>
-                [[Value]]
-              </td>
-              <td>
-                *undefined*
-              </td>
-            </tr>
+              <td>[[Value]]
+              <td>*undefined*
             <tr>
-              <td>
-                [[Get]]
-              </td>
-              <td>
-                *undefined*
-              </td>
-            </tr>
+              <td>[[Get]]
+              <td>*undefined*
             <tr>
-              <td>
-                [[Set]]
-              </td>
-              <td>
-                *undefined*
-              </td>
-            </tr>
+              <td>[[Set]]
+              <td>*undefined*
             <tr>
-              <td>
-                [[Writable]]
-              </td>
-              <td>
-                *false*
-              </td>
-            </tr>
+              <td>[[Writable]]
+              <td>*false*
             <tr>
-              <td>
-                [[Enumerable]]
-              </td>
-              <td>
-                *false*
-              </td>
-            </tr>
+              <td>[[Enumerable]]
+              <td>*false*
             <tr>
-              <td>
-                [[Configurable]]
-              </td>
-              <td>
-                *false*
-              </td>
-            </tr>
-            </tbody>
+              <td>[[Configurable]]
+              <td>*false*
           </table>
         </emu-table>
       </emu-clause>
@@ -1317,180 +1113,71 @@
         <p>The &ldquo;Signature&rdquo; column of <emu-xref href="#table-5"></emu-xref> and other similar tables describes the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names. If a parameter name is the same as an ECMAScript type name then the name describes the required type of the parameter value. If an internal method explicitly returns a value, its parameter list is followed by the symbol &ldquo;&rarr;&rdquo; and the type name of the returned value. The type names used in signatures refer to the types defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> augmented by the following additional names. &ldquo;<em>any</em>&rdquo; means the value may be any ECMAScript language type. An internal method implicitly returns a Completion Record. In addition to its parameters, an internal method always has access to the object that is the target of the method invocation.</p>
         <emu-table id="table-5" caption="Essential Internal Methods">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Internal Method
-              </th>
-              <th>
-                Signature
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <th>Internal Method
+              <th>Signature
+              <th>Description
             <tr>
-              <td>
-                [[GetPrototypeOf]]
-              </td>
-              <td>
-                ( ) <b>&rarr;</b> Object | Null
-              </td>
-              <td>
-                Determine the object that provides inherited properties for this object. A *null* value indicates that there are no inherited properties.
-              </td>
-            </tr>
+              <td>[[GetPrototypeOf]]
+              <td>( ) <b>&rarr;</b> Object | Null
+              <td>Determine the object that provides inherited properties for this object. A *null* value indicates that there are no inherited properties.
             <tr>
-              <td>
-                [[SetPrototypeOf]]
-              </td>
-              <td>
-                (Object | Null) <b>&rarr;</b> Boolean
-              </td>
-              <td>
-                Associate this object with another object that provides inherited properties. Passing *null* indicates that there are no inherited properties. Returns *true* indicating that the operation was completed successfully or *false* indicating that the operation was not successful.
-              </td>
-            </tr>
+              <td>[[SetPrototypeOf]]
+              <td>(Object | Null) <b>&rarr;</b> Boolean
+              <td>Associate this object with another object that provides inherited properties. Passing *null* indicates that there are no inherited properties. Returns *true* indicating that the operation was completed successfully or *false* indicating that the operation was not successful.
             <tr>
-              <td>
-                [[IsExtensible]]
-              </td>
-              <td>
-                ( ) <b>&rarr;</b> Boolean
-              </td>
-              <td>
-                Determine whether it is permitted to add additional properties to this object.
-              </td>
-            </tr>
+              <td>[[IsExtensible]]
+              <td>( ) <b>&rarr;</b> Boolean
+              <td>Determine whether it is permitted to add additional properties to this object.
             <tr>
-              <td>
-                [[PreventExtensions]]
-              </td>
-              <td>
-                ( ) <b>&rarr;</b> Boolean
-              </td>
-              <td>
-                Control whether new properties may be added to this object. Returns *true* if the operation was successful or *false* if the operation was unsuccessful.
-              </td>
-            </tr>
+              <td>[[PreventExtensions]]
+              <td>( ) <b>&rarr;</b> Boolean
+              <td>Control whether new properties may be added to this object. Returns *true* if the operation was successful or *false* if the operation was unsuccessful.
             <tr>
-              <td>
-                [[GetOwnProperty]]
-              </td>
-              <td>
-                (_propertyKey_) <b>&rarr;</b> Undefined | Property Descriptor
-              </td>
-              <td>
-                Return a Property Descriptor for the own property of this object whose key is _propertyKey_, or *undefined* if no such property exists.
-              </td>
-            </tr>
+              <td>[[GetOwnProperty]]
+              <td>(_propertyKey_) <b>&rarr;</b> Undefined | Property Descriptor
+              <td>Return a Property Descriptor for the own property of this object whose key is _propertyKey_, or *undefined* if no such property exists.
             <tr>
-              <td>
-                [[DefineOwnProperty]]
-              </td>
-              <td>
-                (_propertyKey_, _PropertyDescriptor_) <b>&rarr;</b> Boolean
-              </td>
-              <td>
-                Create or alter the own property, whose key is _propertyKey_, to have the state described by _PropertyDescriptor_. Return *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
-              </td>
-            </tr>
+              <td>[[DefineOwnProperty]]
+              <td>(_propertyKey_, _PropertyDescriptor_) <b>&rarr;</b> Boolean
+              <td>Create or alter the own property, whose key is _propertyKey_, to have the state described by _PropertyDescriptor_. Return *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
             <tr>
-              <td>
-                [[HasProperty]]
-              </td>
-              <td>
-                (_propertyKey_) <b>&rarr;</b> Boolean
-              </td>
-              <td>
-                Return a Boolean value indicating whether this object already has either an own or inherited property whose key is _propertyKey_.
-              </td>
-            </tr>
+              <td>[[HasProperty]]
+              <td>(_propertyKey_) <b>&rarr;</b> Boolean
+              <td>Return a Boolean value indicating whether this object already has either an own or inherited property whose key is _propertyKey_.
             <tr>
-              <td>
-                [[Get]]
-              </td>
-              <td>
-                (_propertyKey_, _Receiver_) <b>&rarr;</b> <em>any</em>
-              </td>
-              <td>
-                Return the value of the property whose key is _propertyKey_ from this object. If any ECMAScript code must be executed to retrieve the property value, _Receiver_ is used as the *this* value when evaluating the code.
-              </td>
-            </tr>
+              <td>[[Get]]
+              <td>(_propertyKey_, _Receiver_) <b>&rarr;</b> <em>any</em>
+              <td>Return the value of the property whose key is _propertyKey_ from this object. If any ECMAScript code must be executed to retrieve the property value, _Receiver_ is used as the *this* value when evaluating the code.
             <tr>
-              <td>
-                [[Set]]
-              </td>
-              <td>
-                (_propertyKey_, _value_, _Receiver_) <b>&rarr;</b> Boolean
-              </td>
-              <td>
-                Set the value of the property whose key is _propertyKey_ to _value_. If any ECMAScript code must be executed to set the property value, _Receiver_ is used as the *this* value when evaluating the code. Returns *true* if the property value was set or *false* if it could not be set.
-              </td>
-            </tr>
+              <td>[[Set]]
+              <td>(_propertyKey_, _value_, _Receiver_) <b>&rarr;</b> Boolean
+              <td>Set the value of the property whose key is _propertyKey_ to _value_. If any ECMAScript code must be executed to set the property value, _Receiver_ is used as the *this* value when evaluating the code. Returns *true* if the property value was set or *false* if it could not be set.
             <tr>
-              <td>
-                [[Delete]]
-              </td>
-              <td>
-                (_propertyKey_) <b>&rarr;</b> Boolean
-              </td>
-              <td>
-                Remove the own property whose key is _propertyKey_ from this object. Return *false* if the property was not deleted and is still present. Return *true* if the property was deleted or is not present.
-              </td>
-            </tr>
+              <td>[[Delete]]
+              <td>(_propertyKey_) <b>&rarr;</b> Boolean
+              <td>Remove the own property whose key is _propertyKey_ from this object. Return *false* if the property was not deleted and is still present. Return *true* if the property was deleted or is not present.
             <tr>
-              <td>
-                [[OwnPropertyKeys]]
-              </td>
-              <td>
-                ( ) <b>&rarr;</b> List of propertyKey
-              </td>
-              <td>
-                Return a List whose elements are all of the own property keys for the object.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[OwnPropertyKeys]]
+              <td>( ) <b>&rarr;</b> List of propertyKey
+              <td>Return a List whose elements are all of the own property keys for the object.
           </table>
         </emu-table>
         <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.</p>
         <emu-table id="table-6" caption="Additional Essential Internal Methods of Function Objects">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Internal Method
-              </th>
-              <th>
-                Signature
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <th>Internal Method
+              <th>Signature
+              <th>Description
             <tr>
-              <td>
-                [[Call]]
-              </td>
-              <td>
-                (<em>any</em>, a List of <em>any</em>) <b>&rarr;</b> <em>any</em>
-              </td>
-              <td>
-                Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a list containing the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
-              </td>
-            </tr>
+              <td>[[Call]]
+              <td>(<em>any</em>, a List of <em>any</em>) <b>&rarr;</b> <em>any</em>
+              <td>Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a list containing the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
             <tr>
-              <td>
-                [[Construct]]
-              </td>
-              <td>
-                (a List of <em>any</em>, Object) <b>&rarr;</b> Object
-              </td>
-              <td>
-                Creates an object. Invoked via the `new` or `super` operators. The first argument to the internal method is a list containing the arguments of the operator. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[Construct]]
+              <td>(a List of <em>any</em>, Object) <b>&rarr;</b> Object
+              <td>Creates an object. Invoked via the `new` or `super` operators. The first argument to the internal method is a list containing the arguments of the operator. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
           </table>
         </emu-table>
         <p>The semantics of the essential internal methods for ordinary objects and standard exotic objects are specified in clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>. If any specified use of an internal method of an exotic object is not supported by an implementation, that usage must throw a *TypeError* exception when attempted.</p>
@@ -1670,1211 +1357,450 @@
         <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-7"></emu-xref>.</p>
         <emu-table id="table-7" caption="Well-Known Intrinsic Objects">
           <table>
-            <tbody>
-            <tr>
-              <th>
-                Intrinsic Name
-              </th>
-              <th>
-                Global Name
-              </th>
-              <th>
-                ECMAScript Language Association
-              </th>
-            </tr>
             <tr>
-              <td>
-                %Array%
-              </td>
-              <td>
-                `Array`
-              </td>
-              <td>
-                The `Array` constructor (<emu-xref href="#sec-array-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <th>Intrinsic Name
+              <th>Global Name
+              <th>ECMAScript Language Association
             <tr>
-              <td>
-                %ArrayBuffer%
-              </td>
-              <td>
-                `ArrayBuffer`
-              </td>
-              <td>
-                The `ArrayBuffer` constructor (<emu-xref href="#sec-arraybuffer-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Array%
+              <td>`Array`
+              <td>The `Array` constructor (<emu-xref href="#sec-array-constructor"></emu-xref>)
             <tr>
-              <td>
-                %ArrayBufferPrototype%
-              </td>
-              <td>
-                `ArrayBuffer.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %ArrayBuffer%.
-              </td>
-            </tr>
+              <td>%ArrayBuffer%
+              <td>`ArrayBuffer`
+              <td>The `ArrayBuffer` constructor (<emu-xref href="#sec-arraybuffer-constructor"></emu-xref>)
             <tr>
-              <td>
-                %ArrayIteratorPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ArrayBufferPrototype%
+              <td>`ArrayBuffer.prototype`
+              <td>The initial value of the `prototype` data property of %ArrayBuffer%.
             <tr>
-              <td>
-                %ArrayPrototype%
-              </td>
-              <td>
-                `Array.prototype`
-              </td>
+              <td>%ArrayIteratorPrototype%
               <td>
-                The initial value of the `prototype` data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"></emu-xref>)
             <tr>
-              <td>
-                %ArrayProto_entries%
-              </td>
-              <td>
-                `Array.prototype.entries`
-              </td>
-              <td>
-                The initial value of the `entries` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ArrayPrototype%
+              <td>`Array.prototype`
+              <td>The initial value of the `prototype` data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>)
             <tr>
-              <td>
-                %ArrayProto_forEach%
-              </td>
-              <td>
-                `Array.prototype.forEach`
-              </td>
-              <td>
-                The initial value of the `forEach` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ArrayProto_entries%
+              <td>`Array.prototype.entries`
+              <td>The initial value of the `entries` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>)
             <tr>
-              <td>
-                %ArrayProto_keys%
-              </td>
-              <td>
-                `Array.prototype.keys`
-              </td>
-              <td>
-                The initial value of the `keys` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ArrayProto_forEach%
+              <td>`Array.prototype.forEach`
+              <td>The initial value of the `forEach` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>)
             <tr>
-              <td>
-                %ArrayProto_values%
-              </td>
-              <td>
-                `Array.prototype.values`
-              </td>
-              <td>
-                The initial value of the `values` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ArrayProto_keys%
+              <td>`Array.prototype.keys`
+              <td>The initial value of the `keys` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>)
             <tr>
-              <td>
-                %AsyncFromSyncIteratorPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The prototype of async-from-sync iterator objects (<emu-xref href="#sec-async-from-sync-iterator-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ArrayProto_values%
+              <td>`Array.prototype.values`
+              <td>The initial value of the `values` data property of %ArrayPrototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>)
             <tr>
+              <td>%AsyncFromSyncIteratorPrototype%
               <td>
-                %AsyncFunction%
-              </td>
-              <td>
-              </td>
-              <td>
-                The constructor of async function objects (<emu-xref href="#sec-async-function-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>The prototype of async-from-sync iterator objects (<emu-xref href="#sec-async-from-sync-iterator-objects"></emu-xref>)
             <tr>
+              <td>%AsyncFunction%
               <td>
-                %AsyncFunctionPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %AsyncFunction%
-              </td>
-            </tr>
+              <td>The constructor of async function objects (<emu-xref href="#sec-async-function-constructor"></emu-xref>)
             <tr>
-              <td>
-                %AsyncGenerator%
-              </td>
+              <td>%AsyncFunctionPrototype%
               <td>
-              </td>
-              <td>
-                The initial value of the `prototype` property of %AsyncGeneratorFunction%
-              </td>
-            </tr>
+              <td>The initial value of the `prototype` data property of %AsyncFunction%
             <tr>
-              <td>
-                %AsyncGeneratorFunction%
-              </td>
+              <td>%AsyncGenerator%
               <td>
-              </td>
-              <td>
-                The constructor of async iterator objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>The initial value of the `prototype` property of %AsyncGeneratorFunction%
             <tr>
-              <td>
-                %AsyncGeneratorPrototype%
-              </td>
-              <td>
-              </td>
+              <td>%AsyncGeneratorFunction%
               <td>
-                The initial value of the `prototype` property of %AsyncGenerator%
-              </td>
-            </tr>
+              <td>The constructor of async iterator objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
             <tr>
+              <td>%AsyncGeneratorPrototype%
               <td>
-                %AsyncIteratorPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                An object that all standard built-in async iterator objects indirectly inherit from
-              </td>
-            </tr>
+              <td>The initial value of the `prototype` property of %AsyncGenerator%
             <tr>
-              <td>
-                %Atomics%
-              </td>
-              <td>
-                `Atomics`
-              </td>
+              <td>%AsyncIteratorPrototype%
               <td>
-                The `Atomics` object (<emu-xref href="#sec-atomics-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>An object that all standard built-in async iterator objects indirectly inherit from
             <tr>
-              <td>
-                %Boolean%
-              </td>
-              <td>
-                `Boolean`
-              </td>
-              <td>
-                The `Boolean` constructor (<emu-xref href="#sec-boolean-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Atomics%
+              <td>`Atomics`
+              <td>The `Atomics` object (<emu-xref href="#sec-atomics-object"></emu-xref>)
             <tr>
-              <td>
-                %BooleanPrototype%
-              </td>
-              <td>
-                `Boolean.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Boolean%
+              <td>`Boolean`
+              <td>The `Boolean` constructor (<emu-xref href="#sec-boolean-constructor"></emu-xref>)
             <tr>
-              <td>
-                %DataView%
-              </td>
-              <td>
-                `DataView`
-              </td>
-              <td>
-                The `DataView` constructor (<emu-xref href="#sec-dataview-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%BooleanPrototype%
+              <td>`Boolean.prototype`
+              <td>The initial value of the `prototype` data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>)
             <tr>
-              <td>
-                %DataViewPrototype%
-              </td>
-              <td>
-                `DataView.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %DataView%
-              </td>
-            </tr>
+              <td>%DataView%
+              <td>`DataView`
+              <td>The `DataView` constructor (<emu-xref href="#sec-dataview-constructor"></emu-xref>)
             <tr>
-              <td>
-                %Date%
-              </td>
-              <td>
-                `Date`
-              </td>
-              <td>
-                The `Date` constructor (<emu-xref href="#sec-date-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%DataViewPrototype%
+              <td>`DataView.prototype`
+              <td>The initial value of the `prototype` data property of %DataView%
             <tr>
-              <td>
-                %DatePrototype%
-              </td>
-              <td>
-                `Date.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Date%.
-              </td>
-            </tr>
+              <td>%Date%
+              <td>`Date`
+              <td>The `Date` constructor (<emu-xref href="#sec-date-constructor"></emu-xref>)
             <tr>
-              <td>
-                %decodeURI%
-              </td>
-              <td>
-                `decodeURI`
-              </td>
-              <td>
-                The `decodeURI` function (<emu-xref href="#sec-decodeuri-encodeduri"></emu-xref>)
-              </td>
-            </tr>
+              <td>%DatePrototype%
+              <td>`Date.prototype`
+              <td>The initial value of the `prototype` data property of %Date%.
             <tr>
-              <td>
-                %decodeURIComponent%
-              </td>
-              <td>
-                `decodeURIComponent`
-              </td>
-              <td>
-                The `decodeURIComponent` function (<emu-xref href="#sec-decodeuricomponent-encodeduricomponent"></emu-xref>)
-              </td>
-            </tr>
+              <td>%decodeURI%
+              <td>`decodeURI`
+              <td>The `decodeURI` function (<emu-xref href="#sec-decodeuri-encodeduri"></emu-xref>)
             <tr>
-              <td>
-                %encodeURI%
-              </td>
-              <td>
-                `encodeURI`
-              </td>
-              <td>
-                The `encodeURI` function (<emu-xref href="#sec-encodeuri-uri"></emu-xref>)
-              </td>
-            </tr>
+              <td>%decodeURIComponent%
+              <td>`decodeURIComponent`
+              <td>The `decodeURIComponent` function (<emu-xref href="#sec-decodeuricomponent-encodeduricomponent"></emu-xref>)
             <tr>
-              <td>
-                %encodeURIComponent%
-              </td>
-              <td>
-                `encodeURIComponent`
-              </td>
-              <td>
-                The `encodeURIComponent` function (<emu-xref href="#sec-encodeuricomponent-uricomponent"></emu-xref>)
-              </td>
-            </tr>
+              <td>%encodeURI%
+              <td>`encodeURI`
+              <td>The `encodeURI` function (<emu-xref href="#sec-encodeuri-uri"></emu-xref>)
             <tr>
-              <td>
-                %Error%
-              </td>
-              <td>
-                `Error`
-              </td>
-              <td>
-                The `Error` constructor (<emu-xref href="#sec-error-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%encodeURIComponent%
+              <td>`encodeURIComponent`
+              <td>The `encodeURIComponent` function (<emu-xref href="#sec-encodeuricomponent-uricomponent"></emu-xref>)
             <tr>
-              <td>
-                %ErrorPrototype%
-              </td>
-              <td>
-                `Error.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Error%
-              </td>
-            </tr>
+              <td>%Error%
+              <td>`Error`
+              <td>The `Error` constructor (<emu-xref href="#sec-error-constructor"></emu-xref>)
             <tr>
-              <td>
-                %eval%
-              </td>
-              <td>
-                `eval`
-              </td>
-              <td>
-                The `eval` function (<emu-xref href="#sec-eval-x"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ErrorPrototype%
+              <td>`Error.prototype`
+              <td>The initial value of the `prototype` data property of %Error%
             <tr>
-              <td>
-                %EvalError%
-              </td>
-              <td>
-                `EvalError`
-              </td>
-              <td>
-                The `EvalError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
-              </td>
-            </tr>
+              <td>%eval%
+              <td>`eval`
+              <td>The `eval` function (<emu-xref href="#sec-eval-x"></emu-xref>)
             <tr>
-              <td>
-                %EvalErrorPrototype%
-              </td>
-              <td>
-                `EvalError.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %EvalError%
-              </td>
-            </tr>
+              <td>%EvalError%
+              <td>`EvalError`
+              <td>The `EvalError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
             <tr>
-              <td>
-                %Float32Array%
-              </td>
-              <td>
-                `Float32Array`
-              </td>
-              <td>
-                The `Float32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%EvalErrorPrototype%
+              <td>`EvalError.prototype`
+              <td>The initial value of the `prototype` data property of %EvalError%
             <tr>
-              <td>
-                %Float32ArrayPrototype%
-              </td>
-              <td>
-                `Float32Array.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Float32Array%
-              </td>
-            </tr>
+              <td>%Float32Array%
+              <td>`Float32Array`
+              <td>The `Float32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %Float64Array%
-              </td>
-              <td>
-                `Float64Array`
-              </td>
-              <td>
-                The `Float64Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Float32ArrayPrototype%
+              <td>`Float32Array.prototype`
+              <td>The initial value of the `prototype` data property of %Float32Array%
             <tr>
-              <td>
-                %Float64ArrayPrototype%
-              </td>
-              <td>
-                `Float64Array.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Float64Array%
-              </td>
-            </tr>
+              <td>%Float64Array%
+              <td>`Float64Array`
+              <td>The `Float64Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %Function%
-              </td>
-              <td>
-                `Function`
-              </td>
-              <td>
-                The `Function` constructor (<emu-xref href="#sec-function-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Float64ArrayPrototype%
+              <td>`Float64Array.prototype`
+              <td>The initial value of the `prototype` data property of %Float64Array%
             <tr>
-              <td>
-                %FunctionPrototype%
-              </td>
-              <td>
-                `Function.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Function%
-              </td>
-            </tr>
+              <td>%Function%
+              <td>`Function`
+              <td>The `Function` constructor (<emu-xref href="#sec-function-constructor"></emu-xref>)
             <tr>
-              <td>
-                %Generator%
-              </td>
-              <td>
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %GeneratorFunction%
-              </td>
-            </tr>
+              <td>%FunctionPrototype%
+              <td>`Function.prototype`
+              <td>The initial value of the `prototype` data property of %Function%
             <tr>
+              <td>%Generator%
               <td>
-                %GeneratorFunction%
-              </td>
-              <td>
-              </td>
-              <td>
-                The constructor of generator objects (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>The initial value of the `prototype` data property of %GeneratorFunction%
             <tr>
-              <td>
-                %GeneratorPrototype%
-              </td>
+              <td>%GeneratorFunction%
               <td>
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Generator%
-              </td>
-            </tr>
+              <td>The constructor of generator objects (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
             <tr>
-              <td>
-                %Int8Array%
-              </td>
+              <td>%GeneratorPrototype%
               <td>
-                `Int8Array`
-              </td>
-              <td>
-                The `Int8Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>The initial value of the `prototype` data property of %Generator%
             <tr>
-              <td>
-                %Int8ArrayPrototype%
-              </td>
-              <td>
-                `Int8Array.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Int8Array%
-              </td>
-            </tr>
+              <td>%Int8Array%
+              <td>`Int8Array`
+              <td>The `Int8Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %Int16Array%
-              </td>
-              <td>
-                `Int16Array`
-              </td>
-              <td>
-                The `Int16Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Int8ArrayPrototype%
+              <td>`Int8Array.prototype`
+              <td>The initial value of the `prototype` data property of %Int8Array%
             <tr>
-              <td>
-                %Int16ArrayPrototype%
-              </td>
-              <td>
-                `Int16Array.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Int16Array%
-              </td>
-            </tr>
+              <td>%Int16Array%
+              <td>`Int16Array`
+              <td>The `Int16Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %Int32Array%
-              </td>
-              <td>
-                `Int32Array`
-              </td>
-              <td>
-                The `Int32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Int16ArrayPrototype%
+              <td>`Int16Array.prototype`
+              <td>The initial value of the `prototype` data property of %Int16Array%
             <tr>
-              <td>
-                %Int32ArrayPrototype%
-              </td>
-              <td>
-                `Int32Array.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Int32Array%
-              </td>
-            </tr>
+              <td>%Int32Array%
+              <td>`Int32Array`
+              <td>The `Int32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %isFinite%
-              </td>
-              <td>
-                `isFinite`
-              </td>
-              <td>
-                The `isFinite` function (<emu-xref href="#sec-isfinite-number"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Int32ArrayPrototype%
+              <td>`Int32Array.prototype`
+              <td>The initial value of the `prototype` data property of %Int32Array%
             <tr>
-              <td>
-                %isNaN%
-              </td>
-              <td>
-                `isNaN`
-              </td>
-              <td>
-                The `isNaN` function (<emu-xref href="#sec-isnan-number"></emu-xref>)
-              </td>
-            </tr>
+              <td>%isFinite%
+              <td>`isFinite`
+              <td>The `isFinite` function (<emu-xref href="#sec-isfinite-number"></emu-xref>)
             <tr>
-              <td>
-                %IteratorPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                An object that all standard built-in iterator objects indirectly inherit from
-              </td>
-            </tr>
+              <td>%isNaN%
+              <td>`isNaN`
+              <td>The `isNaN` function (<emu-xref href="#sec-isnan-number"></emu-xref>)
             <tr>
-              <td>
-                %JSON%
-              </td>
-              <td>
-                `JSON`
-              </td>
+              <td>%IteratorPrototype%
               <td>
-                The `JSON` object (<emu-xref href="#sec-json-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>An object that all standard built-in iterator objects indirectly inherit from
             <tr>
-              <td>
-                %JSONParse%
-              </td>
-              <td>
-                `JSON.parse`
-              </td>
-              <td>
-                The initial value of the `parse` data property of %JSON%
-              </td>
-            </tr>
+              <td>%JSON%
+              <td>`JSON`
+              <td>The `JSON` object (<emu-xref href="#sec-json-object"></emu-xref>)
             <tr>
-              <td>
-                %JSONStringify%
-              </td>
-              <td>
-                `JSON.stringify`
-              </td>
-              <td>
-                The initial value of the `stringify` data property of %JSON%
-              </td>
-            </tr>
+              <td>%JSONParse%
+              <td>`JSON.parse`
+              <td>The initial value of the `parse` data property of %JSON%
             <tr>
-              <td>
-                %Map%
-              </td>
-              <td>
-                `Map`
-              </td>
-              <td>
-                The `Map` constructor (<emu-xref href="#sec-map-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%JSONStringify%
+              <td>`JSON.stringify`
+              <td>The initial value of the `stringify` data property of %JSON%
             <tr>
-              <td>
-                %MapIteratorPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The prototype of Map iterator objects (<emu-xref href="#sec-map-iterator-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Map%
+              <td>`Map`
+              <td>The `Map` constructor (<emu-xref href="#sec-map-constructor"></emu-xref>)
             <tr>
+              <td>%MapIteratorPrototype%
               <td>
-                %MapPrototype%
-              </td>
-              <td>
-                `Map.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Map%
-              </td>
-            </tr>
+              <td>The prototype of Map iterator objects (<emu-xref href="#sec-map-iterator-objects"></emu-xref>)
             <tr>
-              <td>
-                %Math%
-              </td>
-              <td>
-                `Math`
-              </td>
-              <td>
-                The `Math` object (<emu-xref href="#sec-math-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>%MapPrototype%
+              <td>`Map.prototype`
+              <td>The initial value of the `prototype` data property of %Map%
             <tr>
-              <td>
-                %Number%
-              </td>
-              <td>
-                `Number`
-              </td>
-              <td>
-                The `Number` constructor (<emu-xref href="#sec-number-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Math%
+              <td>`Math`
+              <td>The `Math` object (<emu-xref href="#sec-math-object"></emu-xref>)
             <tr>
-              <td>
-                %NumberPrototype%
-              </td>
-              <td>
-                `Number.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Number%
-              </td>
-            </tr>
+              <td>%Number%
+              <td>`Number`
+              <td>The `Number` constructor (<emu-xref href="#sec-number-constructor"></emu-xref>)
             <tr>
-              <td>
-                %Object%
-              </td>
-              <td>
-                `Object`
-              </td>
-              <td>
-                The `Object` constructor (<emu-xref href="#sec-object-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%NumberPrototype%
+              <td>`Number.prototype`
+              <td>The initial value of the `prototype` data property of %Number%
             <tr>
-              <td>
-                %ObjectPrototype%
-              </td>
-              <td>
-                `Object.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Object%
+              <td>`Object`
+              <td>The `Object` constructor (<emu-xref href="#sec-object-constructor"></emu-xref>)
             <tr>
-              <td>
-                %ObjProto_toString%
-              </td>
-              <td>
-                `Object.prototype.toString`
-              </td>
-              <td>
-                The initial value of the `toString` data property of %ObjectPrototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ObjectPrototype%
+              <td>`Object.prototype`
+              <td>The initial value of the `prototype` data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>)
             <tr>
-              <td>
-                %ObjProto_valueOf%
-              </td>
-              <td>
-                `Object.prototype.valueOf`
-              </td>
-              <td>
-                The initial value of the `valueOf` data property of %ObjectPrototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ObjProto_toString%
+              <td>`Object.prototype.toString`
+              <td>The initial value of the `toString` data property of %ObjectPrototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>)
             <tr>
-              <td>
-                %parseFloat%
-              </td>
-              <td>
-                `parseFloat`
-              </td>
-              <td>
-                The `parseFloat` function (<emu-xref href="#sec-parsefloat-string"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ObjProto_valueOf%
+              <td>`Object.prototype.valueOf`
+              <td>The initial value of the `valueOf` data property of %ObjectPrototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>)
             <tr>
-              <td>
-                %parseInt%
-              </td>
-              <td>
-                `parseInt`
-              </td>
-              <td>
-                The `parseInt` function (<emu-xref href="#sec-parseint-string-radix"></emu-xref>)
-              </td>
-            </tr>
+              <td>%parseFloat%
+              <td>`parseFloat`
+              <td>The `parseFloat` function (<emu-xref href="#sec-parsefloat-string"></emu-xref>)
             <tr>
-              <td>
-                %Promise%
-              </td>
-              <td>
-                `Promise`
-              </td>
-              <td>
-                The `Promise` constructor (<emu-xref href="#sec-promise-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%parseInt%
+              <td>`parseInt`
+              <td>The `parseInt` function (<emu-xref href="#sec-parseint-string-radix"></emu-xref>)
             <tr>
-              <td>
-                %PromisePrototype%
-              </td>
-              <td>
-                `Promise.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Promise%
-              </td>
-            </tr>
+              <td>%Promise%
+              <td>`Promise`
+              <td>The `Promise` constructor (<emu-xref href="#sec-promise-constructor"></emu-xref>)
             <tr>
-              <td>
-                %PromiseProto_then%
-              </td>
-              <td>
-                `Promise.prototype.then`
-              </td>
-              <td>
-                The initial value of the `then` data property of %PromisePrototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>)
-              </td>
-            </tr>
+              <td>%PromisePrototype%
+              <td>`Promise.prototype`
+              <td>The initial value of the `prototype` data property of %Promise%
             <tr>
-              <td>
-                %Promise_all%
-              </td>
-              <td>
-                `Promise.all`
-              </td>
-              <td>
-                The initial value of the `all` data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>)
-              </td>
-            </tr>
+              <td>%PromiseProto_then%
+              <td>`Promise.prototype.then`
+              <td>The initial value of the `then` data property of %PromisePrototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>)
             <tr>
-              <td>
-                %Promise_reject%
-              </td>
-              <td>
-                `Promise.reject`
-              </td>
-              <td>
-                The initial value of the `reject` data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Promise_all%
+              <td>`Promise.all`
+              <td>The initial value of the `all` data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>)
             <tr>
-              <td>
-                %Promise_resolve%
-              </td>
-              <td>
-                `Promise.resolve`
-              </td>
-              <td>
-                The initial value of the `resolve` data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Promise_reject%
+              <td>`Promise.reject`
+              <td>The initial value of the `reject` data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>)
             <tr>
-              <td>
-                %Proxy%
-              </td>
-              <td>
-                `Proxy`
-              </td>
-              <td>
-                The `Proxy` constructor (<emu-xref href="#sec-proxy-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Promise_resolve%
+              <td>`Promise.resolve`
+              <td>The initial value of the `resolve` data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>)
             <tr>
-              <td>
-                %RangeError%
-              </td>
-              <td>
-                `RangeError`
-              </td>
-              <td>
-                The `RangeError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Proxy%
+              <td>`Proxy`
+              <td>The `Proxy` constructor (<emu-xref href="#sec-proxy-constructor"></emu-xref>)
             <tr>
-              <td>
-                %RangeErrorPrototype%
-              </td>
-              <td>
-                `RangeError.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %RangeError%
-              </td>
-            </tr>
+              <td>%RangeError%
+              <td>`RangeError`
+              <td>The `RangeError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>)
             <tr>
-              <td>
-                %ReferenceError%
-              </td>
-              <td>
-                `ReferenceError`
-              </td>
-              <td>
-                The `ReferenceError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
-              </td>
-            </tr>
+              <td>%RangeErrorPrototype%
+              <td>`RangeError.prototype`
+              <td>The initial value of the `prototype` data property of %RangeError%
             <tr>
-              <td>
-                %ReferenceErrorPrototype%
-              </td>
-              <td>
-                `ReferenceError.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %ReferenceError%
-              </td>
-            </tr>
+              <td>%ReferenceError%
+              <td>`ReferenceError`
+              <td>The `ReferenceError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
             <tr>
-              <td>
-                %Reflect%
-              </td>
-              <td>
-                `Reflect`
-              </td>
-              <td>
-                The `Reflect` object (<emu-xref href="#sec-reflect-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>%ReferenceErrorPrototype%
+              <td>`ReferenceError.prototype`
+              <td>The initial value of the `prototype` data property of %ReferenceError%
             <tr>
-              <td>
-                %RegExp%
-              </td>
-              <td>
-                `RegExp`
-              </td>
-              <td>
-                The `RegExp` constructor (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Reflect%
+              <td>`Reflect`
+              <td>The `Reflect` object (<emu-xref href="#sec-reflect-object"></emu-xref>)
             <tr>
-              <td>
-                %RegExpPrototype%
-              </td>
-              <td>
-                `RegExp.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %RegExp%
-              </td>
-            </tr>
+              <td>%RegExp%
+              <td>`RegExp`
+              <td>The `RegExp` constructor (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
             <tr>
-              <td>
-                %Set%
-              </td>
-              <td>
-                `Set`
-              </td>
-              <td>
-                The `Set` constructor (<emu-xref href="#sec-set-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%RegExpPrototype%
+              <td>`RegExp.prototype`
+              <td>The initial value of the `prototype` data property of %RegExp%
             <tr>
-              <td>
-                %SetIteratorPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The prototype of Set iterator objects (<emu-xref href="#sec-set-iterator-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Set%
+              <td>`Set`
+              <td>The `Set` constructor (<emu-xref href="#sec-set-constructor"></emu-xref>)
             <tr>
-              <td>
-                %SetPrototype%
-              </td>
+              <td>%SetIteratorPrototype%
               <td>
-                `Set.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Set%
-              </td>
-            </tr>
+              <td>The prototype of Set iterator objects (<emu-xref href="#sec-set-iterator-objects"></emu-xref>)
             <tr>
-              <td>
-                %SharedArrayBuffer%
-              </td>
-              <td>
-                `SharedArrayBuffer`
-              </td>
-              <td>
-                The `SharedArrayBuffer` constructor (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%SetPrototype%
+              <td>`Set.prototype`
+              <td>The initial value of the `prototype` data property of %Set%
             <tr>
-              <td>
-                %SharedArrayBufferPrototype%
-              </td>
-              <td>
-                `SharedArrayBuffer.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %SharedArrayBuffer%
-              </td>
-            </tr>
+              <td>%SharedArrayBuffer%
+              <td>`SharedArrayBuffer`
+              <td>The `SharedArrayBuffer` constructor (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
             <tr>
-              <td>
-                %String%
-              </td>
-              <td>
-                `String`
-              </td>
-              <td>
-                The `String` constructor (<emu-xref href="#sec-string-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%SharedArrayBufferPrototype%
+              <td>`SharedArrayBuffer.prototype`
+              <td>The initial value of the `prototype` data property of %SharedArrayBuffer%
             <tr>
-              <td>
-                %StringIteratorPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The prototype of String iterator objects (<emu-xref href="#sec-string-iterator-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%String%
+              <td>`String`
+              <td>The `String` constructor (<emu-xref href="#sec-string-constructor"></emu-xref>)
             <tr>
-              <td>
-                %StringPrototype%
-              </td>
+              <td>%StringIteratorPrototype%
               <td>
-                `String.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %String%
-              </td>
-            </tr>
+              <td>The prototype of String iterator objects (<emu-xref href="#sec-string-iterator-objects"></emu-xref>)
             <tr>
-              <td>
-                %Symbol%
-              </td>
-              <td>
-                `Symbol`
-              </td>
-              <td>
-                The `Symbol` constructor (<emu-xref href="#sec-symbol-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%StringPrototype%
+              <td>`String.prototype`
+              <td>The initial value of the `prototype` data property of %String%
             <tr>
-              <td>
-                %SymbolPrototype%
-              </td>
-              <td>
-                `Symbol.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Symbol%
+              <td>`Symbol`
+              <td>The `Symbol` constructor (<emu-xref href="#sec-symbol-constructor"></emu-xref>)
             <tr>
-              <td>
-                %SyntaxError%
-              </td>
-              <td>
-                `SyntaxError`
-              </td>
-              <td>
-                The `SyntaxError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
-              </td>
-            </tr>
+              <td>%SymbolPrototype%
+              <td>`Symbol.prototype`
+              <td>The initial value of the `prototype` data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>)
             <tr>
-              <td>
-                %SyntaxErrorPrototype%
-              </td>
-              <td>
-                `SyntaxError.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %SyntaxError%
-              </td>
-            </tr>
+              <td>%SyntaxError%
+              <td>`SyntaxError`
+              <td>The `SyntaxError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
             <tr>
-              <td>
-                %ThrowTypeError%
-              </td>
-              <td>
-              </td>
-              <td>
-                A function object that unconditionally throws a new instance of %TypeError%
-              </td>
-            </tr>
+              <td>%SyntaxErrorPrototype%
+              <td>`SyntaxError.prototype`
+              <td>The initial value of the `prototype` data property of %SyntaxError%
             <tr>
-              <td>
-                %TypedArray%
-              </td>
-              <td>
-              </td>
+              <td>%ThrowTypeError%
               <td>
-                The super class of all typed Array constructors (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>)
-              </td>
-            </tr>
+              <td>A function object that unconditionally throws a new instance of %TypeError%
             <tr>
+              <td>%TypedArray%
               <td>
-                %TypedArrayPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %TypedArray%
-              </td>
-            </tr>
+              <td>The super class of all typed Array constructors (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>)
             <tr>
+              <td>%TypedArrayPrototype%
               <td>
-                %TypeError%
-              </td>
-              <td>
-                `TypeError`
-              </td>
-              <td>
-                The `TypeError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
-              </td>
-            </tr>
+              <td>The initial value of the `prototype` data property of %TypedArray%
             <tr>
-              <td>
-                %TypeErrorPrototype%
-              </td>
-              <td>
-                `TypeError.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %TypeError%
-              </td>
-            </tr>
+              <td>%TypeError%
+              <td>`TypeError`
+              <td>The `TypeError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
             <tr>
-              <td>
-                %Uint8Array%
-              </td>
-              <td>
-                `Uint8Array`
-              </td>
-              <td>
-                The `Uint8Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%TypeErrorPrototype%
+              <td>`TypeError.prototype`
+              <td>The initial value of the `prototype` data property of %TypeError%
             <tr>
-              <td>
-                %Uint8ArrayPrototype%
-              </td>
-              <td>
-                `Uint8Array.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Uint8Array%
-              </td>
-            </tr>
+              <td>%Uint8Array%
+              <td>`Uint8Array`
+              <td>The `Uint8Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %Uint8ClampedArray%
-              </td>
-              <td>
-                `Uint8ClampedArray`
-              </td>
-              <td>
-                The `Uint8ClampedArray` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Uint8ArrayPrototype%
+              <td>`Uint8Array.prototype`
+              <td>The initial value of the `prototype` data property of %Uint8Array%
             <tr>
-              <td>
-                %Uint8ClampedArrayPrototype%
-              </td>
-              <td>
-                `Uint8ClampedArray.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Uint8ClampedArray%
-              </td>
-            </tr>
+              <td>%Uint8ClampedArray%
+              <td>`Uint8ClampedArray`
+              <td>The `Uint8ClampedArray` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %Uint16Array%
-              </td>
-              <td>
-                `Uint16Array`
-              </td>
-              <td>
-                The `Uint16Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Uint8ClampedArrayPrototype%
+              <td>`Uint8ClampedArray.prototype`
+              <td>The initial value of the `prototype` data property of %Uint8ClampedArray%
             <tr>
-              <td>
-                %Uint16ArrayPrototype%
-              </td>
-              <td>
-                `Uint16Array.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Uint16Array%
-              </td>
-            </tr>
+              <td>%Uint16Array%
+              <td>`Uint16Array`
+              <td>The `Uint16Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %Uint32Array%
-              </td>
-              <td>
-                `Uint32Array`
-              </td>
-              <td>
-                The `Uint32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Uint16ArrayPrototype%
+              <td>`Uint16Array.prototype`
+              <td>The initial value of the `prototype` data property of %Uint16Array%
             <tr>
-              <td>
-                %Uint32ArrayPrototype%
-              </td>
-              <td>
-                `Uint32Array.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %Uint32Array%
-              </td>
-            </tr>
+              <td>%Uint32Array%
+              <td>`Uint32Array`
+              <td>The `Uint32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
             <tr>
-              <td>
-                %URIError%
-              </td>
-              <td>
-                `URIError`
-              </td>
-              <td>
-                The `URIError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>)
-              </td>
-            </tr>
+              <td>%Uint32ArrayPrototype%
+              <td>`Uint32Array.prototype`
+              <td>The initial value of the `prototype` data property of %Uint32Array%
             <tr>
-              <td>
-                %URIErrorPrototype%
-              </td>
-              <td>
-                `URIError.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %URIError%
-              </td>
-            </tr>
+              <td>%URIError%
+              <td>`URIError`
+              <td>The `URIError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>)
             <tr>
-              <td>
-                %WeakMap%
-              </td>
-              <td>
-                `WeakMap`
-              </td>
-              <td>
-                The `WeakMap` constructor (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%URIErrorPrototype%
+              <td>`URIError.prototype`
+              <td>The initial value of the `prototype` data property of %URIError%
             <tr>
-              <td>
-                %WeakMapPrototype%
-              </td>
-              <td>
-                `WeakMap.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %WeakMap%
-              </td>
-            </tr>
+              <td>%WeakMap%
+              <td>`WeakMap`
+              <td>The `WeakMap` constructor (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
             <tr>
-              <td>
-                %WeakSet%
-              </td>
-              <td>
-                `WeakSet`
-              </td>
-              <td>
-                The `WeakSet` constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
-              </td>
-            </tr>
+              <td>%WeakMapPrototype%
+              <td>`WeakMap.prototype`
+              <td>The initial value of the `prototype` data property of %WeakMap%
             <tr>
-              <td>
-                %WeakSetPrototype%
-              </td>
-              <td>
-                `WeakSet.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %WeakSet%
-              </td>
-            </tr>
-            </tbody>
+              <td>%WeakSet%
+              <td>`WeakSet`
+              <td>The `WeakSet` constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
+            <tr>
+              <td>%WeakSetPrototype%
+              <td>`WeakSet.prototype`
+              <td>The initial value of the `prototype` data property of %WeakSet%
           </table>
         </emu-table>
       </emu-clause>
@@ -2934,52 +1860,22 @@
       <p>Values of the Completion type are Record values whose fields are defined as by <emu-xref href="#table-8"></emu-xref>. Such values are referred to as <dfn>Completion Record</dfn>s.</p>
       <emu-table id="table-8" caption="Completion Record Fields">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Field Name
-            </th>
-            <th>
-              Value
-            </th>
-            <th>
-              Meaning
-            </th>
-          </tr>
+            <th>Field Name
+            <th>Value
+            <th>Meaning
           <tr>
-            <td>
-              [[Type]]
-            </td>
-            <td>
-              One of ~normal~, ~break~, ~continue~, ~return~, or ~throw~
-            </td>
-            <td>
-              The type of completion that occurred.
-            </td>
-          </tr>
+            <td>[[Type]]
+            <td>One of ~normal~, ~break~, ~continue~, ~return~, or ~throw~
+            <td>The type of completion that occurred.
           <tr>
-            <td>
-              [[Value]]
-            </td>
-            <td>
-              any ECMAScript language value or ~empty~
-            </td>
-            <td>
-              The value that was produced.
-            </td>
-          </tr>
+            <td>[[Value]]
+            <td>any ECMAScript language value or ~empty~
+            <td>The value that was produced.
           <tr>
-            <td>
-              [[Target]]
-            </td>
-            <td>
-              any ECMAScript string or ~empty~
-            </td>
-            <td>
-              The target label for directed control transfers.
-            </td>
-          </tr>
-          </tbody>
+            <td>[[Target]]
+            <td>any ECMAScript string or ~empty~
+            <td>The target label for directed control transfers.
         </table>
       </emu-table>
       <p>The term &ldquo;<dfn>abrupt completion</dfn>&rdquo; refers to any completion with a [[Type]] value other than ~normal~.</p>
@@ -3490,72 +2386,30 @@
       <p>The abstract operation ToBoolean converts _argument_ to a value of type Boolean according to <emu-xref href="#table-10"></emu-xref>:</p>
       <emu-table id="table-10" caption="ToBoolean Conversions">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Argument Type
-            </th>
-            <th>
-              Result
-            </th>
-          </tr>
+            <th>Argument Type
+            <th>Result
           <tr>
-            <td>
-              Undefined
-            </td>
-            <td>
-              Return *false*.
-            </td>
-          </tr>
+            <td>Undefined
+            <td>Return *false*.
           <tr>
-            <td>
-              Null
-            </td>
-            <td>
-              Return *false*.
-            </td>
-          </tr>
+            <td>Null
+            <td>Return *false*.
           <tr>
-            <td>
-              Boolean
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
+            <td>Boolean
+            <td>Return _argument_.
           <tr>
-            <td>
-              Number
-            </td>
-            <td>
-              If _argument_ is *+0*, *-0*, or *NaN*, return *false*; otherwise return *true*.
-            </td>
-          </tr>
+            <td>Number
+            <td>If _argument_ is *+0*, *-0*, or *NaN*, return *false*; otherwise return *true*.
           <tr>
-            <td>
-              String
-            </td>
-            <td>
-              If _argument_ is the empty String (its length is zero), return *false*; otherwise return *true*.
-            </td>
-          </tr>
+            <td>String
+            <td>If _argument_ is the empty String (its length is zero), return *false*; otherwise return *true*.
           <tr>
-            <td>
-              Symbol
-            </td>
-            <td>
-              Return *true*.
-            </td>
-          </tr>
+            <td>Symbol
+            <td>Return *true*.
           <tr>
-            <td>
-              Object
-            </td>
-            <td>
-              Return *true*.
-            </td>
-          </tr>
-          </tbody>
+            <td>Object
+            <td>Return *true*.
         </table>
       </emu-table>
     </emu-clause>
@@ -3565,76 +2419,35 @@
       <p>The abstract operation ToNumber converts _argument_ to a value of type Number according to <emu-xref href="#table-11"></emu-xref>:</p>
       <emu-table id="table-11" caption="ToNumber Conversions">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Argument Type
-            </th>
-            <th>
-              Result
-            </th>
-          </tr>
+            <th>Argument Type
+            <th>Result
           <tr>
-            <td>
-              Undefined
-            </td>
-            <td>
-              Return *NaN*.
-            </td>
-          </tr>
+            <td>Undefined
+            <td>Return *NaN*.
           <tr>
-            <td>
-              Null
-            </td>
-            <td>
-              Return *+0*.
-            </td>
-          </tr>
+            <td>Null
+            <td>Return *+0*.
           <tr>
-            <td>
-              Boolean
-            </td>
-            <td>
-              If _argument_ is *true*, return 1. If _argument_ is *false*, return *+0*.
-            </td>
-          </tr>
+            <td>Boolean
+            <td>If _argument_ is *true*, return 1. If _argument_ is *false*, return *+0*.
           <tr>
-            <td>
-              Number
-            </td>
-            <td>
-              Return _argument_ (no conversion).
-            </td>
-          </tr>
+            <td>Number
+            <td>Return _argument_ (no conversion).
           <tr>
-            <td>
-              String
-            </td>
-            <td>
-              See grammar and conversion algorithm below.
-            </td>
-          </tr>
+            <td>String
+            <td>See grammar and conversion algorithm below.
           <tr>
-            <td>
-              Symbol
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
+            <td>Symbol
+            <td>Throw a *TypeError* exception.
           <tr>
-            <td>
-              Object
-            </td>
+            <td>Object
             <td>
               <p>Apply the following steps:</p>
               <emu-alg>
                 1. Let _primValue_ be ? ToPrimitive(_argument_, hint Number).
                 1. Return ? ToNumber(_primValue_).
               </emu-alg>
-            </td>
-          </tr>
-          </tbody>
         </table>
       </emu-table>
 
@@ -3920,77 +2733,37 @@
       <p>The abstract operation ToString converts _argument_ to a value of type String according to <emu-xref href="#table-12"></emu-xref>:</p>
       <emu-table id="table-12" caption="ToString Conversions">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Argument Type
-            </th>
-            <th>
-              Result
-            </th>
-          </tr>
+            <th>Argument Type
+            <th>Result
           <tr>
-            <td>
-              Undefined
-            </td>
-            <td>
-              Return `"undefined"`.
-            </td>
-          </tr>
+            <td>Undefined
+            <td>Return `"undefined"`.
           <tr>
-            <td>
-              Null
-            </td>
-            <td>
-              Return `"null"`.
-            </td>
-          </tr>
+            <td>Null
+            <td>Return `"null"`.
           <tr>
-            <td>
-              Boolean
-            </td>
+            <td>Boolean
             <td>
               <p>If _argument_ is *true*, return `"true"`.</p>
               <p>If _argument_ is *false*, return `"false"`.</p>
-            </td>
-          </tr>
           <tr>
-            <td>
-              Number
-            </td>
-            <td>
-              Return NumberToString(_argument_).
-            </td>
-          </tr>
+            <td>Number
+            <td>Return NumberToString(_argument_).
           <tr>
-            <td>
-              String
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
+            <td>String
+            <td>Return _argument_.
           <tr>
-            <td>
-              Symbol
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
+            <td>Symbol
+            <td>Throw a *TypeError* exception.
           <tr>
-            <td>
-              Object
-            </td>
+            <td>Object
             <td>
               <p>Apply the following steps:</p>
               <emu-alg>
                 1. Let _primValue_ be ? ToPrimitive(_argument_, hint String).
                 1. Return ? ToString(_primValue_).
               </emu-alg>
-            </td>
-          </tr>
-          </tbody>
         </table>
       </emu-table>
 
@@ -4063,72 +2836,30 @@
       <p>The abstract operation ToObject converts _argument_ to a value of type Object according to <emu-xref href="#table-13"></emu-xref>:</p>
       <emu-table id="table-13" caption="ToObject Conversions">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Argument Type
-            </th>
-            <th>
-              Result
-            </th>
-          </tr>
+            <th>Argument Type
+            <th>Result
           <tr>
-            <td>
-              Undefined
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
+            <td>Undefined
+            <td>Throw a *TypeError* exception.
           <tr>
-            <td>
-              Null
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
+            <td>Null
+            <td>Throw a *TypeError* exception.
           <tr>
-            <td>
-              Boolean
-            </td>
-            <td>
-              Return a new Boolean object whose [[BooleanData]] internal slot is set to _argument_. See <emu-xref href="#sec-boolean-objects"></emu-xref> for a description of Boolean objects.
-            </td>
-          </tr>
+            <td>Boolean
+            <td>Return a new Boolean object whose [[BooleanData]] internal slot is set to _argument_. See <emu-xref href="#sec-boolean-objects"></emu-xref> for a description of Boolean objects.
           <tr>
-            <td>
-              Number
-            </td>
-            <td>
-              Return a new Number object whose [[NumberData]] internal slot is set to _argument_. See <emu-xref href="#sec-number-objects"></emu-xref> for a description of Number objects.
-            </td>
-          </tr>
+            <td>Number
+            <td>Return a new Number object whose [[NumberData]] internal slot is set to _argument_. See <emu-xref href="#sec-number-objects"></emu-xref> for a description of Number objects.
           <tr>
-            <td>
-              String
-            </td>
-            <td>
-              Return a new String object whose [[StringData]] internal slot is set to _argument_. See <emu-xref href="#sec-string-objects"></emu-xref> for a description of String objects.
-            </td>
-          </tr>
+            <td>String
+            <td>Return a new String object whose [[StringData]] internal slot is set to _argument_. See <emu-xref href="#sec-string-objects"></emu-xref> for a description of String objects.
           <tr>
-            <td>
-              Symbol
-            </td>
-            <td>
-              Return a new Symbol object whose [[SymbolData]] internal slot is set to _argument_. See <emu-xref href="#sec-symbol-objects"></emu-xref> for a description of Symbol objects.
-            </td>
-          </tr>
+            <td>Symbol
+            <td>Return a new Symbol object whose [[SymbolData]] internal slot is set to _argument_. See <emu-xref href="#sec-symbol-objects"></emu-xref> for a description of Symbol objects.
           <tr>
-            <td>
-              Object
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
-          </tbody>
+            <td>Object
+            <td>Return _argument_.
         </table>
       </emu-table>
     </emu-clause>
@@ -4191,72 +2922,30 @@
       <p>The abstract operation RequireObjectCoercible throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-14"></emu-xref>:</p>
       <emu-table id="table-14" caption="RequireObjectCoercible Results">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Argument Type
-            </th>
-            <th>
-              Result
-            </th>
-          </tr>
+            <th>Argument Type
+            <th>Result
           <tr>
-            <td>
-              Undefined
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
+            <td>Undefined
+            <td>Throw a *TypeError* exception.
           <tr>
-            <td>
-              Null
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
+            <td>Null
+            <td>Throw a *TypeError* exception.
           <tr>
-            <td>
-              Boolean
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
+            <td>Boolean
+            <td>Return _argument_.
           <tr>
-            <td>
-              Number
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
+            <td>Number
+            <td>Return _argument_.
           <tr>
-            <td>
-              String
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
+            <td>String
+            <td>Return _argument_.
           <tr>
-            <td>
-              Symbol
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
+            <td>Symbol
+            <td>Return _argument_.
           <tr>
-            <td>
-              Object
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
-          </tbody>
+            <td>Object
+            <td>Return _argument_.
         </table>
       </emu-table>
     </emu-clause>
@@ -5008,96 +3697,39 @@
       <p>For specification purposes Environment Record values are values of the Record specification type and can be thought of as existing in a simple object-oriented hierarchy where Environment Record is an abstract class with three concrete subclasses, declarative Environment Record, object Environment Record, and global Environment Record. Function Environment Records and module Environment Records are subclasses of declarative Environment Record. The abstract class includes the abstract specification methods defined in <emu-xref href="#table-15"></emu-xref>. These abstract methods have distinct concrete algorithms for each of the concrete subclasses.</p>
       <emu-table id="table-15" caption="Abstract Methods of Environment Records">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Method
-            </th>
-            <th>
-              Purpose
-            </th>
-          </tr>
+            <th>Method
+            <th>Purpose
           <tr>
-            <td>
-              HasBinding(N)
-            </td>
-            <td>
-              Determine if an Environment Record has a binding for the String value _N_. Return *true* if it does and *false* if it does not.
-            </td>
-          </tr>
+            <td>HasBinding(N)
+            <td>Determine if an Environment Record has a binding for the String value _N_. Return *true* if it does and *false* if it does not.
           <tr>
-            <td>
-              CreateMutableBinding(N, D)
-            </td>
-            <td>
-              Create a new but uninitialized mutable binding in an Environment Record. The String value _N_ is the text of the bound name. If the Boolean argument _D_ is *true* the binding may be subsequently deleted.
-            </td>
-          </tr>
+            <td>CreateMutableBinding(N, D)
+            <td>Create a new but uninitialized mutable binding in an Environment Record. The String value _N_ is the text of the bound name. If the Boolean argument _D_ is *true* the binding may be subsequently deleted.
           <tr>
-            <td>
-              CreateImmutableBinding(N, S)
-            </td>
-            <td>
-              Create a new but uninitialized immutable binding in an Environment Record. The String value _N_ is the text of the bound name. If _S_ is *true* then attempts to set it after it has been initialized will always throw an exception, regardless of the strict mode setting of operations that reference that binding.
-            </td>
-          </tr>
+            <td>CreateImmutableBinding(N, S)
+            <td>Create a new but uninitialized immutable binding in an Environment Record. The String value _N_ is the text of the bound name. If _S_ is *true* then attempts to set it after it has been initialized will always throw an exception, regardless of the strict mode setting of operations that reference that binding.
           <tr>
-            <td>
-              InitializeBinding(N, V)
-            </td>
-            <td>
-              Set the value of an already existing but uninitialized binding in an Environment Record. The String value _N_ is the text of the bound name. _V_ is the value for the binding and is a value of any ECMAScript language type.
-            </td>
-          </tr>
+            <td>InitializeBinding(N, V)
+            <td>Set the value of an already existing but uninitialized binding in an Environment Record. The String value _N_ is the text of the bound name. _V_ is the value for the binding and is a value of any ECMAScript language type.
           <tr>
-            <td>
-              SetMutableBinding(N, V, S)
-            </td>
-            <td>
-              Set the value of an already existing mutable binding in an Environment Record. The String value _N_ is the text of the bound name. _V_ is the value for the binding and may be a value of any ECMAScript language type. _S_ is a Boolean flag. If _S_ is *true* and the binding cannot be set throw a *TypeError* exception.
-            </td>
-          </tr>
+            <td>SetMutableBinding(N, V, S)
+            <td>Set the value of an already existing mutable binding in an Environment Record. The String value _N_ is the text of the bound name. _V_ is the value for the binding and may be a value of any ECMAScript language type. _S_ is a Boolean flag. If _S_ is *true* and the binding cannot be set throw a *TypeError* exception.
           <tr>
-            <td>
-              GetBindingValue(N, S)
-            </td>
-            <td>
-              Returns the value of an already existing binding from an Environment Record. The String value _N_ is the text of the bound name. _S_ is used to identify references originating in strict mode code or that otherwise require strict mode reference semantics. If _S_ is *true* and the binding does not exist throw a *ReferenceError* exception. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.
-            </td>
-          </tr>
+            <td>GetBindingValue(N, S)
+            <td>Returns the value of an already existing binding from an Environment Record. The String value _N_ is the text of the bound name. _S_ is used to identify references originating in strict mode code or that otherwise require strict mode reference semantics. If _S_ is *true* and the binding does not exist throw a *ReferenceError* exception. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.
           <tr>
-            <td>
-              DeleteBinding(N)
-            </td>
-            <td>
-              Delete a binding from an Environment Record. The String value _N_ is the text of the bound name. If a binding for _N_ exists, remove the binding and return *true*. If the binding exists but cannot be removed return *false*. If the binding does not exist return *true*.
-            </td>
-          </tr>
+            <td>DeleteBinding(N)
+            <td>Delete a binding from an Environment Record. The String value _N_ is the text of the bound name. If a binding for _N_ exists, remove the binding and return *true*. If the binding exists but cannot be removed return *false*. If the binding does not exist return *true*.
           <tr>
-            <td>
-              HasThisBinding()
-            </td>
-            <td>
-              Determine if an Environment Record establishes a `this` binding. Return *true* if it does and *false* if it does not.
-            </td>
-          </tr>
+            <td>HasThisBinding()
+            <td>Determine if an Environment Record establishes a `this` binding. Return *true* if it does and *false* if it does not.
           <tr>
-            <td>
-              HasSuperBinding()
-            </td>
-            <td>
-              Determine if an Environment Record establishes a `super` method binding. Return *true* if it does and *false* if it does not.
-            </td>
-          </tr>
+            <td>HasSuperBinding()
+            <td>Determine if an Environment Record establishes a `super` method binding. Return *true* if it does and *false* if it does not.
           <tr>
-            <td>
-              WithBaseObject()
-            </td>
-            <td>
-              If this Environment Record is associated with a `with` statement, return the with object. Otherwise, return *undefined*.
-            </td>
-          </tr>
-          </tbody>
+            <td>WithBaseObject()
+            <td>If this Environment Record is associated with a `with` statement, return the with object. Otherwise, return *undefined*.
         </table>
       </emu-table>
 
@@ -5343,113 +3975,47 @@
         <p>Function Environment Records have the additional state fields listed in <emu-xref href="#table-16"></emu-xref>.</p>
         <emu-table id="table-16" caption="Additional Fields of Function Environment Records">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
+              <th>Field Name
+              <th>Value
+              <th>Meaning
             <tr>
-              <td>
-                [[ThisValue]]
-              </td>
-              <td>
-                Any
-              </td>
-              <td>
-                This is the *this* value used for this invocation of the function.
-              </td>
-            </tr>
+              <td>[[ThisValue]]
+              <td>Any
+              <td>This is the *this* value used for this invocation of the function.
             <tr>
-              <td>
-                [[ThisBindingStatus]]
-              </td>
-              <td>
-                `"lexical"` | `"initialized"` | `"uninitialized"`
-              </td>
-              <td>
-                If the value is `"lexical"`, this is an |ArrowFunction| and does not have a local this value.
-              </td>
-            </tr>
+              <td>[[ThisBindingStatus]]
+              <td>`"lexical"` | `"initialized"` | `"uninitialized"`
+              <td>If the value is `"lexical"`, this is an |ArrowFunction| and does not have a local this value.
             <tr>
-              <td>
-                [[FunctionObject]]
-              </td>
-              <td>
-                Object
-              </td>
-              <td>
-                The function object whose invocation caused this Environment Record to be created.
-              </td>
-            </tr>
+              <td>[[FunctionObject]]
+              <td>Object
+              <td>The function object whose invocation caused this Environment Record to be created.
             <tr>
-              <td>
-                [[HomeObject]]
-              </td>
-              <td>
-                Object | *undefined*
-              </td>
-              <td>
-                If the associated function has `super` property accesses and is not an |ArrowFunction|, [[HomeObject]] is the object that the function is bound to as a method. The default value for [[HomeObject]] is *undefined*.
-              </td>
-            </tr>
+              <td>[[HomeObject]]
+              <td>Object | *undefined*
+              <td>If the associated function has `super` property accesses and is not an |ArrowFunction|, [[HomeObject]] is the object that the function is bound to as a method. The default value for [[HomeObject]] is *undefined*.
             <tr>
-              <td>
-                [[NewTarget]]
-              </td>
-              <td>
-                Object | *undefined*
-              </td>
-              <td>
-                If this Environment Record was created by the [[Construct]] internal method, [[NewTarget]] is the value of the [[Construct]] _newTarget_ parameter. Otherwise, its value is *undefined*.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[NewTarget]]
+              <td>Object | *undefined*
+              <td>If this Environment Record was created by the [[Construct]] internal method, [[NewTarget]] is the value of the [[Construct]] _newTarget_ parameter. Otherwise, its value is *undefined*.
           </table>
         </emu-table>
         <p>Function Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and share the same specifications for all of those methods except for HasThisBinding and HasSuperBinding. In addition, function Environment Records support the methods listed in <emu-xref href="#table-17"></emu-xref>:</p>
         <emu-table id="table-17" caption="Additional Methods of Function Environment Records">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Method
-              </th>
-              <th>
-                Purpose
-              </th>
-            </tr>
+              <th>Method
+              <th>Purpose
             <tr>
-              <td>
-                BindThisValue(V)
-              </td>
-              <td>
-                Set the [[ThisValue]] and record that it has been initialized.
-              </td>
-            </tr>
+              <td>BindThisValue(V)
+              <td>Set the [[ThisValue]] and record that it has been initialized.
             <tr>
-              <td>
-                GetThisBinding()
-              </td>
-              <td>
-                Return the value of this Environment Record's `this` binding. Throws a *ReferenceError* if the `this` binding has not been initialized.
-              </td>
-            </tr>
+              <td>GetThisBinding()
+              <td>Return the value of this Environment Record's `this` binding. Throws a *ReferenceError* if the `this` binding has not been initialized.
             <tr>
-              <td>
-                GetSuperBase()
-              </td>
-              <td>
-                Return the object that is the base for `super` property accesses bound in this Environment Record. The object is derived from this Environment Record's [[HomeObject]] field. The value *undefined* indicates that `super` property accesses will produce runtime errors.
-              </td>
-            </tr>
-            </tbody>
+              <td>GetSuperBase()
+              <td>Return the object that is the base for `super` property accesses bound in this Environment Record. The object is derived from this Environment Record's [[HomeObject]] field. The value *undefined* indicates that `super` property accesses will produce runtime errors.
           </table>
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for function Environment Records is defined by the following algorithms:</p>
@@ -5513,141 +4079,57 @@
         <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-18"></emu-xref> and the additional methods listed in <emu-xref href="#table-19"></emu-xref>.</p>
         <emu-table id="table-18" caption="Additional Fields of Global Environment Records">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
+              <th>Field Name
+              <th>Value
+              <th>Meaning
             <tr>
-              <td>
-                [[ObjectRecord]]
-              </td>
-              <td>
-                Object Environment Record
-              </td>
-              <td>
-                Binding object is the global object. It contains global built-in bindings as well as |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| bindings in global code for the associated realm.
-              </td>
-            </tr>
+              <td>[[ObjectRecord]]
+              <td>Object Environment Record
+              <td>Binding object is the global object. It contains global built-in bindings as well as |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| bindings in global code for the associated realm.
             <tr>
-              <td>
-                [[GlobalThisValue]]
-              </td>
-              <td>
-                Object
-              </td>
-              <td>
-                The value returned by `this` in global scope. Hosts may provide any ECMAScript Object value.
-              </td>
-            </tr>
+              <td>[[GlobalThisValue]]
+              <td>Object
+              <td>The value returned by `this` in global scope. Hosts may provide any ECMAScript Object value.
             <tr>
-              <td>
-                [[DeclarativeRecord]]
-              </td>
-              <td>
-                Declarative Environment Record
-              </td>
-              <td>
-                Contains bindings for all declarations in global code for the associated realm code except for |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| _bindings_.
-              </td>
-            </tr>
+              <td>[[DeclarativeRecord]]
+              <td>Declarative Environment Record
+              <td>Contains bindings for all declarations in global code for the associated realm code except for |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| _bindings_.
             <tr>
-              <td>
-                [[VarNames]]
-              </td>
-              <td>
-                List of String
-              </td>
-              <td>
-                The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| declarations in global code for the associated realm.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[VarNames]]
+              <td>List of String
+              <td>The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| declarations in global code for the associated realm.
           </table>
         </emu-table>
         <emu-table id="table-19" caption="Additional Methods of Global Environment Records">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Method
-              </th>
-              <th>
-                Purpose
-              </th>
-            </tr>
+              <th>Method
+              <th>Purpose
             <tr>
-              <td>
-                GetThisBinding()
-              </td>
-              <td>
-                Return the value of this Environment Record's `this` binding.
-              </td>
-            </tr>
+              <td>GetThisBinding()
+              <td>Return the value of this Environment Record's `this` binding.
             <tr>
-              <td>
-                HasVarDeclaration (N)
-              </td>
-              <td>
-                Determines if the argument identifier has a binding in this Environment Record that was created using a |VariableDeclaration|, |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, or |AsyncGeneratorDeclaration|.
-              </td>
-            </tr>
+              <td>HasVarDeclaration (N)
+              <td>Determines if the argument identifier has a binding in this Environment Record that was created using a |VariableDeclaration|, |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, or |AsyncGeneratorDeclaration|.
             <tr>
-              <td>
-                HasLexicalDeclaration (N)
-              </td>
-              <td>
-                Determines if the argument identifier has a binding in this Environment Record that was created using a lexical declaration such as a |LexicalDeclaration| or a |ClassDeclaration|.
-              </td>
-            </tr>
+              <td>HasLexicalDeclaration (N)
+              <td>Determines if the argument identifier has a binding in this Environment Record that was created using a lexical declaration such as a |LexicalDeclaration| or a |ClassDeclaration|.
             <tr>
-              <td>
-                HasRestrictedGlobalProperty (N)
-              </td>
-              <td>
-                Determines if the argument is the name of a global object property that may not be shadowed by a global lexical binding.
-              </td>
-            </tr>
+              <td>HasRestrictedGlobalProperty (N)
+              <td>Determines if the argument is the name of a global object property that may not be shadowed by a global lexical binding.
             <tr>
-              <td>
-                CanDeclareGlobalVar (N)
-              </td>
-              <td>
-                Determines if a corresponding CreateGlobalVarBinding call would succeed if called for the same argument _N_.
-              </td>
-            </tr>
+              <td>CanDeclareGlobalVar (N)
+              <td>Determines if a corresponding CreateGlobalVarBinding call would succeed if called for the same argument _N_.
             <tr>
-              <td>
-                CanDeclareGlobalFunction (N)
-              </td>
-              <td>
-                Determines if a corresponding CreateGlobalFunctionBinding call would succeed if called for the same argument _N_.
-              </td>
-            </tr>
+              <td>CanDeclareGlobalFunction (N)
+              <td>Determines if a corresponding CreateGlobalFunctionBinding call would succeed if called for the same argument _N_.
             <tr>
-              <td>
-                CreateGlobalVarBinding(N, D)
-              </td>
-              <td>
-                Used to create and initialize to *undefined* a global `var` binding in the [[ObjectRecord]] component of a global Environment Record. The binding will be a mutable binding. The corresponding global object property will have attribute values appropriate for a `var`. The String value _N_ is the bound name. If _D_ is *true* the binding may be deleted. Logically equivalent to CreateMutableBinding followed by a SetMutableBinding but it allows var declarations to receive special treatment.
-              </td>
-            </tr>
+              <td>CreateGlobalVarBinding(N, D)
+              <td>Used to create and initialize to *undefined* a global `var` binding in the [[ObjectRecord]] component of a global Environment Record. The binding will be a mutable binding. The corresponding global object property will have attribute values appropriate for a `var`. The String value _N_ is the bound name. If _D_ is *true* the binding may be deleted. Logically equivalent to CreateMutableBinding followed by a SetMutableBinding but it allows var declarations to receive special treatment.
             <tr>
-              <td>
-                CreateGlobalFunctionBinding(N, V, D)
-              </td>
-              <td>
-                Create and initialize a global `function` binding in the [[ObjectRecord]] component of a global Environment Record. The binding will be a mutable binding. The corresponding global object property will have attribute values appropriate for a `function`. The String value _N_ is the bound name. _V_ is the initialization value. If the Boolean argument _D_ is *true* the binding may be deleted. Logically equivalent to CreateMutableBinding followed by a SetMutableBinding but it allows function declarations to receive special treatment.
-              </td>
-            </tr>
-            </tbody>
+              <td>CreateGlobalFunctionBinding(N, V, D)
+              <td>Create and initialize a global `function` binding in the [[ObjectRecord]] component of a global Environment Record. The binding will be a mutable binding. The corresponding global object property will have attribute values appropriate for a `function`. The String value _N_ is the bound name. _V_ is the initialization value. If the Boolean argument _D_ is *true* the binding may be deleted. Logically equivalent to CreateMutableBinding followed by a SetMutableBinding but it allows function declarations to receive special treatment.
           </table>
         </emu-table>
         <p>The behaviour of the concrete specification methods for global Environment Records is defined by the following algorithms.</p>
@@ -5894,32 +4376,15 @@
         <p>Module Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and share the same specifications for all of those methods except for GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding. In addition, module Environment Records support the methods listed in <emu-xref href="#table-20"></emu-xref>:</p>
         <emu-table id="table-20" caption="Additional Methods of Module Environment Records">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Method
-              </th>
-              <th>
-                Purpose
-              </th>
-            </tr>
+              <th>Method
+              <th>Purpose
             <tr>
-              <td>
-                CreateImportBinding(N, M, N2)
-              </td>
-              <td>
-                Create an immutable indirect binding in a module Environment Record. The String value _N_ is the text of the bound name. _M_ is a Module Record, and _N2_ is a binding that exists in M's module Environment Record.
-              </td>
-            </tr>
+              <td>CreateImportBinding(N, M, N2)
+              <td>Create an immutable indirect binding in a module Environment Record. The String value _N_ is the text of the bound name. _M_ is a Module Record, and _N2_ is a binding that exists in M's module Environment Record.
             <tr>
-              <td>
-                GetThisBinding()
-              </td>
-              <td>
-                Return the value of this Environment Record's `this` binding.
-              </td>
-            </tr>
-            </tbody>
+              <td>GetThisBinding()
+              <td>Return the value of this Environment Record's `this` binding.
           </table>
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
@@ -6088,75 +4553,32 @@
     <p>A realm is represented in this specification as a <dfn id="realm-record">Realm Record</dfn> with the fields specified in <emu-xref href="#table-21"></emu-xref>:</p>
     <emu-table id="table-21" caption="Realm Record Fields">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Field Name
-          </th>
-          <th>
-            Value
-          </th>
-          <th>
-            Meaning
-          </th>
-        </tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
         <tr>
-          <td>
-            [[Intrinsics]]
-          </td>
-          <td>
-            Record whose field names are intrinsic keys and whose values are objects
-          </td>
-          <td>
-            The intrinsic values used by code associated with this realm
-          </td>
-        </tr>
+          <td>[[Intrinsics]]
+          <td>Record whose field names are intrinsic keys and whose values are objects
+          <td>The intrinsic values used by code associated with this realm
         <tr>
-          <td>
-            [[GlobalObject]]
-          </td>
-          <td>
-            Object
-          </td>
-          <td>
-            The global object for this realm
-          </td>
-        </tr>
+          <td>[[GlobalObject]]
+          <td>Object
+          <td>The global object for this realm
         <tr>
-          <td>
-            [[GlobalEnv]]
-          </td>
-          <td>
-            Lexical Environment
-          </td>
-          <td>
-            The global environment for this realm
-          </td>
-        </tr>
+          <td>[[GlobalEnv]]
+          <td>Lexical Environment
+          <td>The global environment for this realm
         <tr>
-          <td>
-            [[TemplateMap]]
-          </td>
-          <td>
-            A List of Record { [[Site]]: Parse Node, [[Array]]: Object }.
-          </td>
+          <td>[[TemplateMap]]
+          <td>A List of Record { [[Site]]: Parse Node, [[Array]]: Object }.
           <td>
             <p>Template objects are canonicalized separately for each realm using its Realm Record's [[TemplateMap]]. Each [[Site]] value is a Parse Node that is a |TemplateLiteral|. The associated [[Array]] value is the corresponding template object that is passed to a tag function.</p>
             <emu-note>Once a Parse Node becomes unreachable, the corresponding [[Array]] is also unreachable, and it would be unobservable if an implementation removed the pair from the [[TemplateMap]] list.</emu-note>
-          </td>
-        </tr>
         <tr>
-          <td>
-            [[HostDefined]]
-          </td>
-          <td>
-            Any, default value is *undefined*.
-          </td>
-          <td>
-            Field reserved for use by host environments that need to associate additional information with a Realm Record.
-          </td>
-        </tr>
-        </tbody>
+          <td>[[HostDefined]]
+          <td>Any, default value is *undefined*.
+          <td>Field reserved for use by host environments that need to associate additional information with a Realm Record.
       </table>
     </emu-table>
 
@@ -6231,48 +4653,21 @@
     <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-22"></emu-xref>.</p>
     <emu-table id="table-22" caption="State Components for All Execution Contexts">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Component
-          </th>
-          <th>
-            Purpose
-          </th>
-        </tr>
+          <th>Component
+          <th>Purpose
         <tr>
-          <td>
-            code evaluation state
-          </td>
-          <td>
-            Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
-          </td>
-        </tr>
+          <td>code evaluation state
+          <td>Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
         <tr>
-          <td>
-            Function
-          </td>
-          <td>
-            If this execution context is evaluating the code of a function object, then the value of this component is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
-          </td>
-        </tr>
+          <td>Function
+          <td>If this execution context is evaluating the code of a function object, then the value of this component is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
         <tr>
-          <td>
-            Realm
-          </td>
-          <td>
-            The Realm Record from which associated code accesses ECMAScript resources.
-          </td>
-        </tr>
+          <td>Realm
+          <td>The Realm Record from which associated code accesses ECMAScript resources.
         <tr>
-          <td>
-            ScriptOrModule
-          </td>
-          <td>
-            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in InitializeHostDefinedRealm, the value is *null*.
-          </td>
-        </tr>
-        </tbody>
+          <td>ScriptOrModule
+          <td>The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in InitializeHostDefinedRealm, the value is *null*.
       </table>
     </emu-table>
     <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
@@ -6280,56 +4675,27 @@
     <p>Execution contexts for ECMAScript code have the additional state components listed in <emu-xref href="#table-23"></emu-xref>.</p>
     <emu-table id="table-23" caption="Additional State Components for ECMAScript Code Execution Contexts">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Component
-          </th>
-          <th>
-            Purpose
-          </th>
-        </tr>
+          <th>Component
+          <th>Purpose
         <tr>
-          <td>
-            LexicalEnvironment
-          </td>
-          <td>
-            Identifies the Lexical Environment used to resolve identifier references made by code within this execution context.
-          </td>
-        </tr>
+          <td>LexicalEnvironment
+          <td>Identifies the Lexical Environment used to resolve identifier references made by code within this execution context.
         <tr>
-          <td>
-            VariableEnvironment
-          </td>
-          <td>
-            Identifies the Lexical Environment whose EnvironmentRecord holds bindings created by |VariableStatement|s within this execution context.
-          </td>
-        </tr>
-        </tbody>
+          <td>VariableEnvironment
+          <td>Identifies the Lexical Environment whose EnvironmentRecord holds bindings created by |VariableStatement|s within this execution context.
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Lexical Environments.</p>
     <p>Execution contexts representing the evaluation of generator objects have the additional state components listed in <emu-xref href="#table-24"></emu-xref>.</p>
     <emu-table id="table-24" caption="Additional State Components for Generator Execution Contexts">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Component
-          </th>
-          <th>
-            Purpose
-          </th>
-        </tr>
+          <th>Component
+          <th>Purpose
         <tr>
-          <td>
-            Generator
-          </td>
-          <td>
-            The GeneratorObject that this execution context is evaluating.
-          </td>
-        </tr>
-        </tbody>
+          <td>Generator
+          <td>The GeneratorObject that this execution context is evaluating.
       </table>
     </emu-table>
     <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms &ldquo;LexicalEnvironment&rdquo;, and &ldquo;VariableEnvironment&rdquo; are used without qualification they are in reference to those components of the running execution context.</p>
@@ -6415,106 +4781,45 @@
     <p>Execution of a Job can be initiated only when there is no running execution context and the execution context stack is empty. A PendingJob is a request for the future execution of a Job. A PendingJob is an internal Record whose fields are specified in <emu-xref href="#table-25"></emu-xref>. Once execution of a Job is initiated, the Job always executes to completion. No other Job may be initiated until the currently running Job completes. However, the currently running Job or external events may cause the enqueuing of additional PendingJobs that may be initiated sometime after completion of the currently running Job.</p>
     <emu-table id="table-25" caption="PendingJob Record Fields">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Field Name
-          </th>
-          <th>
-            Value
-          </th>
-          <th>
-            Meaning
-          </th>
-        </tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
         <tr>
-          <td>
-            [[Job]]
-          </td>
-          <td>
-            The name of a Job abstract operation
-          </td>
-          <td>
-            This is the abstract operation that is performed when execution of this PendingJob is initiated.
-          </td>
-        </tr>
+          <td>[[Job]]
+          <td>The name of a Job abstract operation
+          <td>This is the abstract operation that is performed when execution of this PendingJob is initiated.
         <tr>
-          <td>
-            [[Arguments]]
-          </td>
-          <td>
-            A List
-          </td>
-          <td>
-            The List of argument values that are to be passed to [[Job]] when it is activated.
-          </td>
-        </tr>
+          <td>[[Arguments]]
+          <td>A List
+          <td>The List of argument values that are to be passed to [[Job]] when it is activated.
         <tr>
-          <td>
-            [[Realm]]
-          </td>
-          <td>
-            A Realm Record
-          </td>
-          <td>
-            The Realm Record for the initial execution context when this PendingJob is initiated.
-          </td>
-        </tr>
+          <td>[[Realm]]
+          <td>A Realm Record
+          <td>The Realm Record for the initial execution context when this PendingJob is initiated.
         <tr>
-          <td>
-            [[ScriptOrModule]]
-          </td>
-          <td>
-            A Script Record or Module Record
-          </td>
-          <td>
-            The script or module for the initial execution context when this PendingJob is initiated.
-          </td>
-        </tr>
+          <td>[[ScriptOrModule]]
+          <td>A Script Record or Module Record
+          <td>The script or module for the initial execution context when this PendingJob is initiated.
         <tr>
-          <td>
-            [[HostDefined]]
-          </td>
-          <td>
-            Any, default value is *undefined*.
-          </td>
-          <td>
-            Field reserved for use by host environments that need to associate additional information with a pending Job.
-          </td>
-        </tr>
-        </tbody>
+          <td>[[HostDefined]]
+          <td>Any, default value is *undefined*.
+          <td>Field reserved for use by host environments that need to associate additional information with a pending Job.
       </table>
     </emu-table>
     <p>A Job Queue is a FIFO queue of PendingJob records. Each Job Queue has a name and the full set of available Job Queues are defined by an ECMAScript implementation. Every ECMAScript implementation has at least the Job Queues defined in <emu-xref href="#table-26"></emu-xref>.</p>
     <p>Each agent has its own set of named Job Queues.  All references to a named job queue in this specification denote the named job queue of the surrounding agent.</p>
     <emu-table id="table-26" caption="Required Job Queues">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Name
-          </th>
-          <th>
-            Purpose
-          </th>
-        </tr>
+          <th>Name
+          <th>Purpose
         <tr>
-          <td>
-            ScriptJobs
-          </td>
-          <td>
-            Jobs that validate and evaluate ECMAScript |Script| and |Module| source text. See clauses 10 and 15.
-          </td>
-        </tr>
+          <td>ScriptJobs
+          <td>Jobs that validate and evaluate ECMAScript |Script| and |Module| source text. See clauses 10 and 15.
         <tr>
-          <td>
-            PromiseJobs
-          </td>
-          <td>
-            Jobs that are responses to the settlement of a Promise (see <emu-xref href="#sec-promise-objects"></emu-xref>).
-          </td>
-        </tr>
-        </tbody>
+          <td>PromiseJobs
+          <td>Jobs that are responses to the settlement of a Promise (see <emu-xref href="#sec-promise-objects"></emu-xref>).
       </table>
     </emu-table>
     <p>A request for the future execution of a Job is made by enqueueing, on a Job Queue, a PendingJob record that includes a Job abstract operation name and any necessary argument values. When there is no running execution context and the execution context stack is empty, the ECMAScript implementation removes the first PendingJob from a Job Queue and uses the information contained in it to create an execution context and starts execution of the associated Job abstract operation.</p>
@@ -6599,43 +4904,34 @@
     <p>While an agent's executing thread executes the jobs in the agent's job queues, the agent is the <dfn id="surrounding-agent">surrounding agent</dfn> for the code in those jobs.  The code uses the surrounding agent to access the specification level execution objects held within the agent: the running execution context, the execution context stack, the named job queues, and the Agent Record's fields.</p>
     <emu-table id="table-agent-record" caption="Agent Record Fields">
       <table>
-        <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[LittleEndian]]</td>
-            <td>Boolean</td>
-            <td>The default value computed for the <em>isLittleEndian</em> parameter when it is needed by the algorithms GetValueFromBuffer and SetValueInBuffer. The choice is implementation-dependent and should be the alternative that is most efficient for the implementation.  Once the value has been observed it cannot change.</td>
-          </tr>
-          <tr>
-            <td>[[CanBlock]]</td>
-            <td>Boolean</td>
-            <td>Determines whether the agent can block or not.</td>
-          </tr>
-          <tr>
-            <td>[[Signifier]]</td>
-            <td>Any globally-unique value</td>
-            <td>Uniquely identifies the agent within its agent cluster.</td>
-          </tr>
-          <tr>
-            <td>[[IsLockFree1]]</td>
-            <td>Boolean</td>
-            <td>*true* if atomic operations on one-byte values are lock-free, *false* otherwise.</td>
-          </tr>
-          <tr>
-            <td>[[IsLockFree2]]</td>
-            <td>Boolean</td>
-            <td>*true* if atomic operations on two-byte values are lock-free, *false* otherwise.</td>
-          </tr>
-          <tr>
-            <td>[[CandidateExecution]]</td>
-            <td>A candidate execution Record</td>
-            <td>See the memory model.</td>
-          </tr>
-        </tbody>
+        <tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
+        <tr>
+          <td>[[LittleEndian]]
+          <td>Boolean
+          <td>The default value computed for the <em>isLittleEndian</em> parameter when it is needed by the algorithms GetValueFromBuffer and SetValueInBuffer. The choice is implementation-dependent and should be the alternative that is most efficient for the implementation.  Once the value has been observed it cannot change.
+        <tr>
+          <td>[[CanBlock]]
+          <td>Boolean
+          <td>Determines whether the agent can block or not.
+        <tr>
+          <td>[[Signifier]]
+          <td>Any globally-unique value
+          <td>Uniquely identifies the agent within its agent cluster.
+        <tr>
+          <td>[[IsLockFree1]]
+          <td>Boolean
+          <td>*true* if atomic operations on one-byte values are lock-free, *false* otherwise.
+        <tr>
+          <td>[[IsLockFree2]]
+          <td>Boolean
+          <td>*true* if atomic operations on two-byte values are lock-free, *false* otherwise.
+        <tr>
+          <td>[[CandidateExecution]]
+          <td>A candidate execution Record
+          <td>See the memory model.
       </table>
     </emu-table>
 
@@ -7130,129 +5426,50 @@
     <p>ECMAScript function objects have the additional internal slots listed in <emu-xref href="#table-27"></emu-xref>.</p>
     <emu-table id="table-27" caption="Internal Slots of ECMAScript Function Objects">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Internal Slot
-          </th>
-          <th>
-            Type
-          </th>
-          <th>
-            Description
-          </th>
-        </tr>
+          <th>Internal Slot
+          <th>Type
+          <th>Description
         <tr>
-          <td>
-            [[Environment]]
-          </td>
-          <td>
-            Lexical Environment
-          </td>
-          <td>
-            The Lexical Environment that the function was closed over. Used as the outer environment when evaluating the code of the function.
-          </td>
-        </tr>
+          <td>[[Environment]]
+          <td>Lexical Environment
+          <td>The Lexical Environment that the function was closed over. Used as the outer environment when evaluating the code of the function.
         <tr>
-          <td>
-            [[FormalParameters]]
-          </td>
-          <td>
-            Parse Node
-          </td>
-          <td>
-            The root parse node of the source text that defines the function's formal parameter list.
-          </td>
-        </tr>
+          <td>[[FormalParameters]]
+          <td>Parse Node
+          <td>The root parse node of the source text that defines the function's formal parameter list.
         <tr>
-          <td>
-            [[FunctionKind]]
-          </td>
-          <td>
-            String
-          </td>
-          <td>
-            Either `"normal"`, `"classConstructor"`, `"generator"`, or `"async"`.
-          </td>
-        </tr>
+          <td>[[FunctionKind]]
+          <td>String
+          <td>Either `"normal"`, `"classConstructor"`, `"generator"`, or `"async"`.
         <tr>
-          <td>
-            [[ECMAScriptCode]]
-          </td>
-          <td>
-            Parse Node
-          </td>
-          <td>
-            The root parse node of the source text that defines the function's body.
-          </td>
-        </tr>
+          <td>[[ECMAScriptCode]]
+          <td>Parse Node
+          <td>The root parse node of the source text that defines the function's body.
         <tr>
-          <td>
-            [[ConstructorKind]]
-          </td>
-          <td>
-            String
-          </td>
-          <td>
-            Either `"base"` or `"derived"`.
-          </td>
-        </tr>
+          <td>[[ConstructorKind]]
+          <td>String
+          <td>Either `"base"` or `"derived"`.
         <tr>
-          <td>
-            [[Realm]]
-          </td>
-          <td>
-            Realm Record
-          </td>
-          <td>
-            The realm in which the function was created and which provides any intrinsic objects that are accessed when evaluating the function.
-          </td>
-        </tr>
+          <td>[[Realm]]
+          <td>Realm Record
+          <td>The realm in which the function was created and which provides any intrinsic objects that are accessed when evaluating the function.
         <tr>
-          <td>
-            [[ScriptOrModule]]
-          </td>
-          <td>
-            Script Record or Module Record
-          </td>
-          <td>
-            The script or module in which the function was created.
-          </td>
-        </tr>
+          <td>[[ScriptOrModule]]
+          <td>Script Record or Module Record
+          <td>The script or module in which the function was created.
         <tr>
-          <td>
-            [[ThisMode]]
-          </td>
-          <td>
-            (lexical, strict, global)
-          </td>
-          <td>
-            Defines how `this` references are interpreted within the formal parameters and code body of the function. ~lexical~ means that `this` refers to the *this* value of a lexically enclosing function. ~strict~ means that the *this* value is used exactly as provided by an invocation of the function. ~global~ means that a *this* value of *undefined* is interpreted as a reference to the global object.
-          </td>
-        </tr>
+          <td>[[ThisMode]]
+          <td>(lexical, strict, global)
+          <td>Defines how `this` references are interpreted within the formal parameters and code body of the function. ~lexical~ means that `this` refers to the *this* value of a lexically enclosing function. ~strict~ means that the *this* value is used exactly as provided by an invocation of the function. ~global~ means that a *this* value of *undefined* is interpreted as a reference to the global object.
         <tr>
-          <td>
-            [[Strict]]
-          </td>
-          <td>
-            Boolean
-          </td>
-          <td>
-            *true* if this is a strict function, *false* if this is a non-strict function.
-          </td>
-        </tr>
+          <td>[[Strict]]
+          <td>Boolean
+          <td>*true* if this is a strict function, *false* if this is a non-strict function.
         <tr>
-          <td>
-            [[HomeObject]]
-          </td>
-          <td>
-            Object
-          </td>
-          <td>
-            If the function uses `super`, this is the object whose [[GetPrototypeOf]] provides the object where `super` property lookups begin.
-          </td>
-        </tr>
-        </tbody>
+          <td>[[HomeObject]]
+          <td>Object
+          <td>If the function uses `super`, this is the object whose [[GetPrototypeOf]] provides the object where `super` property lookups begin.
       </table>
     </emu-table>
     <p>All ECMAScript function objects have the [[Call]] internal method defined here. ECMAScript functions that are also constructors in addition have the [[Construct]] internal method.</p>
@@ -7724,52 +5941,22 @@
       <p>Bound function objects do not have the internal slots of ECMAScript function objects defined in <emu-xref href="#table-27"></emu-xref>. Instead they have the internal slots defined in <emu-xref href="#table-28"></emu-xref>.</p>
       <emu-table id="table-28" caption="Internal Slots of Bound Function Exotic Objects">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Internal Slot
-            </th>
-            <th>
-              Type
-            </th>
-            <th>
-              Description
-            </th>
-          </tr>
+            <th>Internal Slot
+            <th>Type
+            <th>Description
           <tr>
-            <td>
-              [[BoundTargetFunction]]
-            </td>
-            <td>
-              Callable Object
-            </td>
-            <td>
-              The wrapped function object.
-            </td>
-          </tr>
+            <td>[[BoundTargetFunction]]
+            <td>Callable Object
+            <td>The wrapped function object.
           <tr>
-            <td>
-              [[BoundThis]]
-            </td>
-            <td>
-              Any
-            </td>
-            <td>
-              The value that is always passed as the *this* value when calling the wrapped function.
-            </td>
-          </tr>
+            <td>[[BoundThis]]
+            <td>Any
+            <td>The value that is always passed as the *this* value when calling the wrapped function.
           <tr>
-            <td>
-              [[BoundArguments]]
-            </td>
-            <td>
-              List of Any
-            </td>
-            <td>
-              A list of values whose elements are used as the first arguments to any call to the wrapped function.
-            </td>
-          </tr>
-          </tbody>
+            <td>[[BoundArguments]]
+            <td>List of Any
+            <td>A list of values whose elements are used as the first arguments to any call to the wrapped function.
         </table>
       </emu-table>
       <p>Bound function objects provide all of the essential internal methods as specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. However, they use the following definitions for the essential internal methods of function objects.</p>
@@ -8420,52 +6607,22 @@
       <p>Module namespace objects have the internal slots defined in <emu-xref href="#table-29"></emu-xref>.</p>
       <emu-table id="table-29" caption="Internal Slots of Module Namespace Exotic Objects">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Internal Slot
-            </th>
-            <th>
-              Type
-            </th>
-            <th>
-              Description
-            </th>
-          </tr>
+            <th>Internal Slot
+            <th>Type
+            <th>Description
           <tr>
-            <td>
-              [[Module]]
-            </td>
-            <td>
-              Module Record
-            </td>
-            <td>
-              The Module Record whose exports this namespace exposes.
-            </td>
-          </tr>
+            <td>[[Module]]
+            <td>Module Record
+            <td>The Module Record whose exports this namespace exposes.
           <tr>
-            <td>
-              [[Exports]]
-            </td>
-            <td>
-              List of String
-            </td>
-            <td>
-              A List containing the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
-            </td>
-          </tr>
+            <td>[[Exports]]
+            <td>List of String
+            <td>A List containing the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
           <tr>
-            <td>
-              [[Prototype]]
-            </td>
-            <td>
-              Null
-            </td>
-            <td>
-              This slot always contains the value *null* (see <emu-xref href="#sec-module-namespace-exotic-objects-setprototypeof-v"></emu-xref>).
-            </td>
-          </tr>
-          </tbody>
+            <td>[[Prototype]]
+            <td>Null
+            <td>This slot always contains the value *null* (see <emu-xref href="#sec-module-namespace-exotic-objects-setprototypeof-v"></emu-xref>).
         </table>
       </emu-table>
       <p>Module namespace exotic objects provide alternative definitions for all of the internal methods except [[GetPrototypeOf]], which behaves as defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>.</p>
@@ -8640,120 +6797,48 @@
     <p>A proxy object is an exotic object whose essential internal methods are partially implemented using ECMAScript code. Every proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's <em>handler object</em>, or *null*. Methods (see <emu-xref href="#table-30"></emu-xref>) of a handler object may be used to augment the implementation for one or more of the proxy object's internal methods. Every proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the *null* value. This object is called the proxy's <em>target object</em>.</p>
     <emu-table id="table-30" caption="Proxy Handler Methods">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Internal Method
-          </th>
-          <th>
-            Handler Method
-          </th>
-        </tr>
+          <th>Internal Method
+          <th>Handler Method
         <tr>
-          <td>
-            [[GetPrototypeOf]]
-          </td>
-          <td>
-            `getPrototypeOf`
-          </td>
-        </tr>
+          <td>[[GetPrototypeOf]]
+          <td>`getPrototypeOf`
         <tr>
-          <td>
-            [[SetPrototypeOf]]
-          </td>
-          <td>
-            `setPrototypeOf`
-          </td>
-        </tr>
+          <td>[[SetPrototypeOf]]
+          <td>`setPrototypeOf`
         <tr>
-          <td>
-            [[IsExtensible]]
-          </td>
-          <td>
-            `isExtensible`
-          </td>
-        </tr>
+          <td>[[IsExtensible]]
+          <td>`isExtensible`
         <tr>
-          <td>
-            [[PreventExtensions]]
-          </td>
-          <td>
-            `preventExtensions`
-          </td>
-        </tr>
+          <td>[[PreventExtensions]]
+          <td>`preventExtensions`
         <tr>
-          <td>
-            [[GetOwnProperty]]
-          </td>
-          <td>
-            `getOwnPropertyDescriptor`
-          </td>
-        </tr>
+          <td>[[GetOwnProperty]]
+          <td>`getOwnPropertyDescriptor`
         <tr>
-          <td>
-            [[DefineOwnProperty]]
-          </td>
-          <td>
-            `defineProperty`
-          </td>
-        </tr>
+          <td>[[DefineOwnProperty]]
+          <td>`defineProperty`
         <tr>
-          <td>
-            [[HasProperty]]
-          </td>
-          <td>
-            `has`
-          </td>
-        </tr>
+          <td>[[HasProperty]]
+          <td>`has`
         <tr>
-          <td>
-            [[Get]]
-          </td>
-          <td>
-            `get`
-          </td>
-        </tr>
+          <td>[[Get]]
+          <td>`get`
         <tr>
-          <td>
-            [[Set]]
-          </td>
-          <td>
-            `set`
-          </td>
-        </tr>
+          <td>[[Set]]
+          <td>`set`
         <tr>
-          <td>
-            [[Delete]]
-          </td>
-          <td>
-            `deleteProperty`
-          </td>
-        </tr>
+          <td>[[Delete]]
+          <td>`deleteProperty`
         <tr>
-          <td>
-            [[OwnPropertyKeys]]
-          </td>
-          <td>
-            `ownKeys`
-          </td>
-        </tr>
+          <td>[[OwnPropertyKeys]]
+          <td>`ownKeys`
         <tr>
-          <td>
-            [[Call]]
-          </td>
-          <td>
-            `apply`
-          </td>
-        </tr>
+          <td>[[Call]]
+          <td>`apply`
         <tr>
-          <td>
-            [[Construct]]
-          </td>
-          <td>
-            `construct`
-          </td>
-        </tr>
-        </tbody>
+          <td>[[Construct]]
+          <td>`construct`
       </table>
     </emu-table>
     <p>When a handler method is called to provide the implementation of a proxy object internal method, the handler method is passed the proxy's target object as a parameter. A proxy's handler object does not necessarily have a method corresponding to every essential internal method. Invoking an internal method on the proxy results in the invocation of the corresponding internal method on the proxy's target object if the handler object does not have a method corresponding to the internal trap.</p>
@@ -9411,64 +7496,26 @@
     <p>The special treatment of certain format-control characters outside of comments, string literals, and regular expression literals is summarized in <emu-xref href="#table-31"></emu-xref>.</p>
     <emu-table id="table-31" caption="Format-Control Code Point Usage">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Code Point
-          </th>
-          <th>
-            Name
-          </th>
-          <th>
-            Abbreviation
-          </th>
-          <th>
-            Usage
-          </th>
-        </tr>
+          <th>Code Point
+          <th>Name
+          <th>Abbreviation
+          <th>Usage
         <tr>
-          <td>
-            `U+200C`
-          </td>
-          <td>
-            ZERO WIDTH NON-JOINER
-          </td>
-          <td>
-            &lt;ZWNJ&gt;
-          </td>
-          <td>
-            |IdentifierPart|
-          </td>
-        </tr>
+          <td>`U+200C`
+          <td>ZERO WIDTH NON-JOINER
+          <td>&lt;ZWNJ&gt;
+          <td>|IdentifierPart|
         <tr>
-          <td>
-            `U+200D`
-          </td>
-          <td>
-            ZERO WIDTH JOINER
-          </td>
-          <td>
-            &lt;ZWJ&gt;
-          </td>
-          <td>
-            |IdentifierPart|
-          </td>
-        </tr>
+          <td>`U+200D`
+          <td>ZERO WIDTH JOINER
+          <td>&lt;ZWJ&gt;
+          <td>|IdentifierPart|
         <tr>
-          <td>
-            `U+FEFF`
-          </td>
-          <td>
-            ZERO WIDTH NO-BREAK SPACE
-          </td>
-          <td>
-            &lt;ZWNBSP&gt;
-          </td>
-          <td>
-            |WhiteSpace|
-          </td>
-        </tr>
-        </tbody>
+          <td>`U+FEFF`
+          <td>ZERO WIDTH NO-BREAK SPACE
+          <td>&lt;ZWNBSP&gt;
+          <td>|WhiteSpace|
       </table>
     </emu-table>
   </emu-clause>
@@ -9479,96 +7526,38 @@
     <p>The ECMAScript white space code points are listed in <emu-xref href="#table-32"></emu-xref>.</p>
     <emu-table id="table-32" caption="White Space Code Points">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Code Point
-          </th>
-          <th>
-            Name
-          </th>
-          <th>
-            Abbreviation
-          </th>
-        </tr>
+          <th>Code Point
+          <th>Name
+          <th>Abbreviation
         <tr>
-          <td>
-            `U+0009`
-          </td>
-          <td>
-            CHARACTER TABULATION
-          </td>
-          <td>
-            &lt;TAB&gt;
-          </td>
-        </tr>
+          <td>`U+0009`
+          <td>CHARACTER TABULATION
+          <td>&lt;TAB&gt;
         <tr>
-          <td>
-            `U+000B`
-          </td>
-          <td>
-            LINE TABULATION
-          </td>
-          <td>
-            &lt;VT&gt;
-          </td>
-        </tr>
+          <td>`U+000B`
+          <td>LINE TABULATION
+          <td>&lt;VT&gt;
         <tr>
-          <td>
-            `U+000C`
-          </td>
-          <td>
-            FORM FEED (FF)
-          </td>
-          <td>
-            &lt;FF&gt;
-          </td>
-        </tr>
+          <td>`U+000C`
+          <td>FORM FEED (FF)
+          <td>&lt;FF&gt;
         <tr>
-          <td>
-            `U+0020`
-          </td>
-          <td>
-            SPACE
-          </td>
-          <td>
-            &lt;SP&gt;
-          </td>
-        </tr>
+          <td>`U+0020`
+          <td>SPACE
+          <td>&lt;SP&gt;
         <tr>
-          <td>
-            `U+00A0`
-          </td>
-          <td>
-            NO-BREAK SPACE
-          </td>
-          <td>
-            &lt;NBSP&gt;
-          </td>
-        </tr>
+          <td>`U+00A0`
+          <td>NO-BREAK SPACE
+          <td>&lt;NBSP&gt;
         <tr>
-          <td>
-            `U+FEFF`
-          </td>
-          <td>
-            ZERO WIDTH NO-BREAK SPACE
-          </td>
-          <td>
-            &lt;ZWNBSP&gt;
-          </td>
-        </tr>
+          <td>`U+FEFF`
+          <td>ZERO WIDTH NO-BREAK SPACE
+          <td>&lt;ZWNBSP&gt;
         <tr>
-          <td>
-            Other category &ldquo;Zs&rdquo;
-          </td>
-          <td>
-            Any other Unicode &ldquo;Space_Separator&rdquo; code point
-          </td>
-          <td>
-            &lt;USP&gt;
-          </td>
-        </tr>
-        </tbody>
+          <td>Other category &ldquo;Zs&rdquo;
+          <td>Any other Unicode &ldquo;Space_Separator&rdquo; code point
+          <td>&lt;USP&gt;
       </table>
     </emu-table>
     <p>ECMAScript implementations must recognize as |WhiteSpace| code points listed in the &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;) category.</p>
@@ -9596,63 +7585,26 @@
     <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-33"></emu-xref>.</p>
     <emu-table id="table-33" caption="Line Terminator Code Points">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Code Point
-          </th>
-          <th>
-            Unicode Name
-          </th>
-          <th>
-            Abbreviation
-          </th>
-        </tr>
+          <th>Code Point
+          <th>Unicode Name
+          <th>Abbreviation
         <tr>
-          <td>
-            `U+000A`
-          </td>
-          <td>
-            LINE FEED (LF)
-          </td>
-          <td>
-            &lt;LF&gt;
-          </td>
-        </tr>
+          <td>`U+000A`
+          <td>LINE FEED (LF)
+          <td>&lt;LF&gt;
         <tr>
-          <td>
-            `U+000D`
-          </td>
-          <td>
-            CARRIAGE RETURN (CR)
-          </td>
-          <td>
-            &lt;CR&gt;
-          </td>
-        </tr>
+          <td>`U+000D`
+          <td>CARRIAGE RETURN (CR)
+          <td>&lt;CR&gt;
         <tr>
-          <td>
-            `U+2028`
-          </td>
-          <td>
-            LINE SEPARATOR
-          </td>
-          <td>
-            &lt;LS&gt;
-          </td>
-        </tr>
+          <td>`U+2028`
+          <td>LINE SEPARATOR
+          <td>&lt;LS&gt;
         <tr>
-          <td>
-            `U+2029`
-          </td>
-          <td>
-            PARAGRAPH SEPARATOR
-          </td>
-          <td>
-            &lt;PS&gt;
-          </td>
-        </tr>
-        </tbody>
+          <td>`U+2029`
+          <td>PARAGRAPH SEPARATOR
+          <td>&lt;PS&gt;
       </table>
     </emu-table>
     <p>Only the Unicode code points in <emu-xref href="#table-33"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-32"></emu-xref>. The sequence &lt;CR&gt;&lt;LF&gt; is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
@@ -9855,34 +7807,32 @@
           <p>Use of the following tokens within strict mode code is also reserved. That usage is restricted using static semantic restrictions (see <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>) rather than the lexical grammar:</p>
           <figure>
             <table class="lightweight-table">
-              <tbody>
               <tr>
                 <td>
                   `implements`
-                </td>
+
                 <td>
                   `package`
-                </td>
+
                 <td>
                   `protected`
-                </td>
+
                 <td>
-                </td>
-              </tr>
+
+
               <tr>
                 <td>
                   `interface`
-                </td>
+
                 <td>
                   `private`
-                </td>
+
                 <td>
                   `public`
-                </td>
+
                 <td>
-                </td>
-              </tr>
-              </tbody>
+
+
             </table>
           </figure>
         </emu-note>
@@ -10345,148 +8295,56 @@
         </ul>
         <emu-table id="table-34" caption="String Single Character Escape Sequences">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Escape Sequence
-              </th>
-              <th>
-                Code Unit Value
-              </th>
-              <th>
-                Unicode Character Name
-              </th>
-              <th>
-                Symbol
-              </th>
-            </tr>
+              <th>Escape Sequence
+              <th>Code Unit Value
+              <th>Unicode Character Name
+              <th>Symbol
             <tr>
-              <td>
-                `\\b`
-              </td>
-              <td>
-                `0x0008`
-              </td>
-              <td>
-                BACKSPACE
-              </td>
-              <td>
-                &lt;BS&gt;
-              </td>
-            </tr>
+              <td>`\\b`
+              <td>`0x0008`
+              <td>BACKSPACE
+              <td>&lt;BS&gt;
             <tr>
-              <td>
-                `\\t`
-              </td>
-              <td>
-                `0x0009`
-              </td>
-              <td>
-                CHARACTER TABULATION
-              </td>
-              <td>
-                &lt;HT&gt;
-              </td>
-            </tr>
+              <td>`\\t`
+              <td>`0x0009`
+              <td>CHARACTER TABULATION
+              <td>&lt;HT&gt;
             <tr>
-              <td>
-                `\\n`
-              </td>
-              <td>
-                `0x000A`
-              </td>
-              <td>
-                LINE FEED (LF)
-              </td>
-              <td>
-                &lt;LF&gt;
-              </td>
-            </tr>
+              <td>`\\n`
+              <td>`0x000A`
+              <td>LINE FEED (LF)
+              <td>&lt;LF&gt;
             <tr>
-              <td>
-                `\\v`
-              </td>
-              <td>
-                `0x000B`
-              </td>
-              <td>
-                LINE TABULATION
-              </td>
-              <td>
-                &lt;VT&gt;
-              </td>
-            </tr>
+              <td>`\\v`
+              <td>`0x000B`
+              <td>LINE TABULATION
+              <td>&lt;VT&gt;
             <tr>
-              <td>
-                `\\f`
-              </td>
-              <td>
-                `0x000C`
-              </td>
-              <td>
-                FORM FEED (FF)
-              </td>
-              <td>
-                &lt;FF&gt;
-              </td>
-            </tr>
+              <td>`\\f`
+              <td>`0x000C`
+              <td>FORM FEED (FF)
+              <td>&lt;FF&gt;
             <tr>
-              <td>
-                `\\r`
-              </td>
-              <td>
-                `0x000D`
-              </td>
-              <td>
-                CARRIAGE RETURN (CR)
-              </td>
-              <td>
-                &lt;CR&gt;
-              </td>
-            </tr>
+              <td>`\\r`
+              <td>`0x000D`
+              <td>CARRIAGE RETURN (CR)
+              <td>&lt;CR&gt;
             <tr>
-              <td>
-                `\\"`
-              </td>
-              <td>
-                `0x0022`
-              </td>
-              <td>
-                QUOTATION MARK
-              </td>
-              <td>
-                `"`
-              </td>
-            </tr>
+              <td>`\\"`
+              <td>`0x0022`
+              <td>QUOTATION MARK
+              <td>`"`
             <tr>
-              <td>
-                `\\'`
-              </td>
-              <td>
-                `0x0027`
-              </td>
-              <td>
-                APOSTROPHE
-              </td>
-              <td>
-                `'`
-              </td>
-            </tr>
+              <td>`\\'`
+              <td>`0x0027`
+              <td>APOSTROPHE
+              <td>`'`
             <tr>
-              <td>
-                `\\\\`
-              </td>
-              <td>
-                `0x005C`
-              </td>
-              <td>
-                REVERSE SOLIDUS
-              </td>
-              <td>
-                `\\`
-              </td>
-            </tr>
-            </tbody>
+              <td>`\\\\`
+              <td>`0x005C`
+              <td>REVERSE SOLIDUS
+              <td>`\\`
           </table>
         </emu-table>
         <ul>
@@ -12963,96 +10821,39 @@
         </emu-alg>
         <emu-table id="table-35" caption="typeof Operator Results">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Type of _val_
-              </th>
-              <th>
-                Result
-              </th>
-            </tr>
+              <th>Type of _val_
+              <th>Result
             <tr>
-              <td>
-                Undefined
-              </td>
-              <td>
-                `"undefined"`
-              </td>
-            </tr>
+              <td>Undefined
+              <td>`"undefined"`
             <tr>
-              <td>
-                Null
-              </td>
-              <td>
-                `"object"`
-              </td>
-            </tr>
+              <td>Null
+              <td>`"object"`
             <tr>
-              <td>
-                Boolean
-              </td>
-              <td>
-                `"boolean"`
-              </td>
-            </tr>
+              <td>Boolean
+              <td>`"boolean"`
             <tr>
-              <td>
-                Number
-              </td>
-              <td>
-                `"number"`
-              </td>
-            </tr>
+              <td>Number
+              <td>`"number"`
             <tr>
-              <td>
-                String
-              </td>
-              <td>
-                `"string"`
-              </td>
-            </tr>
+              <td>String
+              <td>`"string"`
             <tr>
-              <td>
-                Symbol
-              </td>
-              <td>
-                `"symbol"`
-              </td>
-            </tr>
+              <td>Symbol
+              <td>`"symbol"`
             <tr>
-              <td>
-                Object (ordinary and does not implement [[Call]])
-              </td>
-              <td>
-                `"object"`
-              </td>
-            </tr>
+              <td>Object (ordinary and does not implement [[Call]])
+              <td>`"object"`
             <tr>
-              <td>
-                Object (standard exotic and does not implement [[Call]])
-              </td>
-              <td>
-                `"object"`
-              </td>
-            </tr>
+              <td>Object (standard exotic and does not implement [[Call]])
+              <td>`"object"`
             <tr>
-              <td>
-                Object (implements [[Call]])
-              </td>
-              <td>
-                `"function"`
-              </td>
-            </tr>
+              <td>Object (implements [[Call]])
+              <td>`"function"`
             <tr>
-              <td>
-                Object (non-standard exotic and does not implement [[Call]])
-              </td>
-              <td>
-                Implementation-defined. Must not be `"undefined"`, `"boolean"`, `"function"`, `"number"`, `"symbol"`, or `"string"`.
-              </td>
-            </tr>
-            </tbody>
+              <td>Object (non-standard exotic and does not implement [[Call]])
+              <td>Implementation-defined. Must not be `"undefined"`, `"boolean"`, `"function"`, `"number"`, `"symbol"`, or `"string"`.
           </table>
         </emu-table>
         <emu-note>
@@ -20895,65 +18696,26 @@
 
       <emu-table id="table-script-records" caption="Script Record Fields">
         <table>
-          <thead>
           <tr>
-            <th>
-              Field Name
-            </th>
-            <th>
-              Value Type
-            </th>
-            <th>
-              Meaning
-            </th>
-          </tr>
-          </thead>
-          <tbody>
+            <th>Field Name
+            <th>Value Type
+            <th>Meaning
           <tr>
-            <td>
-              [[Realm]]
-            </td>
-            <td>
-              Realm Record | *undefined*
-            </td>
-            <td>
-              The realm within which this script was created. *undefined* if not yet assigned.
-            </td>
-          </tr>
+            <td>[[Realm]]
+            <td>Realm Record | *undefined*
+            <td>The realm within which this script was created. *undefined* if not yet assigned.
           <tr>
-            <td>
-              [[Environment]]
-            </td>
-            <td>
-              Lexical Environment | *undefined*
-            </td>
-            <td>
-              The Lexical Environment containing the top level bindings for this script. This field is set when the script is instantiated.
-            </td>
-          </tr>
+            <td>[[Environment]]
+            <td>Lexical Environment | *undefined*
+            <td>The Lexical Environment containing the top level bindings for this script. This field is set when the script is instantiated.
           <tr>
-            <td>
-              [[ECMAScriptCode]]
-            </td>
-            <td>
-              a Parse Node
-            </td>
-            <td>
-              The result of parsing the source text of this module using |Script| as the goal symbol.
-            </td>
-          </tr>
+            <td>[[ECMAScriptCode]]
+            <td>a Parse Node
+            <td>The result of parsing the source text of this module using |Script| as the goal symbol.
           <tr>
-            <td>
-              [[HostDefined]]
-            </td>
-            <td>
-              Any, default value is *undefined*.
-            </td>
-            <td>
-              Field reserved for use by host environments that need to associate additional information with a script.
-            </td>
-          </tr>
-          </tbody>
+            <td>[[HostDefined]]
+            <td>Any, default value is *undefined*.
+            <td>Field reserved for use by host environments that need to associate additional information with a script.
         </table>
       </emu-table>
     </emu-clause>
@@ -21437,113 +19199,49 @@
         <p>Module Record defines the fields listed in <emu-xref href="#table-36"></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-37"></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
         <emu-table id="table-36" caption="Module Record Fields">
           <table>
-            <thead>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value Type
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
-            </thead>
-            <tbody>
+              <th>Field Name
+              <th>Value Type
+              <th>Meaning
             <tr>
-              <td>
-                [[Realm]]
-              </td>
-              <td>
-                Realm Record | *undefined*
-              </td>
-              <td>
-                The Realm within which this module was created. *undefined* if not yet assigned.
-              </td>
-            </tr>
+              <td>[[Realm]]
+              <td>Realm Record | *undefined*
+              <td>The Realm within which this module was created. *undefined* if not yet assigned.
             <tr>
-              <td>
-                [[Environment]]
-              </td>
-              <td>
-                Lexical Environment | *undefined*
-              </td>
-              <td>
-                The Lexical Environment containing the top level bindings for this module. This field is set when the module is instantiated.
-              </td>
-            </tr>
+              <td>[[Environment]]
+              <td>Lexical Environment | *undefined*
+              <td>The Lexical Environment containing the top level bindings for this module. This field is set when the module is instantiated.
             <tr>
-              <td>
-                [[Namespace]]
-              </td>
-              <td>
-                Object | *undefined*
-              </td>
-              <td>
-                The Module Namespace Object (<emu-xref href="#sec-module-namespace-objects"></emu-xref>) if one has been created for this module. Otherwise *undefined*.
-              </td>
-            </tr>
+              <td>[[Namespace]]
+              <td>Object | *undefined*
+              <td>The Module Namespace Object (<emu-xref href="#sec-module-namespace-objects"></emu-xref>) if one has been created for this module. Otherwise *undefined*.
             <tr>
-              <td>
-                [[HostDefined]]
-              </td>
-              <td>
-                Any, default value is *undefined*.
-              </td>
-              <td>
-                Field reserved for use by host environments that need to associate additional information with a module.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[HostDefined]]
+              <td>Any, default value is *undefined*.
+              <td>Field reserved for use by host environments that need to associate additional information with a module.
           </table>
         </emu-table>
         <emu-table id="table-37" caption="Abstract Methods of Module Records">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Method
-              </th>
-              <th>
-                Purpose
-              </th>
-            </tr>
+              <th>Method
+              <th>Purpose
             <tr>
-              <td>
-                GetExportedNames(_exportStarSet_)
-              </td>
-              <td>
-                Return a list of all names that are either directly or indirectly exported from this module.
-              </td>
-            </tr>
+              <td>GetExportedNames(_exportStarSet_)
+              <td>Return a list of all names that are either directly or indirectly exported from this module.
             <tr>
-              <td>
-                ResolveExport(_exportName_, _resolveSet_)
-              </td>
+              <td>ResolveExport(_exportName_, _resolveSet_)
               <td>
                 <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. Return *null* if the name cannot be resolved, or `"ambiguous"` if multiple bindings were found.</p>
                 <p>This operation must be idempotent if it completes normally. Each time it is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result.</p>
-              </td>
-            </tr>
             <tr>
-              <td>
-                Instantiate()
-              </td>
-              <td>
-                <p>Prepare the module for evaluation by transitively resolving all module dependencies and creating a module Environment Record.</p>
-              </td>
-            </tr>
+              <td>Instantiate()
+              <td><p>Prepare the module for evaluation by transitively resolving all module dependencies and creating a module Environment Record.</p>
             <tr>
-              <td>
-                Evaluate()
-              </td>
+              <td>Evaluate()
               <td>
                 <p>If this module has already been evaluated successfully, return *undefined*; if it has already been evaluated unsuccessfully, throw the exception that was produced. Otherwise, transitively evaluate all module dependencies of this module and then evaluate this module.</p>
                 <p>Instantiate must have completed successfully prior to invoking this method.</p>
-              </td>
-            </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -21559,508 +19257,197 @@
 
         <emu-table id="table-38" caption="Additional Fields of Source Text Module Records">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value Type
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
+              <th>Field Name
+              <th>Value Type
+              <th>Meaning
             <tr>
-              <td>
-                [[ECMAScriptCode]]
-              </td>
-              <td>
-                a Parse Node
-              </td>
-              <td>
-                The result of parsing the source text of this module using |Module| as the goal symbol.
-              </td>
-            </tr>
+              <td>[[ECMAScriptCode]]
+              <td>a Parse Node
+              <td>The result of parsing the source text of this module using |Module| as the goal symbol.
             <tr>
-              <td>
-                [[RequestedModules]]
-              </td>
-              <td>
-                List of String
-              </td>
-              <td>
-                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
-              </td>
-            </tr>
+              <td>[[RequestedModules]]
+              <td>List of String
+              <td>A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
             <tr>
-              <td>
-                [[ImportEntries]]
-              </td>
-              <td>
-                List of ImportEntry Records
-              </td>
-              <td>
-                A List of ImportEntry records derived from the code of this module.
-              </td>
-            </tr>
+              <td>[[ImportEntries]]
+              <td>List of ImportEntry Records
+              <td>A List of ImportEntry records derived from the code of this module.
             <tr>
-              <td>
-                [[LocalExportEntries]]
-              </td>
-              <td>
-                List of ExportEntry Records
-              </td>
-              <td>
-                A List of ExportEntry records derived from the code of this module that correspond to declarations that occur within the module.
-              </td>
-            </tr>
+              <td>[[LocalExportEntries]]
+              <td>List of ExportEntry Records
+              <td>A List of ExportEntry records derived from the code of this module that correspond to declarations that occur within the module.
             <tr>
-              <td>
-                [[IndirectExportEntries]]
-              </td>
-              <td>
-                List of ExportEntry Records
-              </td>
-              <td>
-                A List of ExportEntry records derived from the code of this module that correspond to reexported imports that occur within the module.
-              </td>
-            </tr>
+              <td>[[IndirectExportEntries]]
+              <td>List of ExportEntry Records
+              <td>A List of ExportEntry records derived from the code of this module that correspond to reexported imports that occur within the module.
             <tr>
-              <td>
-                [[StarExportEntries]]
-              </td>
-              <td>
-                List of ExportEntry Records
-              </td>
-              <td>
-                A List of ExportEntry records derived from the code of this module that correspond to export * declarations that occur within the module.
-              </td>
-            </tr>
+              <td>[[StarExportEntries]]
+              <td>List of ExportEntry Records
+              <td>A List of ExportEntry records derived from the code of this module that correspond to export * declarations that occur within the module.
             <tr>
-              <td>
-                [[Status]]
-              </td>
-              <td>
-                String
-              </td>
-              <td>
-                Initially `"uninstantiated"`. Transitions to `"instantiating"`, `"instantiated"`, `"evaluating"`, `"evaluated"` (in that order) as the module progresses throughout its lifecycle.
-              </td>
-            </tr>
+              <td>[[Status]]
+              <td>String
+              <td>Initially `"uninstantiated"`. Transitions to `"instantiating"`, `"instantiated"`, `"evaluating"`, `"evaluated"` (in that order) as the module progresses throughout its lifecycle.
             <tr>
-              <td>
-                [[EvaluationError]]
-              </td>
-              <td>
-                An abrupt completion | *undefined*
-              </td>
-              <td>
-                A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not `"evaluated"`.
-              </td>
-            </tr>
+              <td>[[EvaluationError]]
+              <td>An abrupt completion | *undefined*
+              <td>A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not `"evaluated"`.
             <tr>
-              <td>
-                [[DFSIndex]]
-              </td>
-              <td>
-                Integer | *undefined*
-              </td>
-              <td>
-                Auxiliary field used during Instantiate and Evaluate only.
-                If [[Status]] is `"instantiating"` or `"evaluating"`, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
-              </td>
-            </tr>
+              <td>[[DFSIndex]]
+              <td>Integer | *undefined*
+              <td>Auxiliary field used during Instantiate and Evaluate only. If [[Status]] is `"instantiating"` or `"evaluating"`, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
             <tr>
-              <td>
-                [[DFSAncestorIndex]]
-              </td>
-              <td>
-                Integer | *undefined*
-              </td>
-              <td>
-                Auxiliary field used during Instantiate and Evaluate only. If [[Status]] is `"instantiating"` or `"evaluating"`, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[DFSAncestorIndex]]
+              <td>Integer | *undefined*
+              <td>Auxiliary field used during Instantiate and Evaluate only. If [[Status]] is `"instantiating"` or `"evaluating"`, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
           </table>
         </emu-table>
         <p>An <dfn id="importentry-record">ImportEntry Record</dfn> is a Record that digests information about a single declarative import. Each ImportEntry Record has the fields defined in <emu-xref href="#table-39"></emu-xref>:</p>
         <emu-table id="table-39" caption="ImportEntry Record Fields">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value Type
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
+              <th>Field Name
+              <th>Value Type
+              <th>Meaning
             <tr>
-              <td>
-                [[ModuleRequest]]
-              </td>
-              <td>
-                String
-              </td>
-              <td>
-                String value of the |ModuleSpecifier| of the |ImportDeclaration|.
-              </td>
-            </tr>
+              <td>[[ModuleRequest]]
+              <td>String
+              <td>String value of the |ModuleSpecifier| of the |ImportDeclaration|.
             <tr>
-              <td>
-                [[ImportName]]
-              </td>
-              <td>
-                String
-              </td>
-              <td>
-                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value `"*"` indicates that the import request is for the target module's namespace object.
-              </td>
-            </tr>
+              <td>[[ImportName]]
+              <td>String
+              <td>The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value `"*"` indicates that the import request is for the target module's namespace object.
             <tr>
-              <td>
-                [[LocalName]]
-              </td>
-              <td>
-                String
-              </td>
-              <td>
-                The name that is used to locally access the imported value from within the importing module.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[LocalName]]
+              <td>String
+              <td>The name that is used to locally access the imported value from within the importing module.
           </table>
         </emu-table>
         <emu-note>
           <p><emu-xref href="#table-40"></emu-xref> gives examples of ImportEntry records fields used to represent the syntactic import forms:</p>
           <emu-table id="table-40" caption="Import Forms Mappings to ImportEntry Records" informative>
             <table>
-              <tbody>
               <tr>
-                <th>
-                  Import Statement Form
-                </th>
-                <th>
-                  [[ModuleRequest]]
-                </th>
-                <th>
-                  [[ImportName]]
-                </th>
-                <th>
-                  [[LocalName]]
-                </th>
-              </tr>
+                <th>Import Statement Form
+                <th>[[ModuleRequest]]
+                <th>[[ImportName]]
+                <th>[[LocalName]]
               <tr>
-                <td>
-                  `import v from "mod";`
-                </td>
-                <td>
-                  `"mod"`
-                </td>
-                <td>
-                  `"default"`
-                </td>
-                <td>
-                  `"v"`
-                </td>
-              </tr>
+                <td>`import v from "mod";`
+                <td>`"mod"`
+                <td>`"default"`
+                <td>`"v"`
               <tr>
-                <td>
-                  `import * as ns from "mod";`
-                </td>
-                <td>
-                  `"mod"`
-                </td>
-                <td>
-                  `"*"`
-                </td>
-                <td>
-                  `"ns"`
-                </td>
-              </tr>
+                <td>`import * as ns from "mod";`
+                <td>`"mod"`
+                <td>`"*"`
+                <td>`"ns"`
               <tr>
-                <td>
-                  `import {x} from "mod";`
-                </td>
-                <td>
-                  `"mod"`
-                </td>
-                <td>
-                  `"x"`
-                </td>
-                <td>
-                  `"x"`
-                </td>
-              </tr>
+                <td>`import {x} from "mod";`
+                <td>`"mod"`
+                <td>`"x"`
+                <td>`"x"`
               <tr>
-                <td>
-                  `import {x as v} from "mod";`
-                </td>
-                <td>
-                  `"mod"`
-                </td>
-                <td>
-                  `"x"`
-                </td>
-                <td>
-                  `"v"`
-                </td>
-              </tr>
+                <td>`import {x as v} from "mod";`
+                <td>`"mod"`
+                <td>`"x"`
+                <td>`"v"`
               <tr>
-                <td>
-                  `import "mod";`
-                </td>
-                <td colspan="3">
-                  An ImportEntry Record is not created.
-                </td>
-              </tr>
-              </tbody>
+                <td>`import "mod";`
+                <td colspan="3">An ImportEntry Record is not created.
             </table>
           </emu-table>
         </emu-note>
         <p>An <dfn id="exportentry-record">ExportEntry Record</dfn> is a Record that digests information about a single declarative export. Each ExportEntry Record has the fields defined in <emu-xref href="#table-41"></emu-xref>:</p>
         <emu-table id="table-41" caption="ExportEntry Record Fields">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value Type
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
+              <th>Field Name
+              <th>Value Type
+              <th>Meaning
             <tr>
-              <td>
-                [[ExportName]]
-              </td>
-              <td>
-                String | null
-              </td>
-              <td>
-                The name used to export this binding by this module.
-              </td>
-            </tr>
+              <td>[[ExportName]]
+              <td>String | null
+              <td>The name used to export this binding by this module.
             <tr>
-              <td>
-                [[ModuleRequest]]
-              </td>
-              <td>
-                String | null
-              </td>
-              <td>
-                The String value of the |ModuleSpecifier| of the |ExportDeclaration|. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|.
-              </td>
-            </tr>
+              <td>[[ModuleRequest]]
+              <td>String | null
+              <td>The String value of the |ModuleSpecifier| of the |ExportDeclaration|. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|.
             <tr>
-              <td>
-                [[ImportName]]
-              </td>
-              <td>
-                String | null
-              </td>
-              <td>
-                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|. `"*"` indicates that the export request is for all exported bindings.
-              </td>
-            </tr>
+              <td>[[ImportName]]
+              <td>String | null
+              <td>The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|. `"*"` indicates that the export request is for all exported bindings.
             <tr>
-              <td>
-                [[LocalName]]
-              </td>
-              <td>
-                String | null
-              </td>
-              <td>
-                The name that is used to locally access the exported value from within the importing module. *null* if the exported value is not locally accessible from within the module.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[LocalName]]
+              <td>String | null
+              <td>The name that is used to locally access the exported value from within the importing module. *null* if the exported value is not locally accessible from within the module.
           </table>
         </emu-table>
         <emu-note>
           <p><emu-xref href="#table-42"></emu-xref> gives examples of the ExportEntry record fields used to represent the syntactic export forms:</p>
           <emu-table id="table-42" caption="Export Forms Mappings to ExportEntry Records" informative>
             <table>
-              <tbody>
               <tr>
-                <th>
-                  Export Statement Form
-                </th>
-                <th>
-                  [[ExportName]]
-                </th>
-                <th>
-                  [[ModuleRequest]]
-                </th>
-                <th>
-                  [[ImportName]]
-                </th>
-                <th>
-                  [[LocalName]]
-                </th>
-              </tr>
+                <th>Export Statement Form
+                <th>[[ExportName]]
+                <th>[[ModuleRequest]]
+                <th>[[ImportName]]
+                <th>[[LocalName]]
               <tr>
-                <td>
-                  `export var v;`
-                </td>
-                <td>
-                  `"v"`
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  `"v"`
-                </td>
-              </tr>
+                <td>`export var v;`
+                <td>`"v"`
+                <td>*null*
+                <td>*null*
+                <td>`"v"`
               <tr>
-                <td>
-                  `export default function f(){}`
-                </td>
-                <td>
-                  `"default"`
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  `"f"`
-                </td>
-              </tr>
+                <td>`export default function f(){}`
+                <td>`"default"`
+                <td>*null*
+                <td>*null*
+                <td>`"f"`
               <tr>
-                <td>
-                  `export default function(){}`
-                </td>
-                <td>
-                  `"default"`
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  `"*default*"`
-                </td>
-              </tr>
+                <td>`export default function(){}`
+                <td>`"default"`
+                <td>*null*
+                <td>*null*
+                <td>`"*default*"`
               <tr>
-                <td>
-                  `export default 42;`
-                </td>
-                <td>
-                  `"default"`
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  `"*default*"`
-                </td>
-              </tr>
+                <td>`export default 42;`
+                <td>`"default"`
+                <td>*null*
+                <td>*null*
+                <td>`"*default*"`
               <tr>
-                <td>
-                  `export {x};`
-                </td>
-                <td>
-                  `"x"`
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  `"x"`
-                </td>
-              </tr>
+                <td>`export {x};`
+                <td>`"x"`
+                <td>*null*
+                <td>*null*
+                <td>`"x"`
               <tr>
-                <td>
-                  `export {v as x};`
-                </td>
-                <td>
-                  `"x"`
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  `"v"`
-                </td>
-              </tr>
+                <td>`export {v as x};`
+                <td>`"x"`
+                <td>*null*
+                <td>*null*
+                <td>`"v"`
               <tr>
-                <td>
-                  `export {x} from "mod";`
-                </td>
-                <td>
-                  `"x"`
-                </td>
-                <td>
-                  `"mod"`
-                </td>
-                <td>
-                  `"x"`
-                </td>
-                <td>
-                  *null*
-                </td>
-              </tr>
+                <td>`export {x} from "mod";`
+                <td>`"x"`
+                <td>`"mod"`
+                <td>`"x"`
+                <td>*null*
               <tr>
-                <td>
-                  `export {v as x} from "mod";`
-                </td>
-                <td>
-                  `"x"`
-                </td>
-                <td>
-                  `"mod"`
-                </td>
-                <td>
-                  `"v"`
-                </td>
-                <td>
-                  *null*
-                </td>
-              </tr>
+                <td>`export {v as x} from "mod";`
+                <td>`"x"`
+                <td>`"mod"`
+                <td>`"v"`
+                <td>*null*
               <tr>
-                <td>
-                  `export * from "mod";`
-                </td>
-                <td>
-                  *null*
-                </td>
-                <td>
-                  `"mod"`
-                </td>
-                <td>
-                  `"*"`
-                </td>
-                <td>
-                  *null*
-                </td>
-              </tr>
-              </tbody>
+                <td>`export * from "mod";`
+                <td>*null*
+                <td>`"mod"`
+                <td>`"*"`
+                <td>*null*
             </table>
           </emu-table>
         </emu-note>
@@ -23658,165 +21045,74 @@
             <p>In UTF-8, characters are encoded using sequences of 1 to 6 octets. The only octet of a sequence of one has the higher-order bit set to 0, the remaining 7 bits being used to encode the character value. In a sequence of n octets, n &gt; 1, the initial octet has the n higher-order bits set to 1, followed by a bit set to 0. The remaining bits of that octet contain bits from the value of the character to be encoded. The following octets all have the higher-order bit set to 1 and the following bit set to 0, leaving 6 bits in each to contain bits from the character to be encoded. The possible UTF-8 encodings of ECMAScript characters are specified in <emu-xref href="#table-43"></emu-xref>.</p>
             <emu-table id="table-43" caption="UTF-8 Encodings" informative>
               <table>
-                <tbody>
                 <tr>
-                  <th>
-                    Code Unit Value
-                  </th>
-                  <th>
-                    Representation
-                  </th>
-                  <th>
-                    1<sup>st</sup> Octet
-                  </th>
-                  <th>
-                    2<sup>nd</sup> Octet
-                  </th>
-                  <th>
-                    3<sup>rd</sup> Octet
-                  </th>
-                  <th>
-                    4<sup>th</sup> Octet
-                  </th>
-                </tr>
+                  <th>Code Unit Value
+                  <th>Representation
+                  <th>1<sup>st</sup> Octet
+                  <th>2<sup>nd</sup> Octet
+                  <th>3<sup>rd</sup> Octet
+                  <th>4<sup>th</sup> Octet
                 <tr>
+                  <td>`0x0000 - 0x007F`
+                  <td><code>00000000 0<i>zzzzzzz</i></code>
+                  <td><code>0<i>zzzzzzz</i></code>
                   <td>
-                    `0x0000 - 0x007F`
-                  </td>
                   <td>
-                    <code>00000000 0<i>zzzzzzz</i></code>
-                  </td>
                   <td>
-                    <code>0<i>zzzzzzz</i></code>
-                  </td>
-                  <td>
-                  </td>
-                  <td>
-                  </td>
-                  <td>
-                  </td>
-                </tr>
                 <tr>
+                  <td>`0x0080 - 0x07FF`
+                  <td><code>00000<i>yyy yyzzzzzz</i></code>
+                  <td><code>110<i>yyyyy</i></code>
+                  <td><code>10<i>zzzzzz</i></code>
                   <td>
-                    `0x0080 - 0x07FF`
-                  </td>
                   <td>
-                    <code>00000<i>yyy yyzzzzzz</i></code>
-                  </td>
-                  <td>
-                    <code>110<i>yyyyy</i></code>
-                  </td>
-                  <td>
-                    <code>10<i>zzzzzz</i></code>
-                  </td>
-                  <td>
-                  </td>
-                  <td>
-                  </td>
-                </tr>
                 <tr>
+                  <td>`0x0800 - 0xD7FF`
+                  <td><code><i>xxxxyyyy yyzzzzzz</i></code>
+                  <td><code>1110<i>xxxx</i></code>
+                  <td><code>10<i>yyyyyy</i></code>
+                  <td><code>10<i>zzzzzz</i></code>
                   <td>
-                    `0x0800 - 0xD7FF`
-                  </td>
-                  <td>
-                    <code><i>xxxxyyyy yyzzzzzz</i></code>
-                  </td>
-                  <td>
-                    <code>1110<i>xxxx</i></code>
-                  </td>
-                  <td>
-                    <code>10<i>yyyyyy</i></code>
-                  </td>
-                  <td>
-                    <code>10<i>zzzzzz</i></code>
-                  </td>
-                  <td>
-                  </td>
-                </tr>
                 <tr>
-                  <td>
-                    `0xD800 - 0xDBFF`
+                  <td>`0xD800 - 0xDBFF`
                     <br>
                     followed by
                     <br>
                     `0xDC00 - 0xDFFF`
-                  </td>
-                  <td>
-                    <code>110110<i>vv vvwwwwxx</i></code>
+                  <td><code>110110<i>vv vvwwwwxx</i></code>
                     <br>
                     followed by
                     <br>
                     <code>110111<i>yy yyzzzzzz</i></code>
-                  </td>
-                  <td>
-                    <code>11110<i>uuu</i></code>
-                  </td>
-                  <td>
-                    <code>10<i>uuwwww</i></code>
-                  </td>
-                  <td>
-                    <code>10<i>xxyyyy</i></code>
-                  </td>
-                  <td>
-                    <code>10<i>zzzzzz</i></code>
-                  </td>
-                </tr>
+                  <td><code>11110<i>uuu</i></code>
+                  <td><code>10<i>uuwwww</i></code>
+                  <td><code>10<i>xxyyyy</i></code>
+                  <td><code>10<i>zzzzzz</i></code>
                 <tr>
-                  <td>
-                    `0xD800 - 0xDBFF`
+                  <td>`0xD800 - 0xDBFF`
                     <br>
                     not followed by
                     <br>
                     `0xDC00 - 0xDFFF`
-                  </td>
+                  <td>causes `URIError`
                   <td>
-                    causes `URIError`
-                  </td>
                   <td>
-                  </td>
                   <td>
-                  </td>
                   <td>
-                  </td>
-                  <td>
-                  </td>
-                </tr>
                 <tr>
+                  <td>`0xDC00 - 0xDFFF`
+                  <td>causes `URIError`
                   <td>
-                    `0xDC00 - 0xDFFF`
-                  </td>
                   <td>
-                    causes `URIError`
-                  </td>
                   <td>
-                  </td>
                   <td>
-                  </td>
-                  <td>
-                  </td>
-                  <td>
-                  </td>
-                </tr>
                 <tr>
+                  <td>`0xE000 - 0xFFFF`
+                  <td><code><i>xxxxyyyy yyzzzzzz</i></code>
+                  <td><code>1110<i>xxxx</i></code>
+                  <td><code>10<i>yyyyyy</i></code>
+                  <td><code>10<i>zzzzzz</i></code>
                   <td>
-                    `0xE000 - 0xFFFF`
-                  </td>
-                  <td>
-                    <code><i>xxxxyyyy yyzzzzzz</i></code>
-                  </td>
-                  <td>
-                    <code>1110<i>xxxx</i></code>
-                  </td>
-                  <td>
-                    <code>10<i>yyyyyy</i></code>
-                  </td>
-                  <td>
-                    <code>10<i>zzzzzz</i></code>
-                  </td>
-                  <td>
-                  </td>
-                </tr>
-                </tbody>
               </table>
             </emu-table>
             <p>Where
@@ -24950,41 +22246,18 @@
         <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-44"></emu-xref>.</p>
         <emu-table id="table-44" caption="GlobalSymbolRegistry Record Fields">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Usage
-              </th>
-            </tr>
+              <th>Field Name
+              <th>Value
+              <th>Usage
             <tr>
-              <td>
-                [[Key]]
-              </td>
-              <td>
-                A String
-              </td>
-              <td>
-                A string key used to globally identify a Symbol.
-              </td>
-            </tr>
+              <td>[[Key]]
+              <td>A String
+              <td>A string key used to globally identify a Symbol.
             <tr>
-              <td>
-                [[Symbol]]
-              </td>
-              <td>
-                A Symbol
-              </td>
-              <td>
-                A symbol that can be retrieved from any realm.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[Symbol]]
+              <td>A Symbol
+              <td>A symbol that can be retrieved from any realm.
           </table>
         </emu-table>
       </emu-clause>
@@ -26802,104 +24075,102 @@
         <p>Where the fields are as follows:</p>
         <figure>
           <table class="lightweight-table">
-            <tbody>
             <tr>
               <td>
                 `YYYY`
-              </td>
+
               <td>
                 is the decimal digits of the year 0000 to 9999 in the proleptic Gregorian calendar.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `-`
-              </td>
+
               <td>
                 `"-"` (hyphen) appears literally twice in the string.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `MM`
-              </td>
+
               <td>
                 is the month of the year from 01 (January) to 12 (December).
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `DD`
-              </td>
+
               <td>
                 is the day of the month from 01 to 31.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `T`
-              </td>
+
               <td>
                 `"T"` appears literally in the string, to indicate the beginning of the time element.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `HH`
-              </td>
+
               <td>
                 is the number of complete hours that have passed since midnight as two decimal digits from 00 to 24.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `:`
-              </td>
+
               <td>
                 `":"` (colon) appears literally twice in the string.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `mm`
-              </td>
+
               <td>
                 is the number of complete minutes since the start of the hour as two decimal digits from 00 to 59.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `ss`
-              </td>
+
               <td>
                 is the number of complete seconds since the start of the minute as two decimal digits from 00 to 59.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `.`
-              </td>
+
               <td>
                 `"."` (dot) appears literally in the string.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `sss`
-              </td>
+
               <td>
                 is the number of complete milliseconds since the start of the second as three decimal digits.
-              </td>
-            </tr>
+
+
             <tr>
               <td>
                 `Z`
-              </td>
+
               <td>
                 is the time zone offset specified as `"Z"` (for UTC) or either `"+"` or `"-"` followed by a time expression `HH:mm`
-              </td>
-            </tr>
-            </tbody>
+
+
           </table>
         </figure>
         <p>This format includes date-only forms:</p>
@@ -26930,36 +24201,34 @@ THH:mm:ss.sss
             <p>Examples of date-time values with expanded years:</p>
             <figure>
               <table class="lightweight-table">
-                <tbody>
                   <tr>
-                    <td>-271821-04-20T00:00:00Z</td>
-                    <td>271822 B.C.</td>
-                  </tr>
+                    <td>-271821-04-20T00:00:00Z
+                    <td>271822 B.C.
+
                   <tr>
-                    <td>-000001-01-01T00:00:00Z</td>
-                    <td>2 B.C.</td>
-                  </tr>
+                    <td>-000001-01-01T00:00:00Z
+                    <td>2 B.C.
+
                   <tr>
-                    <td>+000000-01-01T00:00:00Z</td>
-                    <td>1 B.C.</td>
-                  </tr>
+                    <td>+000000-01-01T00:00:00Z
+                    <td>1 B.C.
+
                   <tr>
-                    <td>+000001-01-01T00:00:00Z</td>
-                    <td>1 A.D.</td>
-                  </tr>
+                    <td>+000001-01-01T00:00:00Z
+                    <td>1 A.D.
+
                   <tr>
-                    <td>+001970-01-01T00:00:00Z</td>
-                    <td>1970 A.D.</td>
-                  </tr>
+                    <td>+001970-01-01T00:00:00Z
+                    <td>1970 A.D.
+
                   <tr>
-                    <td>+002009-12-15T00:00:00Z</td>
-                    <td>2009 A.D.</td>
-                  </tr>
+                    <td>+002009-12-15T00:00:00Z
+                    <td>2009 A.D.
+
                   <tr>
-                    <td>+275760-09-13T00:00:00Z</td>
-                    <td>275760 A.D.</td>
-                  </tr>
-                </tbody>
+                    <td>+275760-09-13T00:00:00Z
+                    <td>275760 A.D.
+
               </table>
             </figure>
           </emu-note>
@@ -27673,182 +24942,73 @@ THH:mm:ss.sss
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
             <table>
-              <tbody>
               <tr>
-                <th>
-                  Number
-                </th>
-                <th>
-                  Name
-                </th>
-              </tr>
+                <th>Number
+                <th>Name
               <tr>
-                <td>
-                  0
-                </td>
-                <td>
-                  `"Sun"`
-                </td>
-              </tr>
+                <td>0
+                <td>`"Sun"`
               <tr>
-                <td>
-                  1
-                </td>
-                <td>
-                  `"Mon"`
-                </td>
-              </tr>
+                <td>1
+                <td>`"Mon"`
               <tr>
-                <td>
-                  2
-                </td>
-                <td>
-                  `"Tue"`
-                </td>
-              </tr>
+                <td>2
+                <td>`"Tue"`
               <tr>
-                <td>
-                  3
-                </td>
-                <td>
-                  `"Wed"`
-                </td>
-              </tr>
+                <td>3
+                <td>`"Wed"`
               <tr>
-                <td>
-                  4
-                </td>
-                <td>
-                  `"Thu"`
-                </td>
-              </tr>
+                <td>4
+                <td>`"Thu"`
               <tr>
-                <td>
-                  5
-                </td>
-                <td>
-                  `"Fri"`
-                </td>
-              </tr>
+                <td>5
+                <td>`"Fri"`
               <tr>
-                <td>
-                  6
-                </td>
-                <td>
-                  `"Sat"`
-                </td>
-              </tr>
-              </tbody>
+                <td>6
+                <td>`"Sat"`
             </table>
           </emu-table>
           <emu-table id="sec-todatestring-month-names" caption="Names of months of the year">
             <table>
-              <tbody>
               <tr>
-                <th>
-                  Number
-                </th>
-                <th>
-                  Name
-                </th>
-              </tr>
+                <th>Number
+                <th>Name
               <tr>
-                <td>
-                  0
-                </td>
-                <td>
-                  `"Jan"`
-                </td>
-              </tr>
+                <td>0
+                <td>`"Jan"`
               <tr>
-                <td>
-                  1
-                </td>
-                <td>
-                  `"Feb"`
-                </td>
-              </tr>
+                <td>1
+                <td>`"Feb"`
               <tr>
-                <td>
-                  2
-                </td>
-                <td>
-                  `"Mar"`
-                </td>
-              </tr>
+                <td>2
+                <td>`"Mar"`
               <tr>
-                <td>
-                  3
-                </td>
-                <td>
-                  `"Apr"`
-                </td>
-              </tr>
+                <td>3
+                <td>`"Apr"`
               <tr>
-                <td>
-                  4
-                </td>
-                <td>
-                  `"May"`
-                </td>
-              </tr>
+                <td>4
+                <td>`"May"`
               <tr>
-                <td>
-                  5
-                </td>
-                <td>
-                  `"Jun"`
-                </td>
-              </tr>
+                <td>5
+                <td>`"Jun"`
               <tr>
-                <td>
-                  6
-                </td>
-                <td>
-                  `"Jul"`
-                </td>
-              </tr>
+                <td>6
+                <td>`"Jul"`
               <tr>
-                <td>
-                  7
-                </td>
-                <td>
-                  `"Aug"`
-                </td>
-              </tr>
+                <td>7
+                <td>`"Aug"`
               <tr>
-                <td>
-                  8
-                </td>
-                <td>
-                  `"Sep"`
-                </td>
-              </tr>
+                <td>8
+                <td>`"Sep"`
               <tr>
-                <td>
-                  9
-                </td>
-                <td>
-                  `"Oct"`
-                </td>
-              </tr>
+                <td>9
+                <td>`"Oct"`
               <tr>
-                <td>
-                  10
-                </td>
-                <td>
-                  `"Nov"`
-                </td>
-              </tr>
+                <td>10
+                <td>`"Nov"`
               <tr>
-                <td>
-                  11
-                </td>
-                <td>
-                  `"Dec"`
-                </td>
-              </tr>
-              </tbody>
+                <td>11
+                <td>`"Dec"`
             </table>
           </emu-table>
         </emu-clause>
@@ -28443,62 +25603,26 @@ THH:mm:ss.sss
           </emu-alg>
           <emu-table id="table-45" caption="Replacement Text Symbol Substitutions">
             <table>
-              <tbody>
               <tr>
-                <th>
-                  Code units
-                </th>
-                <th>
-                  Unicode Characters
-                </th>
-                <th>
-                  Replacement text
-                </th>
-              </tr>
+                <th>Code units
+                <th>Unicode Characters
+                <th>Replacement text
               <tr>
-                <td>
-                  0x0024, 0x0024
-                </td>
-                <td>
-                  `$$`
-                </td>
-                <td>
-                  `$`
-                </td>
-              </tr>
+                <td>0x0024, 0x0024
+                <td>`$$`
+                <td>`$`
               <tr>
-                <td>
-                  0x0024, 0x0026
-                </td>
-                <td>
-                  `$&amp;`
-                </td>
-                <td>
-                  _matched_
-                </td>
-              </tr>
+                <td>0x0024, 0x0026
+                <td>`$&amp;`
+                <td>_matched_
               <tr>
-                <td>
-                  0x0024, 0x0060
-                </td>
-                <td>
-                  <code>$`</code>
-                </td>
-                <td>
-                  If _position_ is 0, the replacement is the empty String. Otherwise the replacement is the substring of _str_ that starts at index 0 and whose last code unit is at index _position_ - 1.
-                </td>
-              </tr>
+                <td>0x0024, 0x0060
+                <td><code>$`</code>
+                <td>If _position_ is 0, the replacement is the empty String. Otherwise the replacement is the substring of _str_ that starts at index 0 and whose last code unit is at index _position_ - 1.
               <tr>
-                <td>
-                  0x0024, 0x0027
-                </td>
-                <td>
-                  `$'`
-                </td>
-                <td>
-                  If _tailPos_ &ge; _stringLength_, the replacement is the empty String. Otherwise the replacement is the substring of _str_ that starts at index _tailPos_ and continues to the end of _str_.
-                </td>
-              </tr>
+                <td>0x0024, 0x0027
+                <td>`$'`
+                <td>If _tailPos_ &ge; _stringLength_, the replacement is the empty String. Otherwise the replacement is the substring of _str_ that starts at index _tailPos_ and continues to the end of _str_.
               <tr>
                 <td>
                   0x0024, N
@@ -28506,16 +25630,11 @@ THH:mm:ss.sss
                   Where
                   <br>
                   0x0031 &le; N &le; 0x0039
-                </td>
                 <td>
                   `$n` where
                   <br>
                   `n` is one of `1 2 3 4 5 6 7 8 9` and `$n` is not followed by a decimal digit
-                </td>
-                <td>
-                  The _n_<sup>th</sup> element of _captures_, where _n_ is a single digit in the range 1 to 9. If _n_ &le; _m_ and the _n_<sup>th</sup> element of _captures_ is *undefined*, use the empty String instead. If _n_ &gt; _m_, no replacement is done.
-                </td>
-              </tr>
+                <td>The _n_<sup>th</sup> element of _captures_, where _n_ is a single digit in the range 1 to 9. If _n_ &le; _m_ and the _n_<sup>th</sup> element of _captures_ is *undefined*, use the empty String instead. If _n_ &gt; _m_, no replacement is done.
               <tr>
                 <td>
                   0x0024, N, N
@@ -28523,23 +25642,14 @@ THH:mm:ss.sss
                   Where
                   <br>
                   0x0030 &le; N &le; 0x0039
-                </td>
                 <td>
                   `$nn` where
                   <br>
                   `n` is one of `0 1 2 3 4 5 6 7 8 9`
-                </td>
-                <td>
-                  The _nn_<sup>th</sup> element of _captures_, where _nn_ is a two-digit decimal number in the range 01 to 99. If _nn_ &le; _m_ and the _nn_<sup>th</sup> element of _captures_ is *undefined*, use the empty String instead. If _nn_ is 00 or _nn_ &gt; _m_, no replacement is done.
-                </td>
-              </tr>
+                <td>The _nn_<sup>th</sup> element of _captures_, where _nn_ is a two-digit decimal number in the range 01 to 99. If _nn_ &le; _m_ and the _nn_<sup>th</sup> element of _captures_ is *undefined*, use the empty String instead. If _nn_ is 00 or _nn_ &gt; _m_, no replacement is done.
               <tr>
-                <td>
-                  0x0024, 0x003C
-                </td>
-                <td>
-                  `$&lt;`
-                </td>
+                <td>0x0024, 0x003C
+                <td>`$&lt;`
                 <td>
                   <emu-alg>
                     1. If _namedCaptures_ is *undefined*, the replacement text is the String `"$&lt;"`.
@@ -28552,20 +25662,10 @@ THH:mm:ss.sss
                         1. If _capture_ is *undefined*, replace the text through `>` with the empty string.
                         1. Otherwise, replace the text through `>` with ? ToString(_capture_).
                   </emu-alg>
-                </td>
-              </tr>
               <tr>
-                <td>
-                  0x0024
-                </td>
-                <td>
-                  `$` in any context that does not match any of the above.
-                </td>
-                <td>
-                  `$`
-                </td>
-              </tr>
-              </tbody>
+                <td>0x0024
+                <td>`$` in any context that does not match any of the above.
+                <td>`$`
             </table>
           </emu-table>
         </emu-clause>
@@ -28898,32 +25998,15 @@ THH:mm:ss.sss
         <p>String Iterator instances are ordinary objects that inherit properties from the %StringIteratorPrototype% intrinsic object. String Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-46"></emu-xref>.</p>
         <emu-table id="table-46" caption="Internal Slots of String Iterator Instances">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Internal Slot
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <th>Internal Slot
+              <th>Description
             <tr>
-              <td>
-                [[IteratedString]]
-              </td>
-              <td>
-                The String value whose code units are being iterated.
-              </td>
-            </tr>
+              <td>[[IteratedString]]
+              <td>The String value whose code units are being iterated.
             <tr>
-              <td>
-                [[StringIteratorNextIndex]]
-              </td>
-              <td>
-                The integer index of the next string index to be examined by this iteration.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[StringIteratorNextIndex]]
+              <td>The integer index of the next string index to be examined by this iteration.
           </table>
         </emu-table>
       </emu-clause>
@@ -29290,110 +26373,42 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-table id="table-47" caption="ControlEscape Code Point Values">
           <table>
-            <tbody>
             <tr>
-              <th>
-                ControlEscape
-              </th>
-              <th>
-                Code Point Value
-              </th>
-              <th>
-                Code Point
-              </th>
-              <th>
-                Unicode Name
-              </th>
-              <th>
-                Symbol
-              </th>
-            </tr>
+              <th>ControlEscape
+              <th>Code Point Value
+              <th>Code Point
+              <th>Unicode Name
+              <th>Symbol
             <tr>
-              <td>
-                `t`
-              </td>
-              <td>
-                9
-              </td>
-              <td>
-                `U+0009`
-              </td>
-              <td>
-                CHARACTER TABULATION
-              </td>
-              <td>
-                &lt;HT&gt;
-              </td>
-            </tr>
+              <td>`t`
+              <td>9
+              <td>`U+0009`
+              <td>CHARACTER TABULATION
+              <td>&lt;HT&gt;
             <tr>
-              <td>
-                `n`
-              </td>
-              <td>
-                10
-              </td>
-              <td>
-                `U+000A`
-              </td>
-              <td>
-                LINE FEED (LF)
-              </td>
-              <td>
-                &lt;LF&gt;
-              </td>
-            </tr>
+              <td>`n`
+              <td>10
+              <td>`U+000A`
+              <td>LINE FEED (LF)
+              <td>&lt;LF&gt;
             <tr>
-              <td>
-                `v`
-              </td>
-              <td>
-                11
-              </td>
-              <td>
-                `U+000B`
-              </td>
-              <td>
-                LINE TABULATION
-              </td>
-              <td>
-                &lt;VT&gt;
-              </td>
-            </tr>
+              <td>`v`
+              <td>11
+              <td>`U+000B`
+              <td>LINE TABULATION
+              <td>&lt;VT&gt;
             <tr>
-              <td>
-                `f`
-              </td>
-              <td>
-                12
-              </td>
-              <td>
-                `U+000C`
-              </td>
-              <td>
-                FORM FEED (FF)
-              </td>
-              <td>
-                &lt;FF&gt;
-              </td>
-            </tr>
+              <td>`f`
+              <td>12
+              <td>`U+000C`
+              <td>FORM FEED (FF)
+              <td>&lt;FF&gt;
             <tr>
-              <td>
-                `r`
-              </td>
-              <td>
-                13
-              </td>
-              <td>
-                `U+000D`
-              </td>
-              <td>
-                CARRIAGE RETURN (CR)
-              </td>
-              <td>
-                &lt;CR&gt;
-              </td>
-            </tr>
-            </tbody>
+              <td>`r`
+              <td>13
+              <td>`U+000D`
+              <td>CARRIAGE RETURN (CR)
+              <td>&lt;CR&gt;
           </table>
         </emu-table>
         <emu-grammar>CharacterEscape :: `c` ControlLetter</emu-grammar>
@@ -29806,233 +26821,231 @@ THH:mm:ss.sss
             1. Let _A_ be a set of characters containing the sixty-three characters:
             <figure>
               <table class="lightweight-table">
-                <tbody>
                   <tr>
                     <td>
                       `a`
-                    </td>
+
                     <td>
                       `b`
-                    </td>
+
                     <td>
                       `c`
-                    </td>
+
                     <td>
                       `d`
-                    </td>
+
                     <td>
                       `e`
-                    </td>
+
                     <td>
                       `f`
-                    </td>
+
                     <td>
                       `g`
-                    </td>
+
                     <td>
                       `h`
-                    </td>
+
                     <td>
                       `i`
-                    </td>
+
                     <td>
                       `j`
-                    </td>
+
                     <td>
                       `k`
-                    </td>
+
                     <td>
                       `l`
-                    </td>
+
                     <td>
                       `m`
-                    </td>
+
                     <td>
                       `n`
-                    </td>
+
                     <td>
                       `o`
-                    </td>
+
                     <td>
                       `p`
-                    </td>
+
                     <td>
                       `q`
-                    </td>
+
                     <td>
                       `r`
-                    </td>
+
                     <td>
                       `s`
-                    </td>
+
                     <td>
                       `t`
-                    </td>
+
                     <td>
                       `u`
-                    </td>
+
                     <td>
                       `v`
-                    </td>
+
                     <td>
                       `w`
-                    </td>
+
                     <td>
                       `x`
-                    </td>
+
                     <td>
                       `y`
-                    </td>
+
                     <td>
                       `z`
-                    </td>
-                  </tr>
+
+
                   <tr>
                     <td>
                       `A`
-                    </td>
+
                     <td>
                       `B`
-                    </td>
+
                     <td>
                       `C`
-                    </td>
+
                     <td>
                       `D`
-                    </td>
+
                     <td>
                       `E`
-                    </td>
+
                     <td>
                       `F`
-                    </td>
+
                     <td>
                       `G`
-                    </td>
+
                     <td>
                       `H`
-                    </td>
+
                     <td>
                       `I`
-                    </td>
+
                     <td>
                       `J`
-                    </td>
+
                     <td>
                       `K`
-                    </td>
+
                     <td>
                       `L`
-                    </td>
+
                     <td>
                       `M`
-                    </td>
+
                     <td>
                       `N`
-                    </td>
+
                     <td>
                       `O`
-                    </td>
+
                     <td>
                       `P`
-                    </td>
+
                     <td>
                       `Q`
-                    </td>
+
                     <td>
                       `R`
-                    </td>
+
                     <td>
                       `S`
-                    </td>
+
                     <td>
                       `T`
-                    </td>
+
                     <td>
                       `U`
-                    </td>
+
                     <td>
                       `V`
-                    </td>
+
                     <td>
                       `W`
-                    </td>
+
                     <td>
                       `X`
-                    </td>
+
                     <td>
                       `Y`
-                    </td>
+
                     <td>
                       `Z`
-                    </td>
-                  </tr>
+
+
                   <tr>
                     <td>
                       `0`
-                    </td>
+
                     <td>
                       `1`
-                    </td>
+
                     <td>
                       `2`
-                    </td>
+
                     <td>
                       `3`
-                    </td>
+
                     <td>
                       `4`
-                    </td>
+
                     <td>
                       `5`
-                    </td>
+
                     <td>
                       `6`
-                    </td>
+
                     <td>
                       `7`
-                    </td>
+
                     <td>
                       `8`
-                    </td>
+
                     <td>
                       `9`
-                    </td>
+
                     <td>
                       `_`
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
+
                     <td>
-                    </td>
-                  </tr>
-                </tbody>
+
+
               </table>
             </figure>
             1. Let _U_ be an empty set.
@@ -32511,40 +29524,18 @@ THH:mm:ss.sss
         <p>Array Iterator instances are ordinary objects that inherit properties from the %ArrayIteratorPrototype% intrinsic object. Array Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-48"></emu-xref>.</p>
         <emu-table id="table-48" caption="Internal Slots of Array Iterator Instances">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Internal Slot
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <th>Internal Slot
+              <th>Description
             <tr>
-              <td>
-                [[IteratedObject]]
-              </td>
-              <td>
-                The object whose array elements are being iterated.
-              </td>
-            </tr>
+              <td>[[IteratedObject]]
+              <td>The object whose array elements are being iterated.
             <tr>
-              <td>
-                [[ArrayIteratorNextIndex]]
-              </td>
-              <td>
-                The integer index of the next integer index to be examined by this iteration.
-              </td>
-            </tr>
+              <td>[[ArrayIteratorNextIndex]]
+              <td>The integer index of the next integer index to be examined by this iteration.
             <tr>
-              <td>
-                [[ArrayIterationKind]]
-              </td>
-              <td>
-                A String value that identifies what is returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[ArrayIterationKind]]
+              <td>A String value that identifies what is returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`.
           </table>
         </emu-table>
       </emu-clause>
@@ -32556,224 +29547,103 @@ THH:mm:ss.sss
     <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). Each element of a _TypedArray_ instance has the same underlying binary scalar data type. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-49"></emu-xref>, for each of the nine supported element types. Each constructor in <emu-xref href="#table-49"></emu-xref> has a corresponding distinct prototype object.</p>
     <emu-table id="table-49" caption="The TypedArray Constructors">
       <table>
-        <tbody>
         <tr>
-          <th>
-            Constructor Name and Intrinsic
-          </th>
-          <th>
-            Element Type
-          </th>
-          <th>
-            Element Size
-          </th>
-          <th>
-            Conversion Operation
-          </th>
-          <th>
-            Description
-          </th>
-          <th>
-            Equivalent C Type
-          </th>
-        </tr>
+          <th>Constructor Name and Intrinsic
+          <th>Element Type
+          <th>Element Size
+          <th>Conversion Operation
+          <th>Description
+          <th>Equivalent C Type
         <tr>
           <td>
             Int8Array
             <br>
             %Int8Array%
-          </td>
-          <td>
-            Int8
-          </td>
-          <td>
-            1
-          </td>
-          <td>
-            ToInt8
-          </td>
-          <td>
-            8-bit 2's complement signed integer
-          </td>
-          <td>
-            signed char
-          </td>
-        </tr>
+          <td>Int8
+          <td>1
+          <td>ToInt8
+          <td>8-bit 2's complement signed integer
+          <td>signed char
         <tr>
           <td>
             Uint8Array
             <br>
             %Uint8Array%
-          </td>
-          <td>
-            Uint8
-          </td>
-          <td>
-            1
-          </td>
-          <td>
-            ToUint8
-          </td>
-          <td>
-            8-bit unsigned integer
-          </td>
-          <td>
-            unsigned char
-          </td>
-        </tr>
+          <td>Uint8
+          <td>1
+          <td>ToUint8
+          <td>8-bit unsigned integer
+          <td>unsigned char
         <tr>
           <td>
             Uint8ClampedArray
             <br>
             %Uint8ClampedArray%
-          </td>
-          <td>
-            Uint8C
-          </td>
-          <td>
-            1
-          </td>
-          <td>
-            ToUint8Clamp
-          </td>
-          <td>
-            8-bit unsigned integer (clamped conversion)
-          </td>
-          <td>
-            unsigned char
-          </td>
-        </tr>
+          <td>Uint8C
+          <td>1
+          <td>ToUint8Clamp
+          <td>8-bit unsigned integer (clamped conversion)
+          <td>unsigned char
         <tr>
           <td>
             Int16Array
             <br>
             %Int16Array%
-          </td>
-          <td>
-            Int16
-          </td>
-          <td>
-            2
-          </td>
-          <td>
-            ToInt16
-          </td>
-          <td>
-            16-bit 2's complement signed integer
-          </td>
-          <td>
-            short
-          </td>
-        </tr>
+          <td>Int16
+          <td>2
+          <td>ToInt16
+          <td>16-bit 2's complement signed integer
+          <td>short
         <tr>
           <td>
             Uint16Array
             <br>
             %Uint16Array%
-          </td>
-          <td>
-            Uint16
-          </td>
-          <td>
-            2
-          </td>
-          <td>
-            ToUint16
-          </td>
-          <td>
-            16-bit unsigned integer
-          </td>
-          <td>
-            unsigned short
-          </td>
-        </tr>
+          <td>Uint16
+          <td>2
+          <td>ToUint16
+          <td>16-bit unsigned integer
+          <td>unsigned short
         <tr>
           <td>
             Int32Array
             <br>
             %Int32Array%
-          </td>
-          <td>
-            Int32
-          </td>
-          <td>
-            4
-          </td>
-          <td>
-            ToInt32
-          </td>
-          <td>
-            32-bit 2's complement signed integer
-          </td>
-          <td>
-            int
-          </td>
-        </tr>
+          <td>Int32
+          <td>4
+          <td>ToInt32
+          <td>32-bit 2's complement signed integer
+          <td>int
         <tr>
           <td>
             Uint32Array
             <br>
             %Uint32Array%
-          </td>
-          <td>
-            Uint32
-          </td>
-          <td>
-            4
-          </td>
-          <td>
-            ToUint32
-          </td>
-          <td>
-            32-bit unsigned integer
-          </td>
-          <td>
-            unsigned int
-          </td>
-        </tr>
+          <td>Uint32
+          <td>4
+          <td>ToUint32
+          <td>32-bit unsigned integer
+          <td>unsigned int
         <tr>
           <td>
             Float32Array
             <br>
             %Float32Array%
-          </td>
+          <td>Float32
+          <td>4
           <td>
-            Float32
-          </td>
-          <td>
-            4
-          </td>
-          <td>
-          </td>
-          <td>
-            32-bit IEEE floating point
-          </td>
-          <td>
-            float
-          </td>
-        </tr>
+          <td>32-bit IEEE floating point
+          <td>float
         <tr>
           <td>
             Float64Array
             <br>
             %Float64Array%
-          </td>
+          <td>Float64
+          <td>8
           <td>
-            Float64
-          </td>
-          <td>
-            8
-          </td>
-          <td>
-          </td>
-          <td>
-            64-bit IEEE floating point
-          </td>
-          <td>
-            double
-          </td>
-        </tr>
-        </tbody>
+          <td>64-bit IEEE floating point
+          <td>double
       </table>
     </emu-table>
     <p>In the definitions below, references to _TypedArray_ should be replaced with the appropriate constructor name from the above table. The phrase &ldquo;the element size in bytes&rdquo; refers to the value in the Element Size column of the table in the row corresponding to the constructor. The phrase &ldquo;element Type&rdquo; refers to the value in the Element Type column for that row.</p>
@@ -34049,40 +30919,18 @@ THH:mm:ss.sss
         <p>Map Iterator instances are ordinary objects that inherit properties from the %MapIteratorPrototype% intrinsic object. Map Iterator instances are initially created with the internal slots described in <emu-xref href="#table-50"></emu-xref>.</p>
         <emu-table id="table-50" caption="Internal Slots of Map Iterator Instances">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Internal Slot
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <th>Internal Slot
+              <th>Description
             <tr>
-              <td>
-                [[Map]]
-              </td>
-              <td>
-                The Map object that is being iterated.
-              </td>
-            </tr>
+              <td>[[Map]]
+              <td>The Map object that is being iterated.
             <tr>
-              <td>
-                [[MapNextIndex]]
-              </td>
-              <td>
-                The integer index of the next Map data element to be examined by this iterator.
-              </td>
-            </tr>
+              <td>[[MapNextIndex]]
+              <td>The integer index of the next Map data element to be examined by this iterator.
             <tr>
-              <td>
-                [[MapIterationKind]]
-              </td>
-              <td>
-                A String value that identifies what is to be returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[MapIterationKind]]
+              <td>A String value that identifies what is to be returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`.
           </table>
         </emu-table>
       </emu-clause>
@@ -34389,40 +31237,18 @@ THH:mm:ss.sss
         <p>Set Iterator instances are ordinary objects that inherit properties from the %SetIteratorPrototype% intrinsic object. Set Iterator instances are initially created with the internal slots specified in <emu-xref href="#table-51"></emu-xref>.</p>
         <emu-table id="table-51" caption="Internal Slots of Set Iterator Instances">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Internal Slot
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <th>Internal Slot
+              <th>Description
             <tr>
-              <td>
-                [[IteratedSet]]
-              </td>
-              <td>
-                The Set object that is being iterated.
-              </td>
-            </tr>
+              <td>[[IteratedSet]]
+              <td>The Set object that is being iterated.
             <tr>
-              <td>
-                [[SetNextIndex]]
-              </td>
-              <td>
-                The integer index of the next Set data element to be examined by this iterator
-              </td>
-            </tr>
+              <td>[[SetNextIndex]]
+              <td>The integer index of the next Set data element to be examined by this iterator
             <tr>
-              <td>
-                [[SetIterationKind]]
-              </td>
-              <td>
-                A String value that identifies what is to be returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`. `"key"` and `"value"` have the same meaning.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[SetIterationKind]]
+              <td>A String value that identifies what is to be returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`. `"key"` and `"value"` have the same meaning.
           </table>
         </emu-table>
       </emu-clause>
@@ -36093,96 +32919,38 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-table id="table-json-single-character-escapes" caption="JSON Single Character Escape Sequences">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Code Unit Value
-              </th>
-              <th>
-                Unicode Character Name
-              </th>
-              <th>
-                Escape Sequence
-              </th>
-            </tr>
+              <th>Code Unit Value
+              <th>Unicode Character Name
+              <th>Escape Sequence
             <tr>
-              <td>
-                `0x0008`
-              </td>
-              <td>
-                BACKSPACE
-              </td>
-              <td>
-                `\\b`
-              </td>
-            </tr>
+              <td>`0x0008`
+              <td>BACKSPACE
+              <td>`\\b`
             <tr>
-              <td>
-                `0x0009`
-              </td>
-              <td>
-                CHARACTER TABULATION
-              </td>
-              <td>
-                `\\t`
-              </td>
-            </tr>
+              <td>`0x0009`
+              <td>CHARACTER TABULATION
+              <td>`\\t`
             <tr>
-              <td>
-                `0x000A`
-              </td>
-              <td>
-                LINE FEED (LF)
-              </td>
-              <td>
-                `\\n`
-              </td>
-            </tr>
+              <td>`0x000A`
+              <td>LINE FEED (LF)
+              <td>`\\n`
             <tr>
-              <td>
-                `0x000C`
-              </td>
-              <td>
-                FORM FEED (FF)
-              </td>
-              <td>
-                `\\f`
-              </td>
-            </tr>
+              <td>`0x000C`
+              <td>FORM FEED (FF)
+              <td>`\\f`
             <tr>
-              <td>
-                `0x000D`
-              </td>
-              <td>
-                CARRIAGE RETURN (CR)
-              </td>
-              <td>
-                `\\r`
-              </td>
-            </tr>
+              <td>`0x000D`
+              <td>CARRIAGE RETURN (CR)
+              <td>`\\r`
             <tr>
-              <td>
-                `0x0022`
-              </td>
-              <td>
-                QUOTATION MARK
-              </td>
-              <td>
-                `\\"`
-              </td>
-            </tr>
+              <td>`0x0022`
+              <td>QUOTATION MARK
+              <td>`\\"`
             <tr>
-              <td>
-                `0x005C`
-              </td>
-              <td>
-                REVERSE SOLIDUS
-              </td>
-              <td>
-                `\\\\`
-              </td>
-            </tr>
-            </tbody>
+              <td>`0x005C`
+              <td>REVERSE SOLIDUS
+              <td>`\\\\`
           </table>
         </emu-table>
       </emu-clause>
@@ -36299,30 +33067,14 @@ THH:mm:ss.sss
         <p>The <i>Iterable</i> interface includes the property described in <emu-xref href="#table-52"></emu-xref>:</p>
         <emu-table id="table-52" caption="<i>Iterable</i> Interface Required Properties">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Requirements
-              </th>
-            </tr>
+              <th>Property
+              <th>Value
+              <th>Requirements
             <tr>
-              <td>
-                `@@iterator`
-              </td>
-              <td>
-                A function that returns an <i>Iterator</i> object.
-              </td>
-              <td>
-                The returned object must conform to the <i>Iterator</i> interface.
-              </td>
-            </tr>
-            </tbody>
+              <td>`@@iterator`
+              <td>A function that returns an <i>Iterator</i> object.
+              <td>The returned object must conform to the <i>Iterator</i> interface.
           </table>
         </emu-table>
       </emu-clause>
@@ -36332,30 +33084,14 @@ THH:mm:ss.sss
         <p>An object that implements the <i>Iterator</i> interface must include the property in <emu-xref href="#table-53"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-54"></emu-xref>.</p>
         <emu-table id="table-53" caption="<i>Iterator</i> Interface Required Properties">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Requirements
-              </th>
-            </tr>
+              <th>Property
+              <th>Value
+              <th>Requirements
             <tr>
-              <td>
-                `next`
-              </td>
-              <td>
-                A function that returns an <i>IteratorResult</i> object.
-              </td>
-              <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>Iterator</i> has returned an <i>IteratorResult</i> object whose `done` property is *true*, then all subsequent calls to the `next` method of that object should also return an <i>IteratorResult</i> object whose `done` property is *true*. However, this requirement is not enforced.
-              </td>
-            </tr>
-            </tbody>
+              <td>`next`
+              <td>A function that returns an <i>IteratorResult</i> object.
+              <td>The returned object must conform to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>Iterator</i> has returned an <i>IteratorResult</i> object whose `done` property is *true*, then all subsequent calls to the `next` method of that object should also return an <i>IteratorResult</i> object whose `done` property is *true*. However, this requirement is not enforced.
           </table>
         </emu-table>
         <emu-note>
@@ -36363,41 +33099,18 @@ THH:mm:ss.sss
         </emu-note>
         <emu-table id="table-54" caption="<i>Iterator</i> Interface Optional Properties">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Requirements
-              </th>
-            </tr>
+              <th>Property
+              <th>Value
+              <th>Requirements
             <tr>
-              <td>
-                `return`
-              </td>
-              <td>
-                A function that returns an <i>IteratorResult</i> object.
-              </td>
-              <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller does not intend to make any more `next` method calls to the <i>Iterator</i>. The returned <i>IteratorResult</i> object will typically have a `done` property whose value is *true*, and a `value` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.
-              </td>
-            </tr>
+              <td>`return`
+              <td>A function that returns an <i>IteratorResult</i> object.
+              <td>The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller does not intend to make any more `next` method calls to the <i>Iterator</i>. The returned <i>IteratorResult</i> object will typically have a `done` property whose value is *true*, and a `value` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.
             <tr>
-              <td>
-                `throw`
-              </td>
-              <td>
-                A function that returns an <i>IteratorResult</i> object.
-              </td>
-              <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to `throw` the value passed as the argument. If the method does not `throw`, the returned <i>IteratorResult</i> object will typically have a `done` property whose value is *true*.
-              </td>
-            </tr>
-            </tbody>
+              <td>`throw`
+              <td>A function that returns an <i>IteratorResult</i> object.
+              <td>The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to `throw` the value passed as the argument. If the method does not `throw`, the returned <i>IteratorResult</i> object will typically have a `done` property whose value is *true*.
           </table>
         </emu-table>
         <emu-note>
@@ -36410,18 +33123,14 @@ THH:mm:ss.sss
         <p>The <i>AsyncIterable</i> interface includes the properties described in <emu-xref href="#table-async-iterable"></emu-xref>:</p>
         <emu-table id="table-async-iterable" caption="<i>AsyncIterable</i> Interface Required Properties">
           <table>
-            <tbody>
             <tr>
-              <th>Property</th>
-              <th>Value</th>
-              <th>Requirements</th>
-            </tr>
+              <th>Property
+              <th>Value
+              <th>Requirements
             <tr>
-              <td>`@@asyncIterator`</td>
-              <td>A function that returns an <i>AsyncIterator</i> object.</td>
-              <td>The returned object must conform to the <i>AsyncIterator</i> interface.</td>
-            </tr>
-            </tbody>
+              <td>`@@asyncIterator`
+              <td>A function that returns an <i>AsyncIterator</i> object.
+              <td>The returned object must conform to the <i>AsyncIterator</i> interface.
           </table>
         </emu-table>
       </emu-clause>
@@ -36431,22 +33140,16 @@ THH:mm:ss.sss
         <p>An object that implements the <i>AsyncIterator</i> interface must include the properties in <emu-xref href="#table-async-iterator-required"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-async-iterator-optional"></emu-xref>.</p>
         <emu-table id="table-async-iterator-required" caption="<i>AsyncIterator</i> Interface Required Properties">
           <table>
-            <tbody>
             <tr>
-              <th>Property</th>
-              <th>Value</th>
-              <th>Requirements</th>
-            </tr>
+              <th>Property
+              <th>Value
+              <th>Requirements
             <tr>
-              <td>`next`</td>
-              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>`next`
+              <td>A function that returns a promise for an <i>IteratorResult</i> object.
               <td>
                 <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose `done` property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose `done` property is *true*. However, this requirement is not enforced.</p>
-
                 <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
-              </td>
-            </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note>
@@ -36454,31 +33157,22 @@ THH:mm:ss.sss
         </emu-note>
         <emu-table id="table-async-iterator-optional" caption="<i>AsyncIterator</i> Interface Optional Properties">
           <table>
-            <tbody>
             <tr>
-              <th>Property</th>
-              <th>Value</th>
-              <th>Requirements</th>
-            </tr>
+              <th>Property
+              <th>Value
+              <th>Requirements
             <tr>
-              <td>`return`</td>
-              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>`return`
+              <td>A function that returns a promise for an <i>IteratorResult</i> object.
               <td>
                 <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a `done` property whose value is *true*, and a `value` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
-
                 <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `value` property whose value is not a promise (or "thenable"). If the argument value is used in the typical manner, then if it is a rejected promise, a promise rejected with the same reason should be returned; if it is a fulfilled promise, then its fulfillment value should be used as the `value` property of the returned promise's <i>IteratorResult</i> object fulfillment value. However, these requirements are also not enforced.</p>
-              </td>
-            </tr>
             <tr>
-              <td>`throw`</td>
-              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>`throw`
+              <td>A function that returns a promise for an <i>IteratorResult</i> object.
               <td>
                 <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to return a rejected promise which rejects with the value passed as the argument.</p>
-
                 <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a `done` property whose value is *true*. Additionally, it should have a `value` property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
-              </td>
-            </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note>
@@ -36491,41 +33185,18 @@ THH:mm:ss.sss
         <p>The <i>IteratorResult</i> interface includes the properties listed in <emu-xref href="#table-55"></emu-xref>:</p>
         <emu-table id="table-55" caption="<i>IteratorResult</i> Interface Properties">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Requirements
-              </th>
-            </tr>
+              <th>Property
+              <th>Value
+              <th>Requirements
             <tr>
-              <td>
-                `done`
-              </td>
-              <td>
-                Either *true* or *false*.
-              </td>
-              <td>
-                This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached `done` is *true*. If the end was not reached `done` is *false* and a value is available. If a `done` property (either own or inherited) does not exist, it is consider to have the value *false*.
-              </td>
-            </tr>
+              <td>`done`
+              <td>Either *true* or *false*.
+              <td>This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached `done` is *true*. If the end was not reached `done` is *false* and a value is available. If a `done` property (either own or inherited) does not exist, it is consider to have the value *false*.
             <tr>
-              <td>
-                `value`
-              </td>
-              <td>
-                Any ECMAScript language value.
-              </td>
-              <td>
-                If done is *false*, this is the current iteration element value. If done is *true*, this is the return value of the iterator, if it supplied one. If the iterator does not have a return value, `value` is *undefined*. In that case, the `value` property may be absent from the conforming object if it does not inherit an explicit `value` property.
-              </td>
-            </tr>
-            </tbody>
+              <td>`value`
+              <td>Any ECMAScript language value.
+              <td>If done is *false*, this is the current iteration element value. If done is *true*, this is the return value of the iterator, if it supplied one. If the iterator does not have a return value, `value` is *undefined*. In that case, the `value` property may be absent from the conforming object if it does not inherit an explicit `value` property.
           </table>
         </emu-table>
       </emu-clause>
@@ -36691,26 +33362,12 @@ THH:mm:ss.sss
         <p>Async-from-Sync Iterator instances are ordinary objects that inherit properties from the %AsyncFromSyncIteratorPrototype% intrinsic object. Async-from-Sync Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-async-from-sync-iterator-internal-slots"></emu-xref>.</p>
         <emu-table id="table-async-from-sync-iterator-internal-slots" caption="Internal Slots of Async-from-Sync Iterator Instances">
           <table>
-            <thead>
             <tr>
-              <th>
-                Internal Slot
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
-            </thead>
-            <tbody>
+              <th>Internal Slot
+              <th>Description
             <tr>
-              <td>
-                [[SyncIteratorRecord]]
-              </td>
-              <td>
-                A Record, of the type returned by GetIterator, representing the original synchronous iterator which is being adapted.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[SyncIteratorRecord]]
+              <td>A Record, of the type returned by GetIterator, representing the original synchronous iterator which is being adapted.
           </table>
         </emu-table>
       </emu-clause>
@@ -37015,32 +33672,15 @@ THH:mm:ss.sss
       <p>Generator instances are initially created with the internal slots described in <emu-xref href="#table-56"></emu-xref>.</p>
       <emu-table id="table-56" caption="Internal Slots of Generator Instances">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Internal Slot
-            </th>
-            <th>
-              Description
-            </th>
-          </tr>
+            <th>Internal Slot
+            <th>Description
           <tr>
-            <td>
-              [[GeneratorState]]
-            </td>
-            <td>
-              The current execution state of the generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, and `"completed"`.
-            </td>
-          </tr>
+            <td>[[GeneratorState]]
+            <td>The current execution state of the generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, and `"completed"`.
           <tr>
-            <td>
-              [[GeneratorContext]]
-            </td>
-            <td>
-              The execution context that is used when executing the code of this generator.
-            </td>
-          </tr>
-          </tbody>
+            <td>[[GeneratorContext]]
+            <td>The execution context that is used when executing the code of this generator.
         </table>
       </emu-table>
     </emu-clause>
@@ -37225,24 +33865,18 @@ THH:mm:ss.sss
       <p>AsyncGenerator instances are initially created with the internal slots described below:</p>
       <emu-table id="table-internal-slots-of-asyncgenerator-instances" caption="Internal Slots of AsyncGenerator Instances">
         <table>
-          <tbody>
           <tr>
-            <th>Internal Slot</th>
-            <th>Description</th>
-          </tr>
+            <th>Internal Slot
+            <th>Description
           <tr>
-            <td>[[AsyncGeneratorState]]</td>
-            <td>The current execution state of the async generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, `"awaiting-return"`, and `"completed"`.</td>
-          </tr>
+            <td>[[AsyncGeneratorState]]
+            <td>The current execution state of the async generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, `"awaiting-return"`, and `"completed"`.
           <tr>
-            <td>[[AsyncGeneratorContext]]</td>
-            <td>The execution context that is used when executing the code of this async generator.</td>
-          </tr>
+            <td>[[AsyncGeneratorContext]]
+            <td>The execution context that is used when executing the code of this async generator.
           <tr>
-            <td>[[AsyncGeneratorQueue]]</td>
-            <td>A List of AsyncGeneratorRequest records which represent requests to resume the async generator.</td>
-          </tr>
-          </tbody>
+            <td>[[AsyncGeneratorQueue]]
+            <td>A List of AsyncGeneratorRequest records which represent requests to resume the async generator.
         </table>
       </emu-table>
     </emu-clause>
@@ -37255,23 +33889,18 @@ THH:mm:ss.sss
         <p>They have the following fields:</p>
         <emu-table caption="AsyncGeneratorRequest Record Fields">
           <table>
-            <tbody>
             <tr>
-              <th>Field Name</th>
-              <th>Value</th>
-              <th>Meaning</th>
-            </tr>
+              <th>Field Name
+              <th>Value
+              <th>Meaning
             <tr>
-              <td>[[Completion]]</td>
-              <td>A Completion record</td>
-              <td>The completion which should be used to resume the async generator.</td>
-            </tr>
+              <td>[[Completion]]
+              <td>A Completion record
+              <td>The completion which should be used to resume the async generator.
             <tr>
-              <td>[[Capability]]</td>
-              <td>A PromiseCapability record</td>
-              <td>The promise capabilities associated with this request.</td>
-            </tr>
-            </tbody>
+              <td>[[Capability]]
+              <td>A PromiseCapability record
+              <td>The promise capabilities associated with this request.
           </table>
         </emu-table>
       </emu-clause>
@@ -37480,52 +34109,22 @@ THH:mm:ss.sss
         <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-57"></emu-xref>.</p>
         <emu-table id="table-57" caption="PromiseCapability Record Fields">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
+              <th>Field Name
+              <th>Value
+              <th>Meaning
             <tr>
-              <td>
-                [[Promise]]
-              </td>
-              <td>
-                An object
-              </td>
-              <td>
-                An object that is usable as a promise.
-              </td>
-            </tr>
+              <td>[[Promise]]
+              <td>An object
+              <td>An object that is usable as a promise.
             <tr>
-              <td>
-                [[Resolve]]
-              </td>
-              <td>
-                A function object
-              </td>
-              <td>
-                The function that is used to resolve the given promise object.
-              </td>
-            </tr>
+              <td>[[Resolve]]
+              <td>A function object
+              <td>The function that is used to resolve the given promise object.
             <tr>
-              <td>
-                [[Reject]]
-              </td>
-              <td>
-                A function object
-              </td>
-              <td>
-                The function that is used to reject the given promise object.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[Reject]]
+              <td>A function object
+              <td>The function that is used to reject the given promise object.
           </table>
         </emu-table>
 
@@ -37551,52 +34150,22 @@ THH:mm:ss.sss
         <p>PromiseReaction records have the fields listed in <emu-xref href="#table-58"></emu-xref>.</p>
         <emu-table id="table-58" caption="PromiseReaction Record Fields">
           <table>
-            <tbody>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
+              <th>Field Name
+              <th>Value
+              <th>Meaning
             <tr>
-              <td>
-                [[Capability]]
-              </td>
-              <td>
-                A PromiseCapability Record, or *undefined*
-              </td>
-              <td>
-                The capabilities of the promise for which this record provides a reaction handler.
-              </td>
-            </tr>
+              <td>[[Capability]]
+              <td>A PromiseCapability Record, or *undefined*
+              <td>The capabilities of the promise for which this record provides a reaction handler.
             <tr>
-              <td>
-                [[Type]]
-              </td>
-              <td>
-                Either `"Fulfill"` or `"Reject"`.
-              </td>
-              <td>
-                The [[Type]] is used when [[Handler]] is *undefined* to allow for behaviour specific to the settlement type.
-              </td>
-            </tr>
+              <td>[[Type]]
+              <td>Either `"Fulfill"` or `"Reject"`.
+              <td>The [[Type]] is used when [[Handler]] is *undefined* to allow for behaviour specific to the settlement type.
             <tr>
-              <td>
-                [[Handler]]
-              </td>
-              <td>
-                A function object or *undefined*.
-              </td>
-              <td>
-                The function that should be applied to the incoming value, and whose return value will govern what happens to the derived promise. If [[Handler]] is *undefined*, a function that depends on the value of [[Type]] will be used instead.
-              </td>
-            </tr>
-            </tbody>
+              <td>[[Handler]]
+              <td>A function object or *undefined*.
+              <td>The function that should be applied to the incoming value, and whose return value will govern what happens to the derived promise. If [[Handler]] is *undefined*, a function that depends on the value of [[Type]] will be used instead.
           </table>
         </emu-table>
       </emu-clause>
@@ -38195,56 +34764,24 @@ THH:mm:ss.sss
       <p>Promise instances are ordinary objects that inherit properties from the Promise prototype object (the intrinsic, %PromisePrototype%). Promise instances are initially created with the internal slots described in <emu-xref href="#table-59"></emu-xref>.</p>
       <emu-table id="table-59" caption="Internal Slots of Promise Instances">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Internal Slot
-            </th>
-            <th>
-              Description
-            </th>
-          </tr>
+            <th>Internal Slot
+            <th>Description
           <tr>
-            <td>
-              [[PromiseState]]
-            </td>
-            <td>
-              A String value that governs how a promise will react to incoming calls to its `then` method. The possible values are: `"pending"`, `"fulfilled"`, and `"rejected"`.
-            </td>
-          </tr>
+            <td>[[PromiseState]]
+            <td>A String value that governs how a promise will react to incoming calls to its `then` method. The possible values are: `"pending"`, `"fulfilled"`, and `"rejected"`.
           <tr>
-            <td>
-              [[PromiseResult]]
-            </td>
-            <td>
-              The value with which the promise has been fulfilled or rejected, if any. Only meaningful if [[PromiseState]] is not `"pending"`.
-            </td>
-          </tr>
+            <td>[[PromiseResult]]
+            <td>The value with which the promise has been fulfilled or rejected, if any. Only meaningful if [[PromiseState]] is not `"pending"`.
           <tr>
-            <td>
-              [[PromiseFulfillReactions]]
-            </td>
-            <td>
-              A List of PromiseReaction records to be processed when/if the promise transitions from the `"pending"` state to the `"fulfilled"` state.
-            </td>
-          </tr>
+            <td>[[PromiseFulfillReactions]]
+            <td>A List of PromiseReaction records to be processed when/if the promise transitions from the `"pending"` state to the `"fulfilled"` state.
           <tr>
-            <td>
-              [[PromiseRejectReactions]]
-            </td>
-            <td>
-              A List of PromiseReaction records to be processed when/if the promise transitions from the `"pending"` state to the `"rejected"` state.
-            </td>
-          </tr>
+            <td>[[PromiseRejectReactions]]
+            <td>A List of PromiseReaction records to be processed when/if the promise transitions from the `"pending"` state to the `"rejected"` state.
           <tr>
-            <td>
-              [[PromiseIsHandled]]
-            </td>
-            <td>
-              A boolean indicating whether the promise has ever had a fulfillment or rejection handler; used in unhandled rejection tracking.
-            </td>
-          </tr>
-          </tbody>
+            <td>[[PromiseIsHandled]]
+            <td>A boolean indicating whether the promise has ever had a fulfillment or rejection handler; used in unhandled rejection tracking.
         </table>
       </emu-table>
     </emu-clause>
@@ -38631,127 +35168,100 @@ THH:mm:ss.sss
 
     <emu-table id="table-readsharedmemory-fields" caption="ReadSharedMemory Event Fields">
       <table>
-        <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[Order]]</td>
-            <td>`"SeqCst"` or `"Unordered"`</td>
-            <td>The weakest ordering guaranteed by the memory model for the event.</td>
-          </tr>
-          <tr>
-            <td>[[NoTear]]</td>
-            <td>A Boolean</td>
-            <td>Whether this event is allowed to read from multiple write events on equal range as this event.</td>
-          </tr>
-          <tr>
-            <td>[[Block]]</td>
-            <td>A Shared Data Block</td>
-            <td>The block the event operates on.</td>
-          </tr>
-          <tr>
-            <td>[[ByteIndex]]</td>
-            <td>A nonnegative integer</td>
-            <td>The byte address of the read in [[Block]].</td>
-          </tr>
-          <tr>
-            <td>[[ElementSize]]</td>
-            <td>A nonnegative integer</td>
-            <td>The size of the read.</td>
-          </tr>
-        </tbody>
+        <tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
+        <tr>
+          <td>[[Order]]
+          <td>`"SeqCst"` or `"Unordered"`
+          <td>The weakest ordering guaranteed by the memory model for the event.
+        <tr>
+          <td>[[NoTear]]
+          <td>A Boolean
+          <td>Whether this event is allowed to read from multiple write events on equal range as this event.
+        <tr>
+          <td>[[Block]]
+          <td>A Shared Data Block
+          <td>The block the event operates on.
+        <tr>
+          <td>[[ByteIndex]]
+          <td>A nonnegative integer
+          <td>The byte address of the read in [[Block]].
+        <tr>
+          <td>[[ElementSize]]
+          <td>A nonnegative integer
+          <td>The size of the read.
       </table>
     </emu-table>
 
     <emu-table id="table-writesharedmemory-fields" caption="WriteSharedMemory Event Fields">
       <table>
-        <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[Order]]</td>
-            <td>`"SeqCst"`, `"Unordered"`, or `"Init"`</td>
-            <td>The weakest ordering guaranteed by the memory model for the event.</td>
-          </tr>
-          <tr>
-            <td>[[NoTear]]</td>
-            <td>A Boolean</td>
-            <td>Whether this event is allowed to be read from multiple read events with equal range as this event.</td>
-          </tr>
-          <tr>
-            <td>[[Block]]</td>
-            <td>A Shared Data Block</td>
-            <td>The block the event operates on.</td>
-          </tr>
-          <tr>
-            <td>[[ByteIndex]]</td>
-            <td>A nonnegative integer</td>
-            <td>The byte address of the write in [[Block]].</td>
-          </tr>
-          <tr>
-            <td>[[ElementSize]]</td>
-            <td>A nonnegative integer</td>
-            <td>The size of the write.</td>
-          </tr>
-          <tr>
-            <td>[[Payload]]</td>
-            <td>A List</td>
-            <td>The List of byte values to be read by other events.</td>
-          </tr>
-        </tbody>
+        <tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
+        <tr>
+          <td>[[Order]]
+          <td>`"SeqCst"`, `"Unordered"`, or `"Init"`
+          <td>The weakest ordering guaranteed by the memory model for the event.
+        <tr>
+          <td>[[NoTear]]
+          <td>A Boolean
+          <td>Whether this event is allowed to be read from multiple read events with equal range as this event.
+        <tr>
+          <td>[[Block]]
+          <td>A Shared Data Block
+          <td>The block the event operates on.
+        <tr>
+          <td>[[ByteIndex]]
+          <td>A nonnegative integer
+          <td>The byte address of the write in [[Block]].
+        <tr>
+          <td>[[ElementSize]]
+          <td>A nonnegative integer
+          <td>The size of the write.
+        <tr>
+          <td>[[Payload]]
+          <td>A List
+          <td>The List of byte values to be read by other events.
       </table>
     </emu-table>
 
     <emu-table id="table-rmwsharedmemory-fields" caption="ReadModifyWriteSharedMemory Event Fields">
       <table>
-        <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[Order]]</td>
-            <td>`"SeqCst"`</td>
-            <td>Read-modify-write events are always sequentially consistent.</td>
-          </tr>
-          <tr>
-            <td>[[NoTear]]</td>
-            <td>*true*</td>
-            <td>Read-modify-write events cannot tear.</td>
-          </tr>
-          <tr>
-            <td>[[Block]]</td>
-            <td>A Shared Data Block</td>
-            <td>The block the event operates on.</td>
-          </tr>
-          <tr>
-            <td>[[ByteIndex]]</td>
-            <td>A nonnegative integer</td>
-            <td>The byte address of the read-modify-write in [[Block]].</td>
-          </tr>
-          <tr>
-            <td>[[ElementSize]]</td>
-            <td>A nonnegative integer</td>
-            <td>The size of the read-modify-write.</td>
-          </tr>
-          <tr>
-            <td>[[Payload]]</td>
-            <td>A List</td>
-            <td>The List of byte values to be passed to [[ModifyOp]].</td>
-          </tr>
-          <tr>
-            <td>[[ModifyOp]]</td>
-            <td>A semantic function</td>
-            <td>A pure semantic function that returns a modified List of byte values from a read List of byte values and [[Payload]].</td>
-          </tr>
-        </tbody>
+        <tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
+        <tr>
+          <td>[[Order]]
+          <td>`"SeqCst"`
+          <td>Read-modify-write events are always sequentially consistent.
+        <tr>
+          <td>[[NoTear]]
+          <td>*true*
+          <td>Read-modify-write events cannot tear.
+        <tr>
+          <td>[[Block]]
+          <td>A Shared Data Block
+          <td>The block the event operates on.
+        <tr>
+          <td>[[ByteIndex]]
+          <td>A nonnegative integer
+          <td>The byte address of the read-modify-write in [[Block]].
+        <tr>
+          <td>[[ElementSize]]
+          <td>A nonnegative integer
+          <td>The size of the read-modify-write.
+        <tr>
+          <td>[[Payload]]
+          <td>A List
+          <td>The List of byte values to be passed to [[ModifyOp]].
+        <tr>
+          <td>[[ModifyOp]]
+          <td>A semantic function
+          <td>A pure semantic function that returns a modified List of byte values from a read List of byte values and [[Payload]].
       </table>
     </emu-table>
 
@@ -38770,28 +35280,22 @@ THH:mm:ss.sss
     <p>An <dfn>Agent Events Record</dfn> is a Record with the following fields.</p>
     <emu-table id="table-agent-events-records" caption="Agent Events Record Fields">
       <table>
-        <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[AgentSignifier]]</td>
-            <td>A value that admits equality testing</td>
-            <td>The agent whose evaluation resulted in this ordering.</td>
-          </tr>
-          <tr>
-            <td>[[EventList]]</td>
-            <td>A List of events</td>
-            <td>Events are appended to the list during evaluation.</td>
-          </tr>
-          <tr>
-            <td>[[AgentSynchronizesWith]]</td>
-            <td>A List of pairs of Synchronize events</td>
-            <td>Synchronize relationships introduced by the operational semantics.</td>
-          </tr>
-        </tbody>
+        <tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
+        <tr>
+          <td>[[AgentSignifier]]
+          <td>A value that admits equality testing
+          <td>The agent whose evaluation resulted in this ordering.
+        <tr>
+          <td>[[EventList]]
+          <td>A List of events
+          <td>Events are appended to the list during evaluation.
+        <tr>
+          <td>[[AgentSynchronizesWith]]
+          <td>A List of pairs of Synchronize events
+          <td>Synchronize relationships introduced by the operational semantics.
       </table>
     </emu-table>
   </emu-clause>
@@ -38801,23 +35305,18 @@ THH:mm:ss.sss
     <p>A <dfn>Chosen Value Record</dfn> is a Record with the following fields.</p>
     <emu-table id="table-chosen-value-records" caption="Chosen Value Record Fields">
       <table>
-        <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[Event]]</td>
-            <td>A Shared Data Block event</td>
-            <td>The ReadSharedMemory or ReadModifyWriteSharedMemory event that was introduced for this chosen value.</td>
-          </tr>
-          <tr>
-            <td>[[ChosenValue]]</td>
-            <td>A List of byte values</td>
-            <td>The bytes that were nondeterministically chosen during evaluation.</td>
-          </tr>
-        </tbody>
+        <tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
+        <tr>
+          <td>[[Event]]
+          <td>A Shared Data Block event
+          <td>The ReadSharedMemory or ReadModifyWriteSharedMemory event that was introduced for this chosen value.
+        <tr>
+          <td>[[ChosenValue]]
+          <td>A List of byte values
+          <td>The bytes that were nondeterministically chosen during evaluation.
       </table>
     </emu-table>
   </emu-clause>
@@ -38827,53 +35326,42 @@ THH:mm:ss.sss
     <p>A <dfn>candidate execution</dfn> of the evaluation of an agent cluster is a Record with the following fields.</p>
     <emu-table id="table-candidate-execution-records" caption="Candidate Execution Record Fields">
       <table>
-        <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[EventsRecords]]</td>
-            <td>A List of Agent Events Records.</td>
-            <td>Maps an agent to Lists of events appended during the evaluation.</td>
-          </tr>
-          <tr>
-            <td>[[ChosenValues]]</td>
-            <td>A List of Chosen Value Records.</td>
-            <td>Maps ReadSharedMemory or ReadModifyWriteSharedMemory events to the List of byte values chosen during the evaluation.</td>
-          </tr>
-          <tr>
-            <td>[[AgentOrder]]</td>
-            <td>An agent-order Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[ReadsBytesFrom]]</td>
-            <td>A reads-bytes-from semantic function.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[ReadsFrom]]</td>
-            <td>A reads-from Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[HostSynchronizesWith]]</td>
-            <td>A host-synchronizes-with Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[SynchronizesWith]]</td>
-            <td>A synchronizes-with Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[HappensBefore]]</td>
-            <td>A happens-before Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-        </tbody>
+        <tr>
+          <th>Field Name
+          <th>Value
+          <th>Meaning
+        <tr>
+          <td>[[EventsRecords]]
+          <td>A List of Agent Events Records.
+          <td>Maps an agent to Lists of events appended during the evaluation.
+        <tr>
+          <td>[[ChosenValues]]
+          <td>A List of Chosen Value Records.
+          <td>Maps ReadSharedMemory or ReadModifyWriteSharedMemory events to the List of byte values chosen during the evaluation.
+        <tr>
+          <td>[[AgentOrder]]
+          <td>An agent-order Relation.
+          <td>Defined below.
+        <tr>
+          <td>[[ReadsBytesFrom]]
+          <td>A reads-bytes-from semantic function.
+          <td>Defined below.
+        <tr>
+          <td>[[ReadsFrom]]
+          <td>A reads-from Relation.
+          <td>Defined below.
+        <tr>
+          <td>[[HostSynchronizesWith]]
+          <td>A host-synchronizes-with Relation.
+          <td>Defined below.
+        <tr>
+          <td>[[SynchronizesWith]]
+          <td>A synchronizes-with Relation.
+          <td>Defined below.
+        <tr>
+          <td>[[HappensBefore]]
+          <td>A happens-before Relation.
+          <td>Defined below.
       </table>
     </emu-table>
 
@@ -40094,41 +36582,18 @@ THH:mm:ss.sss
       <p>The entries in <emu-xref href="#table-60"></emu-xref> are added to <emu-xref href="#table-7"></emu-xref>.</p>
       <emu-table id="table-60" caption="Additional Well-known Intrinsic Objects">
         <table>
-          <tbody>
           <tr>
-            <th>
-              Intrinsic Name
-            </th>
-            <th>
-              Global Name
-            </th>
-            <th>
-              ECMAScript Language Association
-            </th>
-          </tr>
+            <th>Intrinsic Name
+            <th>Global Name
+            <th>ECMAScript Language Association
           <tr>
-            <td>
-              %escape%
-            </td>
-            <td>
-              `escape`
-            </td>
-            <td>
-              The `escape` function (<emu-xref href="#sec-escape-string"></emu-xref>)
-            </td>
-          </tr>
+            <td>%escape%
+            <td>`escape`
+            <td>The `escape` function (<emu-xref href="#sec-escape-string"></emu-xref>)
           <tr>
-            <td>
-              %unescape%
-            </td>
-            <td>
-              `unescape`
-            </td>
-            <td>
-              The `unescape` function (<emu-xref href="#sec-unescape-string"></emu-xref>)
-            </td>
-          </tr>
-          </tbody>
+            <td>%unescape%
+            <td>`unescape`
+            <td>The `unescape` function (<emu-xref href="#sec-unescape-string"></emu-xref>)
         </table>
       </emu-table>
 
@@ -40913,24 +37378,12 @@ THH:mm:ss.sss
             Additional <emu-xref href="#sec-typeof-operator">`typeof`</emu-xref> Operator Results
           </emu-caption>
           <table>
-            <tbody>
-              <tr>
-                <th>
-                  Type of _val_
-                </th>
-                <th>
-                  Result
-                </th>
-              </tr>
-              <tr>
-                <td>
-                  Object (has an [[IsHTMLDDA]] internal slot)
-                </td>
-                <td>
-                  `"undefined"`
-                </td>
-              </tr>
-            </tbody>
+            <tr>
+              <th>Type of _val_
+              <th>Result
+            <tr>
+              <td>Object (has an [[IsHTMLDDA]] internal slot)
+              <td>`"undefined"`
           </table>
         </emu-table>
       </emu-annex>

--- a/table-binary-unicode-properties.html
+++ b/table-binary-unicode-properties.html
@@ -5,419 +5,325 @@
       <tr>
         <th>Property name and aliases</th>
         <th>Canonical property name</th>
-      </tr>
     </thead>
     <tr>
-      <td>`ASCII`</td>
-      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`ASCII`</a></td>
-    </tr>
+      <td>`ASCII`
+      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`ASCII`</a>
     <tr>
       <td>
         <ul>
           <li>`ASCII_Hex_Digit`</li>
           <li>`AHex`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#ASCII_Hex_Digit">`ASCII_Hex_Digit`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#ASCII_Hex_Digit">`ASCII_Hex_Digit`</a>
     <tr>
       <td>
         <ul>
           <li>`Alphabetic`</li>
           <li>`Alpha`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Alphabetic">`Alphabetic`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Alphabetic">`Alphabetic`</a>
     <tr>
-      <td>`Any`</td>
-      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`Any`</a></td>
-    </tr>
+      <td>`Any`
+      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`Any`</a>
     <tr>
-      <td>`Assigned`</td>
-      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`Assigned`</a></td>
-    </tr>
+      <td>`Assigned`
+      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`Assigned`</a>
     <tr>
       <td>
         <ul>
           <li>`Bidi_Control`</li>
           <li>`Bidi_C`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Bidi_Control">`Bidi_Control`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Bidi_Control">`Bidi_Control`</a>
     <tr>
       <td>
         <ul>
           <li>`Bidi_Mirrored`</li>
           <li>`Bidi_M`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Bidi_Mirrored">`Bidi_Mirrored`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Bidi_Mirrored">`Bidi_Mirrored`</a>
     <tr>
       <td>
         <ul>
           <li>`Case_Ignorable`</li>
           <li>`CI`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Case_Ignorable">`Case_Ignorable`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Case_Ignorable">`Case_Ignorable`</a>
     <tr>
-      <td>`Cased`</td>
-      <td><a href="https://unicode.org/reports/tr44/#Cased">`Cased`</a></td>
-    </tr>
+      <td>`Cased`
+      <td><a href="https://unicode.org/reports/tr44/#Cased">`Cased`</a>
     <tr>
       <td>
         <ul>
           <li>`Changes_When_Casefolded`</li>
           <li>`CWCF`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWCF">`Changes_When_Casefolded`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#CWCF">`Changes_When_Casefolded`</a>
     <tr>
       <td>
         <ul>
           <li>`Changes_When_Casemapped`</li>
           <li>`CWCM`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWCM">`Changes_When_Casemapped`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#CWCM">`Changes_When_Casemapped`</a>
     <tr>
       <td>
         <ul>
           <li>`Changes_When_Lowercased`</li>
           <li>`CWL`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWL">`Changes_When_Lowercased`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#CWL">`Changes_When_Lowercased`</a>
     <tr>
       <td>
         <ul>
           <li>`Changes_When_NFKC_Casefolded`</li>
           <li>`CWKCF`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWKCF">`Changes_When_NFKC_Casefolded`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#CWKCF">`Changes_When_NFKC_Casefolded`</a>
     <tr>
       <td>
         <ul>
           <li>`Changes_When_Titlecased`</li>
           <li>`CWT`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWT">`Changes_When_Titlecased`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#CWT">`Changes_When_Titlecased`</a>
     <tr>
       <td>
         <ul>
           <li>`Changes_When_Uppercased`</li>
           <li>`CWU`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWU">`Changes_When_Uppercased`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#CWU">`Changes_When_Uppercased`</a>
     <tr>
-      <td>`Dash`</td>
-      <td><a href="https://unicode.org/reports/tr44/#Dash">`Dash`</a></td>
-    </tr>
+      <td>`Dash`
+      <td><a href="https://unicode.org/reports/tr44/#Dash">`Dash`</a>
     <tr>
       <td>
         <ul>
           <li>`Default_Ignorable_Code_Point`</li>
           <li>`DI`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Default_Ignorable_Code_Point">`Default_Ignorable_Code_Point`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Default_Ignorable_Code_Point">`Default_Ignorable_Code_Point`</a>
     <tr>
       <td>
         <ul>
           <li>`Deprecated`</li>
           <li>`Dep`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Deprecated">`Deprecated`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Deprecated">`Deprecated`</a>
     <tr>
       <td>
         <ul>
           <li>`Diacritic`</li>
           <li>`Dia`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Diacritic">`Diacritic`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Diacritic">`Diacritic`</a>
     <tr>
-      <td>`Emoji`</td>
-      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji`</a></td>
-    </tr>
+      <td>`Emoji`
+      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji`</a>
     <tr>
-      <td>`Emoji_Component`</td>
-      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji_Component`</a></td>
-    </tr>
+      <td>`Emoji_Component`
+      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji_Component`</a>
     <tr>
-      <td>`Emoji_Modifier`</td>
-      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji_Modifier`</a></td>
-    </tr>
+      <td>`Emoji_Modifier`
+      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji_Modifier`</a>
     <tr>
-      <td>`Emoji_Modifier_Base`</td>
-      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji_Modifier_Base`</a></td>
-    </tr>
+      <td>`Emoji_Modifier_Base`
+      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji_Modifier_Base`</a>
     <tr>
-      <td>`Emoji_Presentation`</td>
-      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji_Presentation`</a></td>
-    </tr>
+      <td>`Emoji_Presentation`
+      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Emoji_Presentation`</a>
     <tr>
-      <td>`Extended_Pictographic`</td>
-      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Extended_Pictographic`</a></td>
-    </tr>
+      <td>`Extended_Pictographic`
+      <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Extended_Pictographic`</a>
     <tr>
       <td>
         <ul>
           <li>`Extender`</li>
           <li>`Ext`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Extender">`Extender`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Extender">`Extender`</a>
     <tr>
       <td>
         <ul>
           <li>`Grapheme_Base`</li>
           <li>`Gr_Base`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Grapheme_Base">`Grapheme_Base`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Grapheme_Base">`Grapheme_Base`</a>
     <tr>
       <td>
         <ul>
           <li>`Grapheme_Extend`</li>
           <li>`Gr_Ext`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Grapheme_Extend">`Grapheme_Extend`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Grapheme_Extend">`Grapheme_Extend`</a>
     <tr>
       <td>
         <ul>
           <li>`Hex_Digit`</li>
           <li>`Hex`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Hex_Digit">`Hex_Digit`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Hex_Digit">`Hex_Digit`</a>
     <tr>
       <td>
         <ul>
           <li>`IDS_Binary_Operator`</li>
           <li>`IDSB`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#IDS_Binary_Operator">`IDS_Binary_Operator`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#IDS_Binary_Operator">`IDS_Binary_Operator`</a>
     <tr>
       <td>
         <ul>
           <li>`IDS_Trinary_Operator`</li>
           <li>`IDST`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#IDS_Trinary_Operator">`IDS_Trinary_Operator`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#IDS_Trinary_Operator">`IDS_Trinary_Operator`</a>
     <tr>
       <td>
         <ul>
           <li>`ID_Continue`</li>
           <li>`IDC`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#ID_Continue">`ID_Continue`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#ID_Continue">`ID_Continue`</a>
     <tr>
       <td>
         <ul>
           <li>`ID_Start`</li>
           <li>`IDS`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#ID_Start">`ID_Start`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#ID_Start">`ID_Start`</a>
     <tr>
       <td>
         <ul>
           <li>`Ideographic`</li>
           <li>`Ideo`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Ideographic">`Ideographic`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Ideographic">`Ideographic`</a>
     <tr>
       <td>
         <ul>
           <li>`Join_Control`</li>
           <li>`Join_C`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Join_Control">`Join_Control`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Join_Control">`Join_Control`</a>
     <tr>
       <td>
         <ul>
           <li>`Logical_Order_Exception`</li>
           <li>`LOE`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Logical_Order_Exception">`Logical_Order_Exception`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Logical_Order_Exception">`Logical_Order_Exception`</a>
     <tr>
       <td>
         <ul>
           <li>`Lowercase`</li>
           <li>`Lower`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Lowercase">`Lowercase`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Lowercase">`Lowercase`</a>
     <tr>
-      <td>`Math`</td>
-      <td><a href="https://unicode.org/reports/tr44/#Math">`Math`</a></td>
-    </tr>
+      <td>`Math`
+      <td><a href="https://unicode.org/reports/tr44/#Math">`Math`</a>
     <tr>
       <td>
         <ul>
           <li>`Noncharacter_Code_Point`</li>
           <li>`NChar`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Noncharacter_Code_Point">`Noncharacter_Code_Point`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Noncharacter_Code_Point">`Noncharacter_Code_Point`</a>
     <tr>
       <td>
         <ul>
           <li>`Pattern_Syntax`</li>
           <li>`Pat_Syn`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Pattern_Syntax">`Pattern_Syntax`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Pattern_Syntax">`Pattern_Syntax`</a>
     <tr>
       <td>
         <ul>
           <li>`Pattern_White_Space`</li>
           <li>`Pat_WS`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Pattern_White_Space">`Pattern_White_Space`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Pattern_White_Space">`Pattern_White_Space`</a>
     <tr>
       <td>
         <ul>
           <li>`Quotation_Mark`</li>
           <li>`QMark`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Quotation_Mark">`Quotation_Mark`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Quotation_Mark">`Quotation_Mark`</a>
     <tr>
-      <td>`Radical`</td>
-      <td><a href="https://unicode.org/reports/tr44/#Radical">`Radical`</a></td>
-    </tr>
+      <td>`Radical`
+      <td><a href="https://unicode.org/reports/tr44/#Radical">`Radical`</a>
     <tr>
       <td>
         <ul>
           <li>`Regional_Indicator`</li>
           <li>`RI`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Regional_Indicator">`Regional_Indicator`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Regional_Indicator">`Regional_Indicator`</a>
     <tr>
       <td>
         <ul>
           <li>`Sentence_Terminal`</li>
           <li>`STerm`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#STerm">`Sentence_Terminal`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#STerm">`Sentence_Terminal`</a>
     <tr>
       <td>
         <ul>
           <li>`Soft_Dotted`</li>
           <li>`SD`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Soft_Dotted">`Soft_Dotted`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Soft_Dotted">`Soft_Dotted`</a>
     <tr>
       <td>
         <ul>
           <li>`Terminal_Punctuation`</li>
           <li>`Term`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Terminal_Punctuation">`Terminal_Punctuation`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Terminal_Punctuation">`Terminal_Punctuation`</a>
     <tr>
       <td>
         <ul>
           <li>`Unified_Ideograph`</li>
           <li>`UIdeo`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Unified_Ideograph">`Unified_Ideograph`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Unified_Ideograph">`Unified_Ideograph`</a>
     <tr>
       <td>
         <ul>
           <li>`Uppercase`</li>
           <li>`Upper`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Uppercase">`Uppercase`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Uppercase">`Uppercase`</a>
     <tr>
       <td>
         <ul>
           <li>`Variation_Selector`</li>
           <li>`VS`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Variation_Selector">`Variation_Selector`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#Variation_Selector">`Variation_Selector`</a>
     <tr>
       <td>
         <ul>
           <li>`White_Space`</li>
           <li>`space`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#White_Space">`White_Space`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#White_Space">`White_Space`</a>
     <tr>
       <td>
         <ul>
           <li>`XID_Continue`</li>
           <li>`XIDC`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#XID_Continue">`XID_Continue`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#XID_Continue">`XID_Continue`</a>
     <tr>
       <td>
         <ul>
           <li>`XID_Start`</li>
           <li>`XIDS`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#XID_Start">`XID_Start`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr44/#XID_Start">`XID_Start`</a>
   </table>
 </emu-table>

--- a/table-nonbinary-unicode-properties.html
+++ b/table-nonbinary-unicode-properties.html
@@ -5,7 +5,6 @@
       <tr>
         <th>Property name and aliases</th>
         <th>Canonical property name</th>
-      </tr>
     </thead>
     <tr>
       <td>
@@ -13,26 +12,20 @@
           <li>`General_Category`</li>
           <li>`gc`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`General_Category`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`General_Category`</a>
     <tr>
       <td>
         <ul>
           <li>`Script`</li>
           <li>`sc`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr24/#Script">`Script`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr24/#Script">`Script`</a>
     <tr>
       <td>
         <ul>
           <li>`Script_Extensions`</li>
           <li>`scx`</li>
         </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr24/#Script_Extensions">`Script_Extensions`</a></td>
-    </tr>
+      <td><a href="https://unicode.org/reports/tr24/#Script_Extensions">`Script_Extensions`</a>
   </table>
 </emu-table>

--- a/table-unicode-general-category-values.html
+++ b/table-unicode-general-category-values.html
@@ -5,7 +5,6 @@
       <tr>
         <th>Property value and aliases</th>
         <th>Canonical property value</th>
-      </tr>
     </thead>
     <tr>
       <td>
@@ -13,27 +12,21 @@
           <li>`Cased_Letter`</li>
           <li>`LC`</li>
         </ul>
-      </td>
-      <td>`Cased_Letter`</td>
-    </tr>
+      <td>`Cased_Letter`
     <tr>
       <td>
         <ul>
           <li>`Close_Punctuation`</li>
           <li>`Pe`</li>
         </ul>
-      </td>
-      <td>`Close_Punctuation`</td>
-    </tr>
+      <td>`Close_Punctuation`
     <tr>
       <td>
         <ul>
           <li>`Connector_Punctuation`</li>
           <li>`Pc`</li>
         </ul>
-      </td>
-      <td>`Connector_Punctuation`</td>
-    </tr>
+      <td>`Connector_Punctuation`
     <tr>
       <td>
         <ul>
@@ -41,27 +34,21 @@
           <li>`Cc`</li>
           <li>`cntrl`</li>
         </ul>
-      </td>
-      <td>`Control`</td>
-    </tr>
+      <td>`Control`
     <tr>
       <td>
         <ul>
           <li>`Currency_Symbol`</li>
           <li>`Sc`</li>
         </ul>
-      </td>
-      <td>`Currency_Symbol`</td>
-    </tr>
+      <td>`Currency_Symbol`
     <tr>
       <td>
         <ul>
           <li>`Dash_Punctuation`</li>
           <li>`Pd`</li>
         </ul>
-      </td>
-      <td>`Dash_Punctuation`</td>
-    </tr>
+      <td>`Dash_Punctuation`
     <tr>
       <td>
         <ul>
@@ -69,81 +56,63 @@
           <li>`Nd`</li>
           <li>`digit`</li>
         </ul>
-      </td>
-      <td>`Decimal_Number`</td>
-    </tr>
+      <td>`Decimal_Number`
     <tr>
       <td>
         <ul>
           <li>`Enclosing_Mark`</li>
           <li>`Me`</li>
         </ul>
-      </td>
-      <td>`Enclosing_Mark`</td>
-    </tr>
+      <td>`Enclosing_Mark`
     <tr>
       <td>
         <ul>
           <li>`Final_Punctuation`</li>
           <li>`Pf`</li>
         </ul>
-      </td>
-      <td>`Final_Punctuation`</td>
-    </tr>
+      <td>`Final_Punctuation`
     <tr>
       <td>
         <ul>
           <li>`Format`</li>
           <li>`Cf`</li>
         </ul>
-      </td>
-      <td>`Format`</td>
-    </tr>
+      <td>`Format`
     <tr>
       <td>
         <ul>
           <li>`Initial_Punctuation`</li>
           <li>`Pi`</li>
         </ul>
-      </td>
-      <td>`Initial_Punctuation`</td>
-    </tr>
+      <td>`Initial_Punctuation`
     <tr>
       <td>
         <ul>
           <li>`Letter`</li>
           <li>`L`</li>
         </ul>
-      </td>
-      <td>`Letter`</td>
-    </tr>
+      <td>`Letter`
     <tr>
       <td>
         <ul>
           <li>`Letter_Number`</li>
           <li>`Nl`</li>
         </ul>
-      </td>
-      <td>`Letter_Number`</td>
-    </tr>
+      <td>`Letter_Number`
     <tr>
       <td>
         <ul>
           <li>`Line_Separator`</li>
           <li>`Zl`</li>
         </ul>
-      </td>
-      <td>`Line_Separator`</td>
-    </tr>
+      <td>`Line_Separator`
     <tr>
       <td>
         <ul>
           <li>`Lowercase_Letter`</li>
           <li>`Ll`</li>
         </ul>
-      </td>
-      <td>`Lowercase_Letter`</td>
-    </tr>
+      <td>`Lowercase_Letter`
     <tr>
       <td>
         <ul>
@@ -151,126 +120,98 @@
           <li>`M`</li>
           <li>`Combining_Mark`</li>
         </ul>
-      </td>
-      <td>`Mark`</td>
-    </tr>
+      <td>`Mark`
     <tr>
       <td>
         <ul>
           <li>`Math_Symbol`</li>
           <li>`Sm`</li>
         </ul>
-      </td>
-      <td>`Math_Symbol`</td>
-    </tr>
+      <td>`Math_Symbol`
     <tr>
       <td>
         <ul>
           <li>`Modifier_Letter`</li>
           <li>`Lm`</li>
         </ul>
-      </td>
-      <td>`Modifier_Letter`</td>
-    </tr>
+      <td>`Modifier_Letter`
     <tr>
       <td>
         <ul>
           <li>`Modifier_Symbol`</li>
           <li>`Sk`</li>
         </ul>
-      </td>
-      <td>`Modifier_Symbol`</td>
-    </tr>
+      <td>`Modifier_Symbol`
     <tr>
       <td>
         <ul>
           <li>`Nonspacing_Mark`</li>
           <li>`Mn`</li>
         </ul>
-      </td>
-      <td>`Nonspacing_Mark`</td>
-    </tr>
+      <td>`Nonspacing_Mark`
     <tr>
       <td>
         <ul>
           <li>`Number`</li>
           <li>`N`</li>
         </ul>
-      </td>
-      <td>`Number`</td>
-    </tr>
+      <td>`Number`
     <tr>
       <td>
         <ul>
           <li>`Open_Punctuation`</li>
           <li>`Ps`</li>
         </ul>
-      </td>
-      <td>`Open_Punctuation`</td>
-    </tr>
+      <td>`Open_Punctuation`
     <tr>
       <td>
         <ul>
           <li>`Other`</li>
           <li>`C`</li>
         </ul>
-      </td>
-      <td>`Other`</td>
-    </tr>
+      <td>`Other`
     <tr>
       <td>
         <ul>
           <li>`Other_Letter`</li>
           <li>`Lo`</li>
         </ul>
-      </td>
-      <td>`Other_Letter`</td>
-    </tr>
+      <td>`Other_Letter`
     <tr>
       <td>
         <ul>
           <li>`Other_Number`</li>
           <li>`No`</li>
         </ul>
-      </td>
-      <td>`Other_Number`</td>
-    </tr>
+      <td>`Other_Number`
     <tr>
       <td>
         <ul>
           <li>`Other_Punctuation`</li>
           <li>`Po`</li>
         </ul>
-      </td>
-      <td>`Other_Punctuation`</td>
-    </tr>
+      <td>`Other_Punctuation`
     <tr>
       <td>
         <ul>
           <li>`Other_Symbol`</li>
           <li>`So`</li>
         </ul>
-      </td>
-      <td>`Other_Symbol`</td>
-    </tr>
+      <td>`Other_Symbol`
     <tr>
       <td>
         <ul>
           <li>`Paragraph_Separator`</li>
           <li>`Zp`</li>
         </ul>
-      </td>
-      <td>`Paragraph_Separator`</td>
-    </tr>
+      <td>`Paragraph_Separator`
     <tr>
       <td>
         <ul>
           <li>`Private_Use`</li>
           <li>`Co`</li>
         </ul>
-      </td>
-      <td>`Private_Use`</td>
-    </tr>
+      <td>`Private_Use`
     <tr>
       <td>
         <ul>
@@ -278,80 +219,62 @@
           <li>`P`</li>
           <li>`punct`</li>
         </ul>
-      </td>
-      <td>`Punctuation`</td>
-    </tr>
+      <td>`Punctuation`
     <tr>
       <td>
         <ul>
           <li>`Separator`</li>
           <li>`Z`</li>
         </ul>
-      </td>
-      <td>`Separator`</td>
-    </tr>
+      <td>`Separator`
     <tr>
       <td>
         <ul>
           <li>`Space_Separator`</li>
           <li>`Zs`</li>
         </ul>
-      </td>
-      <td>`Space_Separator`</td>
-    </tr>
+      <td>`Space_Separator`
     <tr>
       <td>
         <ul>
           <li>`Spacing_Mark`</li>
           <li>`Mc`</li>
         </ul>
-      </td>
-      <td>`Spacing_Mark`</td>
-    </tr>
+      <td>`Spacing_Mark`
     <tr>
       <td>
         <ul>
           <li>`Surrogate`</li>
           <li>`Cs`</li>
         </ul>
-      </td>
-      <td>`Surrogate`</td>
-    </tr>
+      <td>`Surrogate`
     <tr>
       <td>
         <ul>
           <li>`Symbol`</li>
           <li>`S`</li>
         </ul>
-      </td>
-      <td>`Symbol`</td>
-    </tr>
+      <td>`Symbol`
     <tr>
       <td>
         <ul>
           <li>`Titlecase_Letter`</li>
           <li>`Lt`</li>
         </ul>
-      </td>
-      <td>`Titlecase_Letter`</td>
-    </tr>
+      <td>`Titlecase_Letter`
     <tr>
       <td>
         <ul>
           <li>`Unassigned`</li>
           <li>`Cn`</li>
         </ul>
-      </td>
-      <td>`Unassigned`</td>
-    </tr>
+      <td>`Unassigned`
     <tr>
       <td>
         <ul>
           <li>`Uppercase_Letter`</li>
           <li>`Lu`</li>
         </ul>
-      </td>
-      <td>`Uppercase_Letter`</td>
-    </tr>
+      <td>`Uppercase_Letter`
   </table>
 </emu-table>

--- a/table-unicode-script-values.html
+++ b/table-unicode-script-values.html
@@ -5,7 +5,6 @@
       <tr>
         <th>Property value and aliases</th>
         <th>Canonical property value</th>
-      </tr>
     </thead>
     <tr>
       <td>
@@ -13,216 +12,168 @@
           <li>`Adlam`</li>
           <li>`Adlm`</li>
         </ul>
-      </td>
-      <td>`Adlam`</td>
-    </tr>
+      <td>`Adlam`
     <tr>
       <td>
         <ul>
           <li>`Ahom`</li>
           <li>`Ahom`</li>
         </ul>
-      </td>
-      <td>`Ahom`</td>
-    </tr>
+      <td>`Ahom`
     <tr>
       <td>
         <ul>
           <li>`Anatolian_Hieroglyphs`</li>
           <li>`Hluw`</li>
         </ul>
-      </td>
-      <td>`Anatolian_Hieroglyphs`</td>
-    </tr>
+      <td>`Anatolian_Hieroglyphs`
     <tr>
       <td>
         <ul>
           <li>`Arabic`</li>
           <li>`Arab`</li>
         </ul>
-      </td>
-      <td>`Arabic`</td>
-    </tr>
+      <td>`Arabic`
     <tr>
       <td>
         <ul>
           <li>`Armenian`</li>
           <li>`Armn`</li>
         </ul>
-      </td>
-      <td>`Armenian`</td>
-    </tr>
+      <td>`Armenian`
     <tr>
       <td>
         <ul>
           <li>`Avestan`</li>
           <li>`Avst`</li>
         </ul>
-      </td>
-      <td>`Avestan`</td>
-    </tr>
+      <td>`Avestan`
     <tr>
       <td>
         <ul>
           <li>`Balinese`</li>
           <li>`Bali`</li>
         </ul>
-      </td>
-      <td>`Balinese`</td>
-    </tr>
+      <td>`Balinese`
     <tr>
       <td>
         <ul>
           <li>`Bamum`</li>
           <li>`Bamu`</li>
         </ul>
-      </td>
-      <td>`Bamum`</td>
-    </tr>
+      <td>`Bamum`
     <tr>
       <td>
         <ul>
           <li>`Bassa_Vah`</li>
           <li>`Bass`</li>
         </ul>
-      </td>
-      <td>`Bassa_Vah`</td>
-    </tr>
+      <td>`Bassa_Vah`
     <tr>
       <td>
         <ul>
           <li>`Batak`</li>
           <li>`Batk`</li>
         </ul>
-      </td>
-      <td>`Batak`</td>
-    </tr>
+      <td>`Batak`
     <tr>
       <td>
         <ul>
           <li>`Bengali`</li>
           <li>`Beng`</li>
         </ul>
-      </td>
-      <td>`Bengali`</td>
-    </tr>
+      <td>`Bengali`
     <tr>
       <td>
         <ul>
           <li>`Bhaiksuki`</li>
           <li>`Bhks`</li>
         </ul>
-      </td>
-      <td>`Bhaiksuki`</td>
-    </tr>
+      <td>`Bhaiksuki`
     <tr>
       <td>
         <ul>
           <li>`Bopomofo`</li>
           <li>`Bopo`</li>
         </ul>
-      </td>
-      <td>`Bopomofo`</td>
-    </tr>
+      <td>`Bopomofo`
     <tr>
       <td>
         <ul>
           <li>`Brahmi`</li>
           <li>`Brah`</li>
         </ul>
-      </td>
-      <td>`Brahmi`</td>
-    </tr>
+      <td>`Brahmi`
     <tr>
       <td>
         <ul>
           <li>`Braille`</li>
           <li>`Brai`</li>
         </ul>
-      </td>
-      <td>`Braille`</td>
-    </tr>
+      <td>`Braille`
     <tr>
       <td>
         <ul>
           <li>`Buginese`</li>
           <li>`Bugi`</li>
         </ul>
-      </td>
-      <td>`Buginese`</td>
-    </tr>
+      <td>`Buginese`
     <tr>
       <td>
         <ul>
           <li>`Buhid`</li>
           <li>`Buhd`</li>
         </ul>
-      </td>
-      <td>`Buhid`</td>
-    </tr>
+      <td>`Buhid`
     <tr>
       <td>
         <ul>
           <li>`Canadian_Aboriginal`</li>
           <li>`Cans`</li>
         </ul>
-      </td>
-      <td>`Canadian_Aboriginal`</td>
-    </tr>
+      <td>`Canadian_Aboriginal`
     <tr>
       <td>
         <ul>
           <li>`Carian`</li>
           <li>`Cari`</li>
         </ul>
-      </td>
-      <td>`Carian`</td>
-    </tr>
+      <td>`Carian`
     <tr>
       <td>
         <ul>
           <li>`Caucasian_Albanian`</li>
           <li>`Aghb`</li>
         </ul>
-      </td>
-      <td>`Caucasian_Albanian`</td>
-    </tr>
+      <td>`Caucasian_Albanian`
     <tr>
       <td>
         <ul>
           <li>`Chakma`</li>
           <li>`Cakm`</li>
         </ul>
-      </td>
-      <td>`Chakma`</td>
-    </tr>
+      <td>`Chakma`
     <tr>
       <td>
         <ul>
           <li>`Cham`</li>
           <li>`Cham`</li>
         </ul>
-      </td>
-      <td>`Cham`</td>
-    </tr>
+      <td>`Cham`
     <tr>
       <td>
         <ul>
           <li>`Cherokee`</li>
           <li>`Cher`</li>
         </ul>
-      </td>
-      <td>`Cherokee`</td>
-    </tr>
+      <td>`Cherokee`
     <tr>
       <td>
         <ul>
           <li>`Common`</li>
           <li>`Zyyy`</li>
         </ul>
-      </td>
-      <td>`Common`</td>
-    </tr>
+      <td>`Common`
     <tr>
       <td>
         <ul>
@@ -230,243 +181,189 @@
           <li>`Copt`</li>
           <li>`Qaac`</li>
         </ul>
-      </td>
-      <td>`Coptic`</td>
-    </tr>
+      <td>`Coptic`
     <tr>
       <td>
         <ul>
           <li>`Cuneiform`</li>
           <li>`Xsux`</li>
         </ul>
-      </td>
-      <td>`Cuneiform`</td>
-    </tr>
+      <td>`Cuneiform`
     <tr>
       <td>
         <ul>
           <li>`Cypriot`</li>
           <li>`Cprt`</li>
         </ul>
-      </td>
-      <td>`Cypriot`</td>
-    </tr>
+      <td>`Cypriot`
     <tr>
       <td>
         <ul>
           <li>`Cyrillic`</li>
           <li>`Cyrl`</li>
         </ul>
-      </td>
-      <td>`Cyrillic`</td>
-    </tr>
+      <td>`Cyrillic`
     <tr>
       <td>
         <ul>
           <li>`Deseret`</li>
           <li>`Dsrt`</li>
         </ul>
-      </td>
-      <td>`Deseret`</td>
-    </tr>
+      <td>`Deseret`
     <tr>
       <td>
         <ul>
           <li>`Devanagari`</li>
           <li>`Deva`</li>
         </ul>
-      </td>
-      <td>`Devanagari`</td>
-    </tr>
+      <td>`Devanagari`
     <tr>
       <td>
         <ul>
           <li>`Dogra`</li>
           <li>`Dogr`</li>
         </ul>
-      </td>
-      <td>`Dogra`</td>
-    </tr>
+      <td>`Dogra`
     <tr>
       <td>
         <ul>
           <li>`Duployan`</li>
           <li>`Dupl`</li>
         </ul>
-      </td>
-      <td>`Duployan`</td>
-    </tr>
+      <td>`Duployan`
     <tr>
       <td>
         <ul>
           <li>`Egyptian_Hieroglyphs`</li>
           <li>`Egyp`</li>
         </ul>
-      </td>
-      <td>`Egyptian_Hieroglyphs`</td>
-    </tr>
+      <td>`Egyptian_Hieroglyphs`
     <tr>
       <td>
         <ul>
           <li>`Elbasan`</li>
           <li>`Elba`</li>
         </ul>
-      </td>
-      <td>`Elbasan`</td>
-    </tr>
+      <td>`Elbasan`
     <tr>
       <td>
         <ul>
           <li>`Ethiopic`</li>
           <li>`Ethi`</li>
         </ul>
-      </td>
-      <td>`Ethiopic`</td>
-    </tr>
+      <td>`Ethiopic`
     <tr>
       <td>
         <ul>
           <li>`Georgian`</li>
           <li>`Geor`</li>
         </ul>
-      </td>
-      <td>`Georgian`</td>
-    </tr>
+      <td>`Georgian`
     <tr>
       <td>
         <ul>
           <li>`Glagolitic`</li>
           <li>`Glag`</li>
         </ul>
-      </td>
-      <td>`Glagolitic`</td>
-    </tr>
+      <td>`Glagolitic`
     <tr>
       <td>
         <ul>
           <li>`Gothic`</li>
           <li>`Goth`</li>
         </ul>
-      </td>
-      <td>`Gothic`</td>
-    </tr>
+      <td>`Gothic`
     <tr>
       <td>
         <ul>
           <li>`Grantha`</li>
           <li>`Gran`</li>
         </ul>
-      </td>
-      <td>`Grantha`</td>
-    </tr>
+      <td>`Grantha`
     <tr>
       <td>
         <ul>
           <li>`Greek`</li>
           <li>`Grek`</li>
         </ul>
-      </td>
-      <td>`Greek`</td>
-    </tr>
+      <td>`Greek`
     <tr>
       <td>
         <ul>
           <li>`Gujarati`</li>
           <li>`Gujr`</li>
         </ul>
-      </td>
-      <td>`Gujarati`</td>
-    </tr>
+      <td>`Gujarati`
     <tr>
       <td>
         <ul>
           <li>`Gunjala_Gondi`</li>
           <li>`Gong`</li>
         </ul>
-      </td>
-      <td>`Gunjala_Gondi`</td>
-    </tr>
+      <td>`Gunjala_Gondi`
     <tr>
       <td>
         <ul>
           <li>`Gurmukhi`</li>
           <li>`Guru`</li>
         </ul>
-      </td>
-      <td>`Gurmukhi`</td>
-    </tr>
+      <td>`Gurmukhi`
     <tr>
       <td>
         <ul>
           <li>`Han`</li>
           <li>`Hani`</li>
         </ul>
-      </td>
-      <td>`Han`</td>
-    </tr>
+      <td>`Han`
     <tr>
       <td>
         <ul>
           <li>`Hangul`</li>
           <li>`Hang`</li>
         </ul>
-      </td>
-      <td>`Hangul`</td>
-    </tr>
+      <td>`Hangul`
     <tr>
       <td>
         <ul>
           <li>`Hanifi_Rohingya`</li>
           <li>`Rohg`</li>
         </ul>
-      </td>
-      <td>`Hanifi_Rohingya`</td>
-    </tr>
+      <td>`Hanifi_Rohingya`
     <tr>
       <td>
         <ul>
           <li>`Hanunoo`</li>
           <li>`Hano`</li>
         </ul>
-      </td>
-      <td>`Hanunoo`</td>
-    </tr>
+      <td>`Hanunoo`
     <tr>
       <td>
         <ul>
           <li>`Hatran`</li>
           <li>`Hatr`</li>
         </ul>
-      </td>
-      <td>`Hatran`</td>
-    </tr>
+      <td>`Hatran`
     <tr>
       <td>
         <ul>
           <li>`Hebrew`</li>
           <li>`Hebr`</li>
         </ul>
-      </td>
-      <td>`Hebrew`</td>
-    </tr>
+      <td>`Hebrew`
     <tr>
       <td>
         <ul>
           <li>`Hiragana`</li>
           <li>`Hira`</li>
         </ul>
-      </td>
-      <td>`Hiragana`</td>
-    </tr>
+      <td>`Hiragana`
     <tr>
       <td>
         <ul>
           <li>`Imperial_Aramaic`</li>
           <li>`Armi`</li>
         </ul>
-      </td>
-      <td>`Imperial_Aramaic`</td>
-    </tr>
+      <td>`Imperial_Aramaic`
     <tr>
       <td>
         <ul>
@@ -474,872 +371,678 @@
           <li>`Zinh`</li>
           <li>`Qaai`</li>
         </ul>
-      </td>
-      <td>`Inherited`</td>
-    </tr>
+      <td>`Inherited`
     <tr>
       <td>
         <ul>
           <li>`Inscriptional_Pahlavi`</li>
           <li>`Phli`</li>
         </ul>
-      </td>
-      <td>`Inscriptional_Pahlavi`</td>
-    </tr>
+      <td>`Inscriptional_Pahlavi`
     <tr>
       <td>
         <ul>
           <li>`Inscriptional_Parthian`</li>
           <li>`Prti`</li>
         </ul>
-      </td>
-      <td>`Inscriptional_Parthian`</td>
-    </tr>
+      <td>`Inscriptional_Parthian`
     <tr>
       <td>
         <ul>
           <li>`Javanese`</li>
           <li>`Java`</li>
         </ul>
-      </td>
-      <td>`Javanese`</td>
-    </tr>
+      <td>`Javanese`
     <tr>
       <td>
         <ul>
           <li>`Kaithi`</li>
           <li>`Kthi`</li>
         </ul>
-      </td>
-      <td>`Kaithi`</td>
-    </tr>
+      <td>`Kaithi`
     <tr>
       <td>
         <ul>
           <li>`Kannada`</li>
           <li>`Knda`</li>
         </ul>
-      </td>
-      <td>`Kannada`</td>
-    </tr>
+      <td>`Kannada`
     <tr>
       <td>
         <ul>
           <li>`Katakana`</li>
           <li>`Kana`</li>
         </ul>
-      </td>
-      <td>`Katakana`</td>
-    </tr>
+      <td>`Katakana`
     <tr>
       <td>
         <ul>
           <li>`Kayah_Li`</li>
           <li>`Kali`</li>
         </ul>
-      </td>
-      <td>`Kayah_Li`</td>
-    </tr>
+      <td>`Kayah_Li`
     <tr>
       <td>
         <ul>
           <li>`Kharoshthi`</li>
           <li>`Khar`</li>
         </ul>
-      </td>
-      <td>`Kharoshthi`</td>
-    </tr>
+      <td>`Kharoshthi`
     <tr>
       <td>
         <ul>
           <li>`Khmer`</li>
           <li>`Khmr`</li>
         </ul>
-      </td>
-      <td>`Khmer`</td>
-    </tr>
+      <td>`Khmer`
     <tr>
       <td>
         <ul>
           <li>`Khojki`</li>
           <li>`Khoj`</li>
         </ul>
-      </td>
-      <td>`Khojki`</td>
-    </tr>
+      <td>`Khojki`
     <tr>
       <td>
         <ul>
           <li>`Khudawadi`</li>
           <li>`Sind`</li>
         </ul>
-      </td>
-      <td>`Khudawadi`</td>
-    </tr>
+      <td>`Khudawadi`
     <tr>
       <td>
         <ul>
           <li>`Lao`</li>
           <li>`Laoo`</li>
         </ul>
-      </td>
-      <td>`Lao`</td>
-    </tr>
+      <td>`Lao`
     <tr>
       <td>
         <ul>
           <li>`Latin`</li>
           <li>`Latn`</li>
         </ul>
-      </td>
-      <td>`Latin`</td>
-    </tr>
+      <td>`Latin`
     <tr>
       <td>
         <ul>
           <li>`Lepcha`</li>
           <li>`Lepc`</li>
         </ul>
-      </td>
-      <td>`Lepcha`</td>
-    </tr>
+      <td>`Lepcha`
     <tr>
       <td>
         <ul>
           <li>`Limbu`</li>
           <li>`Limb`</li>
         </ul>
-      </td>
-      <td>`Limbu`</td>
-    </tr>
+      <td>`Limbu`
     <tr>
       <td>
         <ul>
           <li>`Linear_A`</li>
           <li>`Lina`</li>
         </ul>
-      </td>
-      <td>`Linear_A`</td>
-    </tr>
+      <td>`Linear_A`
     <tr>
       <td>
         <ul>
           <li>`Linear_B`</li>
           <li>`Linb`</li>
         </ul>
-      </td>
-      <td>`Linear_B`</td>
-    </tr>
+      <td>`Linear_B`
     <tr>
       <td>
         <ul>
           <li>`Lisu`</li>
           <li>`Lisu`</li>
         </ul>
-      </td>
-      <td>`Lisu`</td>
-    </tr>
+      <td>`Lisu`
     <tr>
       <td>
         <ul>
           <li>`Lycian`</li>
           <li>`Lyci`</li>
         </ul>
-      </td>
-      <td>`Lycian`</td>
-    </tr>
+      <td>`Lycian`
     <tr>
       <td>
         <ul>
           <li>`Lydian`</li>
           <li>`Lydi`</li>
         </ul>
-      </td>
-      <td>`Lydian`</td>
-    </tr>
+      <td>`Lydian`
     <tr>
       <td>
         <ul>
           <li>`Mahajani`</li>
           <li>`Mahj`</li>
         </ul>
-      </td>
-      <td>`Mahajani`</td>
-    </tr>
+      <td>`Mahajani`
     <tr>
       <td>
         <ul>
           <li>`Makasar`</li>
           <li>`Maka`</li>
         </ul>
-      </td>
-      <td>`Makasar`</td>
-    </tr>
+      <td>`Makasar`
     <tr>
       <td>
         <ul>
           <li>`Malayalam`</li>
           <li>`Mlym`</li>
         </ul>
-      </td>
-      <td>`Malayalam`</td>
-    </tr>
+      <td>`Malayalam`
     <tr>
       <td>
         <ul>
           <li>`Mandaic`</li>
           <li>`Mand`</li>
         </ul>
-      </td>
-      <td>`Mandaic`</td>
-    </tr>
+      <td>`Mandaic`
     <tr>
       <td>
         <ul>
           <li>`Manichaean`</li>
           <li>`Mani`</li>
         </ul>
-      </td>
-      <td>`Manichaean`</td>
-    </tr>
+      <td>`Manichaean`
     <tr>
       <td>
         <ul>
           <li>`Marchen`</li>
           <li>`Marc`</li>
         </ul>
-      </td>
-      <td>`Marchen`</td>
-    </tr>
+      <td>`Marchen`
     <tr>
       <td>
         <ul>
           <li>`Medefaidrin`</li>
           <li>`Medf`</li>
         </ul>
-      </td>
-      <td>`Medefaidrin`</td>
-    </tr>
+      <td>`Medefaidrin`
     <tr>
       <td>
         <ul>
           <li>`Masaram_Gondi`</li>
           <li>`Gonm`</li>
         </ul>
-      </td>
-      <td>`Masaram_Gondi`</td>
-    </tr>
+      <td>`Masaram_Gondi`
     <tr>
       <td>
         <ul>
           <li>`Meetei_Mayek`</li>
           <li>`Mtei`</li>
         </ul>
-      </td>
-      <td>`Meetei_Mayek`</td>
-    </tr>
+      <td>`Meetei_Mayek`
     <tr>
       <td>
         <ul>
           <li>`Mende_Kikakui`</li>
           <li>`Mend`</li>
         </ul>
-      </td>
-      <td>`Mende_Kikakui`</td>
-    </tr>
+      <td>`Mende_Kikakui`
     <tr>
       <td>
         <ul>
           <li>`Meroitic_Cursive`</li>
           <li>`Merc`</li>
         </ul>
-      </td>
-      <td>`Meroitic_Cursive`</td>
-    </tr>
+      <td>`Meroitic_Cursive`
     <tr>
       <td>
         <ul>
           <li>`Meroitic_Hieroglyphs`</li>
           <li>`Mero`</li>
         </ul>
-      </td>
-      <td>`Meroitic_Hieroglyphs`</td>
-    </tr>
+      <td>`Meroitic_Hieroglyphs`
     <tr>
       <td>
         <ul>
           <li>`Miao`</li>
           <li>`Plrd`</li>
         </ul>
-      </td>
-      <td>`Miao`</td>
-    </tr>
+      <td>`Miao`
     <tr>
       <td>
         <ul>
           <li>`Modi`</li>
           <li>`Modi`</li>
         </ul>
-      </td>
-      <td>`Modi`</td>
-    </tr>
+      <td>`Modi`
     <tr>
       <td>
         <ul>
           <li>`Mongolian`</li>
           <li>`Mong`</li>
         </ul>
-      </td>
-      <td>`Mongolian`</td>
-    </tr>
+      <td>`Mongolian`
     <tr>
       <td>
         <ul>
           <li>`Mro`</li>
           <li>`Mroo`</li>
         </ul>
-      </td>
-      <td>`Mro`</td>
-    </tr>
+      <td>`Mro`
     <tr>
       <td>
         <ul>
           <li>`Multani`</li>
           <li>`Mult`</li>
         </ul>
-      </td>
-      <td>`Multani`</td>
-    </tr>
+      <td>`Multani`
     <tr>
       <td>
         <ul>
           <li>`Myanmar`</li>
           <li>`Mymr`</li>
         </ul>
-      </td>
-      <td>`Myanmar`</td>
-    </tr>
+      <td>`Myanmar`
     <tr>
       <td>
         <ul>
           <li>`Nabataean`</li>
           <li>`Nbat`</li>
         </ul>
-      </td>
-      <td>`Nabataean`</td>
-    </tr>
+      <td>`Nabataean`
     <tr>
       <td>
         <ul>
           <li>`New_Tai_Lue`</li>
           <li>`Talu`</li>
         </ul>
-      </td>
-      <td>`New_Tai_Lue`</td>
-    </tr>
+      <td>`New_Tai_Lue`
     <tr>
       <td>
         <ul>
           <li>`Newa`</li>
           <li>`Newa`</li>
         </ul>
-      </td>
-      <td>`Newa`</td>
-    </tr>
+      <td>`Newa`
     <tr>
       <td>
         <ul>
           <li>`Nko`</li>
           <li>`Nkoo`</li>
         </ul>
-      </td>
-      <td>`Nko`</td>
-    </tr>
+      <td>`Nko`
     <tr>
       <td>
         <ul>
           <li>`Nushu`</li>
           <li>`Nshu`</li>
         </ul>
-      </td>
-      <td>`Nushu`</td>
-    </tr>
+      <td>`Nushu`
     <tr>
       <td>
         <ul>
           <li>`Ogham`</li>
           <li>`Ogam`</li>
         </ul>
-      </td>
-      <td>`Ogham`</td>
-    </tr>
+      <td>`Ogham`
     <tr>
       <td>
         <ul>
           <li>`Ol_Chiki`</li>
           <li>`Olck`</li>
         </ul>
-      </td>
-      <td>`Ol_Chiki`</td>
-    </tr>
+      <td>`Ol_Chiki`
     <tr>
       <td>
         <ul>
           <li>`Old_Hungarian`</li>
           <li>`Hung`</li>
         </ul>
-      </td>
-      <td>`Old_Hungarian`</td>
-    </tr>
+      <td>`Old_Hungarian`
     <tr>
       <td>
         <ul>
           <li>`Old_Italic`</li>
           <li>`Ital`</li>
         </ul>
-      </td>
-      <td>`Old_Italic`</td>
-    </tr>
+      <td>`Old_Italic`
     <tr>
       <td>
         <ul>
           <li>`Old_North_Arabian`</li>
           <li>`Narb`</li>
         </ul>
-      </td>
-      <td>`Old_North_Arabian`</td>
-    </tr>
+      <td>`Old_North_Arabian`
     <tr>
       <td>
         <ul>
           <li>`Old_Permic`</li>
           <li>`Perm`</li>
         </ul>
-      </td>
-      <td>`Old_Permic`</td>
-    </tr>
+      <td>`Old_Permic`
     <tr>
       <td>
         <ul>
           <li>`Old_Persian`</li>
           <li>`Xpeo`</li>
         </ul>
-      </td>
-      <td>`Old_Persian`</td>
-    </tr>
+      <td>`Old_Persian`
     <tr>
       <td>
         <ul>
           <li>`Old_Sogdian`</li>
           <li>`Sogo`</li>
         </ul>
-      </td>
-      <td>`Old_Sogdian`</td>
-    </tr>
+      <td>`Old_Sogdian`
     <tr>
       <td>
         <ul>
           <li>`Old_South_Arabian`</li>
           <li>`Sarb`</li>
         </ul>
-      </td>
-      <td>`Old_South_Arabian`</td>
-    </tr>
+      <td>`Old_South_Arabian`
     <tr>
       <td>
         <ul>
           <li>`Old_Turkic`</li>
           <li>`Orkh`</li>
         </ul>
-      </td>
-      <td>`Old_Turkic`</td>
-    </tr>
+      <td>`Old_Turkic`
     <tr>
       <td>
         <ul>
           <li>`Oriya`</li>
           <li>`Orya`</li>
         </ul>
-      </td>
-      <td>`Oriya`</td>
-    </tr>
+      <td>`Oriya`
     <tr>
       <td>
         <ul>
           <li>`Osage`</li>
           <li>`Osge`</li>
         </ul>
-      </td>
-      <td>`Osage`</td>
-    </tr>
+      <td>`Osage`
     <tr>
       <td>
         <ul>
           <li>`Osmanya`</li>
           <li>`Osma`</li>
         </ul>
-      </td>
-      <td>`Osmanya`</td>
-    </tr>
+      <td>`Osmanya`
     <tr>
       <td>
         <ul>
           <li>`Pahawh_Hmong`</li>
           <li>`Hmng`</li>
         </ul>
-      </td>
-      <td>`Pahawh_Hmong`</td>
-    </tr>
+      <td>`Pahawh_Hmong`
     <tr>
       <td>
         <ul>
           <li>`Palmyrene`</li>
           <li>`Palm`</li>
         </ul>
-      </td>
-      <td>`Palmyrene`</td>
-    </tr>
+      <td>`Palmyrene`
     <tr>
       <td>
         <ul>
           <li>`Pau_Cin_Hau`</li>
           <li>`Pauc`</li>
         </ul>
-      </td>
-      <td>`Pau_Cin_Hau`</td>
-    </tr>
+      <td>`Pau_Cin_Hau`
     <tr>
       <td>
         <ul>
           <li>`Phags_Pa`</li>
           <li>`Phag`</li>
         </ul>
-      </td>
-      <td>`Phags_Pa`</td>
-    </tr>
+      <td>`Phags_Pa`
     <tr>
       <td>
         <ul>
           <li>`Phoenician`</li>
           <li>`Phnx`</li>
         </ul>
-      </td>
-      <td>`Phoenician`</td>
-    </tr>
+      <td>`Phoenician`
     <tr>
       <td>
         <ul>
           <li>`Psalter_Pahlavi`</li>
           <li>`Phlp`</li>
         </ul>
-      </td>
-      <td>`Psalter_Pahlavi`</td>
-    </tr>
+      <td>`Psalter_Pahlavi`
     <tr>
       <td>
         <ul>
           <li>`Rejang`</li>
           <li>`Rjng`</li>
         </ul>
-      </td>
-      <td>`Rejang`</td>
-    </tr>
+      <td>`Rejang`
     <tr>
       <td>
         <ul>
           <li>`Runic`</li>
           <li>`Runr`</li>
         </ul>
-      </td>
-      <td>`Runic`</td>
-    </tr>
+      <td>`Runic`
     <tr>
       <td>
         <ul>
           <li>`Samaritan`</li>
           <li>`Samr`</li>
         </ul>
-      </td>
-      <td>`Samaritan`</td>
-    </tr>
+      <td>`Samaritan`
     <tr>
       <td>
         <ul>
           <li>`Saurashtra`</li>
           <li>`Saur`</li>
         </ul>
-      </td>
-      <td>`Saurashtra`</td>
-    </tr>
+      <td>`Saurashtra`
     <tr>
       <td>
         <ul>
           <li>`Sharada`</li>
           <li>`Shrd`</li>
         </ul>
-      </td>
-      <td>`Sharada`</td>
-    </tr>
+      <td>`Sharada`
     <tr>
       <td>
         <ul>
           <li>`Shavian`</li>
           <li>`Shaw`</li>
         </ul>
-      </td>
-      <td>`Shavian`</td>
-    </tr>
+      <td>`Shavian`
     <tr>
       <td>
         <ul>
           <li>`Siddham`</li>
           <li>`Sidd`</li>
         </ul>
-      </td>
-      <td>`Siddham`</td>
-    </tr>
+      <td>`Siddham`
     <tr>
       <td>
         <ul>
           <li>`SignWriting`</li>
           <li>`Sgnw`</li>
         </ul>
-      </td>
-      <td>`SignWriting`</td>
-    </tr>
+      <td>`SignWriting`
     <tr>
       <td>
         <ul>
           <li>`Sinhala`</li>
           <li>`Sinh`</li>
         </ul>
-      </td>
-      <td>`Sinhala`</td>
-    </tr>
+      <td>`Sinhala`
     <tr>
       <td>
         <ul>
           <li>`Sogdian`</li>
           <li>`Sogd`</li>
         </ul>
-      </td>
-      <td>`Sogdian`</td>
-    </tr>
+      <td>`Sogdian`
     <tr>
       <td>
         <ul>
           <li>`Sora_Sompeng`</li>
           <li>`Sora`</li>
         </ul>
-      </td>
-      <td>`Sora_Sompeng`</td>
-    </tr>
+      <td>`Sora_Sompeng`
     <tr>
       <td>
         <ul>
           <li>`Soyombo`</li>
           <li>`Soyo`</li>
         </ul>
-      </td>
-      <td>`Soyombo`</td>
-    </tr>
+      <td>`Soyombo`
     <tr>
       <td>
         <ul>
           <li>`Sundanese`</li>
           <li>`Sund`</li>
         </ul>
-      </td>
-      <td>`Sundanese`</td>
-    </tr>
+      <td>`Sundanese`
     <tr>
       <td>
         <ul>
           <li>`Syloti_Nagri`</li>
           <li>`Sylo`</li>
         </ul>
-      </td>
-      <td>`Syloti_Nagri`</td>
-    </tr>
+      <td>`Syloti_Nagri`
     <tr>
       <td>
         <ul>
           <li>`Syriac`</li>
           <li>`Syrc`</li>
         </ul>
-      </td>
-      <td>`Syriac`</td>
-    </tr>
+      <td>`Syriac`
     <tr>
       <td>
         <ul>
           <li>`Tagalog`</li>
           <li>`Tglg`</li>
         </ul>
-      </td>
-      <td>`Tagalog`</td>
-    </tr>
+      <td>`Tagalog`
     <tr>
       <td>
         <ul>
           <li>`Tagbanwa`</li>
           <li>`Tagb`</li>
         </ul>
-      </td>
-      <td>`Tagbanwa`</td>
-    </tr>
+      <td>`Tagbanwa`
     <tr>
       <td>
         <ul>
           <li>`Tai_Le`</li>
           <li>`Tale`</li>
         </ul>
-      </td>
-      <td>`Tai_Le`</td>
-    </tr>
+      <td>`Tai_Le`
     <tr>
       <td>
         <ul>
           <li>`Tai_Tham`</li>
           <li>`Lana`</li>
         </ul>
-      </td>
-      <td>`Tai_Tham`</td>
-    </tr>
+      <td>`Tai_Tham`
     <tr>
       <td>
         <ul>
           <li>`Tai_Viet`</li>
           <li>`Tavt`</li>
         </ul>
-      </td>
-      <td>`Tai_Viet`</td>
-    </tr>
+      <td>`Tai_Viet`
     <tr>
       <td>
         <ul>
           <li>`Takri`</li>
           <li>`Takr`</li>
         </ul>
-      </td>
-      <td>`Takri`</td>
-    </tr>
+      <td>`Takri`
     <tr>
       <td>
         <ul>
           <li>`Tamil`</li>
           <li>`Taml`</li>
         </ul>
-      </td>
-      <td>`Tamil`</td>
-    </tr>
+      <td>`Tamil`
     <tr>
       <td>
         <ul>
           <li>`Tangut`</li>
           <li>`Tang`</li>
         </ul>
-      </td>
-      <td>`Tangut`</td>
-    </tr>
+      <td>`Tangut`
     <tr>
       <td>
         <ul>
           <li>`Telugu`</li>
           <li>`Telu`</li>
         </ul>
-      </td>
-      <td>`Telugu`</td>
-    </tr>
+      <td>`Telugu`
     <tr>
       <td>
         <ul>
           <li>`Thaana`</li>
           <li>`Thaa`</li>
         </ul>
-      </td>
-      <td>`Thaana`</td>
-    </tr>
+      <td>`Thaana`
     <tr>
       <td>
         <ul>
           <li>`Thai`</li>
           <li>`Thai`</li>
         </ul>
-      </td>
-      <td>`Thai`</td>
-    </tr>
+      <td>`Thai`
     <tr>
       <td>
         <ul>
           <li>`Tibetan`</li>
           <li>`Tibt`</li>
         </ul>
-      </td>
-      <td>`Tibetan`</td>
-    </tr>
+      <td>`Tibetan`
     <tr>
       <td>
         <ul>
           <li>`Tifinagh`</li>
           <li>`Tfng`</li>
         </ul>
-      </td>
-      <td>`Tifinagh`</td>
-    </tr>
+      <td>`Tifinagh`
     <tr>
       <td>
         <ul>
           <li>`Tirhuta`</li>
           <li>`Tirh`</li>
         </ul>
-      </td>
-      <td>`Tirhuta`</td>
-    </tr>
+      <td>`Tirhuta`
     <tr>
       <td>
         <ul>
           <li>`Ugaritic`</li>
           <li>`Ugar`</li>
         </ul>
-      </td>
-      <td>`Ugaritic`</td>
-    </tr>
+      <td>`Ugaritic`
     <tr>
       <td>
         <ul>
           <li>`Vai`</li>
           <li>`Vaii`</li>
         </ul>
-      </td>
-      <td>`Vai`</td>
-    </tr>
+      <td>`Vai`
     <tr>
       <td>
         <ul>
           <li>`Warang_Citi`</li>
           <li>`Wara`</li>
         </ul>
-      </td>
-      <td>`Warang_Citi`</td>
-    </tr>
+      <td>`Warang_Citi`
     <tr>
       <td>
         <ul>
           <li>`Yi`</li>
           <li>`Yiii`</li>
         </ul>
-      </td>
-      <td>`Yi`</td>
-    </tr>
+      <td>`Yi`
     <tr>
       <td>
         <ul>
           <li>`Zanabazar_Square`</li>
           <li>`Zanb`</li>
         </ul>
-      </td>
-      <td>`Zanabazar_Square`</td>
-    </tr>
+      <td>`Zanabazar_Square`
   </table>
 </emu-table>


### PR DESCRIPTION
Per this discussion: https://github.com/bterlson/ecmarkup/issues/152#issuecomment-460369361

These "minor" modifications remove the ```</tr>```, ```</th>```, ```</td>```, ```<thead>```, ```</thead>```, ```<tbody>```, and ```</tbody>``` tags from the spec.html. The changes also move up lines to the ```<th>``` and ```<td>``` tag when the lines aren't nested tags. (When they were I kept them how they were in the original document).

Motivation for this change are that in my proposal I'm making table changes and adding rows and it was getting very large and easy to make mistakes. These changes make it much easier to follow.