### PR TITLE
Normative: set [[SourceText]] in NamedEvaluation of ClassExpression

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19991,7 +19991,10 @@
       <p>With parameter _name_.</p>
       <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Return the result of ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
+        1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
+        1. ReturnIfAbrupt(_value_).
+        1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
+        1. Return _value_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
In #1560, we discovered that deferring NamedEvaluation to the evaluation algorithm for ClassExpressions would cause an undesirable change in behaviour. So this PR is the alternative: keep NamedEvaluation of ClassExpression special and set its `[[SourceText]]` slot.

This should be the last missing `[[SourceText]]` slot  :crossed_fingers:.