### PR TITLE
Editorial: normalize wording used to apply syntax-directed operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -724,7 +724,7 @@
       <p>When an algorithm is associated with a production alternative, the alternative is typically shown without any &ldquo;[ ]&rdquo; grammar annotations. Such annotations should only affect the syntactic recognition of the alternative and have no effect on the associated semantics for the alternative.</p>
       <p>Syntax-directed operations are invoked with a parse node and, optionally, other parameters by using the conventions on steps 1, 3, and 4 in the following algorithm:</p>
       <emu-alg>
-        1. Let _status_ be the result of performing SyntaxDirectedOperation of |SomeNonTerminal|.
+        1. Let _status_ be SyntaxDirectedOperation of |SomeNonTerminal|.
         2. Let _someParseNode_ be the parse of some source text.
         2. Perform SyntaxDirectedOperation of _someParseNode_.
         2. Perform SyntaxDirectedOperation of _someParseNode_ passing `"value"` as the argument.
@@ -7719,7 +7719,7 @@
               1. Perform ! _lexEnvRec_.CreateMutableBinding(_dn_, *false*).
         1. For each Parse Node _f_ in _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
-          1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
+          1. Let _fo_ be InstantiateFunctionObject of _f_ with argument _lexEnv_.
           1. Perform ! _varEnvRec_.SetMutableBinding(_fn_, _fo_, *false*).
         1. Return NormalCompletion(~empty~).
       </emu-alg>
@@ -10416,7 +10416,7 @@
             The SV of <emu-grammar>DoubleStringCharacter :: &lt;PS&gt;</emu-grammar> is the code unit 0x2029 (PARAGRAPH SEPARATOR).
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
+            The SV of <emu-grammar>DoubleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of |EscapeSequence|.
           </li>
           <li>
             The SV of <emu-grammar>DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
@@ -10431,22 +10431,22 @@
             The SV of <emu-grammar>SingleStringCharacter :: &lt;PS&gt;</emu-grammar> is the code unit 0x2029 (PARAGRAPH SEPARATOR).
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of the |EscapeSequence|.
+            The SV of <emu-grammar>SingleStringCharacter :: `\` EscapeSequence</emu-grammar> is the SV of |EscapeSequence|.
           </li>
           <li>
             The SV of <emu-grammar>SingleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the SV of the |CharacterEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the SV of |CharacterEscapeSequence|.
           </li>
           <li>
             The SV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit 0x0000 (NULL).
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: HexEscapeSequence</emu-grammar> is the SV of the |HexEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: HexEscapeSequence</emu-grammar> is the SV of |HexEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the SV of the |UnicodeEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the SV of |UnicodeEscapeSequence|.
           </li>
           <li>
             The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-34"></emu-xref>.
@@ -10600,7 +10600,7 @@
         </emu-table>
         <ul>
           <li>
-            The SV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
+            The SV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of |NonEscapeCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the UTF16Encoding of the code point value of |SourceCharacter|.
@@ -10853,16 +10853,16 @@
             The TRV of <emu-grammar>TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the TRV of the |CharacterEscapeSequence|.
+            The TRV of <emu-grammar>EscapeSequence :: CharacterEscapeSequence</emu-grammar> is the TRV of |CharacterEscapeSequence|.
           </li>
           <li>
             The TRV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit 0x0030 (DIGIT ZERO).
           </li>
           <li>
-            The TRV of <emu-grammar>EscapeSequence :: HexEscapeSequence</emu-grammar> is the TRV of the |HexEscapeSequence|.
+            The TRV of <emu-grammar>EscapeSequence :: HexEscapeSequence</emu-grammar> is the TRV of |HexEscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the TRV of the |UnicodeEscapeSequence|.
+            The TRV of <emu-grammar>EscapeSequence :: UnicodeEscapeSequence</emu-grammar> is the TRV of |UnicodeEscapeSequence|.
           </li>
           <li>
             The TRV of <emu-grammar>NotEscapeSequence :: `0` DecimalDigit</emu-grammar> is the sequence consisting of the code unit 0x0030 (DIGIT ZERO) followed by the code units of the TRV of |DecimalDigit|.
@@ -10898,10 +10898,10 @@
             The TRV of <emu-grammar>DecimalDigit :: one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`</emu-grammar> is the SV of the |SourceCharacter| that is that single code point.
           </li>
           <li>
-            The TRV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the TRV of the |SingleEscapeCharacter|.
+            The TRV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the TRV of |SingleEscapeCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of the |NonEscapeCharacter|.
+            The TRV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of |NonEscapeCharacter|.
           </li>
           <li>
             The TRV of <emu-grammar>SingleEscapeCharacter :: one of `'` `"` `\` `b` `f` `n` `r` `t` `v`</emu-grammar> is the SV of the |SourceCharacter| that is that single code point.
@@ -11588,8 +11588,7 @@
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _postIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
-          1. ReturnIfAbrupt(_postIndex_).
+          1. Let _postIndex_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
@@ -11599,8 +11598,7 @@
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
         <emu-alg>
-          1. Let _postIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
-          1. ReturnIfAbrupt(_postIndex_).
+          1. Let _postIndex_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _postIndex_ + _padding_.
         </emu-alg>
@@ -11635,8 +11633,7 @@
         <emu-grammar>ArrayLiteral : `[` ElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _len_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
-          1. ReturnIfAbrupt(_len_).
+          1. Let _len_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and 0.
           1. Perform Set(_array_, `"length"`, ToUint32(_len_), *false*).
           1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
           1. Return _array_.
@@ -11644,8 +11641,7 @@
         <emu-grammar>ArrayLiteral : `[` ElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _len_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
-          1. ReturnIfAbrupt(_len_).
+          1. Let _len_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and 0.
           1. Let _padding_ be the ElisionWidth of |Elision|; if |Elision| is not present, use the numeric value zero.
           1. Perform Set(_array_, `"length"`, ToUint32(_padding_ + _len_), *false*).
           1. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
@@ -11789,7 +11785,7 @@
         </emu-alg>
         <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
-          1. Return the String value whose code units are the SV of the |StringLiteral|.
+          1. Return the String value whose code units are the SV of |StringLiteral|.
         </emu-alg>
         <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
@@ -11840,7 +11836,7 @@
         </emu-alg>
         <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
-          1. Return the String value whose code units are the SV of the |StringLiteral|.
+          1. Return the String value whose code units are the SV of |StringLiteral|.
         </emu-alg>
         <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
@@ -11885,7 +11881,7 @@
           1. Let _propKey_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_propKey_).
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
-            1. Let _propValue_ be the result of performing NamedEvaluation for |AssignmentExpression| with argument _propKey_.
+            1. Let _propValue_ be NamedEvaluation of |AssignmentExpression| with argument _propKey_.
           1. Else,
             1. Let _exprValueRef_ be the result of evaluating |AssignmentExpression|.
             1. Let _propValue_ be ? GetValue(_exprValueRef_).
@@ -12073,8 +12069,7 @@
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
           1. Let _firstSubRef_ be the result of evaluating |Expression|.
           1. Let _firstSub_ be ? GetValue(_firstSubRef_).
-          1. Let _restSub_ be SubstitutionEvaluation of |TemplateSpans|.
-          1. ReturnIfAbrupt(_restSub_).
+          1. Let _restSub_ be ? SubstitutionEvaluation of |TemplateSpans|.
           1. Assert: _restSub_ is a List.
           1. Return a List whose first element is _siteObj_, whose second elements is _firstSub_, and whose subsequent elements are the elements of _restSub_, in order. _restSub_ may contain no elements.
         </emu-alg>
@@ -12138,8 +12133,7 @@
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _preceding_ be the result of SubstitutionEvaluation of |TemplateMiddleList|.
-          1. ReturnIfAbrupt(_preceding_).
+          1. Let _preceding_ be ? SubstitutionEvaluation of |TemplateMiddleList|.
           1. Let _nextRef_ be the result of evaluating |Expression|.
           1. Let _next_ be ? GetValue(_nextRef_).
           1. Append _next_ as the last element of the List _preceding_.
@@ -12577,8 +12571,7 @@
             1. Let _constructor_ be ? GetValue(_ref_).
             1. If _arguments_ is ~empty~, let _argList_ be a new empty List.
             1. Else,
-              1. Let _argList_ be ArgumentListEvaluation of _arguments_.
-              1. ReturnIfAbrupt(_argList_).
+              1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
             1. If IsConstructor(_constructor_) is *false*, throw a *TypeError* exception.
             1. Return ? Construct(_constructor_, _argList_).
           </emu-alg>
@@ -12634,8 +12627,7 @@
               1. Let _thisValue_ be _refEnv_.WithBaseObject().
           1. Else,
             1. Let _thisValue_ be *undefined*.
-          1. Let _argList_ be ArgumentListEvaluation of _arguments_.
-          1. ReturnIfAbrupt(_argList_).
+          1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
           1. If Type(_func_) is not Object, throw a *TypeError* exception.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
           1. If _tailPosition_ is *true*, perform PrepareForTailCall().
@@ -12675,8 +12667,7 @@
           1. Let _newTarget_ be GetNewTarget().
           1. Assert: Type(_newTarget_) is Object.
           1. Let _func_ be ? GetSuperConstructor().
-          1. Let _argList_ be ArgumentListEvaluation of |Arguments|.
-          1. ReturnIfAbrupt(_argList_).
+          1. Let _argList_ be ? ArgumentListEvaluation of |Arguments|.
           1. Let _result_ be ? Construct(_func_, _argList_, _newTarget_).
           1. Let _thisER_ be GetThisEnvironment().
           1. Return ? _thisER_.BindThisValue(_result_).
@@ -12743,8 +12734,7 @@
         </emu-alg>
         <emu-grammar>ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _precedingArgs_ be ArgumentListEvaluation of |ArgumentList|.
-          1. ReturnIfAbrupt(_precedingArgs_).
+          1. Let _precedingArgs_ be ? ArgumentListEvaluation of |ArgumentList|.
           1. Let _ref_ be the result of evaluating |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
           1. Append _arg_ to the end of _precedingArgs_.
@@ -12752,8 +12742,7 @@
         </emu-alg>
         <emu-grammar>ArgumentList : ArgumentList `,` `...` AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _precedingArgs_ be ArgumentListEvaluation of |ArgumentList|.
-          1. ReturnIfAbrupt(_precedingArgs_).
+          1. Let _precedingArgs_ be ? ArgumentListEvaluation of |ArgumentList|.
           1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
           1. Let _iteratorRecord_ be ? GetIterator(? GetValue(_spreadRef_)).
           1. Repeat,
@@ -14199,7 +14188,7 @@
           1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
           1. ReturnIfAbrupt(_lref_).
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) and IsIdentifierRef of |LeftHandSideExpression| are both *true*, then
-            1. Let _rval_ be the result of performing NamedEvaluation for |AssignmentExpression| with argument GetReferencedName(_lref_).
+            1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument GetReferencedName(_lref_).
           1. Else,
             1. Let _rref_ be the result of evaluating |AssignmentExpression|.
             1. Let _rval_ be ? GetValue(_rref_).
@@ -14326,7 +14315,7 @@
         <emu-grammar>ArrayAssignmentPattern : `[` Elision `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Let _result_ be the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+          1. Let _result_ be IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
@@ -14334,25 +14323,25 @@
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
           1. If |Elision| is present, then
-            1. Let _status_ be the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+            1. Let _status_ be IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
             1. If _status_ is an abrupt completion, then
               1. Assert: _iteratorRecord_.[[Done]] is *true*.
               1. Return Completion(_status_).
-          1. Let _result_ be the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with _iteratorRecord_ as the argument.
+          1. Let _result_ be IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with argument _iteratorRecord_.
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Let _result_ be the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| using _iteratorRecord_ as the argument.
+          1. Let _result_ be IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_.
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `,` Elision? AssignmentRestElement? `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Let _status_ be the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| using _iteratorRecord_ as the argument.
+          1. Let _status_ be IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_.
           1. If _status_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _status_).
             1. Return Completion(_status_).
@@ -14376,8 +14365,8 @@
         <emu-grammar>ObjectAssignmentPattern : `{` AssignmentPropertyList `,` AssignmentRestProperty `}`</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
-          1. Let _excludedNames_ be the result of performing ? PropertyDestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
-          1. Return the result of performing RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with _value_ and _excludedNames_ as the arguments.
+          1. Let _excludedNames_ be ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
+          1. Return the result of performing RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
         </emu-alg>
       </emu-clause>
 
@@ -14390,8 +14379,8 @@
 
         <emu-grammar>AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
         <emu-alg>
-          1. Let _propertyNames_ be the result of performing ? PropertyDestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
-          1. Let _nextNames_ be the result of performing ? PropertyDestructuringAssignmentEvaluation for |AssignmentProperty| using _value_ as the argument.
+          1. Let _propertyNames_ be ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
+          1. Let _nextNames_ be ? PropertyDestructuringAssignmentEvaluation of |AssignmentProperty| with argument _value_.
           1. Append each item in _nextNames_ to the end of _propertyNames_.
           1. Return _propertyNames_.
         </emu-alg>
@@ -14491,7 +14480,7 @@
           1. If _iteratorRecord_.[[Done]] is *true*, let _value_ be *undefined*.
           1. If |Initializer| is present and _value_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
-              1. Let _v_ be the result of performing NamedEvaluation for |Initializer| with argument GetReferencedName(_lref_).
+              1. Let _v_ be NamedEvaluation of |Initializer| with argument GetReferencedName(_lref_).
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Let _v_ be ? GetValue(_defaultValue_).
@@ -14541,7 +14530,7 @@
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
-              1. Let _rhsValue_ be the result of performing NamedEvaluation for |Initializer| with argument GetReferencedName(_lref_).
+              1. Let _rhsValue_ be NamedEvaluation of |Initializer| with argument GetReferencedName(_lref_).
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Let _rhsValue_ be ? GetValue(_defaultValue_).
@@ -14770,7 +14759,7 @@
       <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
       <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
-        1. Let _stmtResult_ be the result of performing LabelledEvaluation of |IterationStatement| with argument _labelSet_.
+        1. Let _stmtResult_ be LabelledEvaluation of |IterationStatement| with argument _labelSet_.
         1. If _stmtResult_.[[Type]] is ~break~, then
           1. If _stmtResult_.[[Target]] is ~empty~, then
             1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
@@ -15158,7 +15147,7 @@
               1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
           1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
             1. Let _fn_ be the sole element of the BoundNames of _d_.
-            1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
+            1. Let _fo_ be InstantiateFunctionObject of _d_ with argument _env_.
             1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
       </emu-alg>
     </emu-clause>
@@ -15276,7 +15265,7 @@
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ResolveBinding(_bindingId_).
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-            1. Let _value_ be the result of performing NamedEvaluation for |Initializer| with argument _bindingId_.
+            1. Let _value_ be NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
             1. Let _rhs_ be the result of evaluating |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
@@ -15377,7 +15366,7 @@
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_).
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-            1. Let _value_ be the result of performing NamedEvaluation for |Initializer| with argument _bindingId_.
+            1. Let _value_ be NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
             1. Let _rhs_ be the result of evaluating |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
@@ -15625,7 +15614,7 @@
         <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Let _result_ be IteratorBindingInitialization for |ArrayBindingPattern| using _iteratorRecord_ and _environment_ as arguments.
+          1. Let _result_ be IteratorBindingInitialization of |ArrayBindingPattern| with arguments _iteratorRecord_ and _environment_.
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
@@ -15651,8 +15640,8 @@
 
         <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
         <emu-alg>
-          1. Let _excludedNames_ be the result of performing ? PropertyBindingInitialization of |BindingPropertyList| using _value_ and _environment_ as arguments.
-          1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with _value_, _environment_, and _excludedNames_ as the arguments.
+          1. Let _excludedNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
+          1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
         </emu-alg>
       </emu-clause>
 
@@ -15664,8 +15653,8 @@
 
         <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
-          1. Let _boundNames_ be the result of performing ? PropertyBindingInitialization for |BindingPropertyList| using _value_ and _environment_ as arguments.
-          1. Let _nextNames_ be the result of performing ? PropertyBindingInitialization for |BindingProperty| using _value_ and _environment_ as arguments.
+          1. Let _boundNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
+          1. Let _nextNames_ be ? PropertyBindingInitialization of |BindingProperty| with arguments _value_ and _environment_.
           1. Append each item in _nextNames_ to the end of _boundNames_.
           1. Return _boundNames_.
         </emu-alg>
@@ -16380,7 +16369,7 @@
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
           1. Let _loopEnvRec_ be _loopEnv_'s EnvironmentRecord.
-          1. Let _isConst_ be the result of performing IsConstantDeclaration of |LexicalDeclaration|.
+          1. Let _isConst_ be IsConstantDeclaration of |LexicalDeclaration|.
           1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
           1. For each element _dn_ of _boundNames_, do
             1. If _isConst_ is *true*, then
@@ -16846,14 +16835,14 @@
                 1. Let _status_ be PutValue(_lhsRef_, _nextValue_).
             1. Else,
               1. If _lhsKind_ is ~assignment~, then
-                1. Let _status_ be the result of performing DestructuringAssignmentEvaluation of _assignmentPattern_ using _nextValue_ as the argument.
+                1. Let _status_ be DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _nextValue_.
               1. Else if _lhsKind_ is ~varBinding~, then
                 1. Assert: _lhs_ is a |ForBinding|.
-                1. Let _status_ be the result of performing BindingInitialization for _lhs_ passing _nextValue_ and *undefined* as the arguments.
+                1. Let _status_ be BindingInitialization of _lhs_ with arguments _nextValue_ and *undefined*.
               1. Else,
                 1. Assert: _lhsKind_ is ~lexicalBinding~.
                 1. Assert: _lhs_ is a |ForDeclaration|.
-                1. Let _status_ be the result of performing BindingInitialization for _lhs_ passing _nextValue_ and _iterationEnv_ as arguments.
+                1. Let _status_ be BindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_.
             1. If _status_ is an abrupt completion, then
               1. Set the running execution context's LexicalEnvironment to _oldEnv_.
               1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
@@ -17308,7 +17297,7 @@
       <emu-alg>
         1. If the first |CaseClauses| is present, let _names_ be the LexicallyDeclaredNames of the first |CaseClauses|.
         1. Else, let _names_ be a new empty List.
-        1. Append to _names_ the elements of the LexicallyDeclaredNames of the |DefaultClause|.
+        1. Append to _names_ the elements of the LexicallyDeclaredNames of |DefaultClause|.
         1. If the second |CaseClauses| is not present, return _names_.
         1. Return the result of appending to _names_ the elements of the LexicallyDeclaredNames of the second |CaseClauses|.
       </emu-alg>
@@ -17341,7 +17330,7 @@
       <emu-alg>
         1. If the first |CaseClauses| is present, let _declarations_ be the LexicallyScopedDeclarations of the first |CaseClauses|.
         1. Else, let _declarations_ be a new empty List.
-        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of the |DefaultClause|.
+        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |DefaultClause|.
         1. If the second |CaseClauses| is not present, return _declarations_.
         1. Return the result of appending to _declarations_ the elements of the LexicallyScopedDeclarations of the second |CaseClauses|.
       </emu-alg>
@@ -17378,7 +17367,7 @@
       <emu-alg>
         1. If the first |CaseClauses| is present, let _names_ be the VarDeclaredNames of the first |CaseClauses|.
         1. Else, let _names_ be a new empty List.
-        1. Append to _names_ the elements of the VarDeclaredNames of the |DefaultClause|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |DefaultClause|.
         1. If the second |CaseClauses| is not present, return _names_.
         1. Return the result of appending to _names_ the elements of the VarDeclaredNames of the second |CaseClauses|.
       </emu-alg>
@@ -17415,7 +17404,7 @@
       <emu-alg>
         1. If the first |CaseClauses| is present, let _declarations_ be the VarScopedDeclarations of the first |CaseClauses|.
         1. Else, let _declarations_ be a new empty List.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of the |DefaultClause|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |DefaultClause|.
         1. If the second |CaseClauses| is not present, return _declarations_.
         1. Return the result of appending to _declarations_ the elements of the VarScopedDeclarations of the second |CaseClauses|.
       </emu-alg>
@@ -17522,7 +17511,7 @@
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|CaseBlock|, _blockEnv_).
         1. Set the running execution context's LexicalEnvironment to _blockEnv_.
-        1. Let _R_ be the result of performing CaseBlockEvaluation of |CaseBlock| with argument _switchValue_.
+        1. Let _R_ be CaseBlockEvaluation of |CaseBlock| with argument _switchValue_.
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return _R_.
       </emu-alg>
@@ -18006,7 +17995,7 @@
         1. For each element _argName_ of the BoundNames of |CatchParameter|, do
           1. Perform ! _catchEnvRec_.CreateMutableBinding(_argName_, *false*).
         1. Set the running execution context's LexicalEnvironment to _catchEnv_.
-        1. Let _status_ be the result of performing BindingInitialization for |CatchParameter| passing _thrownValue_ and _catchEnv_ as arguments.
+        1. Let _status_ be BindingInitialization of |CatchParameter| with arguments _thrownValue_ and _catchEnv_.
         1. If _status_ is an abrupt completion, then
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Return Completion(_status_).
@@ -18333,7 +18322,7 @@
       <p>The abstract operation IsAnonymousFunctionDefinition determines if its argument is a function definition that does not bind a name. The argument _expr_ is the result of parsing an |AssignmentExpression| or |Initializer|. The following steps are taken:</p>
       <emu-alg>
         1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
-        1. Let _hasName_ be the result of HasName of _expr_.
+        1. Let _hasName_ be HasName of _expr_.
         1. If _hasName_ is *true*, return *false*.
         1. Return *true*.
       </emu-alg>
@@ -18477,7 +18466,7 @@
         1. Let _paramVarEnv_ be NewDeclarativeEnvironment(_originalEnv_).
         1. Set the VariableEnvironment of _currentContext_ to _paramVarEnv_.
         1. Set the LexicalEnvironment of _currentContext_ to _paramVarEnv_.
-        1. Let _result_ be the result of performing IteratorBindingInitialization for |BindingElement| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Let _result_ be IteratorBindingInitialization of |BindingElement| with arguments _iteratorRecord_ and _environment_.
         1. Set the VariableEnvironment of _currentContext_ to _originalEnv_.
         1. Set the LexicalEnvironment of _currentContext_ to _originalEnv_.
         1. Return _result_.
@@ -18495,7 +18484,7 @@
         1. Let _paramVarEnv_ be NewDeclarativeEnvironment(_originalEnv_).
         1. Set the VariableEnvironment of _currentContext_ to _paramVarEnv_.
         1. Set the LexicalEnvironment of _currentContext_ to _paramVarEnv_.
-        1. Let _result_ be the result of performing IteratorBindingInitialization for |BindingRestElement| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Let _result_ be IteratorBindingInitialization of |BindingRestElement| with arguments _iteratorRecord_ and _environment_.
         1. Set the VariableEnvironment of _currentContext_ to _originalEnv_.
         1. Set the LexicalEnvironment of _currentContext_ to _originalEnv_.
         1. Return _result_.
@@ -18963,7 +18952,7 @@
 
     <emu-clause id="sec-runtime-semantics-definemethod">
       <h1>Runtime Semantics: DefineMethod</h1>
-      <p>With parameters _object_ and optional parameter _functionPrototype_.</p>
+      <p>With parameter _object_ and optional parameter _functionPrototype_.</p>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
@@ -18988,8 +18977,7 @@
       <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _methodDef_ be DefineMethod of |MethodDefinition| with argument _object_.
-        1. ReturnIfAbrupt(_methodDef_).
+        1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
         1. Perform SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
         1. Let _desc_ be the PropertyDescriptor { [[Value]]: _methodDef_.[[Closure]], [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _methodDef_.[[Key]], _desc_).
@@ -19783,7 +19771,7 @@
       <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
-        1. Let _inList_ be the result of ComputedPropertyContains for |ClassElementList| with argument _symbol_.
+        1. Let _inList_ be ComputedPropertyContains of |ClassElementList| with argument _symbol_.
         1. If _inList_ is *true*, return *true*.
         1. Return the result of ComputedPropertyContains for |ClassElement| with argument _symbol_.
       </emu-alg>
@@ -19936,8 +19924,7 @@
               <pre><code class="javascript">constructor() {}</code></pre>
               using the syntactic grammar with the goal symbol |MethodDefinition[~Yield, ~Await]|.
         1. Set the running execution context's LexicalEnvironment to _classScope_.
-        1. Let _constructorInfo_ be the result of performing DefineMethod for _constructor_ with arguments _proto_ and _constructorParent_ as the optional _functionPrototype_ argument.
-        1. Assert: _constructorInfo_ is not an abrupt completion.
+        1. Let _constructorInfo_ be DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_
         1. Let _F_ be _constructorInfo_.[[Closure]].
         1. If |ClassHeritage_opt| is present, set _F_.[[ConstructorKind]] to `"derived"`.
         1. Perform MakeConstructor(_F_, *false*, _proto_).
@@ -19949,9 +19936,9 @@
         1. Else, let _methods_ be NonConstructorMethodDefinitions of |ClassBody|.
         1. For each |ClassElement| _m_ in order from _methods_, do
           1. If IsStatic of _m_ is *false*, then
-            1. Let _status_ be the result of performing PropertyDefinitionEvaluation for _m_ with arguments _proto_ and *false*.
+            1. Let _status_ be PropertyDefinitionEvaluation of _m_ with arguments _proto_ and *false*.
           1. Else,
-            1. Let _status_ be the result of performing PropertyDefinitionEvaluation for _m_ with arguments _F_ and *false*.
+            1. Let _status_ be PropertyDefinitionEvaluation of _m_ with arguments _F_ and *false*.
           1. If _status_ is an abrupt completion, then
             1. Set the running execution context's LexicalEnvironment to _lex_.
             1. Return Completion(_status_).
@@ -19967,8 +19954,7 @@
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Let _className_ be StringValue of |BindingIdentifier|.
-        1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
-        1. ReturnIfAbrupt(_value_).
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassDeclaration|.
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Perform ? InitializeBoundName(_className_, _value_, _env_).
@@ -19976,8 +19962,7 @@
       </emu-alg>
       <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and `"default"`.
-        1. ReturnIfAbrupt(_value_).
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and `"default"`.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassDeclaration|.
         1. Return _value_.
       </emu-alg>
@@ -20012,8 +19997,7 @@
       <emu-alg>
         1. If |BindingIdentifier_opt| is not present, let _className_ be *undefined*.
         1. Else, let _className_ be StringValue of |BindingIdentifier|.
-        1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
-        1. ReturnIfAbrupt(_value_).
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
         1. Return _value_.
       </emu-alg>
@@ -20703,7 +20687,7 @@
           1. Let _has_ be *false*.
           1. If the first |CaseClauses| is present, let _has_ be HasCallInTailPosition of the first |CaseClauses| with argument _call_.
           1. If _has_ is *true*, return *true*.
-          1. Let _has_ be HasCallInTailPosition of the |DefaultClause| with argument _call_.
+          1. Let _has_ be HasCallInTailPosition of |DefaultClause| with argument _call_.
           1. If _has_ is *true*, return *true*.
           1. If the second |CaseClauses| is present, let _has_ be HasCallInTailPosition of the second |CaseClauses| with argument _call_.
           1. Return _has_.
@@ -21177,7 +21161,7 @@
               1. Perform ? _envRec_.CreateMutableBinding(_dn_, *false*).
         1. For each Parse Node _f_ in _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
-          1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _env_.
+          1. Let _fo_ be InstantiateFunctionObject of _f_ with argument _env_.
           1. Perform ? _envRec_.CreateGlobalFunctionBinding(_fn_, _fo_, *false*).
         1. For each String _vn_ in _declaredVarNames_, in list order, do
           1. Perform ? _envRec_.CreateGlobalVarBinding(_vn_, *false*).
@@ -22588,7 +22572,7 @@
                 1. Else,
                   1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
                 1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
-                  1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument _env_.
+                  1. Let _fo_ be InstantiateFunctionObject of _d_ with argument _env_.
                   1. Call _envRec_.InitializeBinding(_dn_, _fo_).
             1. Return NormalCompletion(~empty~).
           </emu-alg>
@@ -23358,8 +23342,7 @@
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
-          1. Let _value_ be the result of BindingClassDeclarationEvaluation of |ClassDeclaration|.
-          1. ReturnIfAbrupt(_value_).
+          1. Let _value_ be BindingClassDeclarationEvaluation of |ClassDeclaration|.
           1. Let _className_ be the sole element of BoundNames of |ClassDeclaration|.
           1. If _className_ is `"*default*"`, then
             1. Let _env_ be the running execution context's LexicalEnvironment.
@@ -23369,7 +23352,7 @@
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
-            1. Let _value_ be the result of performing NamedEvaluation for |AssignmentExpression| with argument `"default"`.
+            1. Let _value_ be NamedEvaluation of |AssignmentExpression| with argument `"default"`.
           1. Else,
             1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
@@ -23651,7 +23634,7 @@
                 1. Perform ? _lexEnvRec_.CreateMutableBinding(_dn_, *false*).
           1. For each Parse Node _f_ in _functionsToInitialize_, do
             1. Let _fn_ be the sole element of the BoundNames of _f_.
-            1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
+            1. Let _fo_ be InstantiateFunctionObject of _f_ with argument _lexEnv_.
             1. If _varEnvRec_ is a global Environment Record, then
               1. Perform ? _varEnvRec_.CreateGlobalFunctionBinding(_fn_, _fo_, *true*).
             1. Else,
@@ -40207,19 +40190,19 @@ THH:mm:ss.sss
         <h1>Static Semantics</h1>
         <ul>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the SV of the |LegacyOctalEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the SV of |LegacyOctalEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: OctalDigit</emu-grammar> is the code unit whose value is the MV of the |OctalDigit|.
+            The SV of <emu-grammar>LegacyOctalEscapeSequence :: OctalDigit</emu-grammar> is the code unit whose value is the MV of |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |ZeroToThree|) plus the MV of the |OctalDigit|.
+            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of |ZeroToThree|) plus the MV of |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: FourToSeven OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of the |FourToSeven|) plus the MV of the |OctalDigit|.
+            The SV of <emu-grammar>LegacyOctalEscapeSequence :: FourToSeven OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of |FourToSeven|) plus the MV of |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is the code unit whose value is (64 (that is, 8<sup>2</sup>) times the MV of the |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
+            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is the code unit whose value is (64 (that is, 8<sup>2</sup>) times the MV of |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
           </li>
           <li>
             The MV of <emu-grammar>ZeroToThree :: `0`</emu-grammar> is 0.
@@ -40446,7 +40429,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar>
         <emu-alg>
-          1. Evaluate the SV of the |LegacyOctalEscapeSequence| (see <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>) to obtain a code unit _cu_.
+          1. Evaluate the SV of |LegacyOctalEscapeSequence| (see <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>) to obtain a code unit _cu_.
           1. Return the numeric value of _cu_.
         </emu-alg>
       </emu-annex>
@@ -41024,7 +41007,7 @@ THH:mm:ss.sss
         1. Else,
           1. Let _isProtoSetter_ be *false*.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and _isProtoSetter_ is *false*, then
-          1. Let _propValue_ be the result of performing NamedEvaluation for |AssignmentExpression| with argument _propKey_.
+          1. Let _propValue_ be NamedEvaluation of |AssignmentExpression| with argument _propKey_.
         1. Else,
           1. Let _exprValueRef_ be the result of evaluating |AssignmentExpression|.
           1. Let _propValue_ be ? GetValue(_exprValueRef_).
@@ -41117,7 +41100,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If _strict_ is *false*, then
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|, do
-              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
+              1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of _parameterNames_, then
                 1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
                 1. If _initializedBindings_ does not contain _F_ and _F_ is not `"arguments"`, then
@@ -41144,7 +41127,7 @@ THH:mm:ss.sss
             1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
             1. Append to _declaredFunctionOrVarNames_ the elements of _declaredVarNames_.
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_, do
-              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
+              1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
                 1. If _envRec_.HasLexicalDeclaration(_F_) is *false*, then
                   1. Let _fnDefinable_ be ? _envRec_.CanDeclareGlobalVar(_F_).
@@ -41172,7 +41155,7 @@ THH:mm:ss.sss
             1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
             1. Append to _declaredFunctionOrVarNames_ the elements of _declaredVarNames_.
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _body_, do
-              1. Let _F_ be StringValue of the |BindingIdentifier| of |FunctionDeclaration| _f_.
+              1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _body_, then
                 1. Let _bindingExists_ be *false*.
                 1. Let _thisLex_ be _lexEnv_.
@@ -41343,7 +41326,7 @@ THH:mm:ss.sss
         1. Let _bindingId_ be StringValue of |BindingIdentifier|.
         1. Let _lhs_ be ? ResolveBinding(_bindingId_).
         1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-          1. Let _value_ be the result of performing NamedEvaluation for |Initializer| with argument _bindingId_.
+          1. Let _value_ be NamedEvaluation of |Initializer| with argument _bindingId_.
         1. Else,
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).


### PR DESCRIPTION
* Normalised the wording of applying a syntax-directed operation
* Normalised the wording of passing arguments to a syntax-directed operation
* Used `?` shorthand for syntax-directed operations where applicable

I was a bit conflicted between the terse "Operation of |NonTerminal|" and the verbose "the result of applying Operation {for,of,to} |NonTerminal|". I'm happy either way.

I left "the result of evaluating" alone, both for wording normalisation and for usage of `?`. Even though it's just another syntax-directed operation, it is invoked using a special form. If the editors decide that we should include evaluation in this normalisation, I'll make the change.