### PR TITLE
meta: add snapshot builds for pr previews

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "npm run build-master",
     "build-for-pdf": "npm run build-master -- --old-toc",
     "build-travis": "npm run build-master && npm run build-es2019",
+    "prebuild-snapshot": "npm run clean",
+    "build-snapshot": "npm run build-master && node scripts/insert_snapshot_warning.js",
     "clean": "rm -rf out",
     "test": "exit 0",
     "watch": "npm run build-master -- --watch"
@@ -22,6 +24,7 @@
     "ecmarkup": "^3.16.0"
   },
   "devDependencies": {
-    "@alrra/travis-scripts": "^2.1.0"
+    "@alrra/travis-scripts": "^2.1.0",
+    "jsdom": "^15.0.0"
   }
 }

--- a/scripts/insert_snapshot_warning.js
+++ b/scripts/insert_snapshot_warning.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const { execSync } = require('child_process');
+
+const COMMIT = String(execSync('git rev-parse --verify HEAD'));
+
+const WARNING_HTML = fs.readFileSync(path.join(__dirname, 'snapshot_warning.html'), 'utf8')
+  .replace(/{COMMIT}/g, COMMIT);
+const WARNING_CSS = fs.readFileSync(path.join(__dirname, 'snapshot_warning.css'), 'utf8');
+
+console.log('Inserting snapshot reference warning...');
+
+JSDOM.fromFile('./out/index.html', { contentType: 'text/html; charset=utf-8' }).then((dom) => {
+  const { document } = dom.window;
+
+  const style = document.createElement('style');
+  style.textContent = WARNING_CSS;
+  document.head.append(style);
+
+  // insert WARNING_HTML in beginning of body so it renders
+  // first even on slower devices and browsers
+  document.body.insertAdjacentHTML('afterbegin', WARNING_HTML);
+
+  fs.writeFileSync('./out/index.html', dom.serialize(), 'utf8');
+
+  console.log('Done!');
+}).catch((reason) => {
+  console.error(reason);
+  process.exitCode = 1;
+});

--- a/scripts/netlify.sh
+++ b/scripts/netlify.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+npm run build-master
+
+if [ "${CONTEXT}" != 'production' ]; then
+  node scripts/insert_snapshot_warning
+fi

--- a/scripts/snapshot_warning.css
+++ b/scripts/snapshot_warning.css
@@ -1,0 +1,66 @@
+details.annoying-warning {
+  background-color: #920800;
+  background-image: linear-gradient(transparent 40%, rgba(255, 255, 255, 0.2));
+  border: solid rgba(0, 0, 0, 0.4);
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
+  color: rgba(255, 255, 255, 0.95);
+  opacity: .95;
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+}
+
+details.annoying-warning[open] {
+  top: 10%;
+  top: calc(5vw + 5vh);
+  max-width: 1024px;
+  outline: solid 10000px rgba(255, 255, 255, 0.6);
+}
+
+details.annoying-warning:not([open]) {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 0;
+}
+
+details.annoying-warning > summary {
+  display: list-item; /* polyfill */
+  font-size: 0.875em;
+  font-weight: bold;
+  letter-spacing: 0.02em;
+  padding: 10px 5px;
+  text-align: center;
+  text-transform: uppercase;
+  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.85);
+  cursor: default;
+}
+
+details.annoying-warning > summary::after {
+  content: " Expand";
+  position: absolute;
+  top: 0;
+  right: 5px;
+  font-size: smaller;
+  font-weight: bold;
+}
+
+details.annoying-warning[open] > summary::after {
+  content: " Collapse";
+}
+
+details.annoying-warning p {
+  padding: 0 7.5% 1em;
+  line-height: 1.4;
+  margin: 0;
+  text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.85);
+}
+
+details.annoying-warning a {
+  color: white;
+  text-decoration: underline;
+}

--- a/scripts/snapshot_warning.html
+++ b/scripts/snapshot_warning.html
@@ -1,0 +1,15 @@
+<details class="annoying-warning" open="">
+  <summary>This is a commit snapshot of the specification</summary>
+  <p>
+    This document contains the contents of the specification as of
+    <a href="https://github.com/tc39/ecma262/commit/{COMMIT}">commit {COMMIT}</a>,
+    and should only be used as a historical reference. This commit may not
+    have even been merged into the specification.
+  </p>
+  <p>
+    Do not attempt to implement this version of the specification. Do not
+    reference this version as authoritative in any way. Instead, see
+    <a href="https://tc39.github.io/ecma262">https://tc39.github.io/ecma262</a>
+    for the living specification.
+  </p>
+</details>


### PR DESCRIPTION
this commit adds a warning (stolen from whatpr.org) to "snapshot" builds that exist for non-reference reasons, such as pr previews.

if we add some sort of github action to auto deploy netlify or something on a new pr and then post a comment with the url, this will provide a nice preview. someone with permissions on this repo will have to set that part up.

rendered: https://5ce61b1a493e120007e63323--brave-elion-abb3d4.netlify.com/