### PR TITLE
Editorial: replace `lookahead ∉ { ele }` with `lookahead ≠ ele`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15967,10 +15967,10 @@
       IterationStatement[Yield, Await, Return] :
         `do` Statement[?Yield, ?Await, ?Return] `while` `(` Expression[+In, ?Yield, ?Await] `)` `;`
         `while` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` [lookahead &lt;! {`let` `[`}] Expression[~In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
+        `for` `(` [lookahead != `let` `[`] Expression[~In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` `var` VariableDeclarationList[~In, ?Yield, ?Await] `;` Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` LexicalDeclaration[~In, ?Yield, ?Await] Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` [lookahead &lt;! {`let` `[`}] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+        `for` `(` [lookahead != `let` `[`] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` [lookahead != `let` ] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -29343,7 +29343,7 @@ THH:mm:ss.sss
           `_`
 
         CharacterClass[U] ::
-          `[` [lookahead &lt;! {`^`}] ClassRanges[?U] `]`
+          `[` [lookahead != `^`] ClassRanges[?U] `]`
           `[` `^` ClassRanges[?U] `]`
 
         ClassRanges[U] ::


### PR DESCRIPTION
This is explicitly permitted, and I think clearer. Mostly because I just misread the right-hand side of `lookahead ∉ { let [ }` as a two-element set.