### PR TITLE
Editorial: Don't equate TypedArray types with C types.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32994,9 +32994,6 @@ THH:mm:ss.sss
           <th>
             Description
           </th>
-          <th>
-            Equivalent C Type
-          </th>
         </tr>
         <tr>
           <td>
@@ -33015,9 +33012,6 @@ THH:mm:ss.sss
           </td>
           <td>
             8-bit 2's complement signed integer
-          </td>
-          <td>
-            signed char
           </td>
         </tr>
         <tr>
@@ -33038,9 +33032,6 @@ THH:mm:ss.sss
           <td>
             8-bit unsigned integer
           </td>
-          <td>
-            unsigned char
-          </td>
         </tr>
         <tr>
           <td>
@@ -33059,9 +33050,6 @@ THH:mm:ss.sss
           </td>
           <td>
             8-bit unsigned integer (clamped conversion)
-          </td>
-          <td>
-            unsigned char
           </td>
         </tr>
         <tr>
@@ -33082,9 +33070,6 @@ THH:mm:ss.sss
           <td>
             16-bit 2's complement signed integer
           </td>
-          <td>
-            short
-          </td>
         </tr>
         <tr>
           <td>
@@ -33103,9 +33088,6 @@ THH:mm:ss.sss
           </td>
           <td>
             16-bit unsigned integer
-          </td>
-          <td>
-            unsigned short
           </td>
         </tr>
         <tr>
@@ -33126,9 +33108,6 @@ THH:mm:ss.sss
           <td>
             32-bit 2's complement signed integer
           </td>
-          <td>
-            int
-          </td>
         </tr>
         <tr>
           <td>
@@ -33148,9 +33127,6 @@ THH:mm:ss.sss
           <td>
             32-bit unsigned integer
           </td>
-          <td>
-            unsigned int
-          </td>
         </tr>
         <tr>
           <td>
@@ -33169,9 +33145,6 @@ THH:mm:ss.sss
           <td>
             32-bit IEEE floating point
           </td>
-          <td>
-            float
-          </td>
         </tr>
         <tr>
           <td>
@@ -33189,9 +33162,6 @@ THH:mm:ss.sss
           </td>
           <td>
             64-bit IEEE floating point
-          </td>
-          <td>
-            double
           </td>
         </tr>
         </tbody>


### PR DESCRIPTION
Resolves #1283.