### PR TITLE
Editorial: `parseFloat`/`parseInt`: fix unintentional normative change from #1629

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23708,7 +23708,8 @@
       <p>The `parseFloat` function produces a Number value dictated by interpretation of the contents of the _string_ argument as a decimal literal.</p>
       <p>The `parseFloat` function is the <dfn>%parseFloat%</dfn> intrinsic object. When the `parseFloat` function is called with one argument _string_, the following steps are taken:</p>
       <emu-alg>
-        1. Let _trimmedString_ be ? TrimString(_string_, `"start"`).
+        1. Let _inputString_ be ? ToString(_string_).
+        1. Let _trimmedString_ be ! TrimString(_inputString_, `"start"`).
         1. If neither _trimmedString_ nor any prefix of _trimmedString_ satisfies the syntax of a |StrDecimalLiteral| (see <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>), return *NaN*.
         1. Let _numberString_ be the longest prefix of _trimmedString_, which might be _trimmedString_ itself, that satisfies the syntax of a |StrDecimalLiteral|.
         1. Let _mathFloat_ be MV of _numberString_.
@@ -23727,7 +23728,8 @@
       <p>The `parseInt` function produces an integer value dictated by interpretation of the contents of the _string_ argument according to the specified _radix_. Leading white space in _string_ is ignored. If _radix_ is *undefined* or 0, it is assumed to be 10 except when the number begins with the code unit pairs `0x` or `0X`, in which case a radix of 16 is assumed. If _radix_ is 16, the number may also optionally begin with the code unit pairs `0x` or `0X`.</p>
       <p>The `parseInt` function is the <dfn>%parseInt%</dfn> intrinsic object. When the `parseInt` function is called, the following steps are taken:</p>
       <emu-alg>
-        1. Let _S_ be ? TrimString(_string_, `"start"`).
+        1. Let _inputString_ be ? ToString(_string_).
+        1. Let _S_ be ! TrimString(_inputString_, `"start"`).
         1. Let _sign_ be 1.
         1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002D (HYPHEN-MINUS), set _sign_ to -1.
         1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), remove the first code unit from _S_.


### PR DESCRIPTION
Thanks to @devsnek for discovering.