### PR TITLE
Editorial: Move ToObject out of GetSubstitution

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29796,7 +29796,7 @@ THH:mm:ss.sss
             1. Let _replStr_ be ? ToString(_replValue_).
           1. Else,
             1. Let _captures_ be a new empty List.
-            1. Let _replStr_ be GetSubstitution(_matched_, _string_, _pos_, _captures_, *undefined*, _replaceValue_).
+            1. Let _replStr_ be ! GetSubstitution(_matched_, _string_, _pos_, _captures_, *undefined*, _replaceValue_).
           1. Let _tailPos_ be _pos_ + the number of code units in _matched_.
           1. Let _newString_ be the string-concatenation of the first _pos_ code units of _string_, _replStr_, and the trailing substring of _string_ starting at index _tailPos_. If _pos_ is 0, the first element of the concatenation will be the empty String.
           1. Return _newString_.
@@ -29819,8 +29819,6 @@ THH:mm:ss.sss
             1. Assert: Type(_replacement_) is String.
             1. Let _tailPos_ be _position_ + _matchLength_.
             1. Let _m_ be the number of elements in _captures_.
-            1. If _namedCaptures_ is not *undefined*, then
-              1. Set _namedCaptures_ to ? ToObject(_namedCaptures_).
             1. Let _result_ be the String value derived from _replacement_ by copying code unit elements from _replacement_ to _result_ while performing replacements as specified in <emu-xref href="#table-45"></emu-xref>. These `$` replacements are done left-to-right, and, once such a replacement is performed, the new replacement text is not subject to further replacements.
             1. Return _result_.
           </emu-alg>
@@ -29927,6 +29925,7 @@ THH:mm:ss.sss
                   <emu-alg>
                     1. If _namedCaptures_ is *undefined*, the replacement text is the String *"$&lt;"*.
                     1. Else,
+                      1. Assert: Type(_namedCaptures_) is Object.
                       1. Scan until the next `>` U+003E (GREATER-THAN SIGN).
                       1. If none is found, the replacement text is the String *"$&lt;"*.
                       1. Else,
@@ -32415,7 +32414,9 @@ THH:mm:ss.sss
               1. Let _replValue_ be ? Call(_replaceValue_, *undefined*, _replacerArgs_).
               1. Let _replacement_ be ? ToString(_replValue_).
             1. Else,
-              1. Let _replacement_ be GetSubstitution(_matched_, _S_, _position_, _captures_, _namedCaptures_, _replaceValue_).
+              1. If _namedCaptures_ is not *undefined*, then
+                1. Set _namedCaptures_ to ? ToObject(_namedCaptures_).
+              1. Let _replacement_ be ! GetSubstitution(_matched_, _S_, _position_, _captures_, _namedCaptures_, _replaceValue_).
             1. If _position_ &ge; _nextSourcePosition_, then
               1. NOTE: _position_ should not normally move backwards. If it does, it is an indication of an ill-behaving RegExp subclass or use of an access triggered side-effect to change the global flag or other characteristics of _rx_. In such cases, the corresponding substitution is ignored.
               1. Set _accumulatedResult_ to the string-concatenation of the current value of _accumulatedResult_, the substring of _S_ consisting of the code units from _nextSourcePosition_ (inclusive) up to _position_ (exclusive), and _replacement_.


### PR DESCRIPTION
Object coercion is only relevant to `GetSubstitution` call in [`RegExp.prototype[@@replace]`](https://tc39.es/ecma262/#sec-regexp.prototype-@@replace) (step **14.l.i**), so let's move it there. There are no observable steps between current and proposed locations of `ToObject` call.