### PR TITLE
Editorial: Clarify note re parsing the same string multiple times

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -460,8 +460,13 @@
       <p>When a parse is successful, it constructs a <em>parse tree</em>, a rooted tree structure in which each node is a <dfn>Parse Node</dfn>. Each Parse Node is an <em>instance</em> of a symbol in the grammar; it represents a span of the source text that can be derived from that symbol. The root node of the parse tree, representing the whole of the source text, is an instance of the parse's goal symbol. When a Parse Node is an instance of a nonterminal, it is also an instance of some production that has that nonterminal as its left-hand side. Moreover, it has zero or more <em>children</em>, one for each symbol on the production's right-hand side: each child is a Parse Node that is an instance of the corresponding symbol.</p>
       <p>New Parse Nodes are instantiated for each invocation of the parser and never reused between parses even of identical source text. Parse Nodes are considered <dfn>the same Parse Node</dfn> if and only if they represent the same span of source text, are instances of the same grammar symbol, and resulted from the same parser invocation.</p>
       <emu-note>
-        <p>Parsing the same String multiple times will lead to different Parse Nodes, e.g., as occurs in:</p>
-        <pre><code class="javascript">eval(str); eval(str);</code></pre>
+        <p>Parsing the same String multiple times will lead to different Parse Nodes. For example, consider:</p>
+        <pre><code class="javascript">
+          let str = "1 + 1;";
+          eval(str);
+          eval(str);
+        </code></pre>
+        <p>Each call to `eval` converts the value of `str` into an ECMAScript source text and performs an independent parse that creates its own separate tree of Parse Nodes. The trees are distinct even though each parse operates upon a source text that was derived from the same String value.</p>
       </emu-note>
       <emu-note>Parse Nodes are specification artefacts, and implementations are not required to use an analogous data structure.</emu-note>
       <p>Productions of the syntactic grammar are distinguished by having just one colon &ldquo;<b>:</b>&rdquo; as punctuation.</p>


### PR DESCRIPTION
... which was the subject of issue #1484.

This is basically @allenwb's suggested wording from
https://github.com/tc39/ecma262/issues/1484#issuecomment-473686361

The example string-to-be-eval'ed isn't one for which the distinctness of parse trees actually *matters*. Are there any simple cases for which it does?