### PR TITLE
Editorial: Use `!` on calls to `ToBoolean`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3359,11 +3359,11 @@
           1. Let _desc_ be a new Property Descriptor that initially has no fields.
           1. Let _hasEnumerable_ be ? HasProperty(_Obj_, `"enumerable"`).
           1. If _hasEnumerable_ is *true*, then
-            1. Let _enumerable_ be ToBoolean(? Get(_Obj_, `"enumerable"`)).
+            1. Let _enumerable_ be ! ToBoolean(? Get(_Obj_, `"enumerable"`)).
             1. Set _desc_.[[Enumerable]] to _enumerable_.
           1. Let _hasConfigurable_ be ? HasProperty(_Obj_, `"configurable"`).
           1. If _hasConfigurable_ is *true*, then
-            1. Let _configurable_ be ToBoolean(? Get(_Obj_, `"configurable"`)).
+            1. Let _configurable_ be ! ToBoolean(? Get(_Obj_, `"configurable"`)).
             1. Set _desc_.[[Configurable]] to _configurable_.
           1. Let _hasValue_ be ? HasProperty(_Obj_, `"value"`).
           1. If _hasValue_ is *true*, then
@@ -3371,7 +3371,7 @@
             1. Set _desc_.[[Value]] to _value_.
           1. Let _hasWritable_ be ? HasProperty(_Obj_, `"writable"`).
           1. If _hasWritable_ is *true*, then
-            1. Let _writable_ be ToBoolean(? Get(_Obj_, `"writable"`)).
+            1. Let _writable_ be ! ToBoolean(? Get(_Obj_, `"writable"`)).
             1. Set _desc_.[[Writable]] to _writable_.
           1. Let _hasGet_ be ? HasProperty(_Obj_, `"get"`).
           1. If _hasGet_ is *true*, then
@@ -4382,7 +4382,7 @@
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. Let _matcher_ be ? Get(_argument_, @@match).
-        1. If _matcher_ is not *undefined*, return ToBoolean(_matcher_).
+        1. If _matcher_ is not *undefined*, return ! ToBoolean(_matcher_).
         1. If _argument_ has a [[RegExpMatcher]] internal slot, return *true*.
         1. Return *false*.
       </emu-alg>
@@ -4952,7 +4952,7 @@
       <p>The abstract operation IteratorComplete with argument _iterResult_ performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_iterResult_) is Object.
-        1. Return ToBoolean(? Get(_iterResult_, `"done"`)).
+        1. Return ! ToBoolean(? Get(_iterResult_, `"done"`)).
       </emu-alg>
     </emu-clause>
 
@@ -5308,7 +5308,7 @@
             1. If the _withEnvironment_ flag of _envRec_ is *false*, return *true*.
             1. Let _unscopables_ be ? Get(_bindings_, @@unscopables).
             1. If Type(_unscopables_) is Object, then
-              1. Let _blocked_ be ToBoolean(? Get(_unscopables_, _N_)).
+              1. Let _blocked_ be ! ToBoolean(? Get(_unscopables_, _N_)).
               1. If _blocked_ is *true*, return *false*.
             1. Return *true*.
           </emu-alg>
@@ -8901,7 +8901,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, `"setPrototypeOf"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[SetPrototypeOf]](_V_).
-        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _V_ &raquo;)).
+        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _V_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. If _extensibleTarget_ is *true*, return *true*.
@@ -8933,7 +8933,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, `"isExtensible"`).
         1. If _trap_ is *undefined*, then
           1. Return ? IsExtensible(_target_).
-        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
+        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
         1. Let _targetResult_ be ? IsExtensible(_target_).
         1. If SameValue(_booleanTrapResult_, _targetResult_) is *false*, throw a *TypeError* exception.
         1. Return _booleanTrapResult_.
@@ -8962,7 +8962,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, `"preventExtensions"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[PreventExtensions]]().
-        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
+        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
         1. If _booleanTrapResult_ is *true*, then
           1. Let _extensibleTarget_ be ? IsExtensible(_target_).
           1. If _extensibleTarget_ is *true*, throw a *TypeError* exception.
@@ -9047,7 +9047,7 @@
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[DefineOwnProperty]](_P_, _Desc_).
         1. Let _descObj_ be FromPropertyDescriptor(_Desc_).
-        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _descObj_ &raquo;)).
+        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _descObj_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
@@ -9093,7 +9093,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, `"has"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[HasProperty]](_P_).
-        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
+        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, then
           1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
           1. If _targetDesc_ is not *undefined*, then
@@ -9164,7 +9164,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, `"set"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Set]](_P_, _V_, _Receiver_).
-        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _V_, _Receiver_ &raquo;)).
+        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _V_, _Receiver_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
         1. If _targetDesc_ is not *undefined* and _targetDesc_.[[Configurable]] is *false*, then
@@ -9202,7 +9202,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, `"deleteProperty"`).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Delete]](_P_).
-        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
+        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
         1. If _targetDesc_ is *undefined*, return *true*.
@@ -13236,7 +13236,7 @@
         <emu-grammar>UnaryExpression : `!` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
-          1. Let _oldValue_ be ToBoolean(? GetValue(_expr_)).
+          1. Let _oldValue_ be ! ToBoolean(? GetValue(_expr_)).
           1. If _oldValue_ is *true*, return *false*.
           1. Return *true*.
         </emu-alg>
@@ -13817,7 +13817,7 @@
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _instOfHandler_ be ? GetMethod(_target_, @@hasInstance).
         1. If _instOfHandler_ is not *undefined*, then
-          1. Return ToBoolean(? Call(_instOfHandler_, _target_, &laquo; _V_ &raquo;)).
+          1. Return ! ToBoolean(? Call(_instOfHandler_, _target_, &laquo; _V_ &raquo;)).
         1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
         1. Return ? OrdinaryHasInstance(_target_, _V_).
       </emu-alg>
@@ -14062,7 +14062,7 @@
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalANDExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ToBoolean(_lval_).
+        1. Let _lbool_ be ! ToBoolean(_lval_).
         1. If _lbool_ is *false*, return _lval_.
         1. Let _rref_ be the result of evaluating |BitwiseORExpression|.
         1. Return ? GetValue(_rref_).
@@ -14071,7 +14071,7 @@
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalORExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ToBoolean(_lval_).
+        1. Let _lbool_ be ! ToBoolean(_lval_).
         1. If _lbool_ is *true*, return _lval_.
         1. Let _rref_ be the result of evaluating |LogicalANDExpression|.
         1. Return ? GetValue(_rref_).
@@ -14114,7 +14114,7 @@
       <emu-grammar>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalORExpression|.
-        1. Let _lval_ be ToBoolean(? GetValue(_lref_)).
+        1. Let _lval_ be ! ToBoolean(? GetValue(_lref_)).
         1. If _lval_ is *true*, then
           1. Let _trueRef_ be the result of evaluating the first |AssignmentExpression|.
           1. Return ? GetValue(_trueRef_).
@@ -16032,7 +16032,7 @@
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
-        1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
+        1. Let _exprValue_ be ! ToBoolean(? GetValue(_exprRef_)).
         1. If _exprValue_ is *true*, then
           1. Let _stmtCompletion_ be the result of evaluating the first |Statement|.
         1. Else,
@@ -16042,7 +16042,7 @@
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
-        1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
+        1. Let _exprValue_ be ! ToBoolean(? GetValue(_exprRef_)).
         1. If _exprValue_ is *false*, then
           1. Return NormalCompletion(*undefined*).
         1. Else,
@@ -16195,7 +16195,7 @@
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
             1. Let _exprRef_ be the result of evaluating |Expression|.
             1. Let _exprValue_ be ? GetValue(_exprRef_).
-            1. If ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
+            1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -16261,7 +16261,7 @@
           1. Repeat,
             1. Let _exprRef_ be the result of evaluating |Expression|.
             1. Let _exprValue_ be ? GetValue(_exprRef_).
-            1. If ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
+            1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
             1. Let _stmtResult_ be the result of evaluating |Statement|.
             1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
@@ -16416,7 +16416,7 @@
             1. If _test_ is not ~[empty]~, then
               1. Let _testRef_ be the result of evaluating _test_.
               1. Let _testValue_ be ? GetValue(_testRef_).
-              1. If ToBoolean(_testValue_) is *false*, return NormalCompletion(_V_).
+              1. If ! ToBoolean(_testValue_) is *false*, return NormalCompletion(_V_).
             1. Let _result_ be the result of evaluating _stmt_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, return Completion(UpdateEmpty(_result_, _V_)).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
@@ -25090,7 +25090,7 @@
         <h1>Boolean ( _value_ )</h1>
         <p>When `Boolean` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _b_ be ToBoolean(_value_).
+          1. Let _b_ be ! ToBoolean(_value_).
           1. If NewTarget is *undefined*, return _b_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%BooleanPrototype%"`, &laquo; [[BooleanData]] &raquo;).
           1. Set _O_.[[BooleanData]] to _b_.
@@ -31146,17 +31146,17 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. Let _result_ be the empty String.
-          1. Let _global_ be ToBoolean(? Get(_R_, `"global"`)).
+          1. Let _global_ be ! ToBoolean(? Get(_R_, `"global"`)).
           1. If _global_ is *true*, append the code unit 0x0067 (LATIN SMALL LETTER G) as the last code unit of _result_.
-          1. Let _ignoreCase_ be ToBoolean(? Get(_R_, `"ignoreCase"`)).
+          1. Let _ignoreCase_ be ! ToBoolean(? Get(_R_, `"ignoreCase"`)).
           1. If _ignoreCase_ is *true*, append the code unit 0x0069 (LATIN SMALL LETTER I) as the last code unit of _result_.
-          1. Let _multiline_ be ToBoolean(? Get(_R_, `"multiline"`)).
+          1. Let _multiline_ be ! ToBoolean(? Get(_R_, `"multiline"`)).
           1. If _multiline_ is *true*, append the code unit 0x006D (LATIN SMALL LETTER M) as the last code unit of _result_.
-          1. Let _dotAll_ be ToBoolean(? Get(_R_, `"dotAll"`)).
+          1. Let _dotAll_ be ! ToBoolean(? Get(_R_, `"dotAll"`)).
           1. If _dotAll_ is *true*, append the code unit 0x0073 (LATIN SMALL LETTER S) as the last code unit of _result_.
-          1. Let _unicode_ be ToBoolean(? Get(_R_, `"unicode"`)).
+          1. Let _unicode_ be ! ToBoolean(? Get(_R_, `"unicode"`)).
           1. If _unicode_ is *true*, append the code unit 0x0075 (LATIN SMALL LETTER U) as the last code unit of _result_.
-          1. Let _sticky_ be ToBoolean(? Get(_R_, `"sticky"`)).
+          1. Let _sticky_ be ! ToBoolean(? Get(_R_, `"sticky"`)).
           1. If _sticky_ is *true*, append the code unit 0x0079 (LATIN SMALL LETTER Y) as the last code unit of _result_.
           1. Return _result_.
         </emu-alg>
@@ -31199,12 +31199,12 @@ THH:mm:ss.sss
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
-          1. Let _global_ be ToBoolean(? Get(_rx_, `"global"`)).
+          1. Let _global_ be ! ToBoolean(? Get(_rx_, `"global"`)).
           1. If _global_ is *false*, then
             1. Return ? RegExpExec(_rx_, _S_).
           1. Else,
             1. Assert: _global_ is *true*.
-            1. Let _fullUnicode_ be ToBoolean(? Get(_rx_, `"unicode"`)).
+            1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, `"unicode"`)).
             1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
             1. Let _A_ be ! ArrayCreate(0).
             1. Let _n_ be 0.
@@ -31295,9 +31295,9 @@ THH:mm:ss.sss
           1. Let _functionalReplace_ be IsCallable(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
-          1. Let _global_ be ToBoolean(? Get(_rx_, `"global"`)).
+          1. Let _global_ be ! ToBoolean(? Get(_rx_, `"global"`)).
           1. If _global_ is *true*, then
-            1. Let _fullUnicode_ be ToBoolean(? Get(_rx_, `"unicode"`)).
+            1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, `"unicode"`)).
             1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
           1. Let _results_ be a new empty List.
           1. Let _done_ be *false*.
@@ -31880,7 +31880,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. If Type(_O_) is not Object, return *false*.
             1. Let _spreadable_ be ? Get(_O_, @@isConcatSpreadable).
-            1. If _spreadable_ is not *undefined*, return ToBoolean(_spreadable_).
+            1. If _spreadable_ is not *undefined*, return ! ToBoolean(_spreadable_).
             1. Return ? IsArray(_O_).
           </emu-alg>
         </emu-clause>
@@ -31965,7 +31965,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _testResult_ is *false*, return *false*.
             1. Set _k_ to _k_ + 1.
           1. Return *true*.
@@ -32023,7 +32023,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _selected_ be ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _selected_ is *true*, then
                 1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_to_), _kValue_).
                 1. Set _to_ to _to_ + 1.
@@ -32055,7 +32055,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _testResult_ be ToBoolean(? Call(_predicate_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
             1. If _testResult_ is *true*, return _kValue_.
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
@@ -32084,7 +32084,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _testResult_ be ToBoolean(? Call(_predicate_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
             1. If _testResult_ is *true*, return _k_.
             1. Set _k_ to _k_ + 1.
           1. Return -1.
@@ -32619,7 +32619,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _testResult_ is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -33581,7 +33581,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _selected_ be ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _T_, &laquo; _kValue_, _k_, _O_ &raquo;)).
             1. If _selected_ is *true*, then
               1. Append _kValue_ to the end of _kept_.
               1. Set _captured_ to _captured_ + 1.
@@ -35673,7 +35673,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
-          1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
+          1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
@@ -35693,7 +35693,7 @@ THH:mm:ss.sss
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. Let _numberValue_ be ? ToNumber(_value_).
-          1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
+          1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _viewOffset_ be _view_.[[ByteOffset]].


### PR DESCRIPTION
This follows the years-old editorial direction of prefixing all calls to abstract operations where the result is not an inspected Completion Record (typically, looking for an abrupt completion), with `?` or `!`.