### PR TITLE
in NamedEvaluation of ClassExpression, defer to evaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19929,7 +19929,9 @@
       <p>With parameter _name_.</p>
       <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Return the result of ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
+        1. Let _closure_ be the result of evaluating this |ClassExpression|.
+        1. Perform SetFunctionName(_closure_, _name_).
+        1. Return _closure_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This fixes the missing `[[SourceText]]` issue for classes created using unnamed class expressions in a name-inferred context, for example

```js
export default (class {});
```

or

```js
let C = class {};
```

See also #1548.