### PR TITLE
Editorial: fix capitalization of "RegExp String Iterator"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31534,7 +31534,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-regexp-string-iterator-objects">
       <h1>RegExp String Iterator Objects</h1>
-      <p>A RegExp String Iterator is an object, that represents a specific iteration over some specific String instance object, matching against some specific RegExp instance object. There is not a named constructor for RegExp String Iterator objects. Instead, RegExp String iterator objects are created by calling certain methods of RegExp instance objects.</p>
+      <p>A RegExp String Iterator is an object, that represents a specific iteration over some specific String instance object, matching against some specific RegExp instance object. There is not a named constructor for RegExp String Iterator objects. Instead, RegExp String Iterator objects are created by calling certain methods of RegExp instance objects.</p>
 
       <emu-clause id="sec-%regexpstringiteratorprototype%-object">
         <h1>The %RegExpStringIteratorPrototype% Object</h1>


### PR DESCRIPTION
Looks like I forgot to capitalize one of the 'i's.