### PR TITLE
Editorial: fix inconsistency re type of [[SourceText]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8431,7 +8431,7 @@
             [[SourceText]]
           </td>
           <td>
-            String
+            sequence of Unicode code points
           </td>
           <td>
             The <emu-xref href="#sec-source-text">source text</emu-xref> that defines the function.
@@ -26269,7 +26269,7 @@
             1. Perform SetFunctionName(_F_, *"anonymous"*).
             1. Let _prefix_ be the prefix associated with _kind_ in <emu-xref href="#table-dynamic-function-sourcetext-prefixes"></emu-xref>.
             1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
-            1. Set _F_.[[SourceText]] to _sourceString_.
+            1. Set _F_.[[SourceText]] to ! UTF16DecodeString(_sourceString_).
             1. Return _F_.
           </emu-alg>
           <emu-note>
@@ -26410,7 +26410,8 @@
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If _func_ is a <emu-xref href="#sec-bound-function-exotic-objects">bound function exotic object</emu-xref> or a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ is a <emu-xref href="#sec-well-known-intrinsic-objects">Well-known Intrinsic Object</emu-xref> and is not identified as an anonymous function, the portion of the returned String that would be matched by |PropertyName| must be the initial value of the *"name"* property of _func_.
-          1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and Type(_func_.[[SourceText]]) is String and ! HostHasSourceTextAvailable(_func_) is *true*, then return _func_.[[SourceText]].
+          1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and ! HostHasSourceTextAvailable(_func_) is *true*, then
+            1. Return ! UTF16Encode(_func_.[[SourceText]]).
           1. If Type(_func_) is Object and IsCallable(_func_) is *true*, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
           1. Throw a *TypeError* exception.
         </emu-alg>


### PR DESCRIPTION
The spec was inconsistent on whether _F_.[[SourceText]] was a String or a source text (sequence of Unicode code points). This commit picks the latter.

Resolves #1458.

Web IDL and HTML specs do not refer to this slot.