### PR TITLE
Editorial: Handle abrupt completion in AsyncFromSyncIteratorContinuation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36983,7 +36983,8 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_done_, _promiseCapability_).
           1. Let _value_ be IteratorValue(_result_).
           1. IfAbruptRejectPromise(_value_, _promiseCapability_).
-          1. Let _valueWrapper_ be ? PromiseResolve(%Promise%, &laquo; _value_ &raquo;).
+          1. Let _valueWrapper_ be PromiseResolve(%Promise%, &laquo; _value_ &raquo;).
+          1. IfAbruptRejectPromise(_valueWrapper_, _promiseCapability_).
           1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
           1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, &laquo; [[Done]] &raquo;).
           1. Set _onFulfilled_.[[Done]] to _done_.


### PR DESCRIPTION
As agreed in the referenced issue, made sure `AsyncFromSyncIteratorContinuation` keeps its contract to return rejected promise on abrupt completion.

Fixes #1461.