### PR TITLE
Normative: Let all early errors be SyntaxErrors.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12822,10 +12822,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is an early Reference Error if AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
-        </li>
-        <li>
-          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is ~strict~.
+          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
 
@@ -12836,10 +12833,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is an early Reference Error if AssignmentTargetType of |UnaryExpression| is ~invalid~.
-        </li>
-        <li>
-          It is an early Syntax Error if AssignmentTargetType of |UnaryExpression| is ~strict~.
+          It is an early Syntax Error if AssignmentTargetType of |UnaryExpression| is not ~simple~.
         </li>
       </ul>
     </emu-clause>
@@ -14124,19 +14118,13 @@
           It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and |LeftHandSideExpression| is not covering an |AssignmentPattern|.
         </li>
         <li>
-          It is an early Reference Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
-        </li>
-        <li>
-          It is an early Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType of |LeftHandSideExpression| is ~strict~.
+          It is an early Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <ul>
         <li>
-          It is an early Reference Error if AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
-        </li>
-        <li>
-          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is ~strict~.
+          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
     </emu-clause>
@@ -21070,7 +21058,7 @@
 
       <emu-alg>
         1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
-        1. Parse _sourceText_ using |Script| as the goal symbol and analyse the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* or *ReferenceError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation-dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-dependent, but at least one must be present.
+        1. Parse _sourceText_ using |Script| as the goal symbol and analyse the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation-dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-dependent, but at least one must be present.
         1. If _body_ is a List of errors, return _body_.
         1. Return Script Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[ECMAScriptCode]]: _body_, [[HostDefined]]: _hostDefined_ }.
       </emu-alg>
@@ -22414,7 +22402,7 @@
           <p>The abstract operation ParseModule with arguments _sourceText_, _realm_, and _hostDefined_ creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. ParseModule performs the following steps:</p>
           <emu-alg>
             1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
-            1. Parse _sourceText_ using |Module| as the goal symbol and analyse the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* or *ReferenceError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation-dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-dependent, but at least one must be present.
+            1. Parse _sourceText_ using |Module| as the goal symbol and analyse the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation-dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-dependent, but at least one must be present.
             1. If _body_ is a List of errors, return _body_.
             1. Let _requestedModules_ be the ModuleRequests of _body_.
             1. Let _importEntries_ be ImportEntries of _body_.
@@ -23390,7 +23378,7 @@
     <p>An implementation of HostReportErrors must complete normally in all cases. The default implementation of HostReportErrors is to unconditionally return an empty normal completion.</p>
 
     <emu-note>
-      <p>_errorList_ will be a List of ECMAScript language values. If the errors are parsing errors or early errors, these will always be *SyntaxError* or *ReferenceError* objects. Runtime errors, however, can be any ECMAScript value.</p>
+      <p>_errorList_ will be a List of ECMAScript language values. If the errors are parsing errors or early errors, these will always be *SyntaxError* objects. Runtime errors, however, can be any ECMAScript value.</p>
     </emu-note>
   </emu-clause>
 
@@ -23523,7 +23511,7 @@
             1. Let _inMethod_ be *false*.
             1. Let _inDerivedConstructor_ be *false*.
           1. Perform the following substeps in an implementation-dependent order, possibly interleaving parsing and error detection:
-            1. Let _script_ be the ECMAScript code that is the result of parsing _x_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>).
+            1. Let _script_ be the ECMAScript code that is the result of parsing _x_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* exception (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>).
             1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
             1. Let _body_ be the |ScriptBody| of _script_.
             1. If _inFunction_ is *false*, and _body_ Contains |NewTarget|, throw a *SyntaxError* exception.
@@ -24820,7 +24808,7 @@
               1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
               1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
               1. Let _strict_ be ContainsUseStrict of _body_.
-              1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+              1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* exception. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
               1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
               1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.
               1. If _body_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.


### PR DESCRIPTION
Resolves #691.

(_This does not handle all concerns discussed in that thread, but it does serve as a solution for the OP.  
See https://github.com/tc39/ecma262/issues/691#issuecomment-471251881 onward for my own reasoning; in hindsight, I should've made a separate issue._)