### PR TITLE
Editorial: use "be the *this* value" over "be *this* value"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29078,7 +29078,7 @@ THH:mm:ss.sss
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be *this* value.
+          1. Let _S_ be the *this* value.
           1. Return ? TrimString(_S_, `"start+end"`).
         </emu-alg>
         <emu-note>
@@ -29107,7 +29107,7 @@ THH:mm:ss.sss
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be *this* value.
+          1. Let _S_ be the *this* value.
           1. Return ? TrimString(_S_, `"end"`).
         </emu-alg>
         <emu-note>
@@ -29120,7 +29120,7 @@ THH:mm:ss.sss
         <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be *this* value.
+          1. Let _S_ be the *this* value.
           1. Return ? TrimString(_S_, `"start"`).
         </emu-alg>
         <emu-note>
@@ -33460,7 +33460,7 @@ THH:mm:ss.sss
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.copyWithin` are the same as for `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref>.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be *this* value.
+          1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. Let _relativeTarget_ be ? ToInteger(_target_).


### PR DESCRIPTION
130 occurrences vs 4.