### PR TITLE
Editorial: Remove unnecessary steps before NewPromiseCapability

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38243,7 +38243,6 @@ THH:mm:ss.sss
         <p>The `all` function returns a new promise which is fulfilled with an array of fulfillment values for the passed promises, or rejects with the reason of the first passed promise that rejects. It resolves all elements of the passed iterable to promises as it runs this algorithm.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
-          1. If Type(_C_) is not Object, throw a *TypeError* exception.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _iteratorRecord_ be GetIterator(_iterable_).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
@@ -38331,7 +38330,6 @@ THH:mm:ss.sss
         <p>The `race` function returns a new promise which is settled in the same way as the first passed promise to settle. It resolves all elements of the passed _iterable_ to promises as it runs this algorithm.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
-          1. If Type(_C_) is not Object, throw a *TypeError* exception.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _iteratorRecord_ be GetIterator(_iterable_).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
@@ -38375,7 +38373,6 @@ THH:mm:ss.sss
         <p>The `reject` function returns a new promise rejected with the passed argument.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
-          1. If Type(_C_) is not Object, throw a *TypeError* exception.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Perform ? Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _r_ &raquo;).
           1. Return _promiseCapability_.[[Promise]].


### PR DESCRIPTION
NewPromiseCapability will immediately check if the argument (C) is an Object using IsConstructor and it will throw a TypeError if it's not.

This patch will just simplify the text with a fewer steps but this won't cause any new observable changes.

```
NewPromiseCapability ( _C_ )

1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.

IsConstructor ( _argument_ )

1. If Type(_argument_) is not Object, return *false*.
```

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
