### PR TITLE
Markup: Fix breakage after #1482.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21928,7 +21928,7 @@
             <img alt="A module graph in which module A depends on module B" width="121" height="211" src="img/module-graph-simple.svg">
           </emu-figure>
 
-          <p>Let's first assume that there are no error conditions. When a host first calls _A_.Link(), this will complete successfully by assumption, and recursively link modules _B_ and _C_ as well, such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = `"linked"`. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be `"evaluated`".</p>
+          <p>Let's first assume that there are no error conditions. When a host first calls _A_.Link(), this will complete successfully by assumption, and recursively link modules _B_ and _C_ as well, such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = `"linked"`. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be `"evaluated"`.</p>
 
           <p>Consider then cases involving linking errors. If InnerModuleLinking of _C_ succeeds but, thereafter, fails for _B_, for example because it imports something that _C_ does not provide, then the original _A_.Link() will fail, and both _A_ and _B_'s [[Status]] remain `"unlinked"`. _C_'s [[Status]] has become `"linked"`, though.</p>
 
@@ -22625,7 +22625,7 @@
         <emu-note>
           <p>An example of when _referencingScriptOrModule_ can be *null* is in a web browser host. There, if a user clicks on a control given by</p>
 
-          <pre><code class="html">&lt;button type="button" onclick="import('./foo.mjs')"&rt;Click me&lt;/button&rt;</code></pre>
+          <pre><code class="html">&lt;button type="button" onclick="import('./foo.mjs')"&gt;Click me&lt;/button&gt;</code></pre>
 
           <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression runs. More generally, this can happen in any situation where the host pushes execution contexts with *null* ScriptOrModule components onto the execution context stack.</p>
         </emu-note>
@@ -23440,9 +23440,9 @@
       <li>
         When parsing for the |Module| goal symbol, the lexical grammar extensions defined in <emu-xref href="#sec-html-like-comments"></emu-xref> must not be supported.
       </li>
+      <!-- The following is so that in the future we can potentially add new arguments or support ArgumentList. -->
       <li>
         |ImportCall| must not be extended.
-        <!-- This is so that in the future we can potentially add new arguments or support ArgumentList. -->
       </li>
     </ul>
   </emu-clause>


### PR DESCRIPTION
- Move an ecmarkdown-adjacent HTML comment outside of its containing element to restore style generation on master (_search for <code>\`</code> or `_` and you'll see what I mean_).

- Fix two other typos found while bisecting (`&rt;` → `&gt;`, <code>\`"\`"</code> → <code>\`""\`</code> ).