### PR TITLE
Normative: fix axiomatic model to be SC-DRF, and allow ARMv8 compilation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39418,6 +39418,10 @@ THH:mm:ss.sss
       </emu-note>
 
       <emu-note>
+        <p>`"Init"` events do not participate in synchronizes-with, and are instead constrained directly by happens-before.</p>
+      </emu-note>
+
+      <emu-note>
         <p>Not all `"SeqCst"` events related by reads-from are related by synchronizes-with. Only events that also have equal ranges are related by synchronizes-with.</p>
       </emu-note>
 

--- a/spec.html
+++ b/spec.html
@@ -39511,7 +39511,12 @@ THH:mm:ss.sss
       <ul>
         <li>For each pair (_E_, _D_) in _execution_.[[HappensBefore]], (_E_, _D_) is in memory-order.</li>
         <li>
-          <p>For each pair (_E_, _D_) in _execution_.[[SynchronizesWith]], (_E_, _D_) is in memory-order if there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _W_ in SharedDataBlockEventSet(_execution_) with equal range as _D_ such that _W_ is not _E_, and the pairs (_E_, _W_) and (_W_, _D_) are in memory-order.</p>
+          <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ in SharedDataBlockEventSet(_execution_) such that the pairs (_W_, _V_) and (_V_, _R_) are in memory-order, and any of the following conditions are true.</p>
+          <ul>
+            <li>The pair (_W_, _R_) is in _execution_.[[SynchronizesWith]], and _V_ and _R_ have equal ranges.</li>
+            <li>The pairs (_W_, _R_) and (_V_, _R_) are in _execution_.[[HappensBefore]], _W_.[[Order]] is `"SeqCst"`, and _W_ and _V_ have equal ranges.</li>
+            <li>The pairs (_W_, _R_) and (_W_, _V_) are in _execution_.[[HappensBefore]], _R_.[[Order]] is `"SeqCst"`, and _V_ and _R_ have equal ranges.</li>
+          </ul>
           <emu-note>
             <p>This clause additionally constrains `"SeqCst"` events on equal ranges.</p>
           </emu-note>

--- a/spec.html
+++ b/spec.html
@@ -39511,7 +39511,7 @@ THH:mm:ss.sss
       <ul>
         <li>For each pair (_E_, _D_) in _execution_.[[HappensBefore]], (_E_, _D_) is in memory-order.</li>
         <li>
-          <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ in SharedDataBlockEventSet(_execution_) such that the pairs (_W_, _V_) and (_V_, _R_) are in memory-order, and any of the following conditions are true.</p>
+          <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ in SharedDataBlockEventSet(_execution_) such that _V_.[[Order]] is `"SeqCst"`, the pairs (_W_, _V_) and (_V_, _R_) are in memory-order, and any of the following conditions are true.</p>
           <ul>
             <li>The pair (_W_, _R_) is in _execution_.[[SynchronizesWith]], and _V_ and _R_ have equal ranges.</li>
             <li>The pairs (_W_, _R_) and (_V_, _R_) are in _execution_.[[HappensBefore]], _W_.[[Order]] is `"SeqCst"`, and _W_ and _V_ have equal ranges.</li>

--- a/spec.html
+++ b/spec.html
@@ -39402,13 +39402,7 @@ THH:mm:ss.sss
       <p>For a candidate execution _execution_, _execution_.[[SynchronizesWith]] is the least Relation on events that satisfies the following.</p>
       <ul>
         <li>
-          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if all the following are true.
-          <ul>
-            <li>_R_.[[Order]] is `"SeqCst"`.</li>
-            <li>_W_.[[Order]] is `"SeqCst"` or `"Init"`.</li>
-            <li>If _W_.[[Order]] is `"SeqCst"`, then _R_ and _W_ have equal ranges.</li>
-            <li>If _W_.[[Order]] is `"Init"`, then for each event _V_ such that (_R_, _V_) is in _execution_.[[ReadsFrom]], _V_.[[Order]] is `"Init"`.</li>
-          </ul>
+          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if _R_.[[Order]] is `"SeqCst"`, _W_.[[Order]] is `"SeqCst"`, and _R_ and _W_ have equal ranges.
         </li>
         <li>
           For each element _eventsRecord_ of _execution_.[[EventsRecords]], the following is true.


### PR DESCRIPTION
(PR submitted following co-ordination with @syg)

### Background

In the November TC39 meeting, [consensus was reached](http://tc39.github.io/tc39-notes/2018-11_nov-28.html#memory-model-bug-drf-sc-bug) to strengthen the axiomatic model to provide Sequential Consistency of Data-Race-Free Programs (SC-DRF). This property was [always intended to be provided by the model](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-data-race-freedom) (but see https://github.com/tc39/ecma262/issues/1354 for a counter-example).

A PR to amend the model was drafted (https://github.com/tc39/ecma262/pull/1362), but I asked for a [delay in landing it](https://github.com/tc39/ecma262/pull/1362#issuecomment-443306833) after @stedolan noticed that the JS model (independent of our fix) appeared to be too strong to allow compilation of SC atomics to ARMv8 lda/stl instructions. We've confirmed that this compilation scheme is used "in the wild" in Chrome ([introducing commit](https://codereview.chromium.org/2760963002)), and the violation can be observed experimentally in multi-threaded WebAssembly programs running end-to-end in Chrome on ARMv8 machines. Other engines are also discussing/in the process of implementing this compilation scheme.

In the January TC39 meeting, [consensus was reached](http://tc39.github.io/tc39-notes/2019-01_jan-30.html#amending-the-memory-model-to-support-armv8-ldastl-codegen) to amend the axiomatic model to support compilation from JS SC atomics to ARMv8 lda/stl instructions. To be clear, this makes the model _weaker_ than before, since it previously provided a guarantee on interleaving (racy) non-atomics with SC atomics that ARMv8 does not (see [slides](https://docs.google.com/presentation/d/1qif7z-Y8C-nvJM20UNJQzAKJgLN4wmXS_5NN2Wgipb4/) for a counter-example).

### This PR

This PR incorporates both fixes as normative changes, based on previously proposed wording by @syg for the SC-DRF fix (https://github.com/tc39/ecma262/pull/1362). The fixes are split imprecisely between two commits so the change that weakens the model for the ARMv8 fix can be seen in isolation. That being said, both commits should be taken as a package.

Note that the SC-DRF fix has changed slightly from the precise formulation of the original PR, but the "weak fix" philosophy remains the same. In fact, the new version is a slightly weaker strengthening (I shouldn't have called the previous version "weakest"), and makes one of the SC-DRF conditions more closely mirror an analogous condition in the C++ model.

In support of our changes, we have some proof work/verification that I'd be happy to talk about in more detail over email, including a Coq proof done by @anlun. These proofs don't handle every feature of the memory model (really every proof in this field has a caveat attached), but we've verified at least that the previous model was incorrect, and the revised model isn't incorrect in the same way.

We also observed that one of the SC-DRF additions makes a clause about synchronizing **init** events redundant, and therefore include a separate editorial change to remove it. **init** events were originally included in _synchronizes-with_ so that the following shape is not permitted, where R_sc _reads-from_ W_init and W_sc and R_sc have equal ranges

- W_init _memory-order_ W_sc
- W_sc _memory-order_ R_sc

However, it is guaranteed that W_init _happens-before_ W_sc and W_init _happens-before_ R_sc, and our SC-DRF fix disallows exactly this shape anyway. The third bullet disallows the following shape (for all consistencies of W), where R_sc _reads-from_ W and W_sc and R_sc have equal ranges

- W _happens-before_ W_sc
- W _happens-before_ R_sc
- W_sc _memory-order_ R_sc