### PR TITLE
Normative: `eval(nonString)` should not have observable side effects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12569,13 +12569,12 @@
               1. Let _evalText_ be the first element of _argList_.
               1. If the source code matching this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
               1. Let _evalRealm_ be the current Realm Record.
-              1. Perform ? HostEnsureCanCompileStrings(_evalRealm_, _evalRealm_).
               1. Return ? PerformEval(_evalText_, _evalRealm_, _strictCaller_, *true*).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_func_, _ref_, _arguments_, _tailCall_).
         </emu-alg>
-        <p>A |CallExpression| evaluation that executes step 6.a.vii is a <dfn>direct eval</dfn>.</p>
+        <p>A |CallExpression| evaluation that executes step 6.a.vi is a <dfn>direct eval</dfn>.</p>
         <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |CallExpression|.
@@ -23417,17 +23416,17 @@
         1. Assert: The execution context stack has at least two elements.
         1. Let _callerContext_ be the second to top element of the execution context stack.
         1. Let _callerRealm_ be _callerContext_'s Realm.
-        1. Let _calleeRealm_ be the current Realm Record.
-        1. Perform ? HostEnsureCanCompileStrings(_callerRealm_, _calleeRealm_).
-        1. Return ? PerformEval(_x_, _calleeRealm_, *false*, *false*).
+        1. Return ? PerformEval(_x_, _callerRealm_, *false*, *false*).
       </emu-alg>
 
       <emu-clause id="sec-performeval" aoid="PerformEval">
-        <h1>Runtime Semantics: PerformEval ( _x_, _evalRealm_, _strictCaller_, _direct_ )</h1>
-        <p>The abstract operation PerformEval with arguments _x_, _evalRealm_, _strictCaller_, and _direct_ performs the following steps:</p>
+        <h1>Runtime Semantics: PerformEval ( _x_, _callerRealm_, _strictCaller_, _direct_ )</h1>
+        <p>The abstract operation PerformEval with arguments _x_, _callerRealm_, _strictCaller_, and _direct_ performs the following steps:</p>
         <emu-alg>
           1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
           1. If Type(_x_) is not String, return _x_.
+          1. Let _evalRealm_ be the current Realm Record.
+          1. Perform ? HostEnsureCanCompileStrings(_callerRealm_, _evalRealm_).
           1. Let _thisEnvRec_ be ! GetThisEnvironment().
           1. If _thisEnvRec_ is a function Environment Record, then
             1. Let _F_ be _thisEnvRec_.[[FunctionObject]].


### PR DESCRIPTION
Fixes #1495
which identifies the ordering of host callouts and input
type checks as a spec bug.

This uses option 1 from
https://github.com/tc39/ecma262/issues/1495#issuecomment-478626560
to ensure that type checks happen before host callouts.

This can't be tested in test262 but if this lands, I will follow up
with tests via web-platform-tests/wpt.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
