### PR TITLE
Editorial: Fixed typo in Shared Memory Guidelines note

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39701,7 +39701,7 @@ THH:mm:ss.sss
 
     <emu-note>
       <p>The following are guidelines for ECMAScript implementers generating machine code for shared memory accesses.</p>
-      <p>For architectures with memory models no weaker than those of ARM or Power, non-atomic stores and loads may be compiled to bare stores and loads on the target architecture. Atomic stores and loads may be compiled down to instructions that guarantee sequential consistency. If no such instructions exist, memory barriers are to be employed, such as placing barriers on both sides of a bare store or load. Read-modify-write operations may be compiled to read-modify-write instructions on the target architectrue, such as <code>LOCK</code>-prefixed instructions on x86, load-exclusive/store-exclusive instructions on ARM, and load-link/store-conditional instructions on Power.</p>
+      <p>For architectures with memory models no weaker than those of ARM or Power, non-atomic stores and loads may be compiled to bare stores and loads on the target architecture. Atomic stores and loads may be compiled down to instructions that guarantee sequential consistency. If no such instructions exist, memory barriers are to be employed, such as placing barriers on both sides of a bare store or load. Read-modify-write operations may be compiled to read-modify-write instructions on the target architecture, such as <code>LOCK</code>-prefixed instructions on x86, load-exclusive/store-exclusive instructions on ARM, and load-link/store-conditional instructions on Power.</p>
       <p>Specifically, the memory model is intended to allow code generation as follows.</p>
       <ul>
         <li>Every atomic operation in the program is assumed to be necessary.</li>


### PR DESCRIPTION
Fixed a possible typo in `spec.html`
* `architectrue` -> `architecture`

In case this change isn't required please let me know and I'll close the PR (^_^)
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
