### PR TITLE
Editorial: Remove unused steps from definitions of Contains

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12793,7 +12793,6 @@
         <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
           1. If _symbol_ is a |ReservedWord|, return *false*.
-          1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -13473,21 +13472,18 @@
         <emu-alg>
           1. If |MemberExpression| Contains _symbol_ is *true*, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
-          1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If _symbol_ is the |ReservedWord| `super`, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
-          1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If |CallExpression| Contains _symbol_ is *true*, return *true*.
           1. If _symbol_ is a |ReservedWord|, return *false*.
-          1. If _symbol_ is an |Identifier| and StringValue of _symbol_ is the same value as the StringValue of |IdentifierName|, return *true*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -12792,7 +12792,6 @@
         </emu-note>
         <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
-          1. If _symbol_ is a |ReservedWord|, return *false*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -13471,19 +13470,16 @@
         <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If |MemberExpression| Contains _symbol_ is *true*, return *true*.
-          1. If _symbol_ is a |ReservedWord|, return *false*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If _symbol_ is the |ReservedWord| `super`, return *true*.
-          1. If _symbol_ is a |ReservedWord|, return *false*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If |CallExpression| Contains _symbol_ is *true*, return *true*.
-          1. If _symbol_ is a |ReservedWord|, return *false*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>


### PR DESCRIPTION
... specifically, steps of the form:
```
    If _symbol_ is an |Identifier| and StringValue of _symbol_
    is the same value as the StringValue of |IdentifierName|,
    return *true*.
```

Resolves #831.

As @allenwb points out, the intended use case for such steps does not occur in the spec.

And as I point out, these steps are semantically problematic.

If the intended use case ever *does* occur, I suspect we'll find a different way to handle it.