### PR TITLE
Editorial: Provide context for HostImportModuleDynamically requirement

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22658,6 +22658,9 @@
           </li>
           <li>
             Every call to HostImportModuleDynamically with the same _referencingScriptOrModule_ and _specifier_ arguments must conform to the <em>same</em> set of requirements above as previous calls do. That is, if the host environment takes the success path once for a given _referencingScriptOrModule_, _specifier_ pair, it must always do so, and the same for the failure path.
+            <emu-note>
+              <p>Changes to module caches that are exposed to user code (e.g. `delete require.cache[k]`) must not affect dynamic imports.</p>
+            </emu-note>
           </li>
           <li>
             The operation must not call _promiseCapability_.[[Resolve]] or _promiseCapability_.[[Reject]], but instead must treat _promiseCapability_ as an opaque identifying value to be passed through to FinishDynamicImport.


### PR DESCRIPTION
I had a hard time figuring out the stability requirement:

> Every call to HostImportModuleDynamically with the same
> *referencingScriptOrModule* and *specifier* arguments must conform
> to the <em>same</em> set of requirements above as previous calls
> do. That is, if the host environment takes the success path once for
> a given *referencingScriptOrModule*, *specifier* pair, it must
> always do so, and the same for the failure path.

This adds an editorial note gleaned from discussions on #tc39.

If accurate, it may help others.

@devsnek who explained the context.
@littledan @domenic who probably drafted/championed the requirement.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
