### PR TITLE
Editorial: simplifications around [[FunctionKind]] and _functionKind_

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8265,17 +8265,6 @@
         </tr>
         <tr>
           <td>
-            [[FunctionKind]]
-          </td>
-          <td>
-            ~normal~ | ~classConstructor~ | ~generator~ | ~async~ | ~asyncGenerator~
-          </td>
-          <td>
-            Whether the function is a class constructor, generator, or async function.
-          </td>
-        </tr>
-        <tr>
-          <td>
             [[ECMAScriptCode]]
           </td>
           <td>
@@ -8362,6 +8351,17 @@
             The <emu-xref href="#sec-source-text">source text</emu-xref> that defines the function.
           </td>
         </tr>
+        <tr>
+          <td>
+            [[IsClassConstructor]]
+          </td>
+          <td>
+            Boolean
+          </td>
+          <td>
+            Indicates whether the function is a class constructor. (If *true*, invoking the function's [[Call]] will immediately throw a *TypeError* exception.)
+          </td>
+        </tr>
         </tbody>
       </table>
     </emu-table>
@@ -8372,7 +8372,7 @@
       <p>The [[Call]] internal method for an ECMAScript function object _F_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. If _F_.[[FunctionKind]] is ~classConstructor~, throw a *TypeError* exception.
+        1. If _F_.[[IsClassConstructor]] is *true*, throw a *TypeError* exception.
         1. Let _callerContext_ be the running execution context.
         1. Let _calleeContext_ be PrepareForOrdinaryCall(_F_, *undefined*).
         1. Assert: _calleeContext_ is now the running execution context.
@@ -8483,7 +8483,7 @@
         1. If _needsConstruct_ is *true*, then
           1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
           1. Set _F_.[[ConstructorKind]] to ~base~.
-        1. Set _F_.[[FunctionKind]] to _functionKind_.
+        1. Set _F_.[[IsClassConstructor]] to *false*.
         1. Set _F_.[[Prototype]] to _functionPrototype_.
         1. Set _F_.[[Extensible]] to *true*.
         1. Set _F_.[[Realm]] to the current Realm Record.
@@ -8595,8 +8595,8 @@
       <p>The abstract operation MakeClassConstructor with argument _F_ performs the following steps:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. Assert: _F_.[[FunctionKind]] is ~normal~.
-        1. Set _F_.[[FunctionKind]] to ~classConstructor~.
+        1. Assert: _F_.[[IsClassConstructor]] is *false*.
+        1. Set _F_.[[IsClassConstructor]] to *true*.
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
     </emu-clause>
@@ -8770,7 +8770,7 @@
     <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided function exotic objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
     <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such function exotic objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
     <p>Unless otherwise specified every built-in function object has the %Function.prototype% object as the initial value of its [[Prototype]] internal slot.</p>
-    <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value ~classConstructor~.</p>
+    <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[IsClassConstructor]] internal slot to have the value *true*.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
     <p>Built-in functions that are not constructors do not have a *"prototype"* property unless otherwise specified in the description of a particular function.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
@@ -38480,7 +38480,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-generatorfunction-instances">
       <h1>GeneratorFunction Instances</h1>
-      <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is ~generator~.</p>
+      <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
       <p>Each GeneratorFunction instance has the following own properties:</p>
 
       <emu-clause id="sec-generatorfunction-instances-length">
@@ -38586,7 +38586,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-asyncgeneratorfunction-instances">
       <h1>AsyncGeneratorFunction Instances</h1>
-      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is ~generator~.</p>
+      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
       <p>Each AsyncGeneratorFunction instance has the following own properties:</p>
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-length">
@@ -40113,7 +40113,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-async-function-instances">
       <h1>AsyncFunction Instances</h1>
 
-      <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is ~async~. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructable.</p>
+      <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructable.</p>
       <p>Each AsyncFunction instance has the following own properties:</p>
       <emu-clause id="sec-async-function-instances-length">
         <h1>length</h1>

--- a/spec.html
+++ b/spec.html
@@ -8469,20 +8469,13 @@
     </emu-clause>
 
     <emu-clause id="sec-functionallocate" aoid="FunctionAllocate">
-      <h1>FunctionAllocate ( _functionPrototype_, _functionKind_ )</h1>
-      <p>The abstract operation FunctionAllocate requires the two arguments _functionPrototype_ and _functionKind_. FunctionAllocate performs the following steps:</p>
+      <h1>FunctionAllocate ( _functionPrototype_ )</h1>
+      <p>The abstract operation FunctionAllocate requires the argument _functionPrototype_. FunctionAllocate performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_functionPrototype_) is Object.
-        1. Assert: _functionKind_ is either ~normal~, ~non-constructor~, ~generator~, ~async~, or ~asyncGenerator~.
-        1. If _functionKind_ is ~normal~, let _needsConstruct_ be *true*.
-        1. Else, let _needsConstruct_ be *false*.
-        1. If _functionKind_ is ~non-constructor~, set _functionKind_ to ~normal~.
         1. Let _F_ be a newly created ECMAScript function object with the internal slots listed in <emu-xref href="#table-27"></emu-xref>.
         1. Set _F_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
         1. Set _F_.[[Call]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
-        1. If _needsConstruct_ is *true*, then
-          1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
-          1. Set _F_.[[ConstructorKind]] to ~base~.
         1. Set _F_.[[IsClassConstructor]] to *false*.
         1. Set _F_.[[Prototype]] to _functionPrototype_.
         1. Set _F_.[[Extensible]] to *true*.
@@ -8516,9 +8509,7 @@
       <emu-alg>
         1. If _prototype_ is not present, then
           1. Set _prototype_ to %Function.prototype%.
-        1. If _kind_ is not ~Normal~, let _allocKind_ be ~non-constructor~.
-        1. Else, let _allocKind_ be ~normal~.
-        1. Let _F_ be FunctionAllocate(_prototype_, _allocKind_).
+        1. Let _F_ be FunctionAllocate(_prototype_).
         1. Return FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
     </emu-clause>
@@ -8528,7 +8519,7 @@
       <p>The abstract operation GeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. GeneratorFunctionCreate performs the following steps:</p>
       <emu-alg>
         1. Let _functionPrototype_ be %Generator%.
-        1. Let _F_ be FunctionAllocate(_functionPrototype_, ~generator~).
+        1. Let _F_ be FunctionAllocate(_functionPrototype_).
         1. Return FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
     </emu-clause>
@@ -8538,7 +8529,7 @@
       <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. AsyncGeneratorFunctionCreate performs the following steps:</p>
       <emu-alg>
         1. Let _functionPrototype_ be %AsyncGenerator%.
-        1. Let _F_ be ! FunctionAllocate(_functionPrototype_, ~generator~).
+        1. Let _F_ be ! FunctionAllocate(_functionPrototype_).
         1. Return ! FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
     </emu-clause>
@@ -8548,7 +8539,7 @@
       <p>The abstract operation AsyncFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~, ~Arrow~), a parameter list Parse Node specified by _parameters_, a body Parse Node specified by _body_, a Lexical Environment specified by _Scope_. AsyncFunctionCreate performs the following steps:</p>
       <emu-alg>
         1. Let _functionPrototype_ be %AsyncFunction.prototype%.
-        2. Let _F_ be ! FunctionAllocate(_functionPrototype_, ~async~).
+        2. Let _F_ be ! FunctionAllocate(_functionPrototype_).
         3. Return ! FunctionInitialize(_F_, _kind_, _parameters_, _body_, _Scope_).
       </emu-alg>
     </emu-clause>
@@ -8579,8 +8570,10 @@
       <p>The abstract operation MakeConstructor requires a Function argument _F_ and optionally, a Boolean _writablePrototype_ and an object _prototype_. If _prototype_ is provided it is assumed to already contain, if needed, a *"constructor"* property whose value is _F_. This operation converts _F_ into a constructor by performing the following steps:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. Assert: IsConstructor(_F_) is *true*.
+        1. Assert: IsConstructor(_F_) is *false*.
         1. Assert: _F_ is an extensible object that does not have a *"prototype"* own property.
+        1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
+        1. Set _F_.[[ConstructorKind]] to ~base~.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then
           1. Set _prototype_ to ObjectCreate(%Object.prototype%).
@@ -20805,8 +20798,8 @@
         1. Set the running execution context's LexicalEnvironment to _classScope_.
         1. Let _constructorInfo_ be ! DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_.
         1. Let _F_ be _constructorInfo_.[[Closure]].
-        1. If |ClassHeritage_opt| is present, set _F_.[[ConstructorKind]] to ~derived~.
         1. Perform MakeConstructor(_F_, *false*, _proto_).
+        1. If |ClassHeritage_opt| is present, set _F_.[[ConstructorKind]] to ~derived~.
         1. Perform MakeClassConstructor(_F_).
         1. If _className_ is not *undefined*, then
           1. Perform SetFunctionName(_F_, _className_).
@@ -25772,7 +25765,7 @@
               1. If _strict_ is *true*, then
                 1. If BoundNames of _parameters_ contains any duplicate elements, throw a *SyntaxError* exception.
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _fallbackProto_).
-            1. Let _F_ be FunctionAllocate(_proto_, _kind_).
+            1. Let _F_ be FunctionAllocate(_proto_).
             1. Let _realmF_ be _F_.[[Realm]].
             1. Let _scope_ be _realmF_.[[GlobalEnv]].
             1. Perform FunctionInitialize(_F_, ~Normal~, _parameters_, _body_, _scope_).


### PR DESCRIPTION
Changes arising from discussion in issue #1544.

(The second commit changes the signature of FunctionAllocate, but that operation isn't used by WebIDL or HTML.)

Closes #1544.