### PR TITLE
Editorial: `FlattenIntoArray`: add assertions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32111,6 +32111,12 @@ THH:mm:ss.sss
         <emu-clause id="sec-flattenintoarray" aoid="FlattenIntoArray">
           <h1>FlattenIntoArray ( _target_, _source_, _sourceLen_, _start_, _depth_ [ , _mapperFunction_, _thisArg_ ] )</h1>
           <emu-alg>
+            1. Assert: Type(_target_) is Object.
+            1. Assert: Type(_source_) is Object.
+            1. Assert: _sourceLen_ is an integer Number &ge; 0.
+            1. Assert: _start_ is an integer Number &ge; 0.
+            1. Assert: _depth_ is an integer Number, *+&infin;*, or *-&infin;*.
+            1. Assert: If _mapperFunction_ is present, then ! IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is *1*.
             1. Let _targetIndex_ be _start_.
             1. Let _sourceIndex_ be 0.
             1. Repeat, while _sourceIndex_ &lt; _sourceLen_
@@ -32119,7 +32125,6 @@ THH:mm:ss.sss
               1. If _exists_ is *true*, then
                 1. Let _element_ be ? Get(_source_, _P_).
                 1. If _mapperFunction_ is present, then
-                  1. Assert: _thisArg_ is present.
                   1. Set _element_ to ? Call(_mapperFunction_, _thisArg_, &laquo; _element_, _sourceIndex_, _source_ &raquo;).
                 1. Let _shouldFlatten_ be *false*.
                 1. If _depth_ &gt; 0, then
@@ -32143,7 +32148,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _sourceLen_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
+          1. If ! IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
           1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, 1, _mapperFunction_, _T_).


### PR DESCRIPTION
Add some assertions to clarify the intended usage of this abstract operation.

I wanted to assert that `target` is an Array exotic object, but I think because of `ArraySpeciesCreate` I can't.