### PR TITLE
Normative: change idempotency for HostImportModuleDynamically

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22706,7 +22706,7 @@
             </dl>
           </li>
           <li>
-            Every call to HostImportModuleDynamically with the same _referencingScriptOrModule_ and _specifier_ arguments must conform to the <em>same</em> set of requirements above as previous calls do. That is, if the host environment takes the success path once for a given _referencingScriptOrModule_, _specifier_ pair, it must always do so, and the same for the failure path.
+            If the host environment takes the success path once for a given _referencingScriptOrModule_, _specifier_ pair, it must always do so for subsequent calls.
           </li>
           <li>
             The operation must not call _promiseCapability_.[[Resolve]] or _promiseCapability_.[[Reject]], but instead must treat _promiseCapability_ as an opaque identifying value to be passed through to FinishDynamicImport.


### PR DESCRIPTION
This better matches HostResolveImportedModule, which only requires idempotency when it completes normally (which is analogous to the success case here).

Closes https://github.com/tc39/proposal-dynamic-import/issues/80, at least on the ECMAScript side.

---

To be presented at TC39 today; I thought it'd be easier to have a concrete needs-consensus PR rather than trying to page through https://github.com/tc39/proposal-dynamic-import/issues/80.