### PR TITLE
Normative: Guard IntegerIndexedElementSet with receiver check

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14648,8 +14648,10 @@
           1. If Type(_P_) is String, then
             1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. Perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _V_).
-              1. Return *true*.
+              1. If SameValue(_O_, _Receiver_) is *true*, then
+                1. Perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _V_).
+                1. Return *true*.
+              1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *true*.
           1. Return ? OrdinarySet(_O_, _P_, _V_, _Receiver_).
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Closes #1339.
Closes #1541.

### Recap

In ES6, both [`[[Get]]`](https://262.ecma-international.org/6.0/#sec-integer-indexed-exotic-objects-get-p-receiver) and [`[[Set]]`](https://262.ecma-international.org/6.0/#sec-integer-indexed-exotic-objects-set-p-v-receiver) TypedArray methods had the receiver checks, which were removed in #347 due to consistency with [`[[HasProperty]]`](https://262.ecma-international.org/6.0/#sec-integer-indexed-exotic-objects-hasproperty-p). Removing receiver check from [`[[Set]]`](https://262.ecma-international.org/6.0/#sec-integer-indexed-exotic-objects-set-p-v-receiver) turned out to be [web-incompatible (SM bug)](https://bugzilla.mozilla.org/show_bug.cgi?id=1502889), breaking the 🚀 NASA's WorldWind [web app](https://worldwind.earth/explorer/) and [SDK](https://worldwind.arc.nasa.gov/web/examples/).

I've just checked the links in [Firefox 63 (release binaries)](https://ftp.mozilla.org/pub/firefox/releases/63.0/): the web app and SDK examples still don't work. While there are no other sites that are broken, we can't just fix the WorldWind: it's an educational material that is also distributed offline and viewed via `file:///` protocol.

The breakage was caused by TypedArray instances being in `[[Prototype]]` chain (presumably, for default values) of various objects like [`Matrix`](https://github.com/NASAWorldWind/WebWorldWind/blob/685b44d15afa5ea477d9d071a7846848119ec956/src/geom/Matrix3.js#L70) or [`Vector`](https://github.com/NASAWorldWind/WebWorldWind/blob/685b44d15afa5ea477d9d071a7846848119ec956/src/geom/Vec3.js#L54) instances.

### Proposed change

This PR attempts to specify the most desired behavior while providing the minimum required for web-compatibility: [`OrdinarySet`](https://tc39.es/ecma262/#sec-ordinaryset) is performed for canonical numeric strings that are valid indices only.

* Consistent with [`[[Get]]`](https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-get-p-receiver) and [`[[HasProperty]]`](https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-hasproperty-p) TypedArray methods regarding invalid indices: prototype traversal in stopped.
* Consistent with other `[[Set]]` overrides like of [mapped arguments](https://tc39.es/ecma262/#sec-arguments-exotic-objects-set-p-v-receiver) or [legacy platform objects](https://heycam.github.io/webidl/#legacy-platform-object-set) regarding altered receivers: a simple reference check is performed.
* No value coercion is performed for invalid indices if receiver is altered, which is an expected behavior because coercion result would be unused. #2332 proposes to drop value coercion for direct `[[Set]]` as well.

### Implementation status

* V8 follows the proposed spec except that it performs value coercion even for invalid indices.
* SM follows the proposed spec for valid indices, but creates property on receiver for invalid indices, without traversing prototype chain further.
* JSC doesn't currently invoke `[[Set]]` overrides during prototype chain traversal, and gets `Reflect.set` wrong for non-ordinary `[[Set]]`. [This bug](https://bugs.webkit.org/show_bug.cgi?id=217916) will fix non-index `[[Set]]`, including canonical numeric strings that are invalid indices. Indexed `[[Set]]` will be adjusted in a follow-up, as it's quite different and unaware of receiver.
