### PR TITLE
Editorial: set [[SourceText]] for async arrow functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20533,6 +20533,7 @@
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _parameters_ be |AsyncArrowBindingIdentifier|.
         1. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
+        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncArrowFunction|.
         1. Return _closure_.
       </emu-alg>
       <emu-grammar>
@@ -20544,6 +20545,7 @@
         1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
         1. Let _parameters_ be the |ArrowFormalParameters| of _head_.
         1. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, _strict_).
+        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncArrowFunction|.
         1. Return _closure_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
These lines didn't appear in #697.
@ljharb [says](https://github.com/tc39/ecma262/issues/1458#issuecomment-495930883) that was likely an oversight: