### PR TITLE
Editorial: Don't read the [[Status]] of non-cyclic modules

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21758,11 +21758,11 @@
               1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
                 1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
                 1. Set _index_ to ? InnerModuleInstantiation(_requiredModule_, _stack_, _index_).
-                1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
-                1. Assert: _requiredModule_.[[Status]] is `"instantiating"` if and only if _requiredModule_ is in _stack_.
-                1. If _requiredModule_.[[Status]] is `"instantiating"`, then
-                  1. Assert: _requiredModule_ is a Cyclic Module Record.
-                  1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+                1. If _requiredModule_ is a Cyclic Module Record, then
+                  1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
+                  1. Assert: _requiredModule_.[[Status]] is `"instantiating"` if and only if _requiredModule_ is in _stack_.
+                  1. If _requiredModule_.[[Status]] is `"instantiating"`, then
+                    1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? _module_.InitializeEnvironment().
               1. Assert: _module_ occurs exactly once in _stack_.
               1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
@@ -21771,6 +21771,7 @@
                 1. Repeat, while _done_ is *false*,
                   1. Let _requiredModule_ be the last element in _stack_.
                   1. Remove the last element of _stack_.
+                  1. Assert: _requiredModule_ is a Cyclic Module Record.
                   1. Set _requiredModule_.[[Status]] to `"instantiated"`.
                   1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
               1. Return _index_.
@@ -21795,6 +21796,7 @@
             1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion, then
               1. For each module _m_ in _stack_, do
+                1. Assert: _m_ is a Cyclic Module Record.
                 1. Assert: _m_.[[Status]] is `"evaluating"`.
                 1. Set _m_.[[Status]] to `"evaluated"`.
                 1. Set _m_.[[EvaluationError]] to _result_.
@@ -21830,11 +21832,11 @@
                 1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
                 1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
-                1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
-                1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
-                1. If _requiredModule_.[[Status]] is `"evaluating"`, then
-                  1. Assert: _requiredModule_ is a Cyclic Module Record.
-                  1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+                1. If _requiredModule_ is a Cyclic Module Record,
+                  1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
+                  1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
+                  1. If _requiredModule_.[[Status]] is `"evaluating"`, then
+                    1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? _module_.ExecuteModule().
               1. Assert: _module_ occurs exactly once in _stack_.
               1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
@@ -21843,6 +21845,7 @@
                 1. Repeat, while _done_ is *false*,
                   1. Let _requiredModule_ be the last element in _stack_.
                   1. Remove the last element of _stack_.
+                  1. Assert: _requiredModule_ is a Cyclic Module Record.
                   1. Set _requiredModule_.[[Status]] to `"evaluated"`.
                   1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
               1. Return _index_.

--- a/spec.html
+++ b/spec.html
@@ -22580,7 +22580,7 @@
 
         <emu-alg>
           1. Assert: _module_ is an instance of a concrete subclass of Module Record.
-          1. Assert: _module_.[[Status]] is not `"uninstantiated"`.
+          1. Assert: If _module_ is a Cyclic Module Record, then _module_.[[Status]] is not `"uninstantiated"`.
           1. Let _namespace_ be _module_.[[Namespace]].
           1. If _namespace_ is *undefined*, then
             1. Let _exportedNames_ be ? _module_.GetExportedNames().


### PR DESCRIPTION
[[Status]] is a field of Cyclic Module Records; Abstract Module Records
don't keep track of it.

This patch avoids checking the [[Status]] of modules that don't have one,
instead first checking whether the module is cyclic. All of the use
cases seemed to be when modules were in dependency chains and not leaves.

Given the proposed Synthetic Module Records
https://github.com/tc39/proposal-javascript-standard-library/pull/44
and their possible usage in JSON modules, CSS modules, and WebIDL
modules, it makes sense to avoid these code paths for those cases.

Fixes #1455 

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
