### PR TITLE
Layering: Add GetRequestedModules() to Module Record

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21709,7 +21709,7 @@
                   GetRequestedModules()
                 </td>
                 <td>
-                  Returns a List of Module Records constituting the modules imported from this module.  The List is source code occurrence ordered.
+                  Returns a List of Module Records constituting the modules imported from this module. The List is source code occurrence ordered.
                 </td>
               </tr>
             </tbody>
@@ -21762,8 +21762,8 @@
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Increase _index_ by 1.
               1. Append _module_ to _stack_.
-              1. Let _requiredModules_ be _module_.GetRequestedModules()
-              1. For each module _requiredModule_ that is an element of _requiredModules_, do
+              1. Let _requiredModules_ be _module_.GetRequestedModules().
+              1. For each element _requiredModule_ of _requiredModules_ in List order, do
                 1. Set _index_ to ? InnerModuleInstantiation(_requiredModule_, _stack_, _index_).
                 1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is `"instantiating"` if and only if _requiredModule_ is in _stack_.
@@ -21834,7 +21834,7 @@
               1. Increase _index_ by 1.
               1. Append _module_ to _stack_.
               1. Let _requiredModules_ be _module_.GetRequestedModules().
-              1. For each module _requiredModule_ that is an element of _requiredModules_, do
+              1. For each element _requiredModule_ of _requiredModules_ in List order, do
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
                 1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
@@ -22551,22 +22551,23 @@
           </emu-alg>
         </emu-clause>
 
-      <emu-clause id="sec-source-text-module-record-get-requested-modules" aoid="GetRequestedModules">
-        <h1>GetRequestedModules ( ) Concrete Method</h1>
+        <emu-clause id="sec-source-text-module-record-get-requested-modules" aoid="GetRequestedModules">
+          <h1>GetRequestedModules ( ) Concrete Method</h1>
 
-        <p>The GetRequestedModules concrete method of a Source Text Module Record implements the corresponding Cyclic Module Record abstract method.</p>
+          <p>The GetRequestedModules concrete method of a Source Text Module Record implements the corresponding Cyclic Module Record abstract method.</p>
 
-        <p>This abstract method performs the following steps:</p>
+          <p>This abstract method performs the following steps:</p>
 
-        <emu-alg>
-          1. Let _module_ be this Source Text Module Record.
-          1. Let _requestedModules_ be an empty List of Abstract Module Records.
-          1. For each String _requested_ that is an element of _module_.[[RequestedModules]], do
-            1. Let _requestedModule_ be ! HostResolveImportedModule(_module_, _requested_).
-            1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-            1. Append _requestedModule_ to _requestedModules_.
-          1. Return _requestedModules_.
-        </emu-alg>
+          <emu-alg>
+            1. Let _module_ be this Source Text Module Record.
+            1. Let _requestedModules_ be an empty List of Abstract Module Records.
+            1. For each String _requested_ that is an element of _module_.[[RequestedModules]], do
+              1. Let _requestedModule_ be ! HostResolveImportedModule(_module_, _requested_).
+              1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+              1. Append _requestedModule_ to _requestedModules_.
+            1. Return _requestedModules_.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-hostresolveimportedmodule" aoid="HostResolveImportedModule">

--- a/spec.html
+++ b/spec.html
@@ -22562,8 +22562,7 @@
             1. Let _module_ be this Source Text Module Record.
             1. Let _requestedModules_ be an empty List of Abstract Module Records.
             1. For each String _requested_ that is an element of _module_.[[RequestedModules]], do
-              1. Let _requestedModule_ be ! HostResolveImportedModule(_module_, _requested_).
-              1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+              1. Let _requestedModule_ be ? HostResolveImportedModule(_module_, _requested_).
               1. Append _requestedModule_ to _requestedModules_.
             1. Return _requestedModules_.
           </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -21704,6 +21704,14 @@
                   Initialize the execution context of the module and evaluate the module's code within it.
                 </td>
               </tr>
+              <tr>
+                <td>
+                  GetRequestedModules()
+                </td>
+                <td>
+                  Returns a List of Module Records constituting the modules imported from this module.  The List is source code occurrence ordered.
+                </td>
+              </tr>
             </tbody>
           </table>
         </emu-table>
@@ -21754,8 +21762,8 @@
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Increase _index_ by 1.
               1. Append _module_ to _stack_.
-              1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
-                1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
+              1. Let _requiredModules_ be _module_.GetRequestedModules()
+              1. For each module _requiredModule_ that is an element of _requiredModules_, do
                 1. Set _index_ to ? InnerModuleInstantiation(_requiredModule_, _stack_, _index_).
                 1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is `"instantiating"` if and only if _requiredModule_ is in _stack_.
@@ -21825,9 +21833,8 @@
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Increase _index_ by 1.
               1. Append _module_ to _stack_.
-              1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
-                1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-                1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+              1. Let _requiredModules_ be _module_.GetRequestedModules().
+              1. For each module _requiredModule_ that is an element of _requiredModules_, do
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
                 1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
                 1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
@@ -22543,6 +22550,23 @@
             1. Return Completion(_result_).
           </emu-alg>
         </emu-clause>
+
+      <emu-clause id="sec-source-text-module-record-get-requested-modules" aoid="GetRequestedModules">
+        <h1>GetRequestedModules ( ) Concrete Method</h1>
+
+        <p>The GetRequestedModules concrete method of a Source Text Module Record implements the corresponding Cyclic Module Record abstract method.</p>
+
+        <p>This abstract method performs the following steps:</p>
+
+        <emu-alg>
+          1. Let _module_ be this Source Text Module Record.
+          1. Let _requestedModules_ be an empty List of Abstract Module Records.
+          1. For each String _requested_ that is an element of _module_.[[RequestedModules]], do
+            1. Let _requestedModule_ be ! HostResolveImportedModule(_module_, _requested_).
+            1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+            1. Append _requestedModule_ to _requestedModules_.
+          1. Return _requestedModules_.
+        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-hostresolveimportedmodule" aoid="HostResolveImportedModule">

--- a/spec.html
+++ b/spec.html
@@ -21662,17 +21662,6 @@
                   Auxiliary field used during Instantiate and Evaluate only. If [[Status]] is `"instantiating"` or `"evaluating"`, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
                 </td>
               </tr>
-              <tr>
-                <td>
-                  [[RequestedModules]]
-                </td>
-                <td>
-                  List of String
-                </td>
-                <td>
-                  A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
-                </td>
-              </tr>
             </tbody>
           </table>
         </emu-table>
@@ -21930,6 +21919,17 @@
               </td>
               <td>
                 The result of parsing the source text of this module using |Module| as the goal symbol.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[RequestedModules]]
+              </td>
+              <td>
+                List of String
+              </td>
+              <td>
+                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Add the GetRequestedModules() abstract method to Abstract Module Record, with a corresponding implementation for Source Text Module Record.  Move Cyclic Module Record's [[RequestedModules]] down to Source Text Module Record, as it is now used directly only by STMR, and its presence on Cyclic MR causes problems for derived module types like HTML Module Record that don't necessarily have strings associated with all their child modules.

The purpose of GetRequestedModules() is to abstract out from InnerModuleInstantiation/InnerModuleEvaluation the details of how a Module Record type stores its requested modules, since these are different for HTML Module Records as implemented [here](https://github.com/whatwg/html/pull/4505).

It is not time yet to merge this in given that there are still open questions about the HTML Modules design (mostly tracked over in the [w3c/webcomponents repo](https://github.com/w3c/webcomponents/labels/modules)).  The intent here is to facilitate discussion and tease out issues that can be better found when making changes against the actual spec, with the intention of eventually merging in the updated PR once consensus has been reached on all open issues.  

I've placed the built result of this change here: https://dandclark.github.io/built-specs/ecma262/get-requested-modules.html
