### PR TITLE
Editorial: Consistently represent JavaScript code

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -460,7 +460,7 @@
       <p>New Parse Nodes are instantiated for each invocation of the parser and never reused between parses even of identical source text. Parse Nodes are considered <dfn>the same Parse Node</dfn> if and only if they represent the same span of source text, are instances of the same grammar symbol, and resulted from the same parser invocation.</p>
       <emu-note>
         <p>Parsing the same String multiple times will lead to different Parse Nodes, e.g., as occurs in:</p>
-        <pre><code language="javascript">eval(str); eval(str);</code></pre>
+        <pre><code class="javascript">eval(str); eval(str);</code></pre>
       </emu-note>
       <emu-note>Parse Nodes are specification artefacts, and implementations are not required to use an analogous data structure.</emu-note>
       <p>Productions of the syntactic grammar are distinguished by having just one colon &ldquo;<b>:</b>&rdquo; as punctuation.</p>
@@ -5190,7 +5190,7 @@
           </emu-alg>
           <emu-note>
             <p>An example of ECMAScript code that results in a missing binding at step 2 is:</p>
-            <pre><code language="javascript">function f(){eval("var x; x = (delete x, 0);")}</code></pre>
+            <pre><code class="javascript">function f(){eval("var x; x = (delete x, 0);")}</code></pre>
           </emu-note>
         </emu-clause>
 


### PR DESCRIPTION
There are currently 50 occurrences of `<code class="javascript">` and 2 occurrences of
`<code language="javascript">`. This changes the minority to match the majority.