### PR TITLE
Editorial: Define + use StringToNumber

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4793,7 +4793,7 @@
               String
             </td>
             <td>
-              See grammar and conversion algorithm below.
+              Return ! StringToNumber(_argument_).
             </td>
           </tr>
           <tr>
@@ -4830,7 +4830,7 @@
 
       <emu-clause id="sec-tonumber-applied-to-the-string-type">
         <h1>ToNumber Applied to the String Type</h1>
-        <p>ToNumber applied to Strings applies the following grammar to the input String interpreted as a sequence of UTF-16 encoded code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). If the grammar cannot interpret the String as an expansion of |StringNumericLiteral|, then the result of ToNumber is *NaN*.</p>
+        <p>The abstract operation StringToNumber specifies how to convert a String value to a Number value, using the following grammar.</p>
         <h2>Syntax</h2>
         <emu-grammar type="definition">
           StringNumericLiteral :::
@@ -4884,9 +4884,27 @@
           </ul>
         </emu-note>
 
+        <emu-clause id="sec-stringtonumber" type="abstract operation">
+          <h1>
+            StringToNumber (
+              _str_: a String,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns a Number.</dd>
+          </dl>
+          <emu-alg>
+            1. Let _text_ be ! StringToCodePoints(_str_).
+            1. Let _literal_ be ParseText(_text_, |StringNumericLiteral|).
+            1. If _literal_ is a List of errors, return *NaN*.
+            1. Return StringNumericValue of _literal_.
+          </emu-alg>
+        </emu-clause>
+
         <emu-clause id="sec-runtime-semantics-stringnumericvalue" type="sdo" aoid="StringNumericValue" oldids="sec-runtime-semantics-mv-s">
           <h1>Runtime Semantics: StringNumericValue</h1>
-          <p>The conversion of a String to a Number value is similar overall to the determination of the Number value for a numeric literal (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different, so the process for converting a String numeric literal to a value of the Number type is given here.</p>
+          <p>The conversion of a |StringNumericLiteral| to a Number value is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.</p>
           <emu-grammar>StringNumericLiteral ::: StrWhiteSpace?</emu-grammar>
           <emu-alg>
             1. Return *+0*<sub>𝔽</sub>.

--- a/spec.html
+++ b/spec.html
@@ -4831,9 +4831,6 @@
       <emu-clause id="sec-tonumber-applied-to-the-string-type">
         <h1>ToNumber Applied to the String Type</h1>
         <p>ToNumber applied to Strings applies the following grammar to the input String interpreted as a sequence of UTF-16 encoded code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). If the grammar cannot interpret the String as an expansion of |StringNumericLiteral|, then the result of ToNumber is *NaN*.</p>
-        <emu-note>
-          <p>The terminal symbols of this grammar are all composed of characters in the Unicode Basic Multilingual Plane (BMP). Therefore, the result of ToNumber will be *NaN* if the string contains any <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref> code units, whether paired or unpaired.</p>
-        </emu-note>
         <h2>Syntax</h2>
         <emu-grammar type="definition">
           StringNumericLiteral :::


### PR DESCRIPTION
Formerly, the procedure for applying ToNumber to the String type was spread over three widely-separated prose paragraphs in two different clauses.

This commit brings all that together, expresses it as an actual algorithm, and gives it the name StringToNumber.

Similarly, the prose underlying the syntax-directed operation NumericValue (to get the value of a NumericLiteral) is expressed more algorithmically.