### PR TITLE
 Editorial: Name internal slots of iterators consistently

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6061,9 +6061,9 @@
       <h1>CreateListIteratorRecord ( _list_ )</h1>
       <p>The abstract operation CreateListIteratorRecord with argument _list_ creates an Iterator (<emu-xref href="#sec-iterator-interface"></emu-xref>) object record whose next method returns the successive elements of _list_. It performs the following steps:</p>
       <emu-alg>
-        1. Let _iterator_ be ObjectCreate(%IteratorPrototype%, &laquo; [[IteratedList]], [[ListIteratorNextIndex]] &raquo;).
+        1. Let _iterator_ be ObjectCreate(%IteratorPrototype%, &laquo; [[IteratedList]], [[ListNextIndex]] &raquo;).
         1. Set _iterator_.[[IteratedList]] to _list_.
-        1. Set _iterator_.[[ListIteratorNextIndex]] to 0.
+        1. Set _iterator_.[[ListNextIndex]] to 0.
         1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-listiteratornext-functions" title></emu-xref>.
         1. Let _next_ be ! CreateBuiltinFunction(_steps_, &laquo; &raquo;).
         1. Return Record { [[Iterator]]: _iterator_, [[NextMethod]]: _next_, [[Done]]: *false* }.
@@ -6080,11 +6080,11 @@
           1. Assert: Type(_O_) is Object.
           1. Assert: _O_ has an [[IteratedList]] internal slot.
           1. Let _list_ be _O_.[[IteratedList]].
-          1. Let _index_ be _O_.[[ListIteratorNextIndex]].
+          1. Let _index_ be _O_.[[ListNextIndex]].
           1. Let _len_ be the number of elements of _list_.
           1. If _index_ &ge; _len_, then
             1. Return CreateIterResultObject(*undefined*, *true*).
-          1. Set _O_.[[ListIteratorNextIndex]] to _index_ + 1.
+          1. Set _O_.[[ListNextIndex]] to _index_ + 1.
           1. Return CreateIterResultObject(_list_[_index_], *false*).
         </emu-alg>
         <p>The *"length"* property of a ListIteratorNext function is 0.</p>
@@ -30224,9 +30224,9 @@ THH:mm:ss.sss
         <p>Several methods of String objects return Iterator objects. The abstract operation CreateStringIterator with argument _string_ is used to create such iterator objects. It performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_string_) is String.
-          1. Let _iterator_ be ObjectCreate(%StringIteratorPrototype%, &laquo; [[IteratedString]], [[StringIteratorNextIndex]] &raquo;).
+          1. Let _iterator_ be ObjectCreate(%StringIteratorPrototype%, &laquo; [[IteratedString]], [[StringNextIndex]] &raquo;).
           1. Set _iterator_.[[IteratedString]] to _string_.
-          1. Set _iterator_.[[StringIteratorNextIndex]] to 0.
+          1. Set _iterator_.[[StringNextIndex]] to 0.
           1. Return _iterator_.
         </emu-alg>
       </emu-clause>
@@ -30249,14 +30249,14 @@ THH:mm:ss.sss
             1. If _O_ does not have all of the internal slots of a String Iterator Instance (<emu-xref href="#sec-properties-of-string-iterator-instances"></emu-xref>), throw a *TypeError* exception.
             1. Let _s_ be _O_.[[IteratedString]].
             1. If _s_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
-            1. Let _position_ be _O_.[[StringIteratorNextIndex]].
+            1. Let _position_ be _O_.[[StringNextIndex]].
             1. Let _len_ be the length of _s_.
             1. If _position_ &ge; _len_, then
               1. Set _O_.[[IteratedString]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
             1. Let _cp_ be ! CodePointAt(_s_, _position_).
             1. Let _resultString_ be the String value containing _cp_.[[CodeUnitCount]] consecutive code units from _s_ beginning with the code unit at index _position_.
-            1. Set _O_.[[StringIteratorNextIndex]] to _position_ + _cp_.[[CodeUnitCount]].
+            1. Set _O_.[[StringNextIndex]] to _position_ + _cp_.[[CodeUnitCount]].
             1. Return CreateIterResultObject(_resultString_, *false*).
           </emu-alg>
         </emu-clause>
@@ -30292,10 +30292,10 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                [[StringIteratorNextIndex]]
+                [[StringNextIndex]]
               </td>
               <td>
-                The integer index of the next string index to be examined by this iteration.
+                The integer index of the next string element (code unit) to be examined by this iterator.
               </td>
             </tr>
             </tbody>
@@ -34013,10 +34013,10 @@ THH:mm:ss.sss
         <p>Several methods of Array objects return Iterator objects. The abstract operation CreateArrayIterator with arguments _array_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_array_) is Object.
-          1. Let _iterator_ be ObjectCreate(%ArrayIteratorPrototype%, &laquo; [[IteratedObject]], [[ArrayIteratorNextIndex]], [[ArrayIterationKind]] &raquo;).
-          1. Set _iterator_.[[IteratedObject]] to _array_.
-          1. Set _iterator_.[[ArrayIteratorNextIndex]] to 0.
-          1. Set _iterator_.[[ArrayIterationKind]] to _kind_.
+          1. Let _iterator_ be ObjectCreate(%ArrayIteratorPrototype%, &laquo; [[IteratedArrayLike]], [[ArrayLikeNextIndex]], [[ArrayLikeIterationKind]] &raquo;).
+          1. Set _iterator_.[[IteratedArrayLike]] to _array_.
+          1. Set _iterator_.[[ArrayLikeNextIndex]] to 0.
+          1. Set _iterator_.[[ArrayLikeIterationKind]] to _kind_.
           1. Return _iterator_.
         </emu-alg>
       </emu-clause>
@@ -34037,19 +34037,19 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of an Array Iterator Instance (<emu-xref href="#sec-properties-of-array-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _a_ be _O_.[[IteratedObject]].
+            1. Let _a_ be _O_.[[IteratedArrayLike]].
             1. If _a_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
-            1. Let _index_ be _O_.[[ArrayIteratorNextIndex]].
-            1. Let _itemKind_ be _O_.[[ArrayIterationKind]].
+            1. Let _index_ be _O_.[[ArrayLikeNextIndex]].
+            1. Let _itemKind_ be _O_.[[ArrayLikeIterationKind]].
             1. If _a_ has a [[TypedArrayName]] internal slot, then
               1. If IsDetachedBuffer(_a_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
               1. Let _len_ be _a_.[[ArrayLength]].
             1. Else,
               1. Let _len_ be ? LengthOfArrayLike(_a_).
             1. If _index_ &ge; _len_, then
-              1. Set _O_.[[IteratedObject]] to *undefined*.
+              1. Set _O_.[[IteratedArrayLike]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
-            1. Set _O_.[[ArrayIteratorNextIndex]] to _index_ + 1.
+            1. Set _O_.[[ArrayLikeNextIndex]] to _index_ + 1.
             1. If _itemKind_ is ~key~, return CreateIterResultObject(_index_, *false*).
             1. Let _elementKey_ be ! ToString(_index_).
             1. Let _elementValue_ be ? Get(_a_, _elementKey_).
@@ -34084,23 +34084,23 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                [[IteratedObject]]
+                [[IteratedArrayLike]]
               </td>
               <td>
-                The object whose array elements are being iterated.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[ArrayIteratorNextIndex]]
-              </td>
-              <td>
-                The integer index of the next integer index to be examined by this iteration.
+                The array-like object that is being iterated.
               </td>
             </tr>
             <tr>
               <td>
-                [[ArrayIterationKind]]
+                [[ArrayLikeNextIndex]]
+              </td>
+              <td>
+                The integer index of the next element to be examined by this iterator.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[ArrayLikeIterationKind]]
               </td>
               <td>
                 A String value that identifies what is returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~.
@@ -35549,8 +35549,8 @@ THH:mm:ss.sss
         <p>Several methods of Map objects return Iterator objects. The abstract operation CreateMapIterator with arguments _map_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
-          1. Let _iterator_ be ObjectCreate(%MapIteratorPrototype%, &laquo; [[Map]], [[MapNextIndex]], [[MapIterationKind]] &raquo;).
-          1. Set _iterator_.[[Map]] to _map_.
+          1. Let _iterator_ be ObjectCreate(%MapIteratorPrototype%, &laquo; [[IteratedMap]], [[MapNextIndex]], [[MapIterationKind]] &raquo;).
+          1. Set _iterator_.[[IteratedMap]] to _map_.
           1. Set _iterator_.[[MapNextIndex]] to 0.
           1. Set _iterator_.[[MapIterationKind]] to _kind_.
           1. Return _iterator_.
@@ -35573,7 +35573,7 @@ THH:mm:ss.sss
             1. Let _O_ be the *this* value.
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of a Map Iterator Instance (<emu-xref href="#sec-properties-of-map-iterator-instances"></emu-xref>), throw a *TypeError* exception.
-            1. Let _m_ be _O_.[[Map]].
+            1. Let _m_ be _O_.[[IteratedMap]].
             1. Let _index_ be _O_.[[MapNextIndex]].
             1. Let _itemKind_ be _O_.[[MapIterationKind]].
             1. If _m_ is *undefined*, return CreateIterResultObject(*undefined*, *true*).
@@ -35592,7 +35592,7 @@ THH:mm:ss.sss
                   1. Assert: _itemKind_ is ~key+value~.
                   1. Let _result_ be ! CreateArrayFromList(&laquo; _e_.[[Key]], _e_.[[Value]] &raquo;).
                 1. Return CreateIterResultObject(_result_, *false*).
-            1. Set _O_.[[Map]] to *undefined*.
+            1. Set _O_.[[IteratedMap]] to *undefined*.
             1. Return CreateIterResultObject(*undefined*, *true*).
           </emu-alg>
         </emu-clause>
@@ -35620,7 +35620,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                [[Map]]
+                [[IteratedMap]]
               </td>
               <td>
                 The Map object that is being iterated.
@@ -35631,7 +35631,7 @@ THH:mm:ss.sss
                 [[MapNextIndex]]
               </td>
               <td>
-                The integer index of the next Map data element to be examined by this iterator.
+                The integer index of the next [[MapData]] element to be examined by this iterator.
               </td>
             </tr>
             <tr>
@@ -35639,7 +35639,7 @@ THH:mm:ss.sss
                 [[MapIterationKind]]
               </td>
               <td>
-                A String value that identifies what is to be returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~.
+                A String value that identifies what is returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~.
               </td>
             </tr>
             </tbody>
@@ -35922,6 +35922,7 @@ THH:mm:ss.sss
               1. If _e_ is not ~empty~, then
                 1. If _itemKind_ is ~key+value~, then
                   1. Return CreateIterResultObject(CreateArrayFromList(&laquo; _e_, _e_ &raquo;), *false*).
+                1. Assert: _itemKind_ is ~value~.
                 1. Return CreateIterResultObject(_e_, *false*).
             1. Set _O_.[[IteratedSet]] to *undefined*.
             1. Return CreateIterResultObject(*undefined*, *true*).
@@ -35962,7 +35963,7 @@ THH:mm:ss.sss
                 [[SetNextIndex]]
               </td>
               <td>
-                The integer index of the next Set data element to be examined by this iterator
+                The integer index of the next [[SetData]] element to be examined by this iterator.
               </td>
             </tr>
             <tr>
@@ -35970,7 +35971,7 @@ THH:mm:ss.sss
                 [[SetIterationKind]]
               </td>
               <td>
-                A String value that identifies what is to be returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~. ~key~ and ~value~ have the same meaning.
+                A String value that identifies what is returned for each element of the iteration. The possible values are ~value~ and ~key+value~.
               </td>
             </tr>
             </tbody>


### PR DESCRIPTION
### [List Iterator](https://tc39.es/ecma262/#sec-createlistiteratorRecord)

```diff
  [[IteratedList]]
- [[ListIteratorNextIndex]]
+ [[ListNextIndex]]
```

### [String Iterator](https://tc39.es/ecma262/#sec-properties-of-string-iterator-instances)

```diff
  [[IteratedString]]
- [[StringIteratorNextIndex]]
+ [[StringNextIndex]]
```

### [Array Iterator](https://tc39.es/ecma262/#sec-properties-of-array-iterator-instances)

```diff
- [[IteratedObject]]
+ [[IteratedArrayLike]]
- [[ArrayIteratorNextIndex]]
+ [[ArrayLikeNextIndex]]
- [[ArrayIterationKind]]
+ [[ArrayLikeIterationKind]]
```

### [Map Iterator](https://tc39.es/ecma262/#sec-properties-of-map-iterator-instances)

```diff
- [[Map]]
+ [[IteratedMap]]
  [[MapNextIndex]]
  [[MapIterationKind]]
```

### [Set Iterator](https://tc39.es/ecma262/#sec-properties-of-set-iterator-instances)

**(no changes)**

```diff
[[IteratedSet]]
[[SetNextIndex]]
[[SetIterationKind]]
```

### [RegExp String Iterator](https://tc39.es/ecma262/#sec-properties-of-regexp-string-iterator-instances)

**(no changes)**

```diff
[[IteratingRegExp]]
[[IteratedString]]
[[Global]]
[[Unicode]]
[[Done]]
```