### PR TITLE
Editorial: Tweak format of *.prototype.sort

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33813,27 +33813,31 @@ THH:mm:ss.sss
           1. Let _objIsSparse_ be *false*.
         </emu-alg>
         <p>The implementation-defined sort order condition for exotic objects is not applied by %TypedArray%`.prototype.sort`.</p>
-        <p>The following version of SortCompare is used by %TypedArray%`.prototype.sort`. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. SortCompare has access to the _comparefn_ and _buffer_ values of the current invocation of the `sort` method.</p>
-        <p>When the TypedArray SortCompare abstract operation is called with two arguments _x_ and _y_, the following steps are taken:</p>
-        <emu-alg>
-          1. Assert: Both Type(_x_) and Type(_y_) is Number.
-          1. If _comparefn_ is not *undefined*, then
-            1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
-            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-            1. If _v_ is *NaN*, return *+0*.
-            1. Return _v_.
-          1. If _x_ and _y_ are both *NaN*, return *+0*.
-          1. If _x_ is *NaN*, return 1.
-          1. If _y_ is *NaN*, return -1.
-          1. If _x_ &lt; _y_, return -1.
-          1. If _x_ &gt; _y_, return 1.
-          1. If _x_ is *-0* and _y_ is *+0*, return -1.
-          1. If _x_ is *+0* and _y_ is *-0*, return 1.
-          1. Return *+0*.
-        </emu-alg>
-        <emu-note>
-          <p>Because *NaN* always compares greater than any other value, *NaN* property values always sort to the end of the result when _comparefn_ is not provided.</p>
-        </emu-note>
+        <p>%TypedArray%`.prototype.sort` calls TypedArraySortCompare rather than SortCompare.</p>
+
+        <emu-clause id="sec-typedarraysortcompare" aoid="TypedArraySortCompare">
+          <h1>Runtime Semantics: TypedArraySortCompare ( _x_, _y_ )</h1>
+          <p>The TypedArraySortCompare abstract operation is called with two arguments _x_ and _y_. It also has access to the _comparefn_ and _buffer_ values of the current invocation of the %TypedArray%`.prototype.sort` method. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. The following steps are taken:</p>
+          <emu-alg>
+            1. Assert: Both Type(_x_) and Type(_y_) is Number.
+            1. If _comparefn_ is not *undefined*, then
+              1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
+              1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+              1. If _v_ is *NaN*, return *+0*.
+              1. Return _v_.
+            1. If _x_ and _y_ are both *NaN*, return *+0*.
+            1. If _x_ is *NaN*, return 1.
+            1. If _y_ is *NaN*, return -1.
+            1. If _x_ &lt; _y_, return -1.
+            1. If _x_ &gt; _y_, return 1.
+            1. If _x_ is *-0* and _y_ is *+0*, return -1.
+            1. If _x_ is *+0* and _y_ is *-0*, return 1.
+            1. Return *+0*.
+          </emu-alg>
+          <emu-note>
+            <p>Because *NaN* always compares greater than any other value, *NaN* property values always sort to the end of the result when _comparefn_ is not provided.</p>
+          </emu-note>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.subarray">

--- a/spec.html
+++ b/spec.html
@@ -32609,54 +32609,22 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.sort">
         <h1>Array.prototype.sort ( _comparefn_ )</h1>
         <p>The elements of this array are sorted. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative value if _x_ &lt; _y_, zero if _x_ = _y_, or a positive value if _x_ &gt; _y_.</p>
-        <p>Upon entry, the following steps are performed to initialize evaluation of the `sort` function:</p>
         <emu-alg>
           1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_obj_, `"length"`)).
           1. Let _objIsSparse_ be ObjectIsSparse(_obj_, _len_).
-        </emu-alg>
-
-        <p>The <em>sort order</em> is the ordering, after completion of this function, of the <emu-xref href="#integer-index">integer-indexed</emu-xref> property values of _obj_ whose integer indexes are less than _len_. The result of the `sort` function is then determined as follows:</p>
-        <p>If _comparefn_ is not *undefined* and is not a consistent comparison function for the elements of this array (see below), the sort order is implementation-defined. The sort order is also implementation-defined if _comparefn_ is *undefined* and SortCompare does not act as a consistent comparison function.</p>
-        <p>Let _proto_ be _obj_.[[GetPrototypeOf]](). If _proto_ is not *null* and there exists an integer _j_ such that all of the conditions below are satisfied then the sort order is implementation-defined:</p>
-        <ul>
-          <li>
-            _objIsSparse_ is *true*
-          </li>
-          <li>
-            0 &le; _j_ &lt; _len_
-          </li>
-          <li>
-            HasProperty(_proto_, ToString(_j_)) is *true*.
-          </li>
-        </ul>
-        <p>The sort order is also implementation-defined if _objIsSparse_ is *true* and any of the following conditions are true:</p>
-        <ul>
-          <li>
-            IsExtensible(_obj_) is *false*.
-          </li>
-          <li>
-            Any integer index property of _obj_ whose name is a nonnegative integer less than _len_ is a data property whose [[Configurable]] attribute is *false*.
-          </li>
-        </ul>
-        <p>The sort order is also implementation-defined if any of the following conditions are true:</p>
-        <ul>
-          <li>
-            If _obj_ is an exotic object (including Proxy exotic objects) whose behaviour for [[Get]], [[Set]], [[Delete]], and [[GetOwnProperty]] is not the ordinary object implementation of these internal methods.
-          </li>
-          <li>
-            If any index property of _obj_ whose name is a nonnegative integer less than _len_ is an accessor property or is a data property whose [[Writable]] attribute is *false*.
-          </li>
-          <li>
-            If _comparefn_ is *undefined* and the application of ToString to any value passed as an argument to SortCompare modifies _obj_ or any object on _obj_'s prototype chain.
-          </li>
-          <li>
-            If _comparefn_ is *undefined* and all applications of ToString, to any specific value passed as an argument to SortCompare, do not produce the same result.
-          </li>
-        </ul>
-        <p>The following steps are taken:</p>
-        <emu-alg>
+          1. Let _proto_ be _obj_.[[GetPrototypeOf]]().
+          1. Let _sortOrderIsImplementationDefined_ be *true* if any of the following conditions are satisfied, and let it be *false* otherwise:
+            * _comparefn_ is not *undefined* and is not a consistent comparison function for the elements of this array (see below).
+            * _comparefn_ is *undefined* and SortCompare does not act as a consistent comparison function.
+            * _objIsSparse_ is *true* and _proto_ is not *null* and there exists a nonnegative integer _j_ less than _len_ such that HasProperty(_proto_, ToString(_j_)) is *true*.
+            * _objIsSparse_ is *true* and IsExtensible(_obj_) is *false*.
+            * _objIsSparse_ is *true* and any integer index property of _obj_ whose name is a nonnegative integer less than _len_ is a data property whose [[Configurable]] attribute is *false*.
+            * _obj_ is an exotic object (including Proxy exotic objects) whose behaviour for [[Get]], [[Set]], [[Delete]], and [[GetOwnProperty]] is not the ordinary object implementation of these internal methods.
+            * any index property of _obj_ whose name is a nonnegative integer less than _len_ is an accessor property or is a data property whose [[Writable]] attribute is *false*.
+            * _comparefn_ is *undefined* and the application of ToString to any value passed as an argument to SortCompare modifies _obj_ or any object on _obj_'s prototype chain.
+            * _comparefn_ is *undefined* and all applications of ToString, to any specific value passed as an argument to SortCompare, do not produce the same result.
           1. Perform an implementation-dependent sequence of calls to the [[Get]] and [[Set]] internal methods of _obj_, to the DeletePropertyOrThrow and HasOwnProperty abstract operation with _obj_ as the first argument, and to SortCompare (described below), such that:
             * The property key argument for each call to [[Get]], [[Set]], HasOwnProperty, or DeletePropertyOrThrow is the string representation of a nonnegative integer less than _len_.
             * The arguments for calls to SortCompare are values returned by a previous call to the [[Get]] internal method, unless the properties accessed by those previous calls did not exist according to HasOwnProperty. If both prospective arguments to SortCompare correspond to non-existent properties, use *+0* instead of calling SortCompare. If only the first prospective argument is non-existent use +1. If only the second prospective argument is non-existent use -1.
@@ -32665,7 +32633,7 @@ THH:mm:ss.sss
             * If an abrupt completion is returned from any of these operations, it is immediately returned as the value of this function.
           1. Return _obj_.
         </emu-alg>
-        <p>Unless the sort order is specified above to be implementation-defined, the returned object must have the following two characteristics:</p>
+        <p>The <em>sort order</em> is the ordering, after completion of this function, of the <emu-xref href="#integer-index">integer-indexed</emu-xref> property values of _obj_ whose integer indexes are less than _len_. If _sortOrderIsImplementationDefined_ is *true*, the sort order is implementation-defined. Otherwise, the returned object must have the following two characteristics:</p>
         <ul>
           <li>
             There must be some mathematical permutation &pi; of the nonnegative integers less than _len_, such that for every nonnegative integer _j_ less than _len_, if property <emu-eqn>old[_j_]</emu-eqn> existed, then <emu-eqn>new[&pi;(_j_)]</emu-eqn> is exactly the same value as <emu-eqn>old[_j_]</emu-eqn>. But if property <emu-eqn>old[_j_]</emu-eqn> did not exist, then <emu-eqn>new[&pi;(_j_)]</emu-eqn> does not exist.

--- a/spec.html
+++ b/spec.html
@@ -32614,20 +32614,15 @@ THH:mm:ss.sss
           1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? ToLength(? Get(_obj_, `"length"`)).
+          1. Let _objIsSparse_ be ObjectIsSparse(_obj_, _len_).
         </emu-alg>
-        <p>Within this specification of the `sort` method, an object, _obj_, is said to be <em>sparse</em> if the following algorithm returns *true*:</p>
-        <emu-alg>
-          1. For each integer _i_ in the range 0 &le; _i_ &lt; _len_, do
-            1. Let _elem_ be _obj_.[[GetOwnProperty]](! ToString(_i_)).
-            1. If _elem_ is *undefined*, return *true*.
-          1. Return *false*.
-        </emu-alg>
+
         <p>The <em>sort order</em> is the ordering, after completion of this function, of the <emu-xref href="#integer-index">integer-indexed</emu-xref> property values of _obj_ whose integer indexes are less than _len_. The result of the `sort` function is then determined as follows:</p>
         <p>If _comparefn_ is not *undefined* and is not a consistent comparison function for the elements of this array (see below), the sort order is implementation-defined. The sort order is also implementation-defined if _comparefn_ is *undefined* and SortCompare does not act as a consistent comparison function.</p>
         <p>Let _proto_ be _obj_.[[GetPrototypeOf]](). If _proto_ is not *null* and there exists an integer _j_ such that all of the conditions below are satisfied then the sort order is implementation-defined:</p>
         <ul>
           <li>
-            _obj_ is sparse
+            _objIsSparse_ is *true*
           </li>
           <li>
             0 &le; _j_ &lt; _len_
@@ -32636,7 +32631,7 @@ THH:mm:ss.sss
             HasProperty(_proto_, ToString(_j_)) is *true*.
           </li>
         </ul>
-        <p>The sort order is also implementation-defined if _obj_ is sparse and any of the following conditions are true:</p>
+        <p>The sort order is also implementation-defined if _objIsSparse_ is *true* and any of the following conditions are true:</p>
         <ul>
           <li>
             IsExtensible(_obj_) is *false*.
@@ -32665,7 +32660,7 @@ THH:mm:ss.sss
           1. Perform an implementation-dependent sequence of calls to the [[Get]] and [[Set]] internal methods of _obj_, to the DeletePropertyOrThrow and HasOwnProperty abstract operation with _obj_ as the first argument, and to SortCompare (described below), such that:
             * The property key argument for each call to [[Get]], [[Set]], HasOwnProperty, or DeletePropertyOrThrow is the string representation of a nonnegative integer less than _len_.
             * The arguments for calls to SortCompare are values returned by a previous call to the [[Get]] internal method, unless the properties accessed by those previous calls did not exist according to HasOwnProperty. If both prospective arguments to SortCompare correspond to non-existent properties, use *+0* instead of calling SortCompare. If only the first prospective argument is non-existent use +1. If only the second prospective argument is non-existent use -1.
-            * If _obj_ is not sparse then DeletePropertyOrThrow must not be called.
+            * If _objIsSparse_ is *false* then DeletePropertyOrThrow must not be called.
             * If any [[Set]] call returns *false* a *TypeError* exception is thrown.
             * If an abrupt completion is returned from any of these operations, it is immediately returned as the value of this function.
           1. Return _obj_.
@@ -32710,6 +32705,18 @@ THH:mm:ss.sss
         <emu-note>
           <p>The `sort` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
+
+        <emu-clause id="sec-objectissparse" aoid="ObjectIsSparse">
+          <h1>Runtime Semantics: ObjectIsSparse ( _obj_, _len_ )</h1>
+          <emu-alg>
+            1. Assert: _obj_ is an Object.
+            1. Assert: _len_ is a nonnegative integer.
+            1. For each integer _i_ in the range 0 &le; _i_ &lt; _len_, do
+              1. Let _elem_ be _obj_.[[GetOwnProperty]](! ToString(_i_)).
+              1. If _elem_ is *undefined*, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
 
         <emu-clause id="sec-sortcompare" aoid="SortCompare">
           <h1>Runtime Semantics: SortCompare ( _x_, _y_ )</h1>
@@ -33835,6 +33842,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _buffer_ be ? ValidateTypedArray(_obj_).
           1. Let _len_ be _obj_.[[ArrayLength]].
+          1. Let _objIsSparse_ be *false*.
         </emu-alg>
         <p>The implementation-defined sort order condition for exotic objects is not applied by %TypedArray%`.prototype.sort`.</p>
         <p>The following version of SortCompare is used by %TypedArray%`.prototype.sort`. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. SortCompare has access to the _comparefn_ and _buffer_ values of the current invocation of the `sort` method.</p>

--- a/spec.html
+++ b/spec.html
@@ -32616,13 +32616,13 @@ THH:mm:ss.sss
           1. Let _objIsSparse_ be ObjectIsSparse(_obj_, _len_).
           1. Let _proto_ be _obj_.[[GetPrototypeOf]]().
           1. Let _sortOrderIsImplementationDefined_ be *true* if any of the following conditions are satisfied, and let it be *false* otherwise:
-            * _comparefn_ is not *undefined* and is not a consistent comparison function for the elements of this array (see below).
-            * _comparefn_ is *undefined* and SortCompare does not act as a consistent comparison function.
             * _objIsSparse_ is *true* and _proto_ is not *null* and there exists a nonnegative integer _j_ less than _len_ such that HasProperty(_proto_, ToString(_j_)) is *true*.
             * _objIsSparse_ is *true* and IsExtensible(_obj_) is *false*.
             * _objIsSparse_ is *true* and any integer index property of _obj_ whose name is a nonnegative integer less than _len_ is a data property whose [[Configurable]] attribute is *false*.
             * _obj_ is an exotic object (including Proxy exotic objects) whose behaviour for [[Get]], [[Set]], [[Delete]], and [[GetOwnProperty]] is not the ordinary object implementation of these internal methods.
             * any index property of _obj_ whose name is a nonnegative integer less than _len_ is an accessor property or is a data property whose [[Writable]] attribute is *false*.
+            * _comparefn_ is not *undefined* and is not a consistent comparison function for the elements of this array (see below).
+            * _comparefn_ is *undefined* and SortCompare does not act as a consistent comparison function.
             * _comparefn_ is *undefined* and the application of ToString to any value passed as an argument to SortCompare modifies _obj_ or any object on _obj_'s prototype chain.
             * _comparefn_ is *undefined* and all applications of ToString, to any specific value passed as an argument to SortCompare, do not produce the same result.
           1. Perform an implementation-dependent sequence of calls to the [[Get]] and [[Set]] internal methods of _obj_, to the DeletePropertyOrThrow and HasOwnProperty abstract operation with _obj_ as the first argument, and to SortCompare (described below), such that:


### PR DESCRIPTION
The main point was to to make a single `<emu-alg>` out of some of the bits and pieces that currently define `Array.prototype.sort`.

Also, `%TypedArray%.prototype.sort`'s version of `SortCompare` should have its own name and sub-clause, so I did that.
