### PR TITLE
Normative: Add new BigInt primitive

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1110,30 +1110,898 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-ecmascript-language-types-number-type">
-      <h1>The Number Type</h1>
-      <p>The Number type has exactly 18437736874454810627<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> + 3<sub>ℝ</sub></emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2008 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+    <emu-clause id="sec-numeric-types">
+      <h1>Numeric Types</h1>
+      <p>ECMAScript has two built-in numeric types: Number and BigInt. In this specification, every numeric type _T_ contains a multiplicative identity value denoted _T_::unit. The specification types also have the following abstract operations, likewise denoted _T_::<i>op</i> for a given operation with specification name <i>op</i>. All argument types are _T_. The "Result" column shows the return type, along with an indication if it is possible for some invocations of the operation to return an abrupt completion.</p>
+      <emu-table id="table-numeric-type-ops" caption="Numeric Type Operations">
+        <table>
+          <tbody>
+          <tr>
+            <th>
+              Invocation Synopsis
+            </th>
+            <th>
+              Example source
+            </th>
+            <th>
+              Invoked by the Evaluation semantics of ...
+            </th>
+            <th>
+              Result
+            </th>
+          </tr>
+          <tr>
+            <td>
+              _T_::unaryMinus(x)
+            </td>
+            <td>
+              `-x`
+            </td>
+            <td>
+              <emu-xref href="#sec-unary-minus-operator" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::bitwiseNOT(x)
+            </td>
+            <td>
+              `~x`
+            </td>
+            <td>
+              <emu-xref href="#sec-bitwise-not-operator" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::exponentiate(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;**&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-exp-operator" title></emu-xref>
+              and <emu-xref href="#sec-math.pow" title></emu-xref>
+            </td>
+            <td>
+              _T_, may throw *RangeError*
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::multiply(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;*&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-multiplicative-operators" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::divide(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;/&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-multiplicative-operators" title></emu-xref>
+            </td>
+            <td>
+              _T_, may throw *RangeError*
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::remainder(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;%&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-multiplicative-operators" title></emu-xref>
+            </td>
+            <td>
+              _T_, may throw *RangeError*
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::add(x,&nbsp;y)
+            </td>
+            <td>
+              `x ++`<br>`++ x`<br>`x&nbsp;+&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-postfix-increment-operator" title></emu-xref>,
+              <emu-xref href="#sec-prefix-increment-operator" title></emu-xref>,
+              and <emu-xref href="#sec-addition-operator-plus" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::subtract(x,&nbsp;y)
+            </td>
+            <td>
+              `x --`<br>`-- x`<br>`x&nbsp;-&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-postfix-decrement-operator" title></emu-xref>,
+              <emu-xref href="#sec-prefix-decrement-operator" title></emu-xref>,
+              and <emu-xref href="#sec-subtraction-operator-minus" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::leftShift(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;&lt;&lt;&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-left-shift-operator" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::signedRightShift(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;>>&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-signed-right-shift-operator" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::unsignedRightShift(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;>>>&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-unsigned-right-shift-operator" title></emu-xref>
+            </td>
+            <td>
+              _T_, may throw *TypeError*
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::lessThan(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;&lt;&nbsp;y`<br>`x&nbsp;>&nbsp;y`<br>`x&nbsp;&lt;=&nbsp;y`<br>`x&nbsp;>=&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-relational-operators" title></emu-xref>,
+              via <emu-xref href="#sec-abstract-relational-comparison" title></emu-xref>
+            </td>
+            <td>
+              Boolean or *undefined* (for unordered inputs)
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::equal(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;==&nbsp;y`<br>`x&nbsp;!=&nbsp;y`<br>`x&nbsp;===&nbsp;y`<br>`x&nbsp;!==&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-equality-operators" title></emu-xref>,
+              via <emu-xref href="#sec-strict-equality-comparison" title></emu-xref>
+            </td>
+            <td>
+              Boolean
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::sameValue(x,&nbsp;y)
+            </td>
+            <td>
+            </td>
+            <td>
+              Object internal methods,
+              via <emu-xref href="#sec-samevalue" title></emu-xref>,
+              to test exact value equality
+            </td>
+            <td>
+              Boolean
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::sameValueZero(x,&nbsp;y)
+            </td>
+            <td>
+            </td>
+            <td>
+              Array, Map, and Set methods,
+              via <emu-xref href="#sec-samevaluezero" title></emu-xref>,
+              to test value equality ignoring differences among members of the zero cohort (e.g., *-0* and *+0*)
+            </td>
+            <td>
+              Boolean
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::bitwiseAND(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;&amp;&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-binary-bitwise-operators" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::bitwiseXOR(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;^&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-binary-bitwise-operators" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::bitwiseOR(x,&nbsp;y)
+            </td>
+            <td>
+              `x&nbsp;|&nbsp;y`
+            </td>
+            <td>
+              <emu-xref href="#sec-binary-bitwise-operators" title></emu-xref>
+            </td>
+            <td>
+              _T_
+            </td>
+          </tr>
+          <tr>
+            <td>
+              _T_::toString(x)
+            </td>
+            <td>
+              `String(x)`
+            </td>
+            <td>
+              Many expressions and built-in functions, via <emu-xref href="#sec-tostring" title></emu-xref>
+            </td>
+            <td>
+              String
+            </td>
+
+          </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <p>The _T_::unit value and _T_::_op_ operations are not a part of the ECMAScript language; they are defined here solely to aid the specification of the semantics of the ECMAScript language. Other abstract operations are defined throughout this specification.</p>
+      <p>Because the numeric types are in general not convertible without loss of precision or truncation, the ECMAScript language provides no implicit conversion among these types. Programmers must explicitly call `Number` and `BigInt` functions to convert among types when calling a function which requires another type.</p>
       <emu-note>
-        <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
+        <p>The first and subsequent editions of ECMAScript have provided, for certain operators, implicit numeric conversions that could lose precision or truncate. These legacy implicit conversions are maintained for backward compatibility, but not provided for BigInt in order to minimize opportunity for programmer error, and to leave open the option of generalized <em>value types</em> in a future edition.</p>
       </emu-note>
-      <p>There are two other special values, called *positive Infinity* and *negative Infinity*. For brevity, these values are also referred to for expository purposes by the symbols *+&infin;* and *-&infin;*, respectively. (Note that these two infinite Number values are produced by the program expressions `+Infinity` (or simply `Infinity`) and `-Infinity`.)</p>
-      <p>The other 18437736874454810624<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
-      <p>Note that there is both a *positive zero* and a *negative zero*. For brevity, these values are also referred to for expository purposes by the symbols *+0* and *-0*, respectively. (Note that these two different zero Number values are produced by the program expressions `+0` (or simply `0`) and `-0`.)</p>
-      <p>The 18437736874454810622<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) finite nonzero values are of two kinds:</p>
-      <p>18428729675200069632<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>54<sub>ℝ</sub></sup></emu-eqn>) of them are normalized, having the form</p>
-      <div class="math-display">
-        _s_ &times; _m_ &times; 2<sup>_e_</sup>
-      </div>
-      <p>where _s_ is +1<sub>ℝ</sub> or -1<sub>ℝ</sub>, _m_ is a positive mathematical integer less than 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> but not less than 2<sub>ℝ</sub><sup>52<sub>ℝ</sub></sup>, and _e_ is a mathematical integer ranging from -1074<sub>ℝ</sub> to 971<sub>ℝ</sub>, inclusive.</p>
-      <p>The remaining 9007199254740990<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) values are denormalized, having the form</p>
-      <div class="math-display">
-        _s_ &times; _m_ &times; 2<sup>_e_</sup>
-      </div>
-      <p>where _s_ is +1<sub>ℝ</sub> or -1<sub>ℝ</sub>, _m_ is a positive mathematical integer less than 2<sub>ℝ</sub><sup>52<sub>ℝ</sub></sup>, and _e_ is -1074<sub>ℝ</sub>.</p>
-      <p>Note that all the positive and negative mathematical integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the mathematical integer 0 has two representations, *+0* and *-0*).</p>
-      <p>A finite number has an <em>odd significand</em> if it is nonzero and the mathematical integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
-      <p>In this specification, the phrase &ldquo;the <dfn id="number-value">Number value</dfn> for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> (which is <emu-eqn>+1<sub>ℝ</sub> &times; 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> &times; 2<sub>ℝ</sub><sup>971<sub>ℝ</sub></sup></emu-eqn>) and <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> (which is <emu-eqn>-1<sub>ℝ</sub> &times; 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> &times; 2<sub>ℝ</sub><sup>971<sub>ℝ</sub></sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> and <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> are considered to have even significands. Finally, if 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 roundTiesToEven mode.)</p>
-      <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
+
+      <emu-clause id="sec-ecmascript-language-types-number-type">
+        <h1>The Number Type</h1>
+        <p>The Number type has exactly 18437736874454810627<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> + 3<sub>ℝ</sub></emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2008 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-dependent; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+        <emu-note>
+          <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
+        </emu-note>
+        <p>There are two other special values, called *positive Infinity* and *negative Infinity*. For brevity, these values are also referred to for expository purposes by the symbols *+&infin;* and *-&infin;*, respectively. (Note that these two infinite Number values are produced by the program expressions `+Infinity` (or simply `Infinity`) and `-Infinity`.)</p>
+        <p>The other 18437736874454810624<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
+        <p>Note that there is both a *positive zero* and a *negative zero*. For brevity, these values are also referred to for expository purposes by the symbols *+0* and *-0*, respectively. (Note that these two different zero Number values are produced by the program expressions `+0` (or simply `0`) and `-0`.)</p>
+        <p>The 18437736874454810622<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) finite nonzero values are of two kinds:</p>
+        <p>18428729675200069632<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>54<sub>ℝ</sub></sup></emu-eqn>) of them are normalized, having the form</p>
+        <div class="math-display">
+          _s_ &times; _m_ &times; 2<sup>_e_</sup>
+        </div>
+        <p>where _s_ is +1<sub>ℝ</sub> or -1<sub>ℝ</sub>, _m_ is a positive mathematical integer less than 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> but not less than 2<sub>ℝ</sub><sup>52<sub>ℝ</sub></sup>, and _e_ is a mathematical integer ranging from -1074<sub>ℝ</sub> to 971<sub>ℝ</sub>, inclusive.</p>
+        <p>The remaining 9007199254740990<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) values are denormalized, having the form</p>
+        <div class="math-display">
+          _s_ &times; _m_ &times; 2<sup>_e_</sup>
+        </div>
+        <p>where _s_ is +1<sub>ℝ</sub> or -1<sub>ℝ</sub>, _m_ is a positive mathematical integer less than 2<sub>ℝ</sub><sup>52<sub>ℝ</sub></sup>, and _e_ is -1074<sub>ℝ</sub>.</p>
+        <p>Note that all the positive and negative mathematical integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the mathematical integer 0 has two representations, *+0* and *-0*).</p>
+        <p>A finite number has an <em>odd significand</em> if it is nonzero and the mathematical integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
+        <p>In this specification, the phrase &ldquo;the <dfn id="number-value">Number value</dfn> for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> (which is <emu-eqn>+1<sub>ℝ</sub> &times; 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> &times; 2<sub>ℝ</sub><sup>971<sub>ℝ</sub></sup></emu-eqn>) and <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> (which is <emu-eqn>-1<sub>ℝ</sub> &times; 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> &times; 2<sub>ℝ</sub><sup>971<sub>ℝ</sub></sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> and <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> are considered to have even significands. Finally, if 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2008 roundTiesToEven mode.)</p>
+        <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
+
+        <p>The Number::unit value is *1*.</p>
+
+        <emu-clause id="sec-numeric-types-number-unaryMinus">
+          <h1>Number::unaryMinus ( _x_ )</h1>
+          <emu-alg>
+            1. If _x_ is *NaN*, return *NaN*.
+            1. Return the result of negating _x_; that is, compute a Number with the same magnitude but opposite sign.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-bitwiseNOT">
+          <h1>Number::bitwiseNOT ( _x_ )</h1>
+          <emu-alg>
+            1. Let _oldValue_ be ! ToInt32(_x_).
+            1. Return the result of applying bitwise complement to _oldValue_. The result is a signed 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-exponentiate" oldids="sec-applying-the-exp-operator">
+          <h1>Number::exponentiate ( _base_, _exponent_ )</h1>
+          <p>
+            Returns an implementation-dependent approximation of the result of raising _base_ to the power _exponent_.
+          </p>
+          <ul>
+            <li>If _exponent_ is *NaN*, the result is *NaN*.</li>
+            <li>If _exponent_ is *+0*, the result is 1, even if _base_ is *NaN*.</li>
+            <li>If _exponent_ is *-0*, the result is 1, even if _base_ is *NaN*.</li>
+            <li>If _base_ is *NaN* and _exponent_ is nonzero, the result is *NaN*.</li>
+            <li>If abs(_base_) &gt; 1 and _exponent_ is *+&infin;*, the result is *+&infin;*.</li>
+            <li>If abs(_base_) &gt; 1 and _exponent_ is *-&infin;*, the result is *+0*.</li>
+            <li>If abs(_base_) is 1 and _exponent_ is *+&infin;*, the result is *NaN*.</li>
+            <li>If abs(_base_) is 1 and _exponent_ is *-&infin;*, the result is *NaN*.</li>
+            <li>If abs(_base_) &lt; 1 and _exponent_ is *+&infin;*, the result is *+0*.</li>
+            <li>If abs(_base_) &lt; 1 and _exponent_ is *-&infin;*, the result is *+&infin;*.</li>
+            <li>If _base_ is *+&infin;* and _exponent_ &gt; 0, the result is *+&infin;*.</li>
+            <li>If _base_ is *+&infin;* and _exponent_ &lt; 0, the result is *+0*.</li>
+            <li>If _base_ is *-&infin;* and _exponent_ &gt; 0 and _exponent_ is an odd integer, the result is *-&infin;*.</li>
+            <li>If _base_ is *-&infin;* and _exponent_ &gt; 0 and _exponent_ is not an odd integer, the result is *+&infin;*.</li>
+            <li>If _base_ is *-&infin;* and _exponent_ &lt; 0 and _exponent_ is an odd integer, the result is *-0*.</li>
+            <li>If _base_ is *-&infin;* and _exponent_ &lt; 0 and _exponent_ is not an odd integer, the result is *+0*.</li>
+            <li>If _base_ is *+0* and _exponent_ &gt; 0, the result is *+0*.</li>
+            <li>If _base_ is *+0* and _exponent_ &lt; 0, the result is *+&infin;*.</li>
+            <li>If _base_ is *-0* and _exponent_ &gt; 0 and _exponent_ is an odd integer, the result is *-0*.</li>
+            <li>If _base_ is *-0* and _exponent_ &gt; 0 and _exponent_ is not an odd integer, the result is *+0*.</li>
+            <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is an odd integer, the result is *-&infin;*.</li>
+            <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is not an odd integer, the result is *+&infin;*.</li>
+            <li>If _base_ &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integer, the result is *NaN*.</li>
+          </ul>
+          <emu-note>
+            <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity* differs from IEEE 754-2008. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2008 specified *1*. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
+          </emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-multiply" oldids="sec-applying-the-mul-operator">
+          <h1>Number::multiply ( _x_, _y_ )</h1>
+          <p>The `*` |MultiplicativeOperator| performs multiplication, producing the product of _x_ and _y_. Multiplication is commutative. Multiplication is not always associative in ECMAScript, because of finite precision.</p>
+          <p>The result of a floating-point multiplication is governed by the rules of IEEE 754-2008 binary double-precision arithmetic:</p>
+          <ul>
+            <li>
+              If either operand is *NaN*, the result is *NaN*.
+            </li>
+            <li>
+              The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
+            </li>
+            <li>
+              Multiplication of an infinity by a zero results in *NaN*.
+            </li>
+            <li>
+              Multiplication of an infinity by an infinity results in an infinity. The sign is determined by the rule already stated above.
+            </li>
+            <li>
+              Multiplication of an infinity by a finite nonzero value results in a signed infinity. The sign is determined by the rule already stated above.
+            </li>
+            <li>
+              In the remaining cases, where neither an infinity nor *NaN* is involved, the product is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the result is then a zero of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
+            </li>
+          </ul>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-divide" oldids="sec-applying-the-div-operator">
+          <h1>Number::divide ( _x_, _y_ )</h1>
+          <p>The `/` |MultiplicativeOperator| performs division, producing the quotient of _x_ and _y_. _x_ is the dividend and _y_ is the divisor. ECMAScript does not perform integer division. The operands and result of all division operations are double-precision floating-point numbers. The result of division is determined by the specification of IEEE 754-2008 arithmetic:</p>
+          <ul>
+            <li>
+              If either operand is *NaN*, the result is *NaN*.
+            </li>
+            <li>
+              The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
+            </li>
+            <li>
+              Division of an infinity by an infinity results in *NaN*.
+            </li>
+            <li>
+              Division of an infinity by a zero results in an infinity. The sign is determined by the rule already stated above.
+            </li>
+            <li>
+              Division of an infinity by a nonzero finite value results in a signed infinity. The sign is determined by the rule already stated above.
+            </li>
+            <li>
+              Division of a finite value by an infinity results in zero. The sign is determined by the rule already stated above.
+            </li>
+            <li>
+              Division of a zero by a zero results in *NaN*; division of zero by any other finite value results in zero, with the sign determined by the rule already stated above.
+            </li>
+            <li>
+              Division of a nonzero finite value by a zero results in a signed infinity. The sign is determined by the rule already stated above.
+            </li>
+            <li>
+              In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the quotient is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows; the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the operation underflows and the result is a zero of the appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
+            </li>
+          </ul>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-remainder" oldids="sec-applying-the-mod-operator">
+          <h1>Number::remainder ( _n_, _d_ )</h1>
+          <p>The `%` |MultiplicativeOperator| yields the remainder of its operands from an implied division; _n_ is the dividend and _d_ is the divisor.</p>
+          <emu-note>
+            <p>In C and C++, the remainder operator accepts only integral operands; in ECMAScript, it also accepts floating-point operands.</p>
+          </emu-note>
+          <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2008. The IEEE 754-2008 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual integer remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java integer remainder operator; this may be compared with the C library function fmod.</p>
+          <p>The result of an ECMAScript floating-point remainder operation is determined by the rules of IEEE arithmetic:</p>
+          <ul>
+            <li>
+              If either operand is *NaN*, the result is *NaN*.
+            </li>
+            <li>
+              The sign of the result equals the sign of the dividend.
+            </li>
+            <li>
+              If the dividend is an infinity, or the divisor is a zero, or both, the result is *NaN*.
+            </li>
+            <li>
+              If the dividend is finite and the divisor is an infinity, the result equals the dividend.
+            </li>
+            <li>
+              If the dividend is a zero and the divisor is nonzero and finite, the result is the same as the dividend.
+            </li>
+            <li>
+              In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the floating-point remainder _r_ from a dividend _n_ and a divisor _d_ is defined by the mathematical relation _r_ = _n_ - (_d_ &times; _q_) where _q_ is an integer that is negative only if _n_/_d_ is negative and positive only if _n_/_d_ is positive, and whose magnitude is as large as possible without exceeding the magnitude of the true mathematical quotient of _n_ and _d_. _r_ is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode.
+            </li>
+          </ul>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-add" oldids="sec-applying-the-additive-operators-to-numbers">
+          <h1>Number::add ( _x_, _y_ )</h1>
+          <p>The `+` operator performs addition when applied to _x_ and _y_, producing the sum of the operands.</p>
+          <p>Addition is a commutative operation, but not always associative.</p>
+          <p>The result of an addition is determined using the rules of IEEE 754-2008 binary double-precision arithmetic:</p>
+          <ul>
+            <li>
+              If either operand is *NaN*, the result is *NaN*.
+            </li>
+            <li>
+              The sum of two infinities of opposite sign is *NaN*.
+            </li>
+            <li>
+              The sum of two infinities of the same sign is the infinity of that sign.
+            </li>
+            <li>
+              The sum of an infinity and a finite value is equal to the infinite operand.
+            </li>
+            <li>
+              The sum of two negative zeroes is *-0*. The sum of two positive zeroes, or of two zeroes of opposite sign, is *+0*.
+            </li>
+            <li>
+              The sum of a zero and a nonzero finite value is equal to the nonzero operand.
+            </li>
+            <li>
+              The sum of two nonzero finite values of the same magnitude and opposite sign is *+0*.
+            </li>
+            <li>
+              In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, and the operands have the same sign or have different magnitudes, the sum is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows and the result is then an infinity of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
+            </li>
+          </ul>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-subtract">
+          <h1>Number::subtract ( _x_, _y_ )</h1>
+          <p>The `-` operator performs subtraction when applied to two operands of numeric type, producing the difference of its operands; _x_ is the minuend and _y_ is the subtrahend. It is always the case that `x - y` produces the same result as `x + (-y)`.</p>
+          <p>The result of `-` operator is then _x_ + (-_y_).</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-leftShift">
+          <h1>Number::leftShift ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Let _lnum_ be ! ToInt32(_x_).
+            1. Let _rnum_ be ! ToUint32(_y_).
+            1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
+            1. Return the result of left shifting _lnum_ by _shiftCount_ bits. The result is a signed 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-signedRightShift">
+          <h1>Number::signedRightShift ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Let _lnum_ be ! ToInt32(_x_).
+            1. Let _rnum_ be ! ToUint32(_y_).
+            1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
+            1. Return the result of performing a sign-extending right shift of _lnum_ by _shiftCount_ bits. The most significant bit is propagated. The result is a signed 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-unsignedRightShift">
+          <h1>Number::unsignedRightShift ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Let _lnum_ be ! ToInt32(_x_).
+            1. Let _rnum_ be ! ToUint32(_y_).
+            1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
+            1. Return the result of performing a zero-filling right shift of _lnum_ by _shiftCount_ bits. Vacated bits are filled with zero. The result is an unsigned 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-lessThan">
+          <h1>Number::lessThan ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. If _x_ is *NaN*, return *undefined*.
+            1. If _y_ is *NaN*, return *undefined*.
+            1. If _x_ and _y_ are the same Number value, return *false*.
+            1. If _x_ is *+0* and _y_ is *-0*, return *false*.
+            1. If _x_ is *-0* and _y_ is *+0*, return *false*.
+            1. If _x_ is *+&infin;*, return *false*.
+            1. If _y_ is *+&infin;*, return *true*.
+            1. If _y_ is *-&infin;*, return *false*.
+            1. If _x_ is *-&infin;*, return *true*.
+            1. If the mathematical value of _x_ is less than the mathematical value of _y_&mdash;note that these mathematical values are both finite and not both zero&mdash;return *true*. Otherwise, return *false*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-equal">
+          <h1>Number::equal ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. If _x_ is *NaN*, return *false*.
+            1. If _y_ is *NaN*, return *false*.
+            1. If _x_ is the same Number value as _y_, return *true*.
+            1. If _x_ is *+0* and _y_ is *-0*, return *true*.
+            1. If _x_ is *-0* and _y_ is *+0*, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-sameValue">
+          <h1>Number::sameValue ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
+            1. If _x_ is *+0* and _y_ is *-0*, return *false*.
+            1. If _x_ is *-0* and _y_ is *+0*, return *false*.
+            1. If _x_ is the same Number value as _y_, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-sameValueZero">
+          <h1>Number::sameValueZero ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
+            1. If _x_ is *+0* and _y_ is *-0*, return *true*.
+            1. If _x_ is *-0* and _y_ is *+0*, return *true*.
+            1. If _x_ is the same Number value as _y_, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numberbitwiseop" aoid="NumberBitwiseOp">
+          <h1>NumberBitwiseOp ( _op_, _x_, _y_ )</h1>
+          <emu-alg>
+            1. Let _lnum_ be ! ToInt32(_x_).
+            1. Let _rnum_ be ! ToUint32(_y_).
+            1. Return the result of applying the bitwise operator _op_ to _lnum_ and _rnum_. The result is a signed 32-bit integer.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-bitwiseAND">
+          <h1>Number::bitwiseAND ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Return NumberBitwiseOp(`&amp;`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-bitwiseXOR">
+          <h1>Number::bitwiseXOR ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Return NumberBitwiseOp(`^`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-bitwiseOR">
+          <h1>Number::bitwiseOR ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Return NumberBitwiseOp(`|`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-number-tostring" aoid="Number::toString" oldids="sec-tostring-applied-to-the-number-type">
+          <h1>Number::toString ( _x_ )</h1>
+          <p>The abstract operation Number::toString converts a Number _x_ to String format as follows:</p>
+          <emu-alg>
+            1. If _x_ is *NaN*, return the String `"NaN"`.
+            1. If _x_ is *+0* or *-0*, return the String `"0"`.
+            1. If _x_ is less than zero, return the string-concatenation of `"-"` and ! Number::toString(-_x_).
+            1. If _x_ is *+&infin;*, return the String `"Infinity"`.
+            1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10<sub>ℝ</sub>, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
+            1. If _k_ &le; _n_ &le; 21, return the string-concatenation of:
+              * the code units of the _k_ digits of the decimal representation of _s_ (in order, with no leading zeroes)
+              * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
+            1. If 0 &lt; _n_ &le; 21, return the string-concatenation of:
+              * the code units of the most significant _n_ digits of the decimal representation of _s_
+              * the code unit 0x002E (FULL STOP)
+              * the code units of the remaining _k_ - _n_ digits of the decimal representation of _s_
+            1. If -6 &lt; _n_ &le; 0, return the string-concatenation of:
+              * the code unit 0x0030 (DIGIT ZERO)
+              * the code unit 0x002E (FULL STOP)
+              * -_n_ occurrences of the code unit 0x0030 (DIGIT ZERO)
+              * the code units of the _k_ digits of the decimal representation of _s_
+            1. Otherwise, if _k_ = 1, return the string-concatenation of:
+              * the code unit of the single digit of _s_
+              * the code unit 0x0065 (LATIN SMALL LETTER E)
+              * the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS) according to whether _n_ - 1 is positive or negative
+              * the code units of the decimal representation of the integer abs(_n_ - 1) (with no leading zeroes)
+            1. Return the string-concatenation of:
+              * the code units of the most significant digit of the decimal representation of _s_
+              * the code unit 0x002E (FULL STOP)
+              * the code units of the remaining _k_ - 1 digits of the decimal representation of _s_
+              * the code unit 0x0065 (LATIN SMALL LETTER E)
+              * the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS) according to whether _n_ - 1 is positive or negative
+              * the code units of the decimal representation of the integer abs(_n_ - 1) (with no leading zeroes)
+          </emu-alg>
+          <emu-note>
+            <p>The following observations may be useful as guidelines for implementations, but are not part of the normative requirements of this Standard:</p>
+            <ul>
+              <li>
+                If x is any Number value other than *-0*, then ToNumber(ToString(x)) is exactly the same Number value as x.
+              </li>
+              <li>
+                The least significant digit of s is not always uniquely determined by the requirements listed in step 5.
+              </li>
+            </ul>
+          </emu-note>
+          <emu-note>
+            <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 5 be used as a guideline:</p>
+            <emu-alg>
+              5. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. If there are multiple possibilities for _s_, choose the value of _s_ for which ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is closest in value to ℝ(_x_). If there are two such possible values of _s_, choose the one that is even. Note that _k_ is the number of digits in the decimal representation of _s_ and that _s_ is not divisible by 10<sub>ℝ</sub>.
+            </emu-alg>
+          </emu-note>
+          <emu-note>
+            <p>Implementers of ECMAScript may find useful the paper and code written by David M. Gay for binary-to-decimal conversion of floating-point numbers:</p>
+            <p>Gay, David M. Correctly Rounded Binary-Decimal and Decimal-Binary Conversions. Numerical Analysis, Manuscript 90-10. AT&amp;T Bell Laboratories (Murray Hill, New Jersey). November 30, 1990. Available as
+              <br>
+              <a href="http://ampl.com/REFS/abstracts.html#rounding">http://ampl.com/REFS/abstracts.html#rounding</a>. Associated code available as
+              <br>
+              <a href="http://netlib.sandia.gov/fp/dtoa.c">http://netlib.sandia.gov/fp/dtoa.c</a> and as
+              <br>
+              <a href="http://netlib.sandia.gov/fp/g_fmt.c">http://netlib.sandia.gov/fp/g_fmt.c</a> and may also be found at the various `netlib` mirror sites.</p>
+          </emu-note>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-ecmascript-language-types-bigint-type">
+        <h1>The BigInt Type</h1>
+        <p>The BigInt type represents a mathematical integer value. The value may be any size and is not limited to a particular bit-width. Generally, where not otherwise noted, operations are designed to return exact mathematically-based answers. For binary operations, BigInts act as two's complement binary strings, with negative numbers treated as having bits set infinitely to the left.</p>
+
+        <p>The BigInt::unit value is *1n*.</p>
+
+        <emu-clause id="sec-numeric-types-bigint-unaryMinus">
+          <h1>BigInt::unaryMinus ( _x_ )</h1>
+          <emu-alg>
+            1. If _x_ is *0n*, return *0n*.
+            1. Return the BigInt value that represents the mathematical value of negating _x_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-bitwiseNOT">
+          <h1>BigInt::bitwiseNOT ( _x_ )</h1>
+          <p>The abstract operation BigInt::bitwiseNOT with an argument _x_ of type BigInt returns the one's complement of _x_; that is, -_x_ - 1.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-exponentiate">
+          <h1>BigInt::exponentiate ( _base_, _exponent_ )</h1>
+          <emu-alg>
+            1. If _exponent_ &lt; *0n*, throw a *RangeError* exception.
+            1. If _base_ is *0n* and _exponent_ is *0n*, return *1n*.
+            1. Return the BigInt value that represents the mathematical value of _base_ raised to the power _exponent_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-multiply">
+          <h1>BigInt::multiply ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::multiply with two arguments _x_ and _y_ of type BigInt returns the BigInt value that represents the result of multiplying _x_ and _y_.</p>
+          <emu-note>Even if the result has a much larger bit width than the input, the exact mathematical answer is given.</emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-divide">
+          <h1>BigInt::divide ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. If _y_ is *0n*, throw a *RangeError* exception.
+            1. Let _quotient_ be the mathematical value of _x_ divided by _y_.
+            1. Return the BigInt value that represents _quotient_ rounded towards 0 to the next integral value.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-remainder">
+          <h1>BigInt::remainder ( _n_, _d_ )</h1>
+          <emu-alg>
+            1. If _d_ is *0n*, throw a *RangeError* exception.
+            1. If _n_ is *0n*, return *0n*.
+            1. Let _r_ be the BigInt defined by the mathematical relation _r_ = _n_ - (_d_ &times; _q_) where _q_ is a BigInt that is negative only if _n_/_d_ is negative and positive only if _n_/_d_ is positive, and whose magnitude is as large as possible without exceeding the magnitude of the true mathematical quotient of _n_ and _d_.
+            1. Return _r_.
+          </emu-alg>
+          <emu-note>The sign of the result equals the sign of the dividend.</emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-add">
+          <h1>BigInt::add ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::add with two arguments _x_ and _y_ of type BigInt returns the BigInt value that represents the sum of _x_ and _y_.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-subtract">
+          <h1>BigInt::subtract ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::subtract with two arguments _x_ and _y_ of type BigInt returns the BigInt value that represents the difference _x_ minus _y_.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-leftShift">
+          <h1>BigInt::leftShift ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::leftShift with two arguments _x_ and _y_ of type BigInt performs the following steps:</p>
+          <emu-alg>
+            1. If _y_ &lt; *0n*, then
+              1. Return the BigInt value that represents _x_ &divide; 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.
+            1. Return the BigInt value that represents _x_ &times; 2<sup>_y_</sup>.
+          </emu-alg>
+          <emu-note>Semantics here should be equivalent to a bitwise shift, treating the BigInt as an infinite length string of binary two's complement digits.</emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-signedRightShift">
+          <h1>BigInt::signedRightShift ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::signedRightShift with arguments _x_ and _y_ of type BigInt performs the following steps:</p>
+          <emu-alg>
+            1. Return BigInt::leftShift(_x_, -_y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-unsignedRightShift">
+          <h1>BigInt::unsignedRightShift ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::unsignedRightShift with two arguments _x_ and _y_ of type BigInt performs the following steps:</p>
+          <emu-alg>
+            1. Throw a *TypeError* exception.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-lessThan">
+          <h1>BigInt::lessThan ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::lessThan with two arguments _x_ and _y_ of type BigInt returns *true* if _x_ is less than _y_ and *false* otherwise.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-equal">
+          <h1>BigInt::equal ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::equal with two arguments _x_ and _y_ of type BigInt returns *true* if _x_ and _y_ have the same mathematical integer value and *false* otherwise.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-sameValue">
+          <h1>BigInt::sameValue ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::sameValue with two arguments _x_ and _y_ of type BigInt performs the following steps:</p>
+          <emu-alg>
+            1. Return BigInt::equal(_x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-sameValueZero">
+          <h1>BigInt::sameValueZero ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::sameValueZero with two arguments _x_ and _y_ of type BigInt performs the following steps:</p>
+          <emu-alg>
+            1. Return BigInt::equal(_x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-binaryand" aoid="BinaryAnd">
+          <h1>BinaryAnd ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Assert: _x_ is 0 or 1.
+            1. Assert: _y_ is 0 or 1.
+            1. If _x_ is 1 and _y_ is 1, return 1.
+            1. Else, return 0.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-binaryor" aoid="BinaryOr">
+          <h1>BinaryOr ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Assert: _x_ is 0 or 1.
+            1. Assert: _y_ is 0 or 1.
+            1. If _x_ is 1 or _y_ is 1, return 1.
+            1. Else, return 0.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-binaryxor" aoid="BinaryXor">
+          <h1>BinaryXor ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Assert: _x_ is 0 or 1.
+            1. Assert: _y_ is 0 or 1.
+            1. If _x_ is 1 and _y_ is 0, return 1.
+            1. Else if _x_ is 0 and _y_ is 1, return 1.
+            1. Else, return 0.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-bigintbitwiseop" aoid="BigIntBitwiseOp">
+          <h1>BigIntBitwiseOp ( _op_, _x_, _y_ )</h1>
+          <emu-alg>
+            1. Assert: _op_ is `"&amp;"`, `"|"`, or `"^"`.
+            1. Let _result_ be *0n*.
+            1. Let _shift_ be 0.
+            1. Repeat, until (_x_ = 0 or _x_ = -1) and (_y_ = 0 or _y_ = -1),
+              1. Let _xDigit_ be _x_ modulo 2.
+              1. Let _yDigit_ be _y_ modulo 2.
+              1. If _op_ is `"&amp;"`, let _result_ be _result_ + 2<sup>_shift_</sup> &times; BinaryAnd(_xDigit_, _yDigit_).
+              1. Else if _op_ is `"|"`, let _result_ be _result_ + 2<sup>_shift_</sup> &times; BinaryOr(_xDigit_, _yDigit_).
+              1. Else,
+                1. Assert: _op_ is `"^"`.
+                1. Let _result_ be _result_ + 2<sup>_shift_</sup> &times; BinaryXor(_xDigit_, _yDigit_).
+              1. Let _shift_ be _shift_ + 1.
+              1. Let _x_ be (_x_ - _xDigit_) / 2.
+              1. Let _y_ be (_y_ - _yDigit_) / 2.
+            1. If _op_ is `"&amp;"`, let _tmp_ be BinaryAnd(_x_ modulo 2, _y_ modulo 2).
+            1. Else if _op_ is `"|"`, let _tmp_ be BinaryOr(_x_ modulo 2, _y_ modulo 2).
+            1. Else,
+              1. Assert: _op_ is `"^"`.
+              1. Let _tmp_ be BinaryXor(_x_ modulo 2, _y_ modulo 2).
+            1. If _tmp_ &ne; 0, then
+              1. Let _result_ be _result_ - 2<sup>_shift_</sup>. NOTE: This extends the sign.
+            1. Return _result_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-bitwiseAND">
+          <h1>BigInt::bitwiseAND ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Return BigIntBitwiseOp(`"&amp;"`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-bitwiseXOR">
+          <h1>BigInt::bitwiseXOR ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Return BigIntBitwiseOp(`"^"`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-bitwiseOR">
+          <h1>BigInt::bitwiseOR ( _x_, _y_ )</h1>
+          <emu-alg>
+            1. Return BigIntBitwiseOp(`"|"`, _x_, _y_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numeric-types-bigint-tostring" aoid="BigInt::toString">
+          <h1>BigInt::toString ( _x_ )</h1>
+          <p>The abstract operation BigInt::toString converts a BigInt _x_ to String format as follows:</p>
+          <emu-alg>
+            1. If _x_ is less than zero, return the string-concatenation of the String `"-"` and ! BigInt::toString(-_x_).
+            1. Return the String value consisting of the code units of the digits of the decimal representation of _x_.
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-object-type">
@@ -1915,6 +2783,39 @@
               </td>
               <td>
                 The `Atomics` object (<emu-xref href="#sec-atomics-object"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %BigInt%
+              </td>
+              <td>
+                `BigInt`
+              </td>
+              <td>
+                The `BigInt` constructor (<emu-xref href="#sec-bigint-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %BigInt64Array%
+              </td>
+              <td>
+                `BigInt64Array`
+              </td>
+              <td>
+                The `BigInt64Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %BigUint64Array%
+              </td>
+              <td>
+                `BigUint64Array`
+              </td>
+              <td>
+                The `BigUint64Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3209,7 +4110,7 @@
         <h1>HasPrimitiveBase ( _V_ )</h1>
         <emu-alg>
           1. Assert: Type(_V_) is Reference.
-          1. If Type(_V_'s base value component) is Boolean, String, Symbol, or Number, return *true*; otherwise return *false*.
+          1. If Type(_V_'s base value component) is Boolean, String, Symbol, BigInt, or Number, return *true*; otherwise return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -3510,6 +4411,7 @@
   <emu-clause id="sec-type-conversion">
     <h1>Type Conversion</h1>
     <p>The ECMAScript language implicitly performs automatic type conversion as needed. To clarify the semantics of certain constructs it is useful to define a set of conversion abstract operations. The conversion abstract operations are polymorphic; they can accept a value of any ECMAScript language type. But no other specification types are used with these operations.</p>
+    <p>The BigInt type has no implicit conversions in the ECMAScript language; programmers must call BigInt explicitly to convert values from other types.</p>
 
     <emu-clause id="sec-toprimitive" aoid="ToPrimitive" oldids="table-9">
       <h1>ToPrimitive ( _input_ [ , _PreferredType_ ] )</h1>
@@ -3619,6 +4521,14 @@
           </tr>
           <tr>
             <td>
+              BigInt
+            </td>
+            <td>
+              If _argument_ is *0n*, return *false*; otherwise return *true*.
+            </td>
+          </tr>
+          <tr>
+            <td>
               Object
             </td>
             <td>
@@ -3628,6 +4538,16 @@
           </tbody>
         </table>
       </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-tonumeric" aoid="ToNumeric">
+      <h1>ToNumeric ( _value_ )</h1>
+      <p>The abstract operation ToNumeric returns _value_ converted to a numeric value of type Number or BigInt. This abstract operation functions as follows:</p>
+      <emu-alg>
+        1. Let _primValue_ be ? ToPrimitive(_value_, hint Number).
+        1. If Type(_primValue_) is BigInt, return _primValue_.
+        1. Return ? ToNumber(_primValue_).
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-tonumber" aoid="ToNumber">
@@ -3694,6 +4614,14 @@
           </tr>
           <tr>
             <td>
+              BigInt
+            </td>
+            <td>
+              Throw a *TypeError* exception.
+            </td>
+          </tr>
+          <tr>
+            <td>
               Object
             </td>
             <td>
@@ -3729,9 +4657,7 @@
 
           StrNumericLiteral :::
             StrDecimalLiteral
-            BinaryIntegerLiteral
-            OctalIntegerLiteral
-            HexIntegerLiteral
+            NonDecimalIntegerLiteral
 
           StrDecimalLiteral :::
             StrUnsignedDecimalLiteral
@@ -3763,6 +4689,9 @@
             <li>
               `Infinity` and `-Infinity` are recognized as a |StringNumericLiteral| but not as a |NumericLiteral|.
             </li>
+            <li>
+              A |StringNumericLiteral| cannot include a |BigIntLiteralSuffix|.
+            </li>
           </ul>
         </emu-note>
 
@@ -3783,13 +4712,7 @@
               The MV of <emu-grammar>StrNumericLiteral ::: StrDecimalLiteral</emu-grammar> is the MV of |StrDecimalLiteral|.
             </li>
             <li>
-              The MV of <emu-grammar>StrNumericLiteral ::: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
-            </li>
-            <li>
-              The MV of <emu-grammar>StrNumericLiteral ::: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
-            </li>
-            <li>
-              The MV of <emu-grammar>StrNumericLiteral ::: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
+              The MV of <emu-grammar>StrNumericLiteral ::: NonDecimalIntegerLiteral</emu-grammar> is the MV of |NonDecimalIntegerLiteral|.
             </li>
             <li>
               The MV of <emu-grammar>StrDecimalLiteral ::: StrUnsignedDecimalLiteral</emu-grammar> is the MV of |StrUnsignedDecimalLiteral|.
@@ -3985,6 +4908,118 @@
       </emu-note>
     </emu-clause>
 
+    <emu-clause id="sec-to-bigint" aoid="ToBigInt">
+      <h1>ToBigInt ( _argument_ )</h1>
+      <p>The abstract operation ToBigInt converts its argument _argument_ to a BigInt value, or throws if an implicit conversion from Number would be required.</p>
+      <emu-alg>
+        1. Let _prim_ be ? ToPrimitive(_argument_, hint Number).
+        1. Return the value that _prim_ corresponds to in <emu-xref href="#table-to-bigint"></emu-xref>.
+      </emu-alg>
+      <emu-table id="table-to-bigint" caption="BigInt Conversions">
+        <table>
+          <tbody>
+            <tr>
+              <th>
+                Argument Type
+              </th>
+              <th>
+                Result
+              </th>
+            </tr>
+            <tr>
+              <td>
+                Undefined
+              </td>
+              <td>
+                Throw a *TypeError* exception.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Null
+              </td>
+              <td>
+                Throw a *TypeError* exception.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Boolean
+              </td>
+              <td>
+                Return `1n` if _prim_ is *true* and `0n` if _prim_ is *false*.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                BigInt
+              </td>
+              <td>
+                Return _prim_.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Number
+              </td>
+              <td>
+                Throw a *TypeError* exception.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                String
+              </td>
+              <td>
+                <emu-alg>
+                  1. Let _n_ be ! StringToBigInt(_prim_).
+                  1. If _n_ is *NaN*, throw a *SyntaxError* exception.
+                  1. Return _n_.
+                </emu-alg>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Symbol
+              </td>
+              <td>
+                Throw a *TypeError* exception.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-string-to-bigint" aoid="StringToBigInt">
+      <h1>StringToBigInt ( _argument_ )</h1>
+      <p>Apply the algorithm in <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref> with the following changes:</p>
+      <ul>
+        <li>Replace the |StrUnsignedDecimalLiteral| production with |DecimalDigits| to not allow *Infinity*, decimal points, or exponents.</li>
+        <li>If the MV is *NaN*, return *NaN*, otherwise return the BigInt which exactly corresponds to the MV, rather than rounding to a Number.</li>
+      </ul>
+    </emu-clause>
+
+    <emu-clause id="sec-to-big-int64" aoid="ToBigInt64">
+      <h1>ToBigInt64 ( _argument_ )</h1>
+      <p>The abstract operation ToBigInt64 converts _argument_ to one of 2<sup>64</sup> integer values in the range -2<sup>63</sup> through 2<sup>63</sup>-1, inclusive. This abstract operation functions as follows:</p>
+      <emu-alg>
+        1. Let _n_ be ? ToBigInt(_argument_).
+        1. Let _int64bit_ be _n_ modulo 2<sup>64</sup>.
+        1. If _int64bit_ &ge; 2<sup>63</sup>, return _int64bit_ - 2<sup>64</sup>; otherwise return _int64bit_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-to-big-uint64" aoid="ToBigUint64">
+      <h1>ToBigUint64 ( _argument_ )</h1>
+      <p>The abstract operation ToBigUint64 converts _argument_ to one of 2<sup>64</sup> integer values in the range 0 through 2<sup>64</sup>-1, inclusive. This abstract operation functions as follows:</p>
+      <emu-alg>
+        1. Let _n_ be ? ToBigInt(_argument_).
+        1. Let _int64bit_ be _n_ modulo 2<sup>64</sup>.
+        1. Return _int64bit_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-tostring" aoid="ToString">
       <h1>ToString ( _argument_ )</h1>
       <p>The abstract operation ToString converts _argument_ to a value of type String according to <emu-xref href="#table-12"></emu-xref>:</p>
@@ -4029,7 +5064,7 @@
               Number
             </td>
             <td>
-              Return NumberToString(_argument_).
+              Return ! Number::toString(_argument_).
             </td>
           </tr>
           <tr>
@@ -4050,6 +5085,14 @@
           </tr>
           <tr>
             <td>
+              BigInt
+            </td>
+            <td>
+              Return ! BigInt::toString(_argument_).
+            </td>
+          </tr>
+          <tr>
+            <td>
               Object
             </td>
             <td>
@@ -4063,69 +5106,6 @@
           </tbody>
         </table>
       </emu-table>
-
-      <emu-clause id="sec-tostring-applied-to-the-number-type" aoid="NumberToString">
-        <h1>NumberToString ( _m_ )</h1>
-        <p>The abstract operation NumberToString converts a Number _m_ to String format as follows:</p>
-        <emu-alg>
-          1. If _m_ is *NaN*, return the String `"NaN"`.
-          1. If _m_ is *+0* or *-0*, return the String `"0"`.
-          1. If _m_ is less than zero, return the string-concatenation of `"-"` and ! NumberToString(-_m_).
-          1. If _m_ is *+&infin;*, return the String `"Infinity"`.
-          1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _m_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10<sub>ℝ</sub>, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
-          1. If _k_ &le; _n_ &le; 21, return the string-concatenation of:
-            * the code units of the _k_ digits of the decimal representation of _s_ (in order, with no leading zeroes)
-            * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
-          1. If 0 &lt; _n_ &le; 21, return the string-concatenation of:
-            * the code units of the most significant _n_ digits of the decimal representation of _s_
-            * the code unit 0x002E (FULL STOP)
-            * the code units of the remaining _k_ - _n_ digits of the decimal representation of _s_
-          1. If -6 &lt; _n_ &le; 0, return the string-concatenation of:
-            * the code unit 0x0030 (DIGIT ZERO)
-            * the code unit 0x002E (FULL STOP)
-            * -_n_ occurrences of the code unit 0x0030 (DIGIT ZERO)
-            * the code units of the _k_ digits of the decimal representation of _s_
-          1. Otherwise, if _k_ = 1, return the string-concatenation of:
-            * the code unit of the single digit of _s_
-            * the code unit 0x0065 (LATIN SMALL LETTER E)
-            * the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS) according to whether _n_ - 1 is positive or negative
-            * the code units of the decimal representation of the integer abs(_n_ - 1) (with no leading zeroes)
-          1. Return the string-concatenation of:
-            * the code units of the most significant digit of the decimal representation of _s_
-            * the code unit 0x002E (FULL STOP)
-            * the code units of the remaining _k_ - 1 digits of the decimal representation of _s_
-            * the code unit 0x0065 (LATIN SMALL LETTER E)
-            * the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS) according to whether _n_ - 1 is positive or negative
-            * the code units of the decimal representation of the integer abs(_n_ - 1) (with no leading zeroes)
-        </emu-alg>
-        <emu-note>
-          <p>The following observations may be useful as guidelines for implementations, but are not part of the normative requirements of this Standard:</p>
-          <ul>
-            <li>
-              If x is any Number value other than *-0*, then ToNumber(ToString(x)) is exactly the same Number value as x.
-            </li>
-            <li>
-              The least significant digit of s is not always uniquely determined by the requirements listed in step 5.
-            </li>
-          </ul>
-        </emu-note>
-        <emu-note>
-          <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 5 be used as a guideline:</p>
-          <emu-alg>
-            5. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _m_, and _k_ is as small as possible. If there are multiple possibilities for _s_, choose the value of _s_ for which ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is closest in value to ℝ(_m_). If there are two such possible values of _s_, choose the one that is even. Note that _k_ is the number of digits in the decimal representation of _s_ and that _s_ is not divisible by 10<sub>ℝ</sub>.
-          </emu-alg>
-        </emu-note>
-        <emu-note>
-          <p>Implementers of ECMAScript may find useful the paper and code written by David M. Gay for binary-to-decimal conversion of floating-point numbers:</p>
-          <p>Gay, David M. Correctly Rounded Binary-Decimal and Decimal-Binary Conversions. Numerical Analysis, Manuscript 90-10. AT&amp;T Bell Laboratories (Murray Hill, New Jersey). November 30, 1990. Available as
-            <br>
-            <a href="http://ampl.com/REFS/abstracts.html#rounding">http://ampl.com/REFS/abstracts.html#rounding</a>. Associated code available as
-            <br>
-            <a href="http://netlib.sandia.gov/fp/dtoa.c">http://netlib.sandia.gov/fp/dtoa.c</a> and as
-            <br>
-            <a href="http://netlib.sandia.gov/fp/g_fmt.c">http://netlib.sandia.gov/fp/g_fmt.c</a> and may also be found at the various `netlib` mirror sites.</p>
-        </emu-note>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-toobject" aoid="ToObject">
@@ -4188,6 +5168,14 @@
             </td>
             <td>
               Return a new Symbol object whose [[SymbolData]] internal slot is set to _argument_. See <emu-xref href="#sec-symbol-objects"></emu-xref> for a description of Symbol objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              BigInt
+            </td>
+            <td>
+              Return a new BigInt object whose [[BigIntData]] internal slot is set to _argument_. See <emu-xref href="#sec-bigint-objects"></emu-xref> for a description of BigInt objects.
             </td>
           </tr>
           <tr>
@@ -4320,6 +5308,14 @@
           </tr>
           <tr>
             <td>
+              BigInt
+            </td>
+            <td>
+              Return _argument_.
+            </td>
+          </tr>
+          <tr>
+            <td>
               Object
             </td>
             <td>
@@ -4423,13 +5419,9 @@
       <p>The internal comparison abstract operation SameValue(_x_, _y_), where _x_ and _y_ are ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
-        1. If Type(_x_) is Number, then
-          1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
-          1. If _x_ is *+0* and _y_ is *-0*, return *false*.
-          1. If _x_ is *-0* and _y_ is *+0*, return *false*.
-          1. If _x_ is the same Number value as _y_, return *true*.
-          1. Return *false*.
-        1. Return SameValueNonNumber(_x_, _y_).
+        1. If Type(_x_) is Number or BigInt, then
+          1. Return ! Type(_x_)::sameValue(_x_, _y_).
+        1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>This algorithm differs from the Strict Equality Comparison Algorithm in its treatment of signed zeroes and NaNs.</p>
@@ -4441,24 +5433,20 @@
       <p>The internal comparison abstract operation SameValueZero(_x_, _y_), where _x_ and _y_ are ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
-        1. If Type(_x_) is Number, then
-          1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
-          1. If _x_ is *+0* and _y_ is *-0*, return *true*.
-          1. If _x_ is *-0* and _y_ is *+0*, return *true*.
-          1. If _x_ is the same Number value as _y_, return *true*.
-          1. Return *false*.
-        1. Return SameValueNonNumber(_x_, _y_).
+        1. If Type(_x_) is Number or BigInt, then
+          1. Return ! Type(_x_)::sameValueZero(_x_, _y_).
+        1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>SameValueZero differs from SameValue only in its treatment of *+0* and *-0*.</p>
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-samevaluenonnumber" aoid="SameValueNonNumber">
-      <h1>SameValueNonNumber ( _x_, _y_ )</h1>
-      <p>The internal comparison abstract operation SameValueNonNumber(_x_, _y_), where neither _x_ nor _y_ are Number values, produces *true* or *false*. Such a comparison is performed as follows:</p>
+    <emu-clause id="sec-samevaluenonnumeric" aoid="SameValueNonNumeric" oldids="sec-samevaluenonnumber">
+      <h1>SameValueNonNumeric ( _x_, _y_ )</h1>
+      <p>The internal comparison abstract operation SameValueNonNumeric(_x_, _y_), where neither _x_ nor _y_ are numeric type values, produces *true* or *false*. Such a comparison is performed as follows:</p>
       <emu-alg>
-        1. Assert: Type(_x_) is not Number.
+        1. Assert: Type(_x_) is not Number or BigInt.
         1. Assert: Type(_x_) is the same as Type(_y_).
         1. If Type(_x_) is Undefined, return *true*.
         1. If Type(_x_) is Null, return *true*.
@@ -4491,19 +5479,22 @@
           1. Let _n_ be the integer that is the numeric value of the code unit at index _k_ within _py_.
           1. If _m_ &lt; _n_, return *true*. Otherwise, return *false*.
         1. Else,
-          1. NOTE: Because _px_ and _py_ are primitive values evaluation order is not important.
-          1. Let _nx_ be ? ToNumber(_px_).
-          1. Let _ny_ be ? ToNumber(_py_).
-          1. If _nx_ is *NaN*, return *undefined*.
-          1. If _ny_ is *NaN*, return *undefined*.
-          1. If _nx_ and _ny_ are the same Number value, return *false*.
-          1. If _nx_ is *+0* and _ny_ is *-0*, return *false*.
-          1. If _nx_ is *-0* and _ny_ is *+0*, return *false*.
-          1. If _nx_ is *+&infin;*, return *false*.
-          1. If _ny_ is *+&infin;*, return *true*.
-          1. If _ny_ is *-&infin;*, return *false*.
-          1. If _nx_ is *-&infin;*, return *true*.
-          1. If the mathematical value of _nx_ is less than the mathematical value of _ny_&mdash;note that these mathematical values are both finite and not both zero&mdash;return *true*. Otherwise, return *false*.
+          1. If Type(_px_) is BigInt and Type(_py_) is String, then
+            1. Let _ny_ be ! StringToBigInt(_py_).
+            1. If _ny_ is *NaN*, return *undefined*.
+            1. Return BigInt::lessThan(_px_, _ny_).
+          1. If Type(_px_) is String and Type(_py_) is BigInt, then
+            1. Let _nx_ be ! StringToBigInt(_px_).
+            1. If _nx_ is *NaN*, return *undefined*.
+            1. Return BigInt::lessThan(_nx_, _py_).
+          1. Let _nx_ be ? ToNumeric(_px_). NOTE: Because _px_ and _py_ are primitive values evaluation order is not important.
+          1. Let _ny_ be ? ToNumeric(_py_).
+          1. If Type(_nx_) is the same as Type(_ny_), return Type(_nx_)::lessThan(_nx_, _ny_).
+          1. Assert: Type(_nx_) is BigInt and Type(_ny_) is Number, or Type(_nx_) is Number and Type(_ny_) is BigInt.
+          1. If _nx_ or _ny_ is *NaN*, return *undefined*.
+          1. If _nx_ is *-&infin;* or _ny_ is *+&infin;*, return *true*.
+          1. If _nx_ is *+&infin;* or _ny_ is *-&infin;*, return *false*.
+          1. If the mathematical value of _nx_ is less than the mathematical value of _ny_, return *true*; otherwise return *false*.
       </emu-alg>
       <emu-note>
         <p>Step 3 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
@@ -4523,10 +5514,18 @@
         1. If _x_ is *undefined* and _y_ is *null*, return *true*.
         1. If Type(_x_) is Number and Type(_y_) is String, return the result of the comparison _x_ == ! ToNumber(_y_).
         1. If Type(_x_) is String and Type(_y_) is Number, return the result of the comparison ! ToNumber(_x_) == _y_.
+        1. If Type(_x_) is BigInt and Type(_y_) is String, then
+          1. Let _n_ be ! StringToBigInt(_y_).
+          1. If _n_ is *NaN*, return *false*.
+          1. Return the result of the comparison _x_ == _n_.
+        1. If Type(_x_) is String and Type(_y_) is BigInt, return the result of the comparison _y_ == _x_.
         1. If Type(_x_) is Boolean, return the result of the comparison ! ToNumber(_x_) == _y_.
         1. If Type(_y_) is Boolean, return the result of the comparison _x_ == ! ToNumber(_y_).
-        1. If Type(_x_) is either String, Number, or Symbol and Type(_y_) is Object, return the result of the comparison _x_ == ToPrimitive(_y_).
-        1. If Type(_x_) is Object and Type(_y_) is either String, Number, or Symbol, return the result of the comparison ToPrimitive(_x_) == _y_.
+        1. If Type(_x_) is either String, Number, BigInt, or Symbol and Type(_y_) is Object, return the result of the comparison _x_ == ToPrimitive(_y_).
+        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt, or Symbol, return the result of the comparison ToPrimitive(_x_) == _y_.
+        1. If Type(_x_) is BigInt and Type(_y_) is Number, or if Type(_x_) is Number and Type(_y_) is BigInt, then
+          1. If _x_ or _y_ are any of *NaN*, *+&infin;*, or *-&infin;*, return *false*.
+          1. If the mathematical value of _x_ is equal to the mathematical value of _y_, return *true*; otherwise return *false*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>
@@ -4536,14 +5535,9 @@
       <p>The comparison _x_ === _y_, where _x_ and _y_ are values, produces *true* or *false*. Such a comparison is performed as follows:</p>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
-        1. If Type(_x_) is Number, then
-          1. If _x_ is *NaN*, return *false*.
-          1. If _y_ is *NaN*, return *false*.
-          1. If _x_ is the same Number value as _y_, return *true*.
-          1. If _x_ is *+0* and _y_ is *-0*, return *true*.
-          1. If _x_ is *-0* and _y_ is *+0*, return *true*.
-          1. Return *false*.
-        1. Return SameValueNonNumber(_x_, _y_).
+        1. If Type(_x_) is Number or BigInt, then
+          1. Return ! Type(_x_)::equal(_x_, _y_).
+        1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>This algorithm differs from the SameValue Algorithm in its treatment of signed zeroes and NaNs.</p>
@@ -6720,6 +7714,11 @@
             <td>*true* if atomic operations on two-byte values are lock-free, *false* otherwise.</td>
           </tr>
           <tr>
+            <td>[[IsLockFree8]]</td>
+            <td>Boolean</td>
+            <td>*true* if atomic operations on eight-byte values are lock-free, *false* otherwise.</td>
+          </tr>
+          <tr>
             <td>[[CandidateExecution]]</td>
             <td>A candidate execution Record</td>
             <td>See the memory model.</td>
@@ -8357,7 +9356,7 @@
     <emu-clause id="sec-integer-indexed-exotic-objects">
       <h1>Integer-Indexed Exotic Objects</h1>
       <p>An <dfn id="integer-indexed-exotic-object">Integer-Indexed exotic object</dfn> is an exotic object that performs special handling of integer index property keys.</p>
-      <p><emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref> have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.</p>
+      <p><emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref> have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
       <p><emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref> provide alternative definitions for the following internal methods. All of the other Integer-Indexed exotic object essential internal methods that are not defined below are as specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</p>
 
       <emu-clause id="sec-integer-indexed-exotic-objects-getownproperty-p">
@@ -8453,7 +9452,7 @@
         <p>When the [[OwnPropertyKeys]] internal method of an Integer-Indexed exotic object _O_ is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _keys_ be a new empty List.
-          1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
+          1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.
           1. Let _len_ be _O_.[[ArrayLength]].
           1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
             1. Add ! ToString(_i_) as the last element of _keys_.
@@ -8469,7 +9468,7 @@
         <h1>IntegerIndexedObjectCreate ( _prototype_, _internalSlotsList_ )</h1>
         <p>The abstract operation IntegerIndexedObjectCreate with arguments _prototype_ and _internalSlotsList_ is used to specify the creation of new <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>. The argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. IntegerIndexedObjectCreate performs the following steps:</p>
         <emu-alg>
-          1. Assert: _internalSlotsList_ contains the names [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]].
+          1. Assert: _internalSlotsList_ contains the names [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]].
           1. Let _A_ be a newly created Integer-Indexed exotic object with an internal slot for each name in _internalSlotsList_.
           1. Set _A_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           1. Set _A_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-getownproperty-p"></emu-xref>.
@@ -8489,7 +9488,7 @@
         <p>The abstract operation IntegerIndexedElementGet with arguments _O_ and _index_ performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_index_) is Number.
-          1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
+          1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If IsInteger(_index_) is *false*, return *undefined*.
@@ -8510,8 +9509,9 @@
         <p>The abstract operation IntegerIndexedElementSet with arguments _O_, _index_, and _value_ performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_index_) is Number.
-          1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]] internal slots.
-          1. Let _numValue_ be ? ToNumber(_value_).
+          1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.
+          1. If _O_.[[ContentType]] is `"BigInt"`, let _numValue_ be ? ToBigInt(_value_).
+          1. Otherwise, let _numValue_ be ? ToNumber(_value_).
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If IsInteger(_index_) is *false*, return *false*.
@@ -10092,9 +11092,21 @@
       <emu-grammar type="definition">
         NumericLiteral ::
           DecimalLiteral
+          DecimalBigIntegerLiteral
+          NonDecimalIntegerLiteral
+          NonDecimalIntegerLiteral BigIntLiteralSuffix
+
+        DecimalBigIntegerLiteral ::
+          `0` BigIntLiteralSuffix
+          NonZeroDigit DecimalDigits? BigIntLiteralSuffix
+
+        NonDecimalIntegerLiteral ::
           BinaryIntegerLiteral
           OctalIntegerLiteral
           HexIntegerLiteral
+
+        BigIntLiteralSuffix ::
+          `n`
 
         DecimalLiteral ::
           DecimalIntegerLiteral `.` DecimalDigits? ExponentPart?
@@ -10167,19 +11179,19 @@
 
       <emu-clause id="sec-static-semantics-mv">
         <h1>Static Semantics: MV</h1>
-        <p>A numeric literal stands for a value of the Number type. This value is determined in two steps: first, a mathematical value (MV) is derived from the literal; second, this mathematical value is rounded as described below.</p>
+        <p>A numeric literal stands for a value of the Number type or the BigInt type.</p>
         <ul>
           <li>
             The MV of <emu-grammar>NumericLiteral :: DecimalLiteral</emu-grammar> is the MV of |DecimalLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>NumericLiteral :: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
+            The MV of <emu-grammar>NonDecimalIntegerLiteral :: BinaryIntegerLiteral</emu-grammar> is the MV of |BinaryIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>NumericLiteral :: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
+            The MV of <emu-grammar>NonDecimalIntegerLiteral :: OctalIntegerLiteral</emu-grammar> is the MV of |OctalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>NumericLiteral :: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
+            The MV of <emu-grammar>NonDecimalIntegerLiteral :: HexIntegerLiteral</emu-grammar> is the MV of |HexIntegerLiteral|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.`</emu-grammar> is the MV of |DecimalIntegerLiteral|.
@@ -10317,6 +11329,18 @@
             The MV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16<sub>ℝ</sub>) plus the MV of |HexDigit|.
           </li>
         </ul>
+      </emu-clause>
+
+      <emu-clause id="sec-numericvalue">
+        <h1>Static Semantics: NumericValue</h1>
+        <emu-grammar>NumericLiteral :: DecimalLiteral</emu-grammar>
+        <emu-alg>
+          1. Return the Number value that results from rounding the MV of |DecimalLiteral| as described below.
+        </emu-alg>
+        <emu-grammar>NumericLiteral :: NonDecimalIntegerLiteral</emu-grammar>
+        <emu-alg>
+          1. Return the Number value that results from rounding the MV of |NonDecimalIntegerLiteral| as described below.
+        </emu-alg>
         <p>Once the exact MV for a numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0<sub>ℝ</sub>, then the rounded value is *+0*; otherwise, the rounded value must be the Number value for the MV (as specified in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal is a |DecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit and then incrementing the literal at the 20th significant digit position. A digit is <em>significant</em> if it is not part of an |ExponentPart| and</p>
         <ul>
           <li>
@@ -10326,7 +11350,27 @@
             there is a nonzero digit to its left and there is a nonzero digit, not in the |ExponentPart|, to its right.
           </li>
         </ul>
+
+        <emu-grammar>NumericLiteral :: NonDecimalIntegerLiteral BigIntLiteralSuffix</emu-grammar>
+        <emu-alg>
+          1. Return the BigInt value that represents the MV of |NonDecimalIntegerLiteral|.
+        </emu-alg>
+        <emu-grammar>DecimalBigIntegerLiteral :: `0` BigIntLiteralSuffix</emu-grammar>
+        <emu-alg>
+          1. Return the BigInt value that represents 0<sub>ℝ</sub>.
+        </emu-alg>
+        <emu-grammar>DecimalBigIntegerLiteral :: NonZeroDigit BigIntLiteralSuffix</emu-grammar>
+        <emu-alg>
+          1. Return the BigInt value that represents the MV of |NonZeroDigit|.
+        </emu-alg>
+        <emu-grammar>DecimalBigIntegerLiteral :: NonZeroDigit DecimalDigits BigIntLiteralSuffix</emu-grammar>
+        <emu-alg>
+          1. Let _n_ be the mathematical integer number of code points in |DecimalDigits|.
+          1. Let _mv_ be (the MV of |NonZeroDigit| &times; 10<sub>ℝ</sub><sup>_n_</sup>) plus the MV of |DecimalDigits|.
+          1. Return the BigInt value that represents _mv_.
+        </emu-alg>
       </emu-clause>
+
     </emu-clause>
 
     <emu-clause id="sec-literals-string-literals">
@@ -11557,7 +12601,7 @@
         </emu-alg>
         <emu-grammar>Literal : NumericLiteral</emu-grammar>
         <emu-alg>
-          1. Return the Number value represented by |NumericLiteral| as defined in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.
+          1. Return the NumericValue of |NumericLiteral| as defined in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.
         </emu-alg>
         <emu-grammar>Literal : StringLiteral</emu-grammar>
         <emu-alg>
@@ -11826,7 +12870,7 @@
         </emu-alg>
         <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
-          1. Let _nbr_ be the result of forming the value of the |NumericLiteral|.
+          1. Let _nbr_ be the NumericValue of |NumericLiteral|.
           1. Return ! ToString(_nbr_).
         </emu-alg>
         <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
@@ -11877,7 +12921,7 @@
         </emu-alg>
         <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
-          1. Let _nbr_ be the result of forming the value of the |NumericLiteral|.
+          1. Let _nbr_ be the NumericValue of |NumericLiteral|.
           1. Return ! ToString(_nbr_).
         </emu-alg>
         <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
@@ -12926,8 +13970,8 @@
         <emu-grammar>UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
-          1. Let _oldValue_ be ? ToNumber(? GetValue(_lhs_)).
-          1. Let _newValue_ be the result of adding the value 1 to _oldValue_, using the same rules as for the `+` operator (see <emu-xref href="#sec-applying-the-additive-operators-to-numbers"></emu-xref>).
+          1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
+          1. Let _newValue_ be ! Type(_oldvalue_)::add(_oldValue_, Type(_oldValue_)::unit).
           1. Perform ? PutValue(_lhs_, _newValue_).
           1. Return _oldValue_.
         </emu-alg>
@@ -12942,8 +13986,8 @@
         <emu-grammar>UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
-          1. Let _oldValue_ be ? ToNumber(? GetValue(_lhs_)).
-          1. Let _newValue_ be the result of subtracting the value 1 from _oldValue_, using the same rules as for the `-` operator (see <emu-xref href="#sec-applying-the-additive-operators-to-numbers"></emu-xref>).
+          1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
+          1. Let _newValue_ be ! Type(_oldvalue_)::subtract(_oldValue_, Type(_oldValue_)::unit).
           1. Perform ? PutValue(_lhs_, _newValue_).
           1. Return _oldValue_.
         </emu-alg>
@@ -12958,8 +14002,8 @@
         <emu-grammar>UpdateExpression : `++` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
-          1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
-          1. Let _newValue_ be the result of adding the value 1 to _oldValue_, using the same rules as for the `+` operator (see <emu-xref href="#sec-applying-the-additive-operators-to-numbers"></emu-xref>).
+          1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
+          1. Let _newValue_ be ! Type(_oldvalue_)::add(_oldValue_, Type(_oldValue_)::unit).
           1. Perform ? PutValue(_expr_, _newValue_).
           1. Return _newValue_.
         </emu-alg>
@@ -12974,8 +14018,8 @@
         <emu-grammar>UpdateExpression : `--` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
-          1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
-          1. Let _newValue_ be the result of subtracting the value 1 from _oldValue_, using the same rules as for the `-` operator (see <emu-xref href="#sec-applying-the-additive-operators-to-numbers"></emu-xref>).
+          1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
+          1. Let _newValue_ be ? Type(_oldvalue_)::subtract(_oldValue_, Type(_oldValue_)::unit).
           1. Perform ? PutValue(_expr_, _newValue_).
           1. Return _newValue_.
         </emu-alg>
@@ -13178,6 +14222,14 @@
             </tr>
             <tr>
               <td>
+                BigInt
+              </td>
+              <td>
+                `"bigint"`
+              </td>
+            </tr>
+            <tr>
+              <td>
                 Object (does not implement [[Call]])
               </td>
               <td>
@@ -13226,9 +14278,9 @@
         <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
-          1. Let _oldValue_ be ? ToNumber(? GetValue(_expr_)).
-          1. If _oldValue_ is *NaN*, return *NaN*.
-          1. Return the result of negating _oldValue_; that is, compute a Number with the same magnitude but opposite sign.
+          1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
+          1. Let _T_ be Type(_oldValue_).
+          1. Return ! _T_::unaryMinus(_oldValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -13241,8 +14293,9 @@
         <emu-grammar>UnaryExpression : `~` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
-          1. Let _oldValue_ be ? ToInt32(? GetValue(_expr_)).
-          1. Return the result of applying bitwise complement to _oldValue_. The result is a signed 32-bit integer.
+          1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
+          1. Let _T_ be Type(_oldValue_).
+          1. Return ! _T_::bitwiseNOT(_oldValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -13307,45 +14360,11 @@
         1. Let _leftValue_ be ? GetValue(_left_).
         1. Let _right_ be the result of evaluating |ExponentiationExpression|.
         1. Let _rightValue_ be ? GetValue(_right_).
-        1. Let _base_ be ? ToNumber(_leftValue_).
-        1. Let _exponent_ be ? ToNumber(_rightValue_).
-        1. Return the result of <emu-xref href="#sec-applying-the-exp-operator" title>Applying the ** operator</emu-xref> with _base_ and _exponent_ as specified in <emu-xref href="#sec-applying-the-exp-operator"></emu-xref>.
+        1. Let _base_ be ? ToNumeric(_leftValue_).
+        1. Let _exponent_ be ? ToNumeric(_rightValue_).
+        1. If Type(_base_) is different from Type(_exponent_), throw a *TypeError* exception.
+        1. Return ? Type(_base_)::exponentiate(_base_, _exponent_).
       </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-applying-the-exp-operator">
-      <h1>Applying the `**` Operator</h1>
-      <p>
-        Returns an implementation-dependent approximation of the result of raising _base_ to the power _exponent_.
-      </p>
-      <ul>
-        <li>If _exponent_ is *NaN*, the result is *NaN*.</li>
-        <li>If _exponent_ is *+0*, the result is 1, even if _base_ is *NaN*.</li>
-        <li>If _exponent_ is *-0*, the result is 1, even if _base_ is *NaN*.</li>
-        <li>If _base_ is *NaN* and _exponent_ is nonzero, the result is *NaN*.</li>
-        <li>If abs(_base_) &gt; 1 and _exponent_ is *+&infin;*, the result is *+&infin;*.</li>
-        <li>If abs(_base_) &gt; 1 and _exponent_ is *-&infin;*, the result is *+0*.</li>
-        <li>If abs(_base_) is 1 and _exponent_ is *+&infin;*, the result is *NaN*.</li>
-        <li>If abs(_base_) is 1 and _exponent_ is *-&infin;*, the result is *NaN*.</li>
-        <li>If abs(_base_) &lt; 1 and _exponent_ is *+&infin;*, the result is *+0*.</li>
-        <li>If abs(_base_) &lt; 1 and _exponent_ is *-&infin;*, the result is *+&infin;*.</li>
-        <li>If _base_ is *+&infin;* and _exponent_ &gt; 0, the result is *+&infin;*.</li>
-        <li>If _base_ is *+&infin;* and _exponent_ &lt; 0, the result is *+0*.</li>
-        <li>If _base_ is *-&infin;* and _exponent_ &gt; 0 and _exponent_ is an odd integer, the result is *-&infin;*.</li>
-        <li>If _base_ is *-&infin;* and _exponent_ &gt; 0 and _exponent_ is not an odd integer, the result is *+&infin;*.</li>
-        <li>If _base_ is *-&infin;* and _exponent_ &lt; 0 and _exponent_ is an odd integer, the result is *-0*.</li>
-        <li>If _base_ is *-&infin;* and _exponent_ &lt; 0 and _exponent_ is not an odd integer, the result is *+0*.</li>
-        <li>If _base_ is *+0* and _exponent_ &gt; 0, the result is *+0*.</li>
-        <li>If _base_ is *+0* and _exponent_ &lt; 0, the result is *+&infin;*.</li>
-        <li>If _base_ is *-0* and _exponent_ &gt; 0 and _exponent_ is an odd integer, the result is *-0*.</li>
-        <li>If _base_ is *-0* and _exponent_ &gt; 0 and _exponent_ is not an odd integer, the result is *+0*.</li>
-        <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is an odd integer, the result is *-&infin;*.</li>
-        <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is not an odd integer, the result is *+&infin;*.</li>
-        <li>If _base_ &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integer, the result is *NaN*.</li>
-      </ul>
-      <emu-note>
-        <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity* differs from IEEE 754-2008. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2008 specified *1*. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
-      </emu-note>
     </emu-clause>
   </emu-clause>
 
@@ -13387,100 +14406,14 @@
         1. Let _leftValue_ be ? GetValue(_left_).
         1. Let _right_ be the result of evaluating |ExponentiationExpression|.
         1. Let _rightValue_ be ? GetValue(_right_).
-        1. Let _lnum_ be ? ToNumber(_leftValue_).
-        1. Let _rnum_ be ? ToNumber(_rightValue_).
-        1. Return the result of applying the |MultiplicativeOperator| (`*`, `/`, or `%`) to _lnum_ and _rnum_ as specified in <emu-xref href="#sec-applying-the-mul-operator"></emu-xref>, <emu-xref href="#sec-applying-the-div-operator"></emu-xref>, or <emu-xref href="#sec-applying-the-mod-operator"></emu-xref>.
+        1. Let _lnum_ be ? ToNumeric(_leftValue_).
+        1. Let _rnum_ be ? ToNumeric(_rightValue_).
+        1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+        1. Let _T_ be Type(_lnum_).
+        1. If |MultiplicativeOperator| is `*`, return _T_::multiply(_lnum_, _rnum_).
+        1. If |MultiplicativeOperator| is `/`, return _T_::divide(_lnum_, _rnum_).
+        1. Otherwise, |MultiplicativeOperator| is `%`; return _T_::remainder(_lnum_, _rnum_).
       </emu-alg>
-
-      <emu-clause id="sec-applying-the-mul-operator">
-        <h1>Applying the `*` Operator</h1>
-        <p>The `*` |MultiplicativeOperator| performs multiplication, producing the product of its operands. Multiplication is commutative. Multiplication is not always associative in ECMAScript, because of finite precision.</p>
-        <p>The result of a floating-point multiplication is governed by the rules of IEEE 754-2008 binary double-precision arithmetic:</p>
-        <ul>
-          <li>
-            If either operand is *NaN*, the result is *NaN*.
-          </li>
-          <li>
-            The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
-          </li>
-          <li>
-            Multiplication of an infinity by a zero results in *NaN*.
-          </li>
-          <li>
-            Multiplication of an infinity by an infinity results in an infinity. The sign is determined by the rule already stated above.
-          </li>
-          <li>
-            Multiplication of an infinity by a finite nonzero value results in a signed infinity. The sign is determined by the rule already stated above.
-          </li>
-          <li>
-            In the remaining cases, where neither an infinity nor *NaN* is involved, the product of the mathematical values of the operands is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the result is then a zero of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
-          </li>
-        </ul>
-      </emu-clause>
-
-      <emu-clause id="sec-applying-the-div-operator">
-        <h1>Applying the `/` Operator</h1>
-        <p>The `/` |MultiplicativeOperator| performs division, producing the quotient of its operands. The left operand is the dividend and the right operand is the divisor. ECMAScript does not perform integer division. The operands and result of all division operations are double-precision floating-point numbers. The result of division is determined by the specification of IEEE 754-2008 arithmetic:</p>
-        <ul>
-          <li>
-            If either operand is *NaN*, the result is *NaN*.
-          </li>
-          <li>
-            The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
-          </li>
-          <li>
-            Division of an infinity by an infinity results in *NaN*.
-          </li>
-          <li>
-            Division of an infinity by a zero results in an infinity. The sign is determined by the rule already stated above.
-          </li>
-          <li>
-            Division of an infinity by a nonzero finite value results in a signed infinity. The sign is determined by the rule already stated above.
-          </li>
-          <li>
-            Division of a finite value by an infinity results in zero. The sign is determined by the rule already stated above.
-          </li>
-          <li>
-            Division of a zero by a zero results in *NaN*; division of zero by any other finite value results in zero, with the sign determined by the rule already stated above.
-          </li>
-          <li>
-            Division of a nonzero finite value by a zero results in a signed infinity. The sign is determined by the rule already stated above.
-          </li>
-          <li>
-            In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the quotient of the mathematical values of the operands is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven. If the magnitude is too large to represent, the operation overflows; the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the operation underflows and the result is a zero of the appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
-          </li>
-        </ul>
-      </emu-clause>
-
-      <emu-clause id="sec-applying-the-mod-operator">
-        <h1>Applying the `%` Operator</h1>
-        <p>The `%` |MultiplicativeOperator| yields the remainder of its operands from an implied division; the left operand is the dividend and the right operand is the divisor.</p>
-        <emu-note>
-          <p>In C and C++, the remainder operator accepts only integral operands; in ECMAScript, it also accepts floating-point operands.</p>
-        </emu-note>
-        <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2008. The IEEE 754-2008 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual integer remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java integer remainder operator; this may be compared with the C library function fmod.</p>
-        <p>The result of an ECMAScript floating-point remainder operation is determined by the rules of IEEE arithmetic:</p>
-        <ul>
-          <li>
-            If either operand is *NaN*, the result is *NaN*.
-          </li>
-          <li>
-            The sign of the result equals the sign of the dividend.
-          </li>
-          <li>
-            If the dividend is an infinity, or the divisor is a zero, or both, the result is *NaN*.
-          </li>
-          <li>
-            If the dividend is finite and the divisor is an infinity, the result equals the dividend.
-          </li>
-          <li>
-            If the dividend is a zero and the divisor is nonzero and finite, the result is the same as the dividend.
-          </li>
-          <li>
-            In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the floating-point remainder _r_ from a dividend _n_ and a divisor _d_ is defined by the mathematical relation _r_ = ℝ(_n_) - (ℝ(_d_) &times; _q_) where _q_ is a mathematical integer that is negative only if ℝ(_n_) &divide;<sub>ℝ</sub> ℝ(_d_) is negative and positive only if ℝ(_n_) &divide;<sub>ℝ</sub> ℝ(_d_) is positive, and whose magnitude is as large as possible without exceeding ℝ(_n_) &divide;<sub>ℝ</sub> ℝ(_d_). The result of the operation is the Number value for _r_.
-          </li>
-        </ul>
-      </emu-clause>
     </emu-clause>
   </emu-clause>
 
@@ -13540,9 +14473,11 @@
             1. Let _lstr_ be ? ToString(_lprim_).
             1. Let _rstr_ be ? ToString(_rprim_).
             1. Return the string-concatenation of _lstr_ and _rstr_.
-          1. Let _lnum_ be ? ToNumber(_lprim_).
-          1. Let _rnum_ be ? ToNumber(_rprim_).
-          1. Return the result of applying the addition operation to _lnum_ and _rnum_. See the Note below <emu-xref href="#sec-applying-the-additive-operators-to-numbers"></emu-xref>.
+          1. Let _lnum_ be ? ToNumeric(_lprim_).
+          1. Let _rnum_ be ? ToNumeric(_rprim_).
+          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+          1. Let _T_ be Type(_lnum_).
+          1. Return _T_::add(_lnum_, _rnum_).
         </emu-alg>
         <emu-note>
           <p>No hint is provided in the calls to ToPrimitive in steps 5 and 6. All standard objects except Date objects handle the absence of a hint as if the hint Number were given; Date objects handle the absence of a hint as if the hint String were given. Exotic objects may handle the absence of a hint in some other manner.</p>
@@ -13564,47 +14499,13 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |MultiplicativeExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lnum_ be ? ToNumber(_lval_).
-          1. Let _rnum_ be ? ToNumber(_rval_).
-          1. Return the result of applying the subtraction operation to _lnum_ and _rnum_. See the note below <emu-xref href="#sec-applying-the-additive-operators-to-numbers"></emu-xref>.
+          1. Let _lnum_ be ? ToNumeric(_lval_).
+          1. Let _rnum_ be ? ToNumeric(_rval_).
+          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+          1. Let _T_ be Type(_lnum_).
+          1. Return _T_::subtract(_lnum_, _rnum_).
         </emu-alg>
       </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-applying-the-additive-operators-to-numbers">
-      <h1>Applying the Additive Operators to Numbers</h1>
-      <p>The `+` operator performs addition when applied to two operands of numeric type, producing the sum of the operands. The `-` operator performs subtraction, producing the difference of two numeric operands.</p>
-      <p>Addition is a commutative operation, but not always associative.</p>
-      <p>The result of an addition is determined using the rules of IEEE 754-2008 binary double-precision arithmetic:</p>
-      <ul>
-        <li>
-          If either operand is *NaN*, the result is *NaN*.
-        </li>
-        <li>
-          The sum of two infinities of opposite sign is *NaN*.
-        </li>
-        <li>
-          The sum of two infinities of the same sign is the infinity of that sign.
-        </li>
-        <li>
-          The sum of an infinity and a finite value is equal to the infinite operand.
-        </li>
-        <li>
-          The sum of two negative zeroes is *-0*. The sum of two positive zeroes, or of two zeroes of opposite sign, is *+0*.
-        </li>
-        <li>
-          The sum of a zero and a nonzero finite value is equal to the nonzero operand.
-        </li>
-        <li>
-          The sum of two nonzero finite values of the same magnitude and opposite sign is *+0*.
-        </li>
-        <li>
-          In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, and the operands have the same sign or have different magnitudes, the sum of the mathematical values of the operands is computed and rounded to the nearest representable value using IEEE 754-2008 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows and the result is then an infinity of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2008.
-        </li>
-      </ul>
-      <emu-note>
-        <p>The `-` operator performs subtraction when applied to two operands of numeric type, producing the difference of its operands; the left operand is the minuend and the right operand is the subtrahend. Given numeric operands `a` and `b`, it is always the case that `a - b` produces the same result as `a + (-b)`.</p>
-      </emu-note>
     </emu-clause>
   </emu-clause>
 
@@ -13661,10 +14562,11 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |AdditiveExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lnum_ be ? ToInt32(_lval_).
-          1. Let _rnum_ be ? ToUint32(_rval_).
-          1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
-          1. Return the result of left shifting _lnum_ by _shiftCount_ bits. The result is a signed 32-bit integer.
+          1. Let _lnum_ be ? ToNumeric(_lval_).
+          1. Let _rnum_ be ? ToNumeric(_rval_).
+          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+          1. Let _T_ be Type(_lnum_).
+          1. Return _T_::leftShift(_lnum_, _rnum_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -13683,10 +14585,11 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |AdditiveExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lnum_ be ? ToInt32(_lval_).
-          1. Let _rnum_ be ? ToUint32(_rval_).
-          1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
-          1. Return the result of performing a sign-extending right shift of _lnum_ by _shiftCount_ bits. The most significant bit is propagated. The result is a signed 32-bit integer.
+          1. Let _lnum_ be ? ToNumeric(_lval_).
+          1. Let _rnum_ be ? ToNumeric(_rval_).
+          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+          1. Let _T_ be Type(_lnum_).
+          1. Return _T_::signedRightShift(_lnum_, _rnum_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -13705,10 +14608,11 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |AdditiveExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lnum_ be ? ToUint32(_lval_).
-          1. Let _rnum_ be ? ToUint32(_rval_).
-          1. Let _shiftCount_ be the result of masking out all but the least significant 5 bits of _rnum_, that is, compute _rnum_ &amp; 0x1F.
-          1. Return the result of performing a zero-filling right shift of _lnum_ by _shiftCount_ bits. Vacated bits are filled with zero. The result is an unsigned 32-bit integer.
+          1. Let _lnum_ be ? ToNumeric(_lval_).
+          1. Let _rnum_ be ? ToNumeric(_rval_).
+          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+          1. Let _T_ be Type(_lnum_).
+          1. Return _T_::unsignedRightShift(_lnum_, _rnum_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -14026,9 +14930,13 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating _B_.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _lnum_ be ? ToInt32(_lval_).
-        1. Let _rnum_ be ? ToInt32(_rval_).
-        1. Return the result of applying the bitwise operator @ to _lnum_ and _rnum_. The result is a signed 32-bit integer.
+        1. Let _lnum_ be ? ToNumeric(_lval_).
+        1. Let _rnum_ be ? ToNumeric(_rval_).
+        1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+        1. Let _T_ be Type(_lnum_).
+        1. If @ is `&amp;`, return _T_::bitwiseAND(_lnum_, _rnum_).
+        1. If @ is `|`, return _T_::bitwiseOR(_lnum_, _rnum_).
+        1. Otherwise, @ is `^`; return _T_::bitwiseXOR(_lnum_, _rnum_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -25990,7 +26898,7 @@
           1. Else, let _radixNumber_ be ? ToInteger(_radix_).
           1. If _radixNumber_ &lt; 2 or _radixNumber_ &gt; 36, throw a *RangeError* exception.
           1. If _radixNumber_ = 10, return ! ToString(_x_).
-          1. Return the String representation of this Number value using the radix specified by _radixNumber_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-dependent, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-tostring-applied-to-the-number-type"></emu-xref>.
+          1. Return the String representation of this Number value using the radix specified by _radixNumber_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-dependent, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-number-tostring"></emu-xref>.
         </emu-alg>
         <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Number or a Number object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
         <p>The `"length"` property of the `toString` method is 1.</p>
@@ -26007,6 +26915,135 @@
     <emu-clause id="sec-properties-of-number-instances">
       <h1>Properties of Number Instances</h1>
       <p>Number instances are ordinary objects that inherit properties from the Number prototype object. Number instances also have a [[NumberData]] internal slot. The [[NumberData]] internal slot is the Number value represented by this Number object.</p>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-bigint-objects">
+    <h1>BigInt Objects</h1>
+    <emu-clause id="sec-bigint-constructor">
+      <h1>The BigInt Constructor</h1>
+      <p>The BigInt constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%BigInt%</dfn>.</li>
+        <li>is the initial value of the `BigInt` property of the global object.</li>
+        <li>performs a type conversion when called as a function rather than as a constructor.</li>
+        <li>is not intended to be used with the `new` operator or to be subclassed. It may be used as the value of an `extends` clause of a class definition but a `super` call to the `BigInt` constructor will cause an exception.</li>
+      </ul>
+
+      <emu-clause id="sec-bigint-constructor-number-value">
+        <h1>BigInt ( _value_ )</h1>
+        <p>When `BigInt` is called with argument _value_, the following steps are taken:</p>
+        <emu-alg>
+          1. If NewTarget is not *undefined*, throw a *TypeError* exception.
+          1. Let _prim_ be ? ToPrimitive(_value_, hint Number).
+          1. If Type(_prim_) is Number, return ? NumberToBigInt(_prim_).
+          1. Otherwise, return ? ToBigInt(_value_).
+        </emu-alg>
+
+        <emu-clause id="sec-number-to-bigint" aoid="NumberToBigInt">
+          <h1>Runtime Semantics: NumberToBigInt ( _number_ )</h1>
+          <emu-alg>
+            1. Assert: Type(_number_) is Number.
+            1. If IsInteger(_number_) is *false*, throw a *RangeError* exception.
+            1. Return the BigInt value that represents the mathematical value of _number_.
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-the-bigint-constructor">
+      <h1>Properties of the BigInt Constructor</h1>
+      <p>The value of the [[Prototype]] internal slot of the BigInt constructor is the intrinsic object %FunctionPrototype%.</p>
+      <p>The BigInt constructor has the following properties:</p>
+
+      <emu-clause id="sec-bigint.asintn">
+        <h1>BigInt.asIntN ( _bits_, _bigint_ )</h1>
+        <p>When the `BigInt.asIntN` is called with two arguments _bits_ and _bigint_, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _bits_ be ? ToIndex(_bits_).
+          1. Let _bigint_ be ? ToBigInt(_bigint_).
+          1. Let _mod_ be the BigInt value that represents _bigint_ modulo 2<sup>_bits_</sup>.
+          1. If _mod_ &ge; 2<sup>_bits_ - 1</sup>, return _mod_ - 2<sup>_bits_</sup>; otherwise, return _mod_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-bigint.asuintn">
+        <h1>BigInt.asUintN ( _bits_, _bigint_ )</h1>
+        <p>When the `BigInt.asUintN` function is called with two arguments _bits_ and _bigint_, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _bits_ be ? ToIndex(_bits_).
+          1. Let _bigint_ be ? ToBigInt(_bigint_).
+          1. Return the BigInt value that represents _bigint_ modulo 2<sup>_bits_</sup>.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-bigint.prototype">
+        <h1>BigInt.prototype</h1>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-the-bigint-prototype-object">
+      <h1>Properties of the BigInt Prototype Object</h1>
+      <p>The BigInt prototype object:</p>
+      <ul>
+        <li>is an ordinary object.</li>
+        <li>is not a BigInt object; it does not have a [[BigIntData]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Object.prototype%.</li>
+      </ul>
+
+      <p>The abstract operation <dfn id="sec-thisbigintvalue" aoid="thisBigIntValue">thisBigIntValue</dfn>(_value_) performs the following steps:</p>
+      <emu-alg>
+        1. If Type(_value_) is BigInt, return _value_.
+        1. If Type(_value_) is Object and _value_ has a [[BigIntData]] internal slot, then
+          1. Assert: Type(_value_.[[BigIntData]]) is BigInt.
+          1. Return _value_.[[BigIntData]].
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+      <p>The phrase &ldquo;this BigInt value&rdquo; within the specification of a method refers to the result returned by calling the abstract operation thisBigIntValue with the *this* value of the method invocation passed as the argument.</p>
+
+      <emu-clause id="sec-bigint.prototype.constructor">
+        <h1>BigInt.prototype.constructor</h1>
+        <p>The initial value of `BigInt.prototype.constructor` is the intrinsic object %BigInt%.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-bigint.prototype.tolocalestring">
+        <h1>BigInt.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `BigInt.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
+        <p>Produces a String value that represents this BigInt value formatted according to the conventions of the host environment's current locale. This function is implementation-dependent, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
+        <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-bigint.prototype.tostring">
+        <h1>BigInt.prototype.toString ( [ _radix_ ] )</h1>
+        <emu-note>
+          <p>The optional _radix_ should be an integer value in the inclusive range 2 to 36. If _radix_ not present or is *undefined* the Number 10 is used as the value of _radix_.</p>
+        </emu-note>
+        <p>The following steps are performed:</p>
+        <emu-alg>
+          1. Let _x_ be ? thisBigIntValue(*this* value).
+          1. If _radix_ is not present, let _radixNumber_ be 10.
+          1. Else if _radix_ is *undefined*, let _radixNumber_ be 10.
+          1. Else, let _radixNumber_ be ? ToInteger(_radix_).
+          1. If _radixNumber_ &lt; 2 or _radixNumber_ &gt; 36, throw a *RangeError* exception.
+          1. If _radixNumber_ = 10, return ! ToString(_x_).
+          1. Return the String representation of this Number value using the radix specified by _radixNumber_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-dependent, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-bigint-tostring"></emu-xref>.
+        </emu-alg>
+        <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a BigInt or a BigInt object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-bigint.prototype.valueof">
+        <h1>BigInt.prototype.valueOf ( )</h1>
+        <emu-alg>
+          1. Return ? thisBigIntValue(*this* value).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-bigint.prototype-@@tostringtag">
+        <h1>BigInt.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value `"BigInt"`.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 
@@ -26686,7 +27723,9 @@
       <emu-clause id="sec-math.pow">
         <h1>Math.pow ( _base_, _exponent_ )</h1>
         <emu-alg>
-          1. Return the result of <emu-xref href="#sec-applying-the-exp-operator" title>Applying the ** operator</emu-xref> with _base_ and _exponent_ as specified in <emu-xref href="#sec-applying-the-exp-operator"></emu-xref>.
+          1. Let _base_ be ? ToNumber(_base_).
+          1. Let _exponent_ be ? ToNumber(_exponent_).
+          1. Return ! Number::exponentiate(_base_, _exponent_).
         </emu-alg>
       </emu-clause>
 
@@ -33117,7 +34156,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-typedarray-objects">
     <h1>TypedArray Objects</h1>
-    <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). Each element of a _TypedArray_ instance has the same underlying binary scalar data type. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-49"></emu-xref>, for each of the nine supported element types. Each constructor in <emu-xref href="#table-49"></emu-xref> has a corresponding distinct prototype object.</p>
+    <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). Each element of a _TypedArray_ instance has the same underlying binary scalar data type. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-49"></emu-xref>, for each of the supported element types. Each constructor in <emu-xref href="#table-49"></emu-xref> has a corresponding distinct prototype object.</p>
     <emu-table id="table-49" caption="The TypedArray Constructors">
       <table>
         <tbody>
@@ -33269,6 +34308,44 @@ THH:mm:ss.sss
           </td>
           <td>
             32-bit unsigned integer
+          </td>
+        </tr>
+        <tr>
+          <td>
+            BigInt64Array
+            <br>
+            %BigInt64Array%
+          </td>
+          <td>
+            BigInt64
+          </td>
+          <td>
+            8
+          </td>
+          <td>
+            ToBigInt64
+          </td>
+          <td>
+            64-bit two's complement signed integer
+          </td>
+        </tr>
+        <tr>
+          <td>
+            BigUint64Array
+            <br>
+            %BigUint64Array%
+          </td>
+          <td>
+            BigUint64
+          </td>
+          <td>
+            8
+          </td>
+          <td>
+            ToBigUint64
+          </td>
+          <td>
+            64-bit unsigned integer
           </td>
         </tr>
         <tr>
@@ -33575,7 +34652,8 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. Set _value_ to ? ToNumber(_value_).
+          1. If _O_.[[ContentType]] is `"BigInt"`, let _value_ be ? ToBigInt(_value_).
+          1. Otherwise, let _value_ be ? ToNumber(_value_).
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
@@ -33758,9 +34836,11 @@ THH:mm:ss.sss
             1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ &times; _srcLength_.
             1. Repeat, while _targetByteIndex_ &lt; _limit_
               1. Let _Pk_ be ! ToString(_k_).
-              1. Let _kNumber_ be ? ToNumber(? Get(_src_, _Pk_)).
+              1. Let _value_ be ? Get(_src_, _Pk_).
+              1. If _target_.[[ContentType]] is `"BigInt"`, let _value_ be ? ToBigInt(_value_).
+              1. Otherwise, let _value_ be ? ToNumber(_value_).
               1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _kNumber_, *true*, `"Unordered"`).
+              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, `"Unordered"`).
               1. Set _k_ to _k_ + 1.
               1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
             1. Return *undefined*.
@@ -33792,6 +34872,7 @@ THH:mm:ss.sss
             1. Let _srcLength_ be _typedArray_.[[ArrayLength]].
             1. Let _srcByteOffset_ be _typedArray_.[[ByteOffset]].
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
+            1. If _target_.[[ContentType]] is not equal to _typedArray_.[[ContentType]], throw a *TypeError* exception.
             1. If both IsSharedArrayBuffer(_srcBuffer_) and IsSharedArrayBuffer(_targetBuffer_) are *true*, then
               1. If _srcBuffer_.[[ArrayBufferData]] and _targetBuffer_.[[ArrayBufferData]] are the same Shared Data Block values, let _same_ be *true*; else let _same_ be *false*.
             1. Else, let _same_ be SameValue(_srcBuffer_, _targetBuffer_).
@@ -33887,7 +34968,7 @@ THH:mm:ss.sss
         <p>The following version of SortCompare is used by %TypedArray%`.prototype.sort`. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. SortCompare has access to the _comparefn_ and _buffer_ values of the current invocation of the `sort` method.</p>
         <p>When the TypedArray SortCompare abstract operation is called with two arguments _x_ and _y_, the following steps are taken:</p>
         <emu-alg>
-          1. Assert: Both Type(_x_) and Type(_y_) is Number.
+          1. Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.
           1. If _comparefn_ is not *undefined*, then
             1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
@@ -34014,9 +35095,11 @@ THH:mm:ss.sss
           <p>The abstract operation AllocateTypedArray with arguments _constructorName_, _newTarget_, _defaultProto_ and optional argument _length_ is used to validate and create an instance of a TypedArray constructor. _constructorName_ is required to be the name of a TypedArray constructor in <emu-xref href="#table-49"></emu-xref>. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypedArray_ overloads. AllocateTypedArray performs the following steps:</p>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
-            1. Let _obj_ be IntegerIndexedObjectCreate(_proto_, &laquo; [[ViewedArrayBuffer]], [[TypedArrayName]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;).
+            1. Let _obj_ be IntegerIndexedObjectCreate(_proto_, &laquo; [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;).
             1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
             1. Set _obj_.[[TypedArrayName]] to _constructorName_.
+            1. If _constructorName_ is `"BigInt64Array"` or `"BigUint64Array"`, set _obj_.[[ContentType]] to `"BigInt"`.
+            1. Otherwise, set _obj_.[[ContentType]] to `"Number"`.
             1. If _length_ is not present, then
               1. Set _obj_.[[ByteLength]] to 0.
               1. Set _obj_.[[ByteOffset]] to 0.
@@ -34076,6 +35159,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
             1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
+            1. If _srcArray_.[[ContentType]] is not equal to _O_.[[ContentType]], throw a *TypeError* exception.
             1. Let _srcByteIndex_ be _srcByteOffset_.
             1. Let _targetByteIndex_ be 0.
             1. Let _count_ be _elementLength_.
@@ -34176,10 +35260,13 @@ THH:mm:ss.sss
         <h1>TypedArraySpeciesCreate ( _exemplar_, _argumentList_ )</h1>
         <p>The abstract operation TypedArraySpeciesCreate with arguments _exemplar_ and _argumentList_ is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps:</p>
         <emu-alg>
-          1. Assert: _exemplar_ is an Object that has a [[TypedArrayName]] internal slot.
+          1. Assert: _exemplar_ is an Object that has [[TypedArrayName]] and [[ContentType]] internal slots.
           1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-49"></emu-xref> for _exemplar_.[[TypedArrayName]].
           1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
-          1. Return ? TypedArrayCreate(_constructor_, _argumentList_).
+          1. Let _result_ be ? TypedArrayCreate(_constructor_, _argumentList_).
+          1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
+          1. If _result_.[[ContentType]] is not equal to _exemplar_.[[ContentType]], throw a *TypeError* exception.
+          1. Return _result_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -35287,9 +36374,46 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-rawbytestonumber" aoid="RawBytesToNumber">
-        <h1>RawBytesToNumber ( _type_, _rawBytes_, _isLittleEndian_ )</h1>
-        <p>The abstract operation RawBytesToNumber takes three parameters, a String _type_, a List _rawBytes_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+      <emu-clause id="sec-isunsignedelementtype" aoid="IsUnsignedElementType">
+        <h1>IsUnsignedElementType ( _type_ )</h1>
+        <p>The abstract operation IsUnsignedElementType verifies if the argument _type_ is an unsigned TypedArray element type. This operation performs the following steps:</p>
+        <emu-alg>
+          1. If _type_ is `"Uint8"`, `"Uint8C"`, `"Uint16"`, `"Uint32"`, or `"BigUint64"`, return *true*.
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-isunclampedintegerelementtype" aoid="IsUnclampedIntegerElementType">
+        <h1>IsUnclampedIntegerElementType ( _type_ )</h1>
+        <p>The abstract operation IsUnclampedIntegerElementType verifies if the argument _type_ is an Interger TypedArray element type not including `"Uint8C"`. This operation performs the following steps:</p>
+        <emu-alg>
+          1. If _type_ is `"Int8"`, `"Uint8"`, `"Int16"`, `"Uint16"`, `"Int32"`, or `"Uint32"`, return *true*.
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-isbigintelementtype" aoid="IsBigIntElementType">
+        <h1>IsBigIntElementType ( _type_ )</h1>
+        <p>The abstract operation IsBigIntElementType verifies if the argument _type_ is a BigInt TypedArray element type. This operation performs the following steps:</p>
+        <emu-alg>
+          1. If _type_ is `"BigUint64"` or `"BigInt64"`, return *true*.
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-isnotearconfiguration" aoid="IsNoTearConfiguration">
+        <h1>IsNoTearConfiguration ( _type_, _order_ )</h1>
+        <p>The abstract operation IsNoTearConfiguration with arguments _type_ and _order_ performs the following steps:</p>
+        <emu-alg>
+          1. If ! IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
+          1. If ! IsBigIntElementType(_type_) is *true* and _order_ is not `"Init"` or `"Unordered"`, return *true*.
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-rawbytestonumeric" aoid="RawBytesToNumeric" oldids="sec-rawbytestonumber">
+        <h1>RawBytesToNumeric ( _type_, _rawBytes_, _isLittleEndian_ )</h1>
+        <p>The abstract operation RawBytesToNumeric takes three parameters, a String _type_, a List _rawBytes_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is *false*, reverse the order of the elements of _rawBytes_.
@@ -35301,11 +36425,12 @@ THH:mm:ss.sss
             1. Let _value_ be the byte elements of _rawBytes_ concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2008 binary64 value.
             1. If _value_ is an IEEE 754-2008 binary64 NaN value, return the *NaN* Number value.
             1. Return the Number value that corresponds to _value_.
-          1. If the first code unit of _type_ is the code unit 0x0055 (LATIN CAPITAL LETTER U), then
+          1. If ! IsUnsignedElementType(_type_) is *true*, then
             1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of an unsigned little-endian binary number.
           1. Else,
             1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of a binary little-endian 2's complement number of bit length _elementSize_ &times; 8.
-          1. Return the Number value that corresponds to _intValue_.
+          1. If ! IsBigIntElementType(_type_) is *true*, return the BigInt value that corresponds to _intValue_.
+          1. Otherwise, return the Number value that corresponds to _intValue_.
         </emu-alg>
       </emu-clause>
 
@@ -35321,7 +36446,7 @@ THH:mm:ss.sss
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
             1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
-            1. If _isTypedArray_ is *true* and _type_ is `"Int8"`, `"Uint8"`, `"Int16"`, `"Uint16"`, `"Int32"`, or `"Uint32"`, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
+            1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
             1. Let _rawValue_ be a List of length _elementSize_ of nondeterministically chosen byte values.
             1. NOTE: In implementations, _rawValue_ is the result of a non-atomic or atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
             1. Let _readEvent_ be ReadSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_ }.
@@ -35329,13 +36454,13 @@ THH:mm:ss.sss
             1. Append Chosen Value Record { [[Event]]: _readEvent_, [[ChosenValue]]: _rawValue_ } to _execution_.[[ChosenValues]].
           1. Else, let _rawValue_ be a List of _elementSize_ containing, in order, the _elementSize_ sequence of bytes starting with _block_[_byteIndex_].
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
-          1. Return RawBytesToNumber(_type_, _rawValue_, _isLittleEndian_).
+          1. Return RawBytesToNumeric(_type_, _rawValue_, _isLittleEndian_).
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-numbertorawbytes" aoid="NumberToRawBytes">
-        <h1>NumberToRawBytes ( _type_, _value_, _isLittleEndian_ )</h1>
-        <p>The abstract operation NumberToRawBytes takes three parameters, a String _type_, a Number _value_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+      <emu-clause id="sec-numerictorawbytes" aoid="NumericToRawBytes" oldids="sec-numbertorawbytes">
+        <h1>NumericToRawBytes ( _type_, _value_, _isLittleEndian_ )</h1>
+        <p>The abstract operation NumericToRawBytes takes three parameters, a String _type_, a BigInt or a Number _value_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
           1. If _type_ is `"Float32"`, then
             1. Let _rawBytes_ be a List containing the 4 bytes that are the result of converting _value_ to IEEE 754-2008 binary32 format using roundTiesToEven mode. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2008 binary32 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
@@ -35344,7 +36469,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _n_ be the Element Size specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
             1. Let _convOp_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
-            1. Let _intValue_ be _convOp_(_value_).
+            1. Let _intValue_ be _convOp_(_value_) treated as a mathematical value, whether the result is a BigInt or Number.
             1. If _intValue_ &ge; 0, then
               1. Let _rawBytes_ be a List containing the _n_-byte binary encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
             1. Else,
@@ -35360,15 +36485,15 @@ THH:mm:ss.sss
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
           1. Assert: _byteIndex_ is an integer value &ge; 0.
-          1. Assert: Type(_value_) is Number.
+          1. Assert: Type(_value_) is BigInt if ! IsBigIntElementType(_type_) is *true*; otherwise, Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
-          1. Let _rawBytes_ be NumberToRawBytes(_type_, _value_, _isLittleEndian_).
+          1. Let _rawBytes_ be NumericToRawBytes(_type_, _value_, _isLittleEndian_).
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
             1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
-            1. If _isTypedArray_ is *true* and _type_ is `"Int8"`, `"Uint8"`, `"Int16"`, `"Uint16"`, `"Int32"`, or `"Uint32"`, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
+            1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
             1. Append WriteSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_ } to _eventList_.
           1. Else, store the individual bytes of _rawBytes_ into _block_, in order, starting at _block_[_byteIndex_].
           1. Return NormalCompletion(*undefined*).
@@ -35382,11 +36507,11 @@ THH:mm:ss.sss
           1. Assert: IsSharedArrayBuffer(_arrayBuffer_) is *true*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
           1. Assert: _byteIndex_ is an integer value &ge; 0.
-          1. Assert: Type(_value_) is Number.
+          1. Assert: Type(_value_) is BigInt if ! IsBigIntElementType(_type_) is *true*; otherwise, Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
-          1. Let _rawBytes_ be NumberToRawBytes(_type_, _value_, _isLittleEndian_).
+          1. Let _rawBytes_ be NumericToRawBytes(_type_, _value_, _isLittleEndian_).
           1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
           1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _rawBytesRead_ be a List of length _elementSize_ of nondeterministically chosen byte values.
@@ -35394,7 +36519,7 @@ THH:mm:ss.sss
           1. Let _rmwEvent_ be ReadModifyWriteSharedMemory { [[Order]]: `"SeqCst"`, [[NoTear]]: *true*, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_, [[ModifyOp]]: _op_ }.
           1. Append _rmwEvent_ to _eventList_.
           1. Append Chosen Value Record { [[Event]]: _rmwEvent_, [[ChosenValue]]: _rawBytesRead_ } to _execution_.[[ChosenValues]].
-          1. Return RawBytesToNumber(_type_, _rawBytesRead_, _isLittleEndian_).
+          1. Return RawBytesToNumeric(_type_, _rawBytesRead_, _isLittleEndian_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -35716,7 +36841,8 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
-          1. Let _numberValue_ be ? ToNumber(_value_).
+          1. If ! IsBigIntElementType(_type_) is *true*, let _numberValue_ be ? ToBigInt(_value_).
+          1. Otherwise, let _numberValue_ be ? ToInteger(_value_).
           1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
@@ -35836,6 +36962,26 @@ THH:mm:ss.sss
         <p>The initial value of `DataView.prototype.constructor` is %DataView%.</p>
       </emu-clause>
 
+      <emu-clause id="sec-dataview.prototype.getbigint64">
+        <h1>DataView.prototype.getBigInt64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
+        <p>When the `getBigInt64` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _v_ be the *this* value.
+          1. If _littleEndian_ is not present, let _littleEndian_ be *undefined*.
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"BigInt64"`).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-dataview.prototype.getbiguint64">
+        <h1>DataView.prototype.getBigUint64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
+        <p>When the `getBigUint64` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _v_ be the *this* value.
+          1. If _littleEndian_ is not present, let _littleEndian_ be *undefined*.
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"BigUint64"`).
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-dataview.prototype.getfloat32">
         <h1>DataView.prototype.getFloat32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>When the `getFloat32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
@@ -35911,6 +37057,26 @@ THH:mm:ss.sss
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint32"`).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-dataview.prototype.setbigint64">
+        <h1>DataView.prototype.setBigInt64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
+        <p>When the `setBigInt64` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _v_ be the *this* value.
+          1. If _littleEndian_ is not present, let _littleEndian_ be *undefined*.
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"BigInt64"`, _value_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-dataview.prototype.setbiguint64">
+        <h1>DataView.prototype.setBigUint64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
+        <p>When the `setBigUint64` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _v_ be the *this* value.
+          1. If _littleEndian_ is not present, let _littleEndian_ be *undefined*.
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"BigUint64"`, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -36028,16 +37194,17 @@ THH:mm:ss.sss
       <h1>Abstract Operations for Atomics</h1>
 
       <emu-clause id="sec-validatesharedintegertypedarray" aoid="ValidateSharedIntegerTypedArray">
-        <h1>ValidateSharedIntegerTypedArray ( _typedArray_ [ , _onlyInt32_ ] )</h1>
-        <p>The abstract operation ValidateSharedIntegerTypedArray takes one argument _typedArray_ and an optional Boolean _onlyInt32_. It performs the following steps:</p>
+        <h1>ValidateSharedIntegerTypedArray ( _typedArray_ [ , _waitable_ ] )</h1>
+        <p>The abstract operation ValidateSharedIntegerTypedArray takes one argument _typedArray_ and an optional Boolean _waitable_. It performs the following steps:</p>
         <emu-alg>
-          1. If _onlyInt32_ is not present, set _onlyInt32_ to *false*.
+          1. If _waitable_ is not present, set _waitable_ to *false*.
           1. Perform ? RequireInternalSlot(_typedArray_, [[TypedArrayName]]).
           1. Let _typeName_ be _typedArray_.[[TypedArrayName]].
-          1. If _onlyInt32_ is *true*, then
-            1. If _typeName_ is not `"Int32Array"`, throw a *TypeError* exception.
+          1. Let _type_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _typeName_.
+          1. If _waitable_ is *true*, then
+            1. If _typeName_ is not `"Int32Array"` or `"BigInt64Array"`, throw a *TypeError* exception.
           1. Else,
-            1. If _typeName_ is not `"Int8Array"`, `"Uint8Array"`, `"Int16Array"`, `"Uint16Array"`, `"Int32Array"`, or `"Uint32Array"`, throw a *TypeError* exception.
+            1. If ! IsUnclampedIntegerElementType(_type_) is *false* and ! IsBigIntElementType(_type_) is *false*, throw a *TypeError* exception.
           1. Assert: _typedArray_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
           1. If IsSharedArrayBuffer(_buffer_) is *false*, throw a *TypeError* exception.
@@ -36170,8 +37337,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
           1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-          1. Let _v_ be ? ToInteger(_value_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
+          1. If _typedArray_.[[ContentType]] is `"BigInt"`, let _v_ be ? ToBigInt(_v_).
+          1. Otherwise, let _v_ be ? ToInteger(_value_).
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _offset_ be _typedArray_.[[ByteOffset]].
@@ -36220,12 +37388,16 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-        1. Let _expected_ be ? ToInteger(_expectedValue_).
-        1. Let _replacement_ be ? ToInteger(_replacementValue_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
+        1. If _typedArray_.[[ContentType]] is `"BigInt"`, then
+          1. Let _expected_ be ? ToBigInt(_expectedValue_).
+          1. Let _replacement_ be ? ToBigInt(_replacementValue_).
+        1. Else,
+          1. Let _expected_ be ? ToInteger(_expectedValue_).
+          1. Let _replacement_ be ? ToInteger(_replacementValue_).
         1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
-        1. Let _expectedBytes_ be NumberToRawBytes(_elementType_, _expected_, _isLittleEndian_).
+        1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _offset_ be _typedArray_.[[ByteOffset]].
         1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
@@ -36252,11 +37424,13 @@ THH:mm:ss.sss
         1. If _n_ equals 1, return _AR_.[[IsLockFree1]].
         1. If _n_ equals 2, return _AR_.[[IsLockFree2]].
         1. If _n_ equals 4, return *true*.
+        1. If _n_ equals 8, return _AR_.[[IsLockFree8]].
         1. Return *false*.
       </emu-alg>
       <emu-note>
         <p>`Atomics.isLockFree`() is an optimization primitive. The intuition is that if the atomic step of an atomic primitive (`compareExchange`, `load`, `store`, `add`, `sub`, `and`, `or`, `xor`, or `exchange`) on a datum of size _n_ bytes will be performed without the calling agent acquiring a lock outside the _n_ bytes comprising the datum, then `Atomics.isLockFree`(_n_) will return *true*. High-performance algorithms will use Atomics.isLockFree to determine whether to use locks or atomic operations in critical sections. If an atomic primitive is not lock-free then it is often more efficient for an algorithm to provide its own locking.</p>
         <p>`Atomics.isLockFree`(4) always returns *true* as that can be supported on all known relevant hardware. Being able to assume this will generally simplify programs.</p>
+        <p>Regardless of the value of `Atomics.isLockFree`, all atomic operations are guaranteed to be atomic. For example, they will never have a visible operation take place in the middle of the operation (e.g., "tearing").</p>
       </emu-note>
     </emu-clause>
     <emu-clause id="sec-atomics.load">
@@ -36282,7 +37456,8 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-        1. Let _v_ be ? ToInteger(_value_).
+        1. If _arrayTypeName_ is `"BigUint64Array"` or `"BigInt64Array"`, let _v_ be ? ToBigInt(_value_).
+        1. Otherwise, let _v_ be ? ToInteger(_value_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
@@ -36308,14 +37483,16 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_, *true*).
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-        1. Let _v_ be ? ToInt32(_value_).
+        1. If _typedArray_.[[TypedArrayName]] is `"BigInt64Array"`, let _v_ be ? ToBigInt64(_value_).
+        1. Otherwise, let _v_ be ? ToInt32(_value_).
         1. Let _q_ be ? ToNumber(_timeout_).
         1. If _q_ is *NaN*, let _t_ be *+&infin;*; else let _t_ be max(_q_, 0).
         1. Let _B_ be AgentCanSuspend().
         1. If _B_ is *false*, throw a *TypeError* exception.
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; 4) + _offset_.
+        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Perform EnterCriticalSection(_WL_).
         1. Let _w_ be ! AtomicLoad(_typedArray_, _i_).
@@ -36347,7 +37524,8 @@ THH:mm:ss.sss
           1. Let _c_ be max(_intCount_, 0).
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; 4) + _offset_.
+        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Let _n_ be 0.
         1. Perform EnterCriticalSection(_WL_).
@@ -36557,6 +37735,8 @@ THH:mm:ss.sss
               1. Set _value_ to ? ToString(_value_).
             1. Else if _value_ has a [[BooleanData]] internal slot, then
               1. Set _value_ to _value_.[[BooleanData]].
+            1. Else if _value_ has a [[BigIntData]] internal slot, then
+              1. Set _value_ to _value_.[[BigIntData]].
           1. If _value_ is *null*, return `"null"`.
           1. If _value_ is *true*, return `"true"`.
           1. If _value_ is *false*, return `"false"`.
@@ -36564,6 +37744,7 @@ THH:mm:ss.sss
           1. If Type(_value_) is Number, then
             1. If _value_ is finite, return ! ToString(_value_).
             1. Return `"null"`.
+          1. If Type(_value_) is BigInt, throw a *TypeError* exception.
           1. If Type(_value_) is Object and IsCallable(_value_) is *false*, then
             1. Let _isArray_ be ? IsArray(_value_).
             1. If _isArray_ is *true*, return ? SerializeJSONArray(_value_).
@@ -39794,6 +40975,9 @@ THH:mm:ss.sss
     <emu-prodref name=NullLiteral></emu-prodref>
     <emu-prodref name=BooleanLiteral></emu-prodref>
     <emu-prodref name=NumericLiteral></emu-prodref>
+    <emu-prodref name=DecimalBigIntegerLiteral></emu-prodref>
+    <emu-prodref name=NonDecimalIntegerLiteral></emu-prodref>
+    <emu-prodref name=BigIntLiteralSuffix></emu-prodref>
     <emu-prodref name=DecimalLiteral></emu-prodref>
     <emu-prodref name=DecimalIntegerLiteral></emu-prodref>
     <emu-prodref name=DecimalDigits></emu-prodref>
@@ -40147,9 +41331,9 @@ THH:mm:ss.sss
       <emu-grammar type="definition">
         NumericLiteral ::
           DecimalLiteral
-          BinaryIntegerLiteral
-          OctalIntegerLiteral
-          HexIntegerLiteral
+          DecimalBigIntegerLiteral
+          NonDecimalIntegerLiteral
+          NonDecimalIntegerLiteral BigIntLiteralSuffix
           LegacyOctalIntegerLiteral
 
         LegacyOctalIntegerLiteral ::


### PR DESCRIPTION
This PR is include changes to integrate [tc39/proposal-bigint](https://github.com/tc39/proposal-bigint) into ECMA262 text. It contains changes on:

1. Grammar to support BigInt literals.
2. Abstract Operations to consider this new primitive.
3. Semantics of arithmetic expressions to support BigInts.
4. The specification of BigInt objects, including the constructor and BigInt.prototype.
5. Including `BigInt64Array` and `BigUint64Array` as new types of `TypedArray`.
6. Changes on `DataView` operations to support new types.

Proposal author: Daniel Ehrenberg and Brendan Eich