### PR TITLE
Normative: Make `JSON.stringify(-0)` preserve the sign

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36323,6 +36323,7 @@ THH:mm:ss.sss
           1. If _value_ is *false*, return `"false"`.
           1. If Type(_value_) is String, return QuoteJSONString(_value_).
           1. If Type(_value_) is Number, then
+            1. If _value_ is *-0*, return `"-0"`.
             1. If _value_ is finite, return ! ToString(_value_).
             1. Return `"null"`.
           1. If Type(_value_) is Object and IsCallable(_value_) is *false*, then


### PR DESCRIPTION
Although JSON supports `-0` per ECMA-404 and `JSON.parse('-0')` returns `-0`, `JSON.stringify(-0)` currently loses the sign, outputting just `'0'`.

This patch makes `JSON.stringify(-0)` return `'-0'` instead, so that the following holds:

```js
Object.is(JSON.parse('-0'), -0);
// → true (this is already the case, even without this patch)
JSON.stringify(-0);
// → '-0'
Object.is(JSON.parse(JSON.stringify(-0)), -0);
// → true
```

Results in current JavaScript engines:

```
$ eshost -se 'Object.is(JSON.parse("-0"), -0)'
#### Chakra, JavaScriptCore, SpiderMonkey, V8, V8 --harmony
true

#### XS
false

$ eshost -se 'JSON.stringify(-0)'
#### Chakra, JavaScriptCore, SpiderMonkey, V8, V8 --harmony, XS
0

$ eshost -se 'Object.is(JSON.parse(JSON.stringify(-0)), -0)'
#### Chakra
true

#### JavaScriptCore, SpiderMonkey, V8, V8 --harmony, XS
false
```