### PR TITLE
Editorial: Added %RegExpStringIteratorPrototype% to well know Intrinsic objects table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2576,6 +2576,16 @@
             </tr>
             <tr>
               <td>
+                %RegExpStringIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of RegExp String Iterator objects (<emu-xref href="#sec-regexp-string-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 %Set%
               </td>
               <td>


### PR DESCRIPTION
Fixes #1624 

`%RegExpStringIteratorPrototype%` which previously was undocumented
in well known Intrinsic Objects table is now added to the table.

If anything in this PR seems out of place or requires a change please let me know and I'll make the necessary changes ASAP (^_^)
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
