### PR TITLE
Normative: correct spec bug in `RegExp.prototype[Symbol.matchAll]`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31129,7 +31129,8 @@ THH:mm:ss.sss
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
           1. Let _C_ be ? SpeciesConstructor(_R_, %RegExp%).
-          1. Let _flags_ be ? ToString(? Get(_R_, `"flags"`)).
+          1. Let _flagsValue_ be ? Get(_R_, `"flags"`).
+          1. If _flagsValue_ is *undefined*, let _flags_ be the empty String, else let _flags_ be ? ToString(_flagsValue_).
           1. Let _matcher_ be ? Construct(_C_, &laquo; _R_, _flags_ &raquo;).
           1. Let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
           1. Perform ? Set(_matcher_, `"lastIndex"`, _lastIndex_, *true*).


### PR DESCRIPTION
Filed on v8 as https://bugs.chromium.org/p/v8/issues/detail?id=9174, which it turns out matched the spec but not the intention/convention of the RegExp flags value.