### PR TITLE
Normative: CreateDynamicFunction early concatenates bodyText

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25776,7 +25776,7 @@
                 1. Set _P_ to the string-concatenation of the previous value of _P_, *","* (a comma), and _nextArgString_.
                 1. Set _k_ to _k_ + 1.
               1. Let _bodyText_ be _args_[_k_].
-            1. Set _bodyText_ to ? ToString(_bodyText_).
+            1. Set _bodyText_ to be the string-concatenation of 0x000A (LINE FEED), ? ToString(_bodyText_), and 0x000A (LINE FEED).
             1. Perform the following substeps in an implementation-dependent order, possibly interleaving parsing and error detection:
               1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
               1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
@@ -25809,7 +25809,7 @@
             1. NOTE: Async functions are not constructable and do not have a [[Construct]] internal method or a *"prototype"* property.
             1. Perform SetFunctionName(_F_, *"anonymous"*).
             1. Let _prefix_ be the prefix associated with _kind_ in <emu-xref href="#table-dynamic-function-sourcetext-prefixes"></emu-xref>.
-            1. Let _sourceText_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, 0x000A (LINE FEED), _bodyText_, 0x000A (LINE FEED), and *"}"*.
+            1. Let _sourceText_ be the string-concatenation of _prefix_, `" anonymous("`, _P_, 0x000A (LINE FEED), `") {"`, _bodyText_, and `"}"`.
             1. Set _F_.[[SourceText]] to _sourceText_.
             1. Return _F_.
           </emu-alg>


### PR DESCRIPTION
Ref tc39/test262#2102
Ref tc39/test262#2109

This normative change matches the current behavior of V8, SpiderMonkey, and JSC (e.g. `Function("-->")`. This is not only for the convenience of reflecting the observed behaviors, ~~but this will allow some guard for potential false positives like `Function("#!hashbang")`~~.

