### PR TITLE
Editorial: Normalize code spacing.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -867,7 +867,7 @@
       <h1>Mathematical Operations</h1>
       <p>Mathematical operations such as addition, subtraction, negation, multiplication, division, and the mathematical functions defined later in this clause should always be understood as computing exact mathematical results on mathematical real numbers, which unless otherwise noted do not include infinities and do not include a negative zero that is distinguished from positive zero. Algorithms in this standard that model floating-point arithmetic include explicit steps, where necessary, to handle infinities and signed zero and to perform rounding. If a mathematical operation or function is applied to a floating-point number, it should be understood as being applied to the exact mathematical value represented by that floating-point number; such a floating-point number must be finite, and if it is *+0* or *-0* then the corresponding mathematical value is simply 0.</p>
       <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs">abs(_x_)</emu-eqn> produces the absolute value of _x_, which is <emu-eqn>-_x_</emu-eqn> if _x_ is negative (less than zero) and otherwise is _x_ itself.</p>
-      <p>The mathematical function <emu-eqn id="eqn-min" aoid="min">min(_x1_, _x2_, ..., _xN_)</emu-eqn> produces the mathematically smallest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max">max(_x1_, _x2_, ..., _xN_)</emu-eqn> produces the mathematically largest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The domain and range of these mathematical functions include *+&infin;* and *-&infin;*.</p>
+      <p>The mathematical function <emu-eqn id="eqn-min" aoid="min">min(_x1_, _x2_, &hellip; , _xN_)</emu-eqn> produces the mathematically smallest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max">max(_x1_, _x2_, &hellip; , _xN_)</emu-eqn> produces the mathematically largest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The domain and range of these mathematical functions include *+&infin;* and *-&infin;*.</p>
       <p>The notation &ldquo;<emu-eqn id="eqn-modulo" aoid="modulo">_x_ modulo _y_</emu-eqn>&rdquo; (_y_ must be finite and nonzero) computes a value _k_ of the same sign as _y_ (or zero) such that <emu-eqn>abs(_k_) &lt; abs(_y_) and _x_ - _k_ = _q_ &times; _y_</emu-eqn> for some integer _q_.</p>
       <p>The mathematical function <emu-eqn id="eqn-floor" aoid="floor">floor(_x_)</emu-eqn> produces the largest integer (closest to positive infinity) that is not larger than _x_.</p>
       <emu-note>
@@ -5198,7 +5198,7 @@
           </emu-alg>
           <emu-note>
             <p>An example of ECMAScript code that results in a missing binding at step 2 is:</p>
-            <pre><code class="javascript">function f(){eval("var x; x = (delete x, 0);")}</code></pre>
+            <pre><code class="javascript">function f() { eval("var x; x = (delete x, 0);"); }</code></pre>
           </emu-note>
         </emu-clause>
 
@@ -19922,11 +19922,11 @@
         1. If _constructor_ is ~empty~, then
           1. If |ClassHeritage_opt| is present, then
             1. Set _constructor_ to the result of parsing the source text
-              <pre><code class="javascript">constructor(... args){ super (...args);}</code></pre>
+              <pre><code class="javascript">constructor(...args) { super(...args); }</code></pre>
               using the syntactic grammar with the goal symbol |MethodDefinition[~Yield, ~Await]|.
           1. Else,
             1. Set _constructor_ to the result of parsing the source text
-              <pre><code class="javascript">constructor(){ }</code></pre>
+              <pre><code class="javascript">constructor() {}</code></pre>
               using the syntactic grammar with the goal symbol |MethodDefinition[~Yield, ~Await]|.
         1. Set the running execution context's LexicalEnvironment to _classScope_.
         1. Let _constructorInfo_ be the result of performing DefineMethod for _constructor_ with arguments _proto_ and _constructorParent_ as the optional _functionPrototype_ argument.
@@ -22281,7 +22281,7 @@
               </tr>
               <tr>
                 <td>
-                  `export default function f(){}`
+                  `export default function f() {}`
                 </td>
                 <td>
                   `"default"`
@@ -22298,7 +22298,7 @@
               </tr>
               <tr>
                 <td>
-                  `export default function(){}`
+                  `export default function () {}`
                 </td>
                 <td>
                   `"default"`
@@ -37317,7 +37317,7 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction">
-        <h1>AsyncGeneratorFunction ( _p1_, _p2_, ..., _pn_, _body_ )</h1>
+        <h1>AsyncGeneratorFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
         <p>The last argument specifies the body (executable code) of an async generator function; any preceding arguments specify formal parameters.</p>
         <p>When the `AsyncGeneratorFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no "_p_" arguments, and where _body_ might also not be provided), the following steps are taken:</p>
         <emu-alg>
@@ -38728,7 +38728,7 @@ THH:mm:ss.sss
 
         <p>The last argument specifies the body (executable code) of an async function. Any preceding arguments specify formal parameters.</p>
 
-        <p>When the `AsyncFunction` function is called with some arguments _p1_, _p2_, &hellip;, _pn_, _body_ (where _n_ might be 0, that is, there are no _p_ arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+        <p>When the `AsyncFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no _p_ arguments, and where _body_ might also not be provided), the following steps are taken:</p>
 
         <emu-alg>
           1. Let _C_ be the active function object.


### PR DESCRIPTION
@devsnek pointed out that [14.6.13](https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation) step 10 has extremely odd spacing:

```js
constructor(... args){ super (...args);}
```

Like Gus, I'd rather not battle over style here, but I think anyone can agree that that line needs fixing.

The first commit here fixes parentheses and braces to align with the style shown in [13.7.5.15](https://tc39.es/ecma262/#sec-enumerate-object-properties)'s note. (_Strictly speaking, this is more than necessary; even just **removing** spaces would be an improvement._)

The second commit normalizes a couple of `...,` cases to our more typical `&hellip; ,`.