### PR TITLE
Editorial: Introduce abstract ops UTF16Encode + UTF16DecodeString

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37996,7 +37996,7 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. Parse ! UTF16DecodeString(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
         1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
-        1. Let _completion_ be the result of parsing and evaluating _scriptString_ as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
+        1. Let _completion_ be the result of parsing and evaluating ! UTF16DecodeString(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then

--- a/spec.html
+++ b/spec.html
@@ -13834,10 +13834,10 @@
             1. If SameValue(_func_, %eval%) is *true*, then
               1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
               1. If _argList_ has no elements, return *undefined*.
-              1. Let _evalText_ be the first element of _argList_.
+              1. Let _evalArg_ be the first element of _argList_.
               1. If the source code matching this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
               1. Let _evalRealm_ be the current Realm Record.
-              1. Return ? PerformEval(_evalText_, _evalRealm_, _strictCaller_, *true*).
+              1. Return ? PerformEval(_evalArg_, _evalRealm_, _strictCaller_, *true*).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_func_, _ref_, _arguments_, _tailCall_).
@@ -26172,8 +26172,8 @@
               1. Let _fallbackProto_ be *"%AsyncGenerator%"*.
             1. Let _argCount_ be the number of elements in _args_.
             1. Let _P_ be the empty String.
-            1. If _argCount_ = 0, let _bodyText_ be the empty String.
-            1. Else if _argCount_ = 1, let _bodyText_ be _args_[0].
+            1. If _argCount_ = 0, let _bodyArg_ be the empty String.
+            1. Else if _argCount_ = 1, let _bodyArg_ be _args_[0].
             1. Else,
               1. Assert: _argCount_ &gt; 1.
               1. Let _firstArg_ be _args_[0].
@@ -26184,11 +26184,11 @@
                 1. Let _nextArgString_ be ? ToString(_nextArg_).
                 1. Set _P_ to the string-concatenation of the previous value of _P_, *","* (a comma), and _nextArgString_.
                 1. Set _k_ to _k_ + 1.
-              1. Let _bodyText_ be _args_[_k_].
-            1. Set _bodyText_ to the string-concatenation of 0x000A (LINE FEED), ? ToString(_bodyText_), and 0x000A (LINE FEED).
+              1. Let _bodyArg_ be _args_[_k_].
+            1. Let _bodyString_ be the string-concatenation of 0x000A (LINE FEED), ? ToString(_bodyArg_), and 0x000A (LINE FEED).
             1. Perform the following substeps in an implementation-dependent order, possibly interleaving parsing and error detection:
               1. Let _parameters_ be the result of parsing ! UTF16DecodeString(_P_), using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
-              1. Let _body_ be the result of parsing ! UTF16DecodeString(_bodyText_), using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
+              1. Let _body_ be the result of parsing ! UTF16DecodeString(_bodyString_), using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
               1. Let _strict_ be ContainsUseStrict of _body_.
               1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* exception. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
               1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
@@ -26217,8 +26217,8 @@
             1. NOTE: Async functions are not constructable and do not have a [[Construct]] internal method or a *"prototype"* property.
             1. Perform SetFunctionName(_F_, *"anonymous"*).
             1. Let _prefix_ be the prefix associated with _kind_ in <emu-xref href="#table-dynamic-function-sourcetext-prefixes"></emu-xref>.
-            1. Let _sourceText_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyText_, and *"}"*.
-            1. Set _F_.[[SourceText]] to _sourceText_.
+            1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
+            1. Set _F_.[[SourceText]] to _sourceString_.
             1. Return _F_.
           </emu-alg>
           <emu-note>
@@ -37993,10 +37993,10 @@ THH:mm:ss.sss
       <p>The `parse` function parses a JSON text (a JSON-formatted String) and produces an ECMAScript value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
       <p>The optional _reviver_ parameter is a function that takes two parameters, _key_ and _value_. It can filter and transform the results. It is called with each of the _key_/_value_ pairs produced by the parse, and its return value is used instead of the original value. If it returns what it received, the structure is not modified. If it returns *undefined* then the property is deleted from the result.</p>
       <emu-alg>
-        1. Let _JText_ be ? ToString(_text_).
-        1. Parse ! UTF16DecodeString(_JText_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
-        1. Let _scriptText_ be the string-concatenation of *"("*, _JText_, and *");"*.
-        1. Let _completion_ be the result of parsing and evaluating _scriptText_ as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
+        1. Let _jsonString_ be ? ToString(_text_).
+        1. Parse ! UTF16DecodeString(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
+        1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
+        1. Let _completion_ be the result of parsing and evaluating _scriptString_ as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then
@@ -38010,7 +38010,7 @@ THH:mm:ss.sss
       <p>This function is the <dfn>%JSONParse%</dfn> intrinsic object.</p>
       <p>The *"length"* property of the `parse` function is 2.</p>
       <emu-note>
-        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by Step 4 above. Step 2 verifies that _JText_ conforms to that subset, and step 6 verifies that that parsing and evaluation returns a value of an appropriate type.</p>
+        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by Step 4 above. Step 2 verifies that _jsonString_ conforms to that subset, and step 6 verifies that that parsing and evaluation returns a value of an appropriate type.</p>
       </emu-note>
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">

--- a/spec.html
+++ b/spec.html
@@ -10455,6 +10455,21 @@
         1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 2, [[IsUnpairedSurrogate]]: *false* }.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-utf16decodestring" aoid="UTF16DecodeString">
+      <h1>Static Semantics: UTF16DecodeString ( _string_ )</h1>
+      <p>This abstract operation accepts a String value _string_ and returns the sequence of Unicode code points that results from interpreting it as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+      <emu-alg>
+        1. Let _codePoints_ be a new empty List.
+        1. Let _size_ be the length of _string_.
+        1. Let _position_ be 0.
+        1. Repeat, while _position_ &lt; _size_,
+          1. Let _cp_ be ! CodePointAt(_string_, _position_).
+          1. Append _cp_.[[CodePoint]] to _codePoints_.
+          1. Set _position_ to _position_ + _cp_.[[CodeUnitCount]].
+        1. Return _codePoints_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-types-of-source-code">
@@ -24863,7 +24878,7 @@
             1. Let _inMethod_ be *false*.
             1. Let _inDerivedConstructor_ be *false*.
           1. Perform the following substeps in an implementation-dependent order, possibly interleaving parsing and error detection:
-            1. Let _script_ be the ECMAScript code that is the result of parsing _x_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* exception (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>).
+            1. Let _script_ be the ECMAScript code that is the result of parsing ! UTF16DecodeString(_x_), for the goal symbol |Script|. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* exception (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>).
             1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
             1. Let _body_ be the |ScriptBody| of _script_.
             1. If _inFunction_ is *false*, and _body_ Contains |NewTarget|, throw a *SyntaxError* exception.
@@ -26172,8 +26187,8 @@
               1. Let _bodyText_ be _args_[_k_].
             1. Set _bodyText_ to the string-concatenation of 0x000A (LINE FEED), ? ToString(_bodyText_), and 0x000A (LINE FEED).
             1. Perform the following substeps in an implementation-dependent order, possibly interleaving parsing and error detection:
-              1. Let _parameters_ be the result of parsing _P_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
-              1. Let _body_ be the result of parsing _bodyText_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
+              1. Let _parameters_ be the result of parsing ! UTF16DecodeString(_P_), using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
+              1. Let _body_ be the result of parsing ! UTF16DecodeString(_bodyText_), using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
               1. Let _strict_ be ContainsUseStrict of _body_.
               1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* exception. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
               1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
@@ -30533,9 +30548,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _cpList_ be a List containing in order the code points as defined in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref> of _S_, starting at the first element of _S_.
-          1. Let _cuList_ be a List where the elements are the result of toLowercase(_cpList_), according to the Unicode Default Case Conversion algorithm.
-          1. Let _L_ be ! UTF16Encode(_cuList_).
+          1. Let _sText_ be ! UTF16DecodeString(_S_).
+          1. Let _lowerText_ be the result of toLowercase(_sText_), according to the Unicode Default Case Conversion algorithm.
+          1. Let _L_ be ! UTF16Encode(_lowerText_).
           1. Return _L_.
         </emu-alg>
         <p>The result must be derived according to the locale-insensitive case mappings in the Unicode Character Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive mappings in the SpecialCasings.txt file that accompanies it).</p>
@@ -31357,7 +31372,7 @@ THH:mm:ss.sss
           1. Evaluate |Disjunction| with +1 as its _direction_ argument to obtain a Matcher _m_.
           1. Return an internal closure that takes two arguments, a String _str_ and an integer _index_, and performs the following steps:
             1. Assert: _index_ &le; the length of _str_.
-            1. If _Unicode_ is *true*, let _Input_ be a List consisting of the sequence of code points of _str_ interpreted as a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) Unicode string. Otherwise, let _Input_ be a List consisting of the sequence of code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
+            1. If _Unicode_ is *true*, let _Input_ be a List consisting of the sequence of code points of ! UTF16DecodeString(_str_). Otherwise, let _Input_ be a List consisting of the sequence of code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
             1. Let _InputLength_ be the number of characters contained in _Input_. This variable will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.
             1. Let _listIndex_ be the index into _Input_ of the character that was obtained from element _index_ of _str_.
             1. Let _c_ be a Continuation that always returns its State argument as a successful MatchResult.
@@ -32409,11 +32424,11 @@ THH:mm:ss.sss
               1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting each of its 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]| and use this result instead. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code unit elements of _P_.
             1. Else,
-              1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting _P_ as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). The goal symbol for the parse is |Pattern[+U, +N]|. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
-              1. Let _patternCharacters_ be a List whose elements are the code points resulting from applying UTF-16 decoding to _P_'s sequence of elements.
+              1. Parse ! UTF16DecodeString(_P_) using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[+U, +N]|. Throw a *SyntaxError* exception if the source text did not conform to the grammar, if any elements of it were not matched by the parse, or if any Early Error conditions exist.
+              1. Let _patternCharacters_ be a List whose elements are the code points of ! UTF16DecodeString(_P_).
             1. Set _obj_.[[OriginalSource]] to _P_.
             1. Set _obj_.[[OriginalFlags]] to _F_.
-            1. Set _obj_.[[RegExpMatcher]] to the internal procedure that evaluates the above parse of _P_ by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
+            1. Set _obj_.[[RegExpMatcher]] to the internal procedure that evaluates the above parse by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
             1. Perform ? Set(_obj_, *"lastIndex"*, 0, *true*).
             1. Return _obj_.
           </emu-alg>
@@ -37979,7 +37994,7 @@ THH:mm:ss.sss
       <p>The optional _reviver_ parameter is a function that takes two parameters, _key_ and _value_. It can filter and transform the results. It is called with each of the _key_/_value_ pairs produced by the parse, and its return value is used instead of the original value. If it returns what it received, the structure is not modified. If it returns *undefined* then the property is deleted from the result.</p>
       <emu-alg>
         1. Let _JText_ be ? ToString(_text_).
-        1. Parse _JText_ interpreted as UTF-16 encoded Unicode points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if _JText_ is not a valid JSON text as defined in that specification.
+        1. Parse ! UTF16DecodeString(_JText_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
         1. Let _scriptText_ be the string-concatenation of *"("*, _JText_, and *");"*.
         1. Let _completion_ be the result of parsing and evaluating _scriptText_ as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
@@ -38160,8 +38175,7 @@ THH:mm:ss.sss
         <p>This operation interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
-          1. Let _cpList_ be a List containing in order the code points of _value_ when interpreted as a sequence of UTF-16 encoded code points as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.
-          1. For each code point _C_ in _cpList_, do
+          1. For each code point _C_ in ! UTF16DecodeString(_value_), do
             1. If _C_ is listed in the &ldquo;Code Point&rdquo; column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
               1. Set _product_ to the string-concatenation of _product_ and the escape sequence for _C_ as specified in the &ldquo;Escape Sequence&rdquo; column of the corresponding row.
             1. Else if _C_ has a numeric value less than 0x0020 (SPACE), or if _C_ has the same numeric value as a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, then

--- a/spec.html
+++ b/spec.html
@@ -32421,11 +32421,13 @@ THH:mm:ss.sss
             1. If _F_ contains any code unit other than *"g"*, *"i"*, *"m"*, *"s"*, *"u"*, or *"y"* or if it contains the same code unit more than once, throw a *SyntaxError* exception.
             1. If _F_ contains *"u"*, let _BMP_ be *false*; else let _BMP_ be *true*.
             1. If _BMP_ is *true*, then
-              1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting each of its 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]| and use this result instead. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
+              1. Let _pText_ be the sequence of code points resulting from interpreting each of the 16-bit elements of _P_ as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
+              1. Parse _pText_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]| and use this result instead. Throw a *SyntaxError* exception if _pText_ did not conform to the grammar, if any elements of _pText_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code unit elements of _P_.
             1. Else,
-              1. Parse ! UTF16DecodeString(_P_) using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[+U, +N]|. Throw a *SyntaxError* exception if the source text did not conform to the grammar, if any elements of it were not matched by the parse, or if any Early Error conditions exist.
-              1. Let _patternCharacters_ be a List whose elements are the code points of ! UTF16DecodeString(_P_).
+              1. Let _pText_ be ! UTF16DecodeString(_P_).
+              1. Parse _pText_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[+U, +N]|. Throw a *SyntaxError* exception if _pText_ did not conform to the grammar, if any elements of _pText_ were not matched by the parse, or if any Early Error conditions exist.
+              1. Let _patternCharacters_ be a List whose elements are the code points of _pText_.
             1. Set _obj_.[[OriginalSource]] to _P_.
             1. Set _obj_.[[OriginalFlags]] to _F_.
             1. Set _obj_.[[RegExpMatcher]] to the internal procedure that evaluates the above parse by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.

--- a/spec.html
+++ b/spec.html
@@ -10418,6 +10418,14 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-utf16encode" aoid="UTF16Encode">
+      <h1>Static Semantics: UTF16Encode ( _text_ )</h1>
+      <p>This abstract operation converts _text_, a sequence of Unicode code points, into a String value, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+      <emu-alg>
+        1. Return the string-concatenation of the code units that are the UTF16Encoding of each code point in _text_, in order.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-utf16decode" aoid="UTF16Decode">
       <h1>Static Semantics: UTF16Decode ( _lead_, _trail_ )</h1>
       <p>Two code units, _lead_ and _trail_, that form a UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> are converted to a code point by performing the following steps:</p>
@@ -10959,7 +10967,9 @@
             IdentifierName IdentifierPart
         </emu-grammar>
         <emu-alg>
-          1. Return the String value consisting of the sequence of code units corresponding to |IdentifierName|. In determining the sequence any occurrences of `\\` |UnicodeEscapeSequence| are first replaced with the code point represented by the |UnicodeEscapeSequence| and then the code points of the entire |IdentifierName| are converted to code units by UTF16Encoding each code point.
+          1. Let _idText_ be the source text matched by |IdentifierName|.
+          1. Let _idTextUnescaped_ be the result of replacing any occurrences of `\\` |UnicodeEscapeSequence| in _idText_ with the code point represented by the |UnicodeEscapeSequence|.
+          1. Return ! UTF16Encode(_idTextUnescaped_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -13052,8 +13062,8 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
         <emu-alg>
-          1. Let _pattern_ be the String value consisting of the UTF16Encoding of each code point of BodyText of |RegularExpressionLiteral|.
-          1. Let _flags_ be the String value consisting of the UTF16Encoding of each code point of FlagText of |RegularExpressionLiteral|.
+          1. Let _pattern_ be ! UTF16Encode(BodyText of |RegularExpressionLiteral|).
+          1. Let _flags_ be ! UTF16Encode(FlagText of |RegularExpressionLiteral|).
           1. Return RegExpCreate(_pattern_, _flags_).
         </emu-alg>
       </emu-clause>
@@ -30525,7 +30535,7 @@ THH:mm:ss.sss
           1. Let _S_ be ? ToString(_O_).
           1. Let _cpList_ be a List containing in order the code points as defined in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref> of _S_, starting at the first element of _S_.
           1. Let _cuList_ be a List where the elements are the result of toLowercase(_cpList_), according to the Unicode Default Case Conversion algorithm.
-          1. Let _L_ be the String value whose code units are the UTF16Encoding of the code points of _cuList_.
+          1. Let _L_ be ! UTF16Encode(_cuList_).
           1. Return _L_.
         </emu-alg>
         <p>The result must be derived according to the locale-insensitive case mappings in the Unicode Character Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive mappings in the SpecialCasings.txt file that accompanies it).</p>
@@ -31273,7 +31283,9 @@ THH:mm:ss.sss
             RegExpIdentifierName[?U] RegExpIdentifierPart[?U]
         </emu-grammar>
         <emu-alg>
-          1. Return the String value consisting of the sequence of code units corresponding to |RegExpIdentifierName|. In determining the sequence any occurrences of `\\` |RegExpUnicodeEscapeSequence| are first replaced with the code point represented by the |RegExpUnicodeEscapeSequence| and then the code points of the entire |RegExpIdentifierName| are converted to code units by UTF16Encoding each code point.
+          1. Let _idText_ be the source text matched by |RegExpIdentifierName|.
+          1. Let _idTextUnescaped_ be the result of replacing any occurrences of `\\` |RegExpUnicodeEscapeSequence| in _idText_ with the code point represented by the |RegExpUnicodeEscapeSequence|.
+          1. Return ! UTF16Encode(_idTextUnescaped_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -32556,7 +32568,7 @@ THH:mm:ss.sss
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
               1. Else if _fullUnicode_ is *true*, then
                 1. Assert: _captureI_ is a List of code points.
-                1. Let _capturedValue_ be the String value whose code units are the UTF16Encoding of the code points of _captureI_.
+                1. Let _capturedValue_ be ! UTF16Encode(_captureI_).
               1. Else,
                 1. Assert: _fullUnicode_ is *false*.
                 1. Assert: _captureI_ is a List of code units.

--- a/spec.html
+++ b/spec.html
@@ -960,7 +960,7 @@
           A code unit that is not a <emu-xref href="#leading-surrogate"></emu-xref> and not a <emu-xref href="#trailing-surrogate"></emu-xref> is interpreted as a code point with the same value.
         </li>
         <li>
-          A sequence of two code units, where the first code unit _c1_ is a <emu-xref href="#leading-surrogate"></emu-xref> and the second code unit _c2_ a <emu-xref href="#trailing-surrogate"></emu-xref>, is a <dfn id="surrogate-pair">surrogate pair</dfn> and is interpreted as a code point with the value (_c1_ - 0xD800) &times; 0x400 + (_c2_ - 0xDC00) + 0x10000. (See <emu-xref href="#sec-utf16decode"></emu-xref>)
+          A sequence of two code units, where the first code unit _c1_ is a <emu-xref href="#leading-surrogate"></emu-xref> and the second code unit _c2_ a <emu-xref href="#trailing-surrogate"></emu-xref>, is a <dfn id="surrogate-pair">surrogate pair</dfn> and is interpreted as a code point with the value (_c1_ - 0xD800) &times; 0x400 + (_c2_ - 0xDC00) + 0x10000. (See <emu-xref href="#sec-utf16decodesurrogatepair"></emu-xref>)
         </li>
         <li>
           A code unit that is a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, but is not part of a <emu-xref href="#surrogate-pair"></emu-xref>, is interpreted as a code point with the same value.
@@ -10426,8 +10426,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-utf16decode" aoid="UTF16Decode">
-      <h1>Static Semantics: UTF16Decode ( _lead_, _trail_ )</h1>
+    <emu-clause id="sec-utf16decodesurrogatepair" aoid="UTF16DecodeSurrogatePair" oldids="sec-utf16decode">
+      <h1>Static Semantics: UTF16DecodeSurrogatePair ( _lead_, _trail_ )</h1>
       <p>Two code units, _lead_ and _trail_, that form a UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> are converted to a code point by performing the following steps:</p>
       <emu-alg>
         1. Assert: _lead_ is a <emu-xref href="#leading-surrogate"></emu-xref> and _trail_ is a <emu-xref href="#trailing-surrogate"></emu-xref>.
@@ -10451,7 +10451,7 @@
         1. Let _second_ be the code unit at index _position_ + 1 within _string_.
         1. If _second_ is not a <emu-xref href="#trailing-surrogate"></emu-xref>, then
           1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 1, [[IsUnpairedSurrogate]]: *true* }.
-        1. Set _cp_ to ! UTF16Decode(_first_, _second_).
+        1. Set _cp_ to ! UTF16DecodeSurrogatePair(_first_, _second_).
         1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 2, [[IsUnpairedSurrogate]]: *false* }.
       </emu-alg>
     </emu-clause>
@@ -31222,7 +31222,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _lead_ be the CharacterValue of |LeadSurrogate|.
           1. Let _trail_ be the CharacterValue of |TrailSurrogate|.
-          1. Let _cp_ be UTF16Decode(_lead_, _trail_).
+          1. Let _cp_ be UTF16DecodeSurrogatePair(_lead_, _trail_).
           1. Return the code point value of _cp_.
         </emu-alg>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u` LeadSurrogate</emu-grammar>
@@ -31297,7 +31297,7 @@ THH:mm:ss.sss
       <p>The syntax and semantics of |Pattern| is defined as if the source code for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>
       <emu-note>
         <p>For example, consider a pattern expressed in source text as the single non-BMP character U+1D11E (MUSICAL SYMBOL G CLEF). Interpreted as a Unicode pattern, it would be a single element (character) List consisting of the single code point 0x1D11E. However, interpreted as a BMP pattern, it is first UTF-16 encoded to produce a two element List consisting of the code units 0xD834 and 0xDD1E.</p>
-        <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the string would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16Decode must be used in producing a List consisting of a single pattern character, the code point U+1D11E.</p>
+        <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the string would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16DecodeSurrogatePair must be used in producing a List consisting of a single pattern character, the code point U+1D11E.</p>
         <p>An implementation may not actually perform such translations to or from UTF-16, but the semantics of this specification requires that the result of pattern matching be as if such translations were performed.</p>
       </emu-note>
 


### PR DESCRIPTION
The main commits are the 1 and 3, which define UTF16Encode and UTF16Decode respectively. Everything else is related editorial changes.

(Yes, there's already an op called UTF16Decode, but commit 2 renames it to something more appropriate.
So this changes the signature/behavior of UTF16Decode, but Web IDL and HTML don't reference it.)
