### PR TITLE
Meta: Refactor package.json scripts to use prebuild.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "description": "The ECMAScript specification",
   "scripts": {
     "build-es2019": "git remote remove origin && git remote add origin \"git@github.com:$TRAVIS_REPO_SLUG.git\" && git fetch --quiet origin && git checkout --quiet es2019 && mkdir \"out/2019\" && cp -R img \"out/2019\" && ecmarkup --verbose spec.html out/2019/index.html --css out/2019/ecmarkup.css --js out/2019/ecmarkup.js && git checkout --quiet test-travis",
-    "build-master": "mkdir out && cp -R img out && ecmarkup --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
-    "build": "npm run clean && npm run build-master",
-    "build-for-pdf": "npm run build -- -- -- --old-toc",
-    "build-travis": "npm run clean && npm run build-master && npm run build-es2019",
+    "prebuild-master": "npm run clean && mkdir out && cp -R img out",
+    "build-master": "ecmarkup --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
+    "build": "npm run build-master",
+    "build-for-pdf": "npm run build-master -- --old-toc",
+    "build-travis": "npm run build-master && npm run build-es2019",
     "clean": "rm -rf out",
     "test": "exit 0",
-    "watch": "npm run clean && mkdir out && cp -R img out && ecmarkup --watch --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js"
+    "watch": "npm run build-master -- --watch"
   },
   "repository": "tc39/ecma262",
   "author": "ECMA TC39",


### PR DESCRIPTION
By @ljharb's [suggestion](https://github.com/tc39/proposal-nullish-coalescing/pull/41#issuecomment-511162676).

We could ditch `build-master` entirely, but I left it to start with, just in case we prefer the explicitness.