### PR TITLE
Editorial: Fix incorrect use of "ECMAScript code execution context"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7718,7 +7718,7 @@
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
         1. If _callerContext_ is not already suspended, suspend _callerContext_.
-        1. Let _calleeContext_ be a new ECMAScript code execution context.
+        1. Let _calleeContext_ be a new execution context.
         1. Set the Function of _calleeContext_ to _F_.
         1. Let _calleeRealm_ be _F_.[[Realm]].
         1. Set the Realm of _calleeContext_ to _calleeRealm_.


### PR DESCRIPTION
Change "ECMAScript code execution context" to just "execution context" in the [[Call]] algorithm for a built-in function that *isn't* an ECMAScript function.

(An ECMAScript code execution context is a kind of execution context that's specifically for executing ECMAScript code, which is not the case here.)