### PR TITLE
Editorial: Tweak handling of negative `space` values in JSON.stringify

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36345,7 +36345,7 @@ THH:mm:ss.sss
             1. Set _space_ to ? ToString(_space_).
         1. If Type(_space_) is Number, then
           1. Set _space_ to min(10, ! ToInteger(_space_)).
-          1. Let _gap_ be the String value containing _space_ occurrences of the code unit 0x0020 (SPACE). This will be the empty String if _space_ is less than 1.
+          1. If _space_ &lt; 1, let _gap_ be the empty String; otherwise let _gap_ be the String value containing _space_ occurrences of the code unit 0x0020 (SPACE).
         1. Else if Type(_space_) is String, then
           1. If the length of _space_ is 10 or less, let _gap_ be _space_; otherwise let _gap_ be the String value consisting of the first 10 code units of _space_.
         1. Else,


### PR DESCRIPTION
Throughout the spec, there are 7 usages of "`X` occurrences of the code unit `Y`".
`X` is always non-negative in all usages except this one in `JSON.stringify`.
