### PR TITLE
Editorial: Rephrase "ListIterator next"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6043,7 +6043,7 @@
         1. Let _iterator_ be ObjectCreate(%IteratorPrototype%, &laquo; [[IteratedList]], [[ListIteratorNextIndex]] &raquo;).
         1. Set _iterator_.[[IteratedList]] to _list_.
         1. Set _iterator_.[[ListIteratorNextIndex]] to 0.
-        1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-listiterator-next" title></emu-xref>.
+        1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-listiteratornext-functions" title></emu-xref>.
         1. Let _next_ be ! CreateBuiltinFunction(_steps_, &laquo; &raquo;).
         1. Return Record { [[Iterator]]: _iterator_, [[NextMethod]]: _next_, [[Done]]: *false* }.
       </emu-alg>
@@ -6051,9 +6051,9 @@
         <p>The list iterator object is never directly accessible to ECMAScript code.</p>
       </emu-note>
 
-      <emu-clause id="sec-listiterator-next">
-        <h1>ListIterator next ( )</h1>
-        <p>The ListIterator `next` method is a standard built-in function object (clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>) that performs the following steps:</p>
+      <emu-clause id="sec-listiteratornext-functions" oldids="sec-listiterator-next">
+        <h1>ListIteratorNext Functions</h1>
+        <p>A ListIteratorNext function is an anonymous built-in function. When called with no arguments, it performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Assert: Type(_O_) is Object.
@@ -6066,6 +6066,7 @@
           1. Set _O_.[[ListIteratorNextIndex]] to _index_ + 1.
           1. Return CreateIterResultObject(_list_[_index_], *false*).
         </emu-alg>
+        <p>The `"length"` property of a ListIteratorNext function is 0.</p>
       </emu-clause>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
Formerly, the heading and preamble of [7.4.9.1 ListIterator next ( )](https://tc39.es/ecma262/#sec-listiterator-next) suggested that there was a built-in object named "ListIterator" with a method named "next", none of which is true.

This PR changes the heading and preamble to be more like those of other arbitrarily-many-per-realm anonymous built-in functions.

(This is the one exception I mentioned [here](https://github.com/tc39/ecma262/pull/1635#discussion_r305586256).)