### PR TITLE
Editorial: correctly determine flags for static RegExp parsing

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12925,12 +12925,23 @@
         <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if BodyText of |RegularExpressionLiteral| cannot be recognized using the goal symbol |Pattern| of the ECMAScript RegExp grammar specified in <emu-xref href="#sec-patterns"></emu-xref>.
-          </li>
-          <li>
-            It is a Syntax Error if FlagText of |RegularExpressionLiteral| contains any code points other than `g`, `i`, `m`, `s`, `u`, or `y`, or if it contains the same code point more than once.
+            It is a Syntax Error if IsValidRegularExpressionLiteral(|RegularExpressionLiteral|) is *false*.
           </li>
         </ul>
+      </emu-clause>
+
+      <emu-clause id="sec-isvalidregularexpressionliteral" aoid="IsValidRegularExpressionLiteral">
+        <h1>Static Semantics: IsValidRegularExpressionLiteral ( _literal_ )</h1>
+        <p>The abstract operation IsValidRegularExpressionLiteral determines if its argument is a valid regular expression literal. The following steps are taken:</p>
+        <emu-alg>
+          1. Assert: _literal_ is a |RegularExpressionLiteral|.
+          1. If FlagText of _literal_ contains any code points other than `g`, `i`, `m`, `s`, `u`, or `y`, or if it contains the same code point more than once, return *false*.
+          1. Let _P_ be BodyText of _literal_.
+          1. If FlagText of _literal_ contains `u`, then
+            1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[+U, +N]|. If _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist, return *false*.
+            1. Otherwise, return *true*.
+          1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]|. If _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist, return *false*. Otherwise, return *true*.
+        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-regular-expression-literals-runtime-semantics-evaluation">


### PR DESCRIPTION
Fixes #1343 according to the approach [discussed therein](https://github.com/tc39/ecma262/issues/1343#issuecomment-458646159); see that issue for full context, but briefly, the current spec text says to do a parse according to "the goal symbol Pattern", which is meaningless in the current spec because Pattern has flags, which must be provided. Determining these flags is a little involved.

As it says there, this is heavily duplicated with [the runtime semantics for RegExpInitialize](https://tc39.github.io/ecma262/#sec-regexpinitialize). If the editors think this is worth noting, or avoiding, I can try to come up with something.

I'd particularly appreciate reviews from @jmdyck and @waldemarhorwat.