### PR TITLE
Normative: specify web reality for Array.prototype.join with cyclic values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32143,6 +32143,9 @@ THH:mm:ss.sss
         <emu-note>
           <p>The elements of the array are converted to Strings, and these Strings are then concatenated, separated by occurrences of the _separator_. If no separator is provided, a single comma is used as the separator.</p>
         </emu-note>
+        <emu-note>
+          The `join` method has a [[SeenObjects]] internal slot whose value is a new empty List.
+        </emu-note>
         <p>The `join` method takes one argument, _separator_, and performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
@@ -32151,12 +32154,18 @@ THH:mm:ss.sss
           1. Else, let _sep_ be ? ToString(_separator_).
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
+          1. Let _seen_ be %Array.prototype.join%.[[SeenObjects]].
           1. Repeat, while _k_ &lt; _len_
             1. If _k_ &gt; 0, set _R_ to the string-concatenation of _R_ and _sep_.
             1. Let _element_ be ? Get(_O_, ! ToString(_k_)).
-            1. If _element_ is *undefined* or *null*, let _next_ be the empty String; otherwise, let _next_ be ? ToString(_element_).
+            1. If Type(_element_) is Object and _seen_ contains _element_, then
+              1. Let _next_ be the empty String.
+            1. Else,
+              1. If Type(_element_) is Object, append _element_ to _seen_.
+              1. If _element_ is *undefined* or *null*, let _next_ be the empty String; otherwise, let _next_ be ? ToString(_element_).
             1. Set _R_ to the string-concatenation of _R_ and _next_.
             1. Increase _k_ by 1.
+          1. Set %Array.prototype.join%.[[SeenObjects]] to a new empty List.
           1. Return _R_.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
Fixes #289.

This is *an attempt*, based on my reading of #289, to specify web reality for `Array.prototype.join` when the array is cyclic.

I'm using a slot on the current realm to keep a "seen" List, which I hope will avoid the reentrancy issues discussed [here](https://github.com/tc39/ecma262/issues/289#issuecomment-172637042).

I have no strong opinion about this PR implementation, so if anyone has any better suggestions I am more than happy to accommodate them! Reviews are welcome.