### PR TITLE
Normative: Make B.1 "Additional Syntax" normative

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34258,13 +34258,10 @@ THH:mm:ss.sss
           Alternative[?UnicodeMode, ?N] Term[?UnicodeMode, ?N]
 
         Term[UnicodeMode, N] ::!
-          [+UnicodeMode] Assertion[+UnicodeMode, ?N]
-          [+UnicodeMode] Atom[+UnicodeMode, ?N] Quantifier
-          [+UnicodeMode] Atom[+UnicodeMode, ?N]
           [~UnicodeMode] QuantifiableAssertion[~UnicodeMode, ?N] Quantifier
-          [~UnicodeMode] Assertion[~UnicodeMode, ?N]
-          [~UnicodeMode] Atom[~UnicodeMode, ?N] Quantifier
-          [~UnicodeMode] Atom[~UnicodeMode, ?N]
+          Assertion[?UnicodeMode, ?N]
+          Atom[?UnicodeMode, ?N] Quantifier
+          Atom[?UnicodeMode, ?N]
 
         Assertion[UnicodeMode, N] ::
           `^`

--- a/spec.html
+++ b/spec.html
@@ -520,7 +520,7 @@
     <emu-clause id="sec-lexical-and-regexp-grammars">
       <h1>The Lexical and RegExp Grammars</h1>
       <p>A <em>lexical grammar</em> for ECMAScript is given in clause <emu-xref href="#sec-ecmascript-language-lexical-grammar"></emu-xref>. This grammar has as its terminal symbols Unicode code points that conform to the rules for |SourceCharacter| defined in <emu-xref href="#sec-source-text"></emu-xref>. It defines a set of productions, starting from the goal symbol |InputElementDiv|, |InputElementTemplateTail|, or |InputElementRegExp|, or |InputElementRegExpOrTemplateTail|, that describe how sequences of such code points are translated into a sequence of input elements.</p>
-      <p>Input elements other than white space and comments form the terminal symbols for the syntactic grammar for ECMAScript and are called ECMAScript <em>tokens</em>. These tokens are the reserved words, identifiers, literals, and punctuators of the ECMAScript language. Moreover, line terminators, although not considered to be tokens, also become part of the stream of input elements and guide the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). Simple white space and single-line comments are discarded and do not appear in the stream of input elements for the syntactic grammar. A |MultiLineComment| (that is, a comment of the form `/*`&hellip;`*/` regardless of whether it spans more than one line) is likewise simply discarded if it contains no line terminator; but if a |MultiLineComment| contains one or more line terminators, then it is replaced by a single line terminator, which becomes part of the stream of input elements for the syntactic grammar.</p>
+      <p>Input elements other than white space and comments form the terminal symbols for the syntactic grammar for ECMAScript and are called ECMAScript <em>tokens</em>. These tokens are the reserved words, identifiers, literals, and punctuators of the ECMAScript language. Moreover, line terminators, although not considered to be tokens, also become part of the stream of input elements and guide the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). Simple white space and single-line comments are discarded and do not appear in the stream of input elements for the syntactic grammar. A |MultiLineComment| (that is, a comment of the form `/*`&hellip;`*/` that spans more than one line) is replaced by a single line terminator, which becomes part of the stream of input elements for the syntactic grammar.</p>
       <p>A <em>RegExp grammar</em> for ECMAScript is given in <emu-xref href="#sec-patterns"></emu-xref>. This grammar also has as its terminal symbols the code points as defined by |SourceCharacter|. It defines a set of productions, starting from the goal symbol |Pattern|, that describe how sequences of code points are translated into regular expression patterns.</p>
       <p>Productions of the lexical and RegExp grammars are distinguished by having two colons &ldquo;<b>::</b>&rdquo; as separating punctuation. The lexical and RegExp grammars share some productions.</p>
     </emu-clause>
@@ -16018,7 +16018,7 @@
   <emu-clause id="sec-line-terminators">
     <h1>Line Terminators</h1>
     <p>Like white space code points, line terminator code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other. However, unlike white space code points, line terminators have some influence over the behaviour of the syntactic grammar. In general, line terminators may occur between any two tokens, but there are a few places where they are forbidden by the syntactic grammar. Line terminators also affect the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A line terminator cannot occur within any token except a |StringLiteral|, |Template|, or |TemplateSubstitutionTail|. &lt;LF&gt; and &lt;CR&gt; line terminators cannot occur within a |StringLiteral| token except as part of a |LineContinuation|.</p>
-    <p>A line terminator can occur within a |MultiLineComment| but cannot occur within a |SingleLineComment|.</p>
+    <p>A line terminator must occur within a |MultiLineComment| but cannot occur within a |SingleLineDelimitedComment| or a |SingleLineComment|.</p>
     <p>Line terminators are included in the set of white space code points that are matched by the `\\s` class in regular expressions.</p>
     <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-line-terminator-code-points"></emu-xref>.</p>
     <emu-table id="table-line-terminator-code-points" caption="Line Terminator Code Points" oldids="table-33">
@@ -16104,15 +16104,21 @@
     <h1>Comments</h1>
     <p>Comments can be either single or multi-line. Multi-line comments cannot nest.</p>
     <p>Because a single-line comment can contain any Unicode code point except a |LineTerminator| code point, and because of the general rule that a token is always as long as possible, a single-line comment always consists of all code points from the `//` marker to the end of the line. However, the |LineTerminator| at the end of the line is not considered to be part of the single-line comment; it is recognized separately by the lexical grammar and becomes part of the stream of input elements for the syntactic grammar. This point is very important, because it implies that the presence or absence of single-line comments does not affect the process of automatic semicolon insertion (see <emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>).</p>
-    <p>Comments behave like white space and are discarded except that, if a |MultiLineComment| contains a line terminator code point, then the entire comment is considered to be a |LineTerminator| for purposes of parsing by the syntactic grammar.</p>
+    <p>Comments behave like white space and are discarded except that a |MultiLineComment| or a |SingleLineHTMLCloseComment| is considered to be a |LineTerminator| for purposes of parsing by the syntactic grammar.</p>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       Comment ::
         MultiLineComment
         SingleLineComment
+        SingleLineHTMLOpenComment
+        SingleLineHTMLCloseComment
+        SingleLineDelimitedComment
 
       MultiLineComment ::
-        `/*` MultiLineCommentChars? `*/`
+        `/*` FirstCommentLine? LineTerminator MultiLineCommentChars? `*/` HTMLCloseComment?
+
+      FirstCommentLine ::
+        SingleLineDelimitedCommentChars
 
       MultiLineCommentChars ::
         MultiLineNotAsteriskChar MultiLineCommentChars?
@@ -16131,13 +16137,59 @@
       SingleLineComment ::
         `//` SingleLineCommentChars?
 
+      SingleLineHTMLOpenComment ::
+        `&lt;!--` SingleLineCommentChars?
+
+      SingleLineHTMLCloseComment ::
+        LineTerminatorSequence HTMLCloseComment
+
+      HTMLCloseComment ::
+        WhiteSpaceSequence? SingleLineDelimitedCommentSequence? `--&gt;` SingleLineCommentChars?
+
+      SingleLineDelimitedCommentSequence ::
+        SingleLineDelimitedComment WhiteSpaceSequence? SingleLineDelimitedCommentSequence?
+
+      WhiteSpaceSequence ::
+        WhiteSpace WhiteSpaceSequence?
+
       SingleLineCommentChars ::
         SingleLineCommentChar SingleLineCommentChars?
 
       SingleLineCommentChar ::
         SourceCharacter but not LineTerminator
+
+      SingleLineDelimitedComment ::
+        `/*` SingleLineDelimitedCommentChars? `*/`
+
+      SingleLineDelimitedCommentChars ::
+        SingleLineNotAsteriskChar SingleLineDelimitedCommentChars?
+        `*` SingleLinePostAsteriskCommentChars?
+
+      SingleLineNotAsteriskChar ::
+        SourceCharacter but not one of `*` or LineTerminator
+
+      SingleLinePostAsteriskCommentChars ::
+        SingleLineNotForwardSlashOrAsteriskChar SingleLineDelimitedCommentChars?
+        `*` SingleLinePostAsteriskCommentChars?
+
+      SingleLineNotForwardSlashOrAsteriskChar ::
+        SourceCharacter but not one of `/` or `*` or LineTerminator
     </emu-grammar>
-    <p>A number of productions in this section are given alternative definitions in section <emu-xref href="#sec-html-like-comments"></emu-xref></p>
+
+    <emu-clause id="sec-comments-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>
+        SingleLineHTMLOpenComment ::
+          `&lt;!--` SingleLineCommentChars?
+
+        HTMLCloseComment ::
+          WhiteSpaceSequence? SingleLineDelimitedCommentSequence? `--&gt;` SingleLineCommentChars?
+      </emu-grammar>
+      <ul>
+        <li>It is a Syntax Error if a |Module| contains the source code matching this production.</li>
+      </ul>
+      <emu-note>In a |Script|, this syntax is allowed, but deprecated.</emu-note>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-tokens">
@@ -28297,9 +28349,6 @@
       </li>
       <li>
         When processing strict mode code, the extensions defined in <emu-xref href="#sec-labelled-function-declarations"></emu-xref>, <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>, <emu-xref href="#sec-functiondeclarations-in-ifstatement-statement-clauses"></emu-xref>, and <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref> must not be supported.
-      </li>
-      <li>
-        When parsing for the |Module| goal symbol, the lexical grammar extensions defined in <emu-xref href="#sec-html-like-comments"></emu-xref> must not be supported.
       </li>
       <!-- The following is so that in the future we can potentially add new arguments or support ArgumentList. -->
       <li>
@@ -46088,13 +46137,24 @@ THH:mm:ss.sss
     <emu-prodref name="LineTerminatorSequence"></emu-prodref>
     <emu-prodref name="Comment"></emu-prodref>
     <emu-prodref name="MultiLineComment"></emu-prodref>
+    <emu-prodref name="FirstCommentLine"></emu-prodref>
     <emu-prodref name="MultiLineCommentChars"></emu-prodref>
     <emu-prodref name="PostAsteriskCommentChars"></emu-prodref>
     <emu-prodref name="MultiLineNotAsteriskChar"></emu-prodref>
     <emu-prodref name="MultiLineNotForwardSlashOrAsteriskChar"></emu-prodref>
     <emu-prodref name="SingleLineComment"></emu-prodref>
+    <emu-prodref name="SingleLineHTMLOpenComment"></emu-prodref>
+    <emu-prodref name="SingleLineHTMLCloseComment"></emu-prodref>
+    <emu-prodref name="HTMLCloseComment"></emu-prodref>
+    <emu-prodref name="SingleLineDelimitedCommentSequence"></emu-prodref>
+    <emu-prodref name="WhiteSpaceSequence"></emu-prodref>
     <emu-prodref name="SingleLineCommentChars"></emu-prodref>
     <emu-prodref name="SingleLineCommentChar"></emu-prodref>
+    <emu-prodref name="SingleLineDelimitedComment"></emu-prodref>
+    <emu-prodref name="SingleLineDelimitedCommentChars"></emu-prodref>
+    <emu-prodref name="SingleLineNotAsteriskChar"></emu-prodref>
+    <emu-prodref name="SingleLinePostAsteriskCommentChars"></emu-prodref>
+    <emu-prodref name="SingleLineNotForwardSlashOrAsteriskChar"></emu-prodref>
     <emu-prodref name="CommonToken"></emu-prodref>
     <emu-prodref name="PrivateIdentifier"></emu-prodref>
     <emu-prodref name="IdentifierName"></emu-prodref>
@@ -46506,55 +46566,7 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-html-like-comments">
       <h1>HTML-like Comments</h1>
-      <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source code using the goal symbol |Module|:</p>
-      <h2>Syntax</h2>
-      <emu-grammar type="definition">
-        Comment ::
-          MultiLineComment
-          SingleLineComment
-          SingleLineHTMLOpenComment
-          SingleLineHTMLCloseComment
-          SingleLineDelimitedComment
-
-        MultiLineComment ::
-          `/*` FirstCommentLine? LineTerminator MultiLineCommentChars? `*/` HTMLCloseComment?
-
-        FirstCommentLine ::
-          SingleLineDelimitedCommentChars
-
-        SingleLineHTMLOpenComment ::
-          `&lt;!--` SingleLineCommentChars?
-
-        SingleLineHTMLCloseComment ::
-          LineTerminatorSequence HTMLCloseComment
-
-        SingleLineDelimitedComment ::
-          `/*` SingleLineDelimitedCommentChars? `*/`
-
-        HTMLCloseComment ::
-          WhiteSpaceSequence? SingleLineDelimitedCommentSequence? `--&gt;` SingleLineCommentChars?
-
-        SingleLineDelimitedCommentChars ::
-          SingleLineNotAsteriskChar SingleLineDelimitedCommentChars?
-          `*` SingleLinePostAsteriskCommentChars?
-
-        SingleLineNotAsteriskChar ::
-          SourceCharacter but not one of `*` or LineTerminator
-
-        SingleLinePostAsteriskCommentChars ::
-          SingleLineNotForwardSlashOrAsteriskChar SingleLineDelimitedCommentChars?
-          `*` SingleLinePostAsteriskCommentChars?
-
-        SingleLineNotForwardSlashOrAsteriskChar ::
-          SourceCharacter but not one of `/` or `*` or LineTerminator
-
-        WhiteSpaceSequence ::
-          WhiteSpace WhiteSpaceSequence?
-
-        SingleLineDelimitedCommentSequence ::
-          SingleLineDelimitedComment WhiteSpaceSequence? SingleLineDelimitedCommentSequence?
-      </emu-grammar>
-      <p>Similar to a |MultiLineComment| that contains a line terminator code point, a |SingleLineHTMLCloseComment| is considered to be a |LineTerminator| for purposes of parsing by the syntactic grammar.</p>
+      <p>The HTML-like comment syntax used to be normative optional outside |Module|s.</p>
     </emu-annex>
 
     <emu-annex id="sec-regular-expressions-patterns">

--- a/spec.html
+++ b/spec.html
@@ -34296,19 +34296,16 @@ THH:mm:ss.sss
           `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[?UnicodeMode, ?N] `)`
           [~UnicodeMode] InvalidBracedQuantifier
-          [+UnicodeMode] PatternCharacter
-          [~UnicodeMode] ExtendedPatternCharacter
+          PatternCharacter[?UnicodeMode]
 
         InvalidBracedQuantifier ::
           `{` DecimalDigits[~Sep] `}`
           `{` DecimalDigits[~Sep] `,` `}`
           `{` DecimalDigits[~Sep] `,` DecimalDigits[~Sep] `}`
 
-        ExtendedPatternCharacter ::
-          SourceCharacter but not one of `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `|`
-
-        PatternCharacter ::
-          SourceCharacter but not SyntaxCharacter
+        PatternCharacter[U] ::
+          [+U] SourceCharacter but not SyntaxCharacter
+          [~U] SourceCharacter but not one of `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `|`
 
         SyntaxCharacter :: one of
           `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `]` `{` `}` `|`
@@ -35399,12 +35396,6 @@ THH:mm:ss.sss
         <p>The production <emu-grammar>Atom ::! `(` `?` `:` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Disjunction| with argument _direction_.
-        </emu-alg>
-        <p>The production <emu-grammar>Atom ::! ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Let _ch_ be the character represented by |ExtendedPatternCharacter|.
-          1. Let _A_ be a one-element CharSet containing the character _ch_.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
         <p>The production <emu-grammar>Atom ::! PatternCharacter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
@@ -46618,7 +46609,6 @@ THH:mm:ss.sss
     <emu-prodref name="QuantifierPrefix"></emu-prodref>
     <emu-prodref name="Atom"></emu-prodref>
     <emu-prodref name="InvalidBracedQuantifier"></emu-prodref>
-    <emu-prodref name="ExtendedPatternCharacter"></emu-prodref>
     <emu-prodref name="PatternCharacter"></emu-prodref>
     <emu-prodref name="SyntaxCharacter"></emu-prodref>
     <emu-prodref name="GroupSpecifier"></emu-prodref>

--- a/spec.html
+++ b/spec.html
@@ -521,7 +521,7 @@
       <h1>The Lexical and RegExp Grammars</h1>
       <p>A <em>lexical grammar</em> for ECMAScript is given in clause <emu-xref href="#sec-ecmascript-language-lexical-grammar"></emu-xref>. This grammar has as its terminal symbols Unicode code points that conform to the rules for |SourceCharacter| defined in <emu-xref href="#sec-source-text"></emu-xref>. It defines a set of productions, starting from the goal symbol |InputElementDiv|, |InputElementTemplateTail|, or |InputElementRegExp|, or |InputElementRegExpOrTemplateTail|, that describe how sequences of such code points are translated into a sequence of input elements.</p>
       <p>Input elements other than white space and comments form the terminal symbols for the syntactic grammar for ECMAScript and are called ECMAScript <em>tokens</em>. These tokens are the reserved words, identifiers, literals, and punctuators of the ECMAScript language. Moreover, line terminators, although not considered to be tokens, also become part of the stream of input elements and guide the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). Simple white space and single-line comments are discarded and do not appear in the stream of input elements for the syntactic grammar. A |MultiLineComment| (that is, a comment of the form `/*`&hellip;`*/` that spans more than one line) is replaced by a single line terminator, which becomes part of the stream of input elements for the syntactic grammar.</p>
-      <p>A <em>RegExp grammar</em> for ECMAScript is given in <emu-xref href="#sec-patterns"></emu-xref>. This grammar also has as its terminal symbols the code points as defined by |SourceCharacter|. It defines a set of productions, starting from the goal symbol |Pattern|, that describe how sequences of code points are translated into regular expression patterns.</p>
+      <p>A <em>RegExp grammar</em> for ECMAScript is given in <emu-xref href="#sec-syntax-for-patterns"></emu-xref>. This grammar also has as its terminal symbols the code points as defined by |SourceCharacter|. It defines a set of productions, starting from the goal symbol |Pattern|, that describe how sequences of code points are translated into regular expression patterns.</p>
       <p>Productions of the lexical and RegExp grammars are distinguished by having two colons &ldquo;<b>::</b>&rdquo; as separating punctuation. The lexical and RegExp grammars share some productions.</p>
     </emu-clause>
 
@@ -17111,8 +17111,8 @@
       <emu-note>
         <p>A regular expression literal is an input element that is converted to a RegExp object (see <emu-xref href="#sec-regexp-regular-expression-objects"></emu-xref>) each time the literal is evaluated. Two regular expression literals in a program evaluate to regular expression objects that never compare as `===` to each other even if the two literals' contents are identical. A RegExp object may also be created at runtime by `new RegExp` or calling the RegExp constructor as a function (see <emu-xref href="#sec-regexp-constructor"></emu-xref>).</p>
       </emu-note>
-      <p>The productions below describe the syntax for a regular expression literal and are used by the input element scanner to find the end of the regular expression literal. The source text comprising the |RegularExpressionBody| and the |RegularExpressionFlags| are subsequently parsed again using the more stringent ECMAScript Regular Expression grammar (<emu-xref href="#sec-patterns"></emu-xref>).</p>
-      <p>An implementation may extend the ECMAScript Regular Expression grammar defined in <emu-xref href="#sec-patterns"></emu-xref>, but it must not extend the |RegularExpressionBody| and |RegularExpressionFlags| productions defined below or the productions used by these productions.</p>
+      <p>The productions below describe the syntax for a regular expression literal and are used by the input element scanner to find the end of the regular expression literal. The source text comprising the |RegularExpressionBody| and the |RegularExpressionFlags| are subsequently parsed again using the more stringent ECMAScript Regular Expression grammar (<emu-xref href="#sec-syntax-for-patterns"></emu-xref>).</p>
+      <p>An implementation may extend the ECMAScript Regular Expression grammar defined in <emu-xref href="#sec-syntax-for-patterns"></emu-xref>, but it must not extend the |RegularExpressionBody| and |RegularExpressionFlags| productions defined below or the productions used by these productions.</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
         RegularExpressionLiteral ::
@@ -28336,7 +28336,7 @@
         The behaviour of built-in methods which are specified in ECMA-402, such as those named `toLocaleString`, must not be extended except as specified in ECMA-402.
       </li>
       <li>
-        The RegExp pattern grammars in <emu-xref href="#sec-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[+UnicodeMode]| when the <sub>[UnicodeMode]</sub> grammar parameter is present.
+        The RegExp pattern grammars in <emu-xref href="#sec-syntax-for-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[+UnicodeMode]| when the <sub>[UnicodeMode]</sub> grammar parameter is present.
       </li>
       <li>
         The Syntactic Grammar must not be extended in any manner that allows the token `:` to immediately follow source text that matches the |BindingIdentifier| nonterminal symbol.
@@ -34240,7 +34240,7 @@ THH:mm:ss.sss
       <p>The form and functionality of regular expressions is modelled after the regular expression facility in the Perl 5 programming language.</p>
     </emu-note>
 
-    <emu-clause id="sec-patterns">
+    <emu-clause id="sec-syntax-for-patterns" oldids="sec-patterns">
       <h1>Syntax for Patterns</h1>
       <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
       <h2>Syntax</h2>
@@ -34859,7 +34859,7 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-pattern-semantics">
+    <emu-clause id="sec-runtime-semantics-for-patterns" oldids="sec-pattern-semantics">
       <h1>Runtime Semantics for Patterns</h1>
       <p>A regular expression pattern is converted into an Abstract Closure using the process described below. An implementation is encouraged to use more efficient algorithms than the ones listed below, as long as the results are the same. The Abstract Closure is used as the value of a RegExp object's [[RegExpMatcher]] internal slot.</p>
       <p>A |Pattern| is either a BMP pattern or a Unicode pattern depending upon whether or not its associated flags contain a `u`. A BMP pattern matches against a String interpreted as consisting of a sequence of 16-bit values that are Unicode code points in the range of the Basic Multilingual Plane. A Unicode pattern matches against a String interpreted as consisting of Unicode code points encoded using UTF-16. In the context of describing the behaviour of a BMP pattern &ldquo;character&rdquo; means a single 16-bit Unicode BMP code point. In the context of describing the behaviour of a Unicode pattern &ldquo;character&rdquo; means a UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). In either context, &ldquo;character value&rdquo; means the numeric value of the corresponding non-encoded code point.</p>
@@ -34927,8 +34927,8 @@ THH:mm:ss.sss
           1. Return a new Abstract Closure with parameters (_str_, _index_) that captures _m_ and performs the following steps when called:
             1. Assert: Type(_str_) is String.
             1. Assert: _index_ is a non-negative integer which is &le; the length of _str_.
-            1. If _Unicode_ is *true*, let _Input_ be ! StringToCodePoints(_str_). Otherwise, let _Input_ be a List whose elements are the code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
-            1. Let _InputLength_ be the number of characters contained in _Input_. This alias will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.
+            1. If _Unicode_ is *true*, let _Input_ be ! StringToCodePoints(_str_). Otherwise, let _Input_ be a List whose elements are the code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-runtime-semantics-for-patterns"></emu-xref>. Each element of _Input_ is considered to be a character.
+            1. Let _InputLength_ be the number of characters contained in _Input_. This alias will be used throughout the algorithms in <emu-xref href="#sec-runtime-semantics-for-patterns"></emu-xref>.
             1. Let _listIndex_ be the index into _Input_ of the character that was obtained from element _index_ of _str_.
             1. Let _c_ be a new Continuation with parameters (_y_) that captures nothing and performs the following steps when called:
               1. Assert: _y_ is a State.
@@ -34938,7 +34938,7 @@ THH:mm:ss.sss
             1. Return _m_(_x_, _c_).
         </emu-alg>
         <emu-note>
-          <p>A Pattern evaluates (&ldquo;compiles&rdquo;) to an Abstract Closure value. RegExpBuiltinExec can then apply this procedure to a String and an offset within the String to determine whether the pattern would match starting at exactly that offset within the String, and, if it does match, what the values of the capturing parentheses would be. The algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref> are designed so that compiling a pattern may throw a *SyntaxError* exception; on the other hand, once the pattern is successfully compiled, applying the resulting Abstract Closure to find a match in a String cannot throw an exception (except for any implementation-defined exceptions that can occur anywhere such as out-of-memory).</p>
+          <p>A Pattern evaluates (&ldquo;compiles&rdquo;) to an Abstract Closure value. RegExpBuiltinExec can then apply this procedure to a String and an offset within the String to determine whether the pattern would match starting at exactly that offset within the String, and, if it does match, what the values of the capturing parentheses would be. The algorithms in <emu-xref href="#sec-runtime-semantics-for-patterns"></emu-xref> are designed so that compiling a pattern may throw a *SyntaxError* exception; on the other hand, once the pattern is successfully compiled, applying the resulting Abstract Closure to find a match in a String cannot throw an exception (except for any implementation-defined exceptions that can occur anywhere such as out-of-memory).</p>
         </emu-note>
       </emu-clause>
 
@@ -35845,7 +35845,7 @@ THH:mm:ss.sss
             1. Assert: _parseResult_ is a |Pattern| Parse Node.
             1. Set _obj_.[[OriginalSource]] to _P_.
             1. Set _obj_.[[OriginalFlags]] to _F_.
-            1. Set _obj_.[[RegExpMatcher]] to the Abstract Closure that evaluates _parseResult_ by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
+            1. Set _obj_.[[RegExpMatcher]] to the Abstract Closure that evaluates _parseResult_ by applying the semantics provided in <emu-xref href="#sec-runtime-semantics-for-patterns"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
             1. Perform ? Set(_obj_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
             1. Return _obj_.
           </emu-alg>
@@ -46572,7 +46572,7 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-regular-expressions-patterns">
       <h1>Regular Expressions Patterns</h1>
-      <p>The syntax of <emu-xref href="#sec-patterns"></emu-xref> is modified and extended as follows. These changes introduce ambiguities that are broken by the ordering of grammar productions and by contextual information. When parsing using the following grammar, each alternative is considered only if previous production alternatives do not match.</p>
+      <p>The syntax of <emu-xref href="#sec-syntax-for-patterns"></emu-xref> is modified and extended as follows. These changes introduce ambiguities that are broken by the ordering of grammar productions and by contextual information. When parsing using the following grammar, each alternative is considered only if previous production alternatives do not match.</p>
       <p>This alternative pattern grammar and semantics only changes the syntax and semantics of BMP patterns. The following grammar extensions include productions parameterized with the [UnicodeMode] parameter. However, none of these extensions change the syntax of Unicode patterns recognized when parsing with the [UnicodeMode] parameter present on the goal symbol.</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -46727,7 +46727,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-regular-expression-patterns-semantics">
         <h1>Pattern Semantics</h1>
-        <p>The semantics of <emu-xref href="#sec-pattern-semantics"></emu-xref> is extended as follows:</p>
+        <p>The semantics of <emu-xref href="#sec-runtime-semantics-for-patterns"></emu-xref> is extended as follows:</p>
         <p>Within <emu-xref href="#sec-term"></emu-xref> reference to &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar>ExtendedAtom :: `(` Disjunction `)`</emu-grammar> &rdquo;.</p>
 
         <p>Term (<emu-xref href="#sec-term"></emu-xref>) includes the following additional evaluation rules:</p>

--- a/spec.html
+++ b/spec.html
@@ -35238,36 +35238,6 @@ THH:mm:ss.sss
             1. If _a_ is *true* and _b_ is *true*, or if _a_ is *false* and _b_ is *false*, return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
-        <p>The production <emu-grammar>QuantifiableAssertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
-          1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
-            1. Assert: _x_ is a State.
-            1. Assert: _c_ is a Continuation.
-            1. Let _d_ be a new Continuation with parameters (_y_) that captures nothing and performs the following steps when called:
-              1. Assert: _y_ is a State.
-              1. Return _y_.
-            1. Let _r_ be _m_(_x_, _d_).
-            1. If _r_ is ~failure~, return ~failure~.
-            1. Let _y_ be _r_'s State.
-            1. Let _cap_ be _y_'s _captures_ List.
-            1. Let _xe_ be _x_'s _endIndex_.
-            1. Let _z_ be the State (_xe_, _cap_).
-            1. Return _c_(_z_).
-        </emu-alg>
-        <p>The production <emu-grammar>QuantifiableAssertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
-          1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
-            1. Assert: _x_ is a State.
-            1. Assert: _c_ is a Continuation.
-            1. Let _d_ be a new Continuation with parameters (_y_) that captures nothing and performs the following steps when called:
-              1. Assert: _y_ is a State.
-              1. Return _y_.
-            1. Let _r_ be _m_(_x_, _d_).
-            1. If _r_ is not ~failure~, return ~failure~.
-            1. Return _c_(_x_).
-        </emu-alg>
         <p>The production <emu-grammar>Assertion :: QuantifiableAssertion</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |QuantifiableAssertion| to obtain a Matcher _m_.
@@ -35293,6 +35263,36 @@ THH:mm:ss.sss
         <p>The production <emu-grammar>Assertion :: `(` `?` `&lt;!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| with -1 as its _direction_ argument to obtain a Matcher _m_.
+          1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
+            1. Assert: _x_ is a State.
+            1. Assert: _c_ is a Continuation.
+            1. Let _d_ be a new Continuation with parameters (_y_) that captures nothing and performs the following steps when called:
+              1. Assert: _y_ is a State.
+              1. Return _y_.
+            1. Let _r_ be _m_(_x_, _d_).
+            1. If _r_ is not ~failure~, return ~failure~.
+            1. Return _c_(_x_).
+        </emu-alg>
+        <p>The production <emu-grammar>QuantifiableAssertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
+          1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
+            1. Assert: _x_ is a State.
+            1. Assert: _c_ is a Continuation.
+            1. Let _d_ be a new Continuation with parameters (_y_) that captures nothing and performs the following steps when called:
+              1. Assert: _y_ is a State.
+              1. Return _y_.
+            1. Let _r_ be _m_(_x_, _d_).
+            1. If _r_ is ~failure~, return ~failure~.
+            1. Let _y_ be _r_'s State.
+            1. Let _cap_ be _y_'s _captures_ List.
+            1. Let _xe_ be _x_'s _endIndex_.
+            1. Let _z_ be the State (_xe_, _cap_).
+            1. Return _c_(_z_).
+        </emu-alg>
+        <p>The production <emu-grammar>QuantifiableAssertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
           1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.

--- a/spec.html
+++ b/spec.html
@@ -34241,8 +34241,8 @@ THH:mm:ss.sss
     </emu-note>
 
     <emu-clause id="sec-patterns">
-      <h1>Patterns</h1>
-      <p>The RegExp constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
+      <h1>Syntax for Patterns</h1>
+      <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
         Pattern[UnicodeMode, N] ::
@@ -34441,6 +34441,10 @@ THH:mm:ss.sss
           CharacterClassEscape[?UnicodeMode]
           CharacterEscape[?UnicodeMode]
       </emu-grammar>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-for-patterns">
+      <h1>Static Semantics for Patterns</h1>
 
       <emu-note>
         <p>A number of productions in this section are given alternative definitions in section <emu-xref href="#sec-regular-expressions-patterns"></emu-xref>.</p>
@@ -34856,10 +34860,7 @@ THH:mm:ss.sss
     </emu-clause>
 
     <emu-clause id="sec-pattern-semantics">
-      <h1>Pattern Semantics</h1>
-      <emu-note>
-        <p>This section is amended in <emu-xref href="#sec-regular-expression-patterns-semantics"></emu-xref>.</p>
-      </emu-note>
+      <h1>Runtime Semantics for Patterns</h1>
       <p>A regular expression pattern is converted into an Abstract Closure using the process described below. An implementation is encouraged to use more efficient algorithms than the ones listed below, as long as the results are the same. The Abstract Closure is used as the value of a RegExp object's [[RegExpMatcher]] internal slot.</p>
       <p>A |Pattern| is either a BMP pattern or a Unicode pattern depending upon whether or not its associated flags contain a `u`. A BMP pattern matches against a String interpreted as consisting of a sequence of 16-bit values that are Unicode code points in the range of the Basic Multilingual Plane. A Unicode pattern matches against a String interpreted as consisting of Unicode code points encoded using UTF-16. In the context of describing the behaviour of a BMP pattern &ldquo;character&rdquo; means a single 16-bit Unicode BMP code point. In the context of describing the behaviour of a Unicode pattern &ldquo;character&rdquo; means a UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). In either context, &ldquo;character value&rdquo; means the numeric value of the corresponding non-encoded code point.</p>
       <p>The syntax and semantics of |Pattern| is defined as if the source code for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>

--- a/spec.html
+++ b/spec.html
@@ -28336,7 +28336,7 @@
         The behaviour of built-in methods which are specified in ECMA-402, such as those named `toLocaleString`, must not be extended except as specified in ECMA-402.
       </li>
       <li>
-        The RegExp pattern grammars in <emu-xref href="#sec-syntax-for-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[+UnicodeMode]| when the <sub>[UnicodeMode]</sub> grammar parameter is present.
+        The RegExp pattern grammars in <emu-xref href="#sec-syntax-for-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape| when the <sub>[UnicodeMode]</sub> grammar parameter is present.
       </li>
       <li>
         The Syntactic Grammar must not be extended in any manner that allows the token `:` to immediately follow source text that matches the |BindingIdentifier| nonterminal symbol.
@@ -34243,6 +34243,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-syntax-for-patterns" oldids="sec-patterns">
       <h1>Syntax for Patterns</h1>
       <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
+      <p>Some of these productions (indicated by &ldquo;<b>::!</b>&rdquo;) introduce ambiguities that are broken by the ordering of alternatives. When parsing using such productions, each alternative is considered only if previous alternatives do not match.</p>
       <h2>Patterns</h2>
       <emu-grammar type="definition">
         Pattern[UnicodeMode, N] ::
@@ -34256,20 +34257,29 @@ THH:mm:ss.sss
           [empty]
           Alternative[?UnicodeMode, ?N] Term[?UnicodeMode, ?N]
 
-        Term[UnicodeMode, N] ::
-          Assertion[?UnicodeMode, ?N]
-          Atom[?UnicodeMode, ?N]
-          Atom[?UnicodeMode, ?N] Quantifier
+        Term[UnicodeMode, N] ::!
+          [+UnicodeMode] Assertion[+UnicodeMode, ?N]
+          [+UnicodeMode] Atom[+UnicodeMode, ?N] Quantifier
+          [+UnicodeMode] Atom[+UnicodeMode, ?N]
+          [~UnicodeMode] QuantifiableAssertion[?N] Quantifier
+          [~UnicodeMode] Assertion[~UnicodeMode, ?N]
+          [~UnicodeMode] ExtendedAtom[?N] Quantifier
+          [~UnicodeMode] ExtendedAtom[?N]
 
         Assertion[UnicodeMode, N] ::
           `^`
           `$`
           `\` `b`
           `\` `B`
-          `(` `?` `=` Disjunction[?UnicodeMode, ?N] `)`
-          `(` `?` `!` Disjunction[?UnicodeMode, ?N] `)`
+          [+UnicodeMode] `(` `?` `=` Disjunction[+UnicodeMode, ?N] `)`
+          [+UnicodeMode] `(` `?` `!` Disjunction[+UnicodeMode, ?N] `)`
+          [~UnicodeMode] QuantifiableAssertion[?N]
           `(` `?` `&lt;=` Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `&lt;!` Disjunction[?UnicodeMode, ?N] `)`
+
+        QuantifiableAssertion[N] ::
+          `(` `?` `=` Disjunction[~UnicodeMode, ?N] `)`
+          `(` `?` `!` Disjunction[~UnicodeMode, ?N] `)`
 
         Quantifier ::
           QuantifierPrefix
@@ -34283,6 +34293,16 @@ THH:mm:ss.sss
           `{` DecimalDigits[~Sep] `,` `}`
           `{` DecimalDigits[~Sep] `,` DecimalDigits[~Sep] `}`
 
+        ExtendedAtom[N] ::!
+          `.`
+          `\` AtomEscape[~UnicodeMode, ?N]
+          `\` [lookahead == `c`]
+          CharacterClass[~UnicodeMode]
+          `(` Disjunction[~UnicodeMode, ?N] `)`
+          `(` `?` `:` Disjunction[~UnicodeMode, ?N] `)`
+          InvalidBracedQuantifier
+          ExtendedPatternCharacter
+
         Atom[UnicodeMode, N] ::
           PatternCharacter
           `.`
@@ -34290,6 +34310,14 @@ THH:mm:ss.sss
           CharacterClass[?UnicodeMode]
           `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[?UnicodeMode, ?N] `)`
+
+        InvalidBracedQuantifier ::
+          `{` DecimalDigits[~Sep] `}`
+          `{` DecimalDigits[~Sep] `,` `}`
+          `{` DecimalDigits[~Sep] `,` DecimalDigits[~Sep] `}`
+
+        ExtendedPatternCharacter ::
+          SourceCharacter but not one of `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `|`
 
         PatternCharacter ::
           SourceCharacter but not SyntaxCharacter
@@ -34352,23 +34380,30 @@ THH:mm:ss.sss
           `-`
           ClassAtomNoDash[?UnicodeMode]
 
-        ClassAtomNoDash[UnicodeMode] ::
+        ClassAtomNoDash[UnicodeMode, N] ::!
           SourceCharacter but not one of `\` or `]` or `-`
-          `\` ClassEscape[?UnicodeMode]
+          `\` ClassEscape[?UnicodeMode, ?N]
+          `\` [lookahead == `c`]
       </emu-grammar>
 
       <h2>Escapes</h2>
       <emu-grammar type="definition">
-        ClassEscape[UnicodeMode] ::
+        ClassEscape[UnicodeMode, N] ::!
           `b`
           [+UnicodeMode] `-`
+          [~UnicodeMode] `c` ClassControlLetter
           CharacterClassEscape[?UnicodeMode]
-          CharacterEscape[?UnicodeMode]
+          CharacterEscape[?UnicodeMode, ?N]
 
-        AtomEscape[UnicodeMode, N] ::
-          DecimalEscape
+        ClassControlLetter ::
+          DecimalDigit
+          `_`
+
+        AtomEscape[UnicodeMode, N] ::!
+          [+UnicodeMode] DecimalEscape
+          [~UnicodeMode] DecimalEscape [> but only if the CapturingGroupNumber of |DecimalEscape| is &le; _NcapturingParens_]
           CharacterClassEscape[?UnicodeMode]
-          CharacterEscape[?UnicodeMode]
+          CharacterEscape[?UnicodeMode, ?N]
           [+N] `k` GroupName[?UnicodeMode]
 
         DecimalEscape ::
@@ -34411,13 +34446,14 @@ THH:mm:ss.sss
           ControlLetter
           `_`
 
-        CharacterEscape[UnicodeMode] ::
+        CharacterEscape[UnicodeMode, N] ::!
           ControlEscape
           `c` ControlLetter
           `0` [lookahead &notin; DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?UnicodeMode]
-          IdentityEscape[?UnicodeMode]
+          [~UnicodeMode] LegacyOctalEscapeSequence
+          IdentityEscape[?UnicodeMode, ?N]
 
         ControlEscape :: one of
           `f` `n` `r` `t` `v`
@@ -34445,25 +34481,36 @@ THH:mm:ss.sss
         HexNonSurrogate ::
           Hex4Digits [> but only if the MV of |Hex4Digits| is not in the inclusive range 0xD800 to 0xDFFF]
 
-        IdentityEscape[UnicodeMode] ::
+        IdentityEscape[UnicodeMode, N] ::
           [+UnicodeMode] SyntaxCharacter
           [+UnicodeMode] `/`
-          [~UnicodeMode] SourceCharacter but not UnicodeIDContinue
+          [~UnicodeMode] SourceCharacterIdentityEscape[?N]
+
+        SourceCharacterIdentityEscape[N] ::
+          [~N] SourceCharacter but not `c`
+          [+N] SourceCharacter but not one of `c` or `k`
       </emu-grammar>
+      <emu-note>
+        <p>Patterns that use the following productions are allowed, but deprecated:</p>
+        <emu-grammar>
+          Term ::! QuantifiableAssertion Quantifier
+
+          ExtendedAtom ::! `\` [lookahead == `c`]
+
+          ClassAtomNoDash ::! `\` [lookahead == `c`]
+
+          ClassEscape ::! `c` ClassControlLetter
+
+          CharacterEscape ::! LegacyOctalEscapeSequence
+        </emu-grammar>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-for-patterns">
       <h1>Static Semantics for Patterns</h1>
 
-      <emu-note>
-        <p>A number of productions in this section are given alternative definitions in section <emu-xref href="#sec-regular-expressions-patterns"></emu-xref>.</p>
-      </emu-note>
-
-      <emu-clause id="sec-patterns-static-semantics-early-errors">
+      <emu-clause id="sec-patterns-static-semantics-early-errors" oldids="sec-patterns-static-semantics-early-errors-annexb">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-note>
-          <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-early-errors-annexb"></emu-xref>.</p>
-        </emu-note>
         <emu-grammar>Pattern :: Disjunction</emu-grammar>
         <ul>
           <li>
@@ -34477,6 +34524,12 @@ THH:mm:ss.sss
         <ul>
           <li>
             It is a Syntax Error if the MV of the first |DecimalDigits| is larger than the MV of the second |DecimalDigits|.
+          </li>
+        </ul>
+        <emu-grammar>ExtendedAtom ::! InvalidBracedQuantifier</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if any source text matches this rule.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
@@ -34506,7 +34559,7 @@ THH:mm:ss.sss
         <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *true* or IsCharacterClass of the second |ClassAtom| is *true*.
+            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *true* or IsCharacterClass of the second |ClassAtom| is *true* and this production has a <sub>[UnicodeMode]</sub> parameter.
           </li>
           <li>
             It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *false* and IsCharacterClass of the second |ClassAtom| is *false* and the CharacterValue of the first |ClassAtom| is larger than the CharacterValue of the second |ClassAtom|.
@@ -34515,19 +34568,19 @@ THH:mm:ss.sss
         <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *true* or IsCharacterClass of |ClassAtom| is *true*.
+            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *true* or IsCharacterClass of |ClassAtom| is *true* and this production has a <sub>[UnicodeMode]</sub> parameter.
           </li>
           <li>
             It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false* and IsCharacterClass of |ClassAtom| is *false* and the CharacterValue of |ClassAtomNoDash| is larger than the CharacterValue of |ClassAtom|.
           </li>
         </ul>
-        <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar>
+        <emu-grammar>AtomEscape ::! DecimalEscape</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the CapturingGroupNumber of |DecimalEscape| is larger than _NcapturingParens_ (<emu-xref href="#sec-notation"></emu-xref>).
           </li>
         </ul>
-        <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
+        <emu-grammar>AtomEscape ::! `k` GroupName</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the enclosing |Pattern| does not contain a |GroupSpecifier| with an enclosed |RegExpIdentifierName| whose CapturingGroupName equals the CapturingGroupName of the |RegExpIdentifierName| of this production's |GroupName|.
@@ -34554,9 +34607,6 @@ THH:mm:ss.sss
         <h1>Static Semantics: CapturingGroupNumber</h1>
         <dl class="header">
         </dl>
-        <emu-note>
-          <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-early-errors-annexb"></emu-xref>.</p>
-        </emu-note>
         <emu-grammar>DecimalEscape :: NonZeroDigit</emu-grammar>
         <emu-alg>
           1. Return the MV of |NonZeroDigit|.
@@ -34569,40 +34619,36 @@ THH:mm:ss.sss
         <p>The definitions of &ldquo;the MV of |NonZeroDigit|&rdquo; and &ldquo;the MV of |DecimalDigits|&rdquo; are in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
       </emu-clause>
 
-      <emu-clause id="sec-patterns-static-semantics-is-character-class" type="sdo">
+      <emu-clause id="sec-patterns-static-semantics-is-character-class" type="sdo" oldids="sec-patterns-static-semantics-is-character-class-annexb">
         <h1>Static Semantics: IsCharacterClass</h1>
         <dl class="header">
         </dl>
-        <emu-note>
-          <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-is-character-class-annexb"></emu-xref>.</p>
-        </emu-note>
         <emu-grammar>
           ClassAtom :: `-`
 
-          ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`
+          ClassAtomNoDash ::! SourceCharacter but not one of `\` or `]` or `-`
 
-          ClassEscape :: `b`
+          ClassAtomNoDash ::! `\` [lookahead == `c`]
 
-          ClassEscape :: `-`
+          ClassEscape ::! `b`
 
-          ClassEscape :: CharacterEscape
+          ClassEscape ::! `-`
+
+          ClassEscape ::! CharacterEscape
         </emu-grammar>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
-        <emu-grammar>ClassEscape :: CharacterClassEscape</emu-grammar>
+        <emu-grammar>ClassEscape ::! CharacterClassEscape</emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-patterns-static-semantics-character-value" type="sdo">
+      <emu-clause id="sec-patterns-static-semantics-character-value" type="sdo" oldids="sec-patterns-static-semantics-character-value-annexb">
         <h1>Static Semantics: CharacterValue</h1>
         <dl class="header">
         </dl>
-        <emu-note>
-          <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-character-value-annexb"></emu-xref>.</p>
-        </emu-note>
         <emu-grammar>
           ClassAtom :: `-`
         </emu-grammar>
@@ -34610,25 +34656,37 @@ THH:mm:ss.sss
           1. Return the code point value of U+002D (HYPHEN-MINUS).
         </emu-alg>
         <emu-grammar>
-          ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`
+          ClassAtomNoDash ::! SourceCharacter but not one of `\` or `]` or `-`
         </emu-grammar>
         <emu-alg>
           1. Let _ch_ be the code point matched by |SourceCharacter|.
           1. Return the code point value of _ch_.
         </emu-alg>
         <emu-grammar>
-          ClassEscape :: `b`
+          ClassAtomNoDash ::! `\` [lookahead == `c`]
+        </emu-grammar>
+        <emu-alg>
+          1. Return the code point value of U+005C (REVERSE SOLIDUS).
+        </emu-alg>
+        <emu-grammar>
+          ClassEscape ::! `b`
         </emu-grammar>
         <emu-alg>
           1. Return the code point value of U+0008 (BACKSPACE).
         </emu-alg>
         <emu-grammar>
-          ClassEscape :: `-`
+          ClassEscape ::! `-`
         </emu-grammar>
         <emu-alg>
           1. Return the code point value of U+002D (HYPHEN-MINUS).
         </emu-alg>
-        <emu-grammar>CharacterEscape :: ControlEscape</emu-grammar>
+        <emu-grammar>ClassEscape ::! `c` ClassControlLetter</emu-grammar>
+        <emu-alg>
+          1. Let _ch_ be the code point matched by |ClassControlLetter|.
+          1. Let _i_ be _ch_'s code point value.
+          1. Return the remainder of dividing _i_ by 32.
+        </emu-alg>
+        <emu-grammar>CharacterEscape ::! ControlEscape</emu-grammar>
         <emu-alg>
           1. Return the code point value according to <emu-xref href="#table-controlescape-code-point-values"></emu-xref>.
         </emu-alg>
@@ -34740,22 +34798,26 @@ THH:mm:ss.sss
             </tbody>
           </table>
         </emu-table>
-        <emu-grammar>CharacterEscape :: `c` ControlLetter</emu-grammar>
+        <emu-grammar>CharacterEscape ::! `c` ControlLetter</emu-grammar>
         <emu-alg>
           1. Let _ch_ be the code point matched by |ControlLetter|.
           1. Let _i_ be _ch_'s code point value.
           1. Return the remainder of dividing _i_ by 32.
         </emu-alg>
-        <emu-grammar>CharacterEscape :: `0` [lookahead &notin; DecimalDigit]</emu-grammar>
+        <emu-grammar>CharacterEscape ::! `0` [lookahead &notin; DecimalDigit]</emu-grammar>
         <emu-alg>
           1. Return the code point value of U+0000 (NULL).
         </emu-alg>
         <emu-note>
           <p>`\\0` represents the &lt;NUL&gt; character and cannot be followed by a decimal digit.</p>
         </emu-note>
-        <emu-grammar>CharacterEscape :: HexEscapeSequence</emu-grammar>
+        <emu-grammar>CharacterEscape ::! HexEscapeSequence</emu-grammar>
         <emu-alg>
           1. Return the MV of |HexEscapeSequence|.
+        </emu-alg>
+        <emu-grammar>CharacterEscape ::! LegacyOctalEscapeSequence</emu-grammar>
+        <emu-alg>
+          1. Return the MV of |LegacyOctalEscapeSequence| (see <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>).
         </emu-alg>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u` HexLeadSurrogate `\u` HexTrailSurrogate</emu-grammar>
         <emu-alg>
@@ -34868,7 +34930,7 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-for-patterns" oldids="sec-pattern-semantics">
+    <emu-clause id="sec-runtime-semantics-for-patterns" oldids="sec-pattern-semantics,sec-regular-expression-patterns-semantics">
       <h1>Runtime Semantics for Patterns</h1>
       <p>A regular expression pattern is converted into an Abstract Closure using the process described below. An implementation is encouraged to use more efficient algorithms than the ones listed below, as long as the results are the same. The Abstract Closure is used as the value of a RegExp object's [[RegExpMatcher]] internal slot.</p>
       <p>A |Pattern| is either a BMP pattern or a Unicode pattern depending upon whether or not its associated flags contain a `u`. A BMP pattern matches against a String interpreted as consisting of a sequence of 16-bit values that are Unicode code points in the range of the Basic Multilingual Plane. A Unicode pattern matches against a String interpreted as consisting of Unicode code points encoded using UTF-16. In the context of describing the behaviour of a BMP pattern &ldquo;character&rdquo; means a single 16-bit Unicode BMP code point. In the context of describing the behaviour of a Unicode pattern &ldquo;character&rdquo; means a UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). In either context, &ldquo;character value&rdquo; means the numeric value of the corresponding non-encoded code point.</p>
@@ -35023,18 +35085,18 @@ THH:mm:ss.sss
       <emu-clause id="sec-term">
         <h1>Term</h1>
         <p>With parameter _direction_.</p>
-        <p>The production <emu-grammar>Term :: Assertion</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Term ::! Assertion</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Assertion|.
         </emu-alg>
         <emu-note>
           <p>The resulting Matcher is independent of _direction_.</p>
         </emu-note>
-        <p>The production <emu-grammar>Term :: Atom</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Term ::! Atom</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Atom| with argument _direction_.
         </emu-alg>
-        <p>The production <emu-grammar>Term :: Atom Quantifier</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Term ::! Atom Quantifier</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Atom| with argument _direction_ to obtain a Matcher _m_.
           1. Evaluate |Quantifier| to obtain the three results: a non-negative integer _min_, a non-negative integer (or +&infin;) _max_, and Boolean _greedy_.
@@ -35046,6 +35108,11 @@ THH:mm:ss.sss
             1. Assert: _c_ is a Continuation.
             1. Return ! RepeatMatcher(_m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_).
         </emu-alg>
+        <p>----</p>
+        <p>In the above algorithm, references to <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> are to be interpreted as meaning <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> or <emu-grammar>ExtendedAtom ::! `(` Disjunction `)`</emu-grammar> .</p>
+        <p>The production <emu-grammar>Term ::! QuantifiableAssertion Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term ::! Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
+        <p>The production <emu-grammar>Term ::! ExtendedAtom Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term ::! Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
+        <p>The production <emu-grammar>Term ::! ExtendedAtom</emu-grammar> evaluates the same as the production <emu-grammar>Term ::! Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
 
         <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" type="abstract operation">
           <h1>
@@ -35203,6 +35270,11 @@ THH:mm:ss.sss
             1. If _r_ is not ~failure~, return ~failure~.
             1. Return _c_(_x_).
         </emu-alg>
+        <p>The production <emu-grammar>Assertion :: QuantifiableAssertion</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Evaluate |QuantifiableAssertion| to obtain a Matcher _m_.
+          1. Return _m_.
+        </emu-alg>
         <p>The production <emu-grammar>Assertion :: `(` `?` `&lt;=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| with -1 as its _direction_ argument to obtain a Matcher _m_.
@@ -35233,6 +35305,8 @@ THH:mm:ss.sss
             1. If _r_ is not ~failure~, return ~failure~.
             1. Return _c_(_x_).
         </emu-alg>
+        <p>----</p>
+        <p>The evaluation rules for the <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
 
         <emu-clause id="sec-runtime-semantics-iswordchar-abstract-operation" type="abstract operation">
           <h1>
@@ -35312,6 +35386,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |AtomEscape| with argument _direction_.
         </emu-alg>
+        <p>The production <emu-grammar>ExtendedAtom ::! `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
+          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+        </emu-alg>
         <p>The production <emu-grammar>Atom :: CharacterClass</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterClass| to obtain a CharSet _A_ and a Boolean _invert_.
@@ -35345,6 +35424,14 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Disjunction| with argument _direction_.
         </emu-alg>
+        <p>The production <emu-grammar>ExtendedAtom ::! ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Let _ch_ be the character represented by |ExtendedPatternCharacter|.
+          1. Let _A_ be a one-element CharSet containing the character _ch_.
+          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+        </emu-alg>
+        <p>----</p>
+        <p>The evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|.</p>
 
         <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" type="abstract operation">
           <h1>
@@ -35516,9 +35603,27 @@ THH:mm:ss.sss
           1. Evaluate the first |ClassAtom| to obtain a CharSet _A_.
           1. Evaluate the second |ClassAtom| to obtain a CharSet _B_.
           1. Evaluate |ClassRanges| to obtain a CharSet _C_.
-          1. Let _D_ be ! CharacterRange(_A_, _B_).
+          1. Let _D_ be ! CharacterRangeOrUnion(_A_, _B_).
           1. Return the union of _D_ and _C_.
         </emu-alg>
+
+        <emu-clause id="sec-runtime-semantics-characterrangeorunion-abstract-operation" type="abstract operation">
+          <h1>
+            CharacterRangeOrUnion (
+              _A_: a CharSet,
+              _B_: a CharSet,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. If _Unicode_ is *false*, then
+              1. If _A_ does not contain exactly one character or _B_ does not contain exactly one character, then
+                1. Let _C_ be the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
+                1. Return the union of CharSets _A_, _B_ and _C_.
+            1. Return ! CharacterRange(_A_, _B_).
+          </emu-alg>
+        </emu-clause>
 
         <emu-clause id="sec-runtime-semantics-characterrange-abstract-operation" type="abstract operation">
           <h1>
@@ -35558,7 +35663,7 @@ THH:mm:ss.sss
           1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
           1. Evaluate |ClassAtom| to obtain a CharSet _B_.
           1. Evaluate |ClassRanges| to obtain a CharSet _C_.
-          1. Let _D_ be ! CharacterRange(_A_, _B_).
+          1. Let _D_ be ! CharacterRangeOrUnion(_A_, _B_).
           1. Return the union of _D_ and _C_.
         </emu-alg>
         <emu-note>
@@ -35586,25 +35691,32 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-classatomnodash">
         <h1>ClassAtomNoDash</h1>
-        <p>The production <emu-grammar>ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassAtomNoDash ::! SourceCharacter but not one of `\` or `]` or `-`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet containing the character matched by |SourceCharacter|.
         </emu-alg>
-        <p>The production <emu-grammar>ClassAtomNoDash :: `\` ClassEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>ClassAtomNoDash ::! `\` ClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |ClassEscape|.
         </emu-alg>
+        <p>The production <emu-grammar>ClassAtomNoDash ::! `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
+        </emu-alg>
+        <emu-note>This production can only be reached from the sequence `\c` within a character class where it is not followed by an acceptable control character.</emu-note>
       </emu-clause>
 
       <emu-clause id="sec-classescape">
         <h1>ClassEscape</h1>
         <p>The |ClassEscape| productions evaluate as follows:</p>
         <emu-grammar>
-          ClassEscape :: `b`
+          ClassEscape ::! `b`
 
-          ClassEscape :: `-`
+          ClassEscape ::! `-`
 
-          ClassEscape :: CharacterEscape
+          ClassEscape ::! `c` ClassControlLetter
+
+          ClassEscape ::! CharacterEscape
         </emu-grammar>
         <emu-alg>
           1. Let _cv_ be the CharacterValue of this |ClassEscape|.
@@ -35612,7 +35724,7 @@ THH:mm:ss.sss
           1. Return the CharSet containing the single character _c_.
         </emu-alg>
         <emu-grammar>
-          ClassEscape :: CharacterClassEscape
+          ClassEscape ::! CharacterClassEscape
         </emu-grammar>
         <emu-alg>
           1. Return the CharSet that is the result of evaluating |CharacterClassEscape|.
@@ -35625,13 +35737,13 @@ THH:mm:ss.sss
       <emu-clause id="sec-atomescape">
         <h1>AtomEscape</h1>
         <p>With parameter _direction_.</p>
-        <p>The production <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>AtomEscape ::! DecimalEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |DecimalEscape| to obtain an integer _n_.
           1. Assert: _n_ &le; _NcapturingParens_.
           1. Return ! BackreferenceMatcher(_n_, _direction_).
         </emu-alg>
-        <p>The production <emu-grammar>AtomEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>AtomEscape ::! CharacterClassEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterClassEscape| to obtain a CharSet _A_.
           1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
@@ -35639,13 +35751,13 @@ THH:mm:ss.sss
         <emu-note>
           <p>An escape sequence of the form `\\` followed by a non-zero decimal number _n_ matches the result of the _n_<sup>th</sup> set of capturing parentheses (<emu-xref href="#sec-notation"></emu-xref>). It is an error if the regular expression has fewer than _n_ capturing parentheses. If the regular expression has _n_ or more capturing parentheses but the _n_<sup>th</sup> one is *undefined* because it has not captured anything, then the backreference always succeeds.</p>
         </emu-note>
-        <p>The production <emu-grammar>AtomEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>AtomEscape ::! CharacterEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterEscape| to obtain a character _ch_.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
           1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
-        <p>The production <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>AtomEscape ::! `k` GroupName</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |RegExpIdentifierName| which has a CapturingGroupName equal to the CapturingGroupName of the |RegExpIdentifierName| contained in |GroupName|.
           1. Assert: A unique such |GroupSpecifier| is found.
@@ -35752,12 +35864,13 @@ THH:mm:ss.sss
         <h1>CharacterEscape</h1>
         <p>The |CharacterEscape| productions evaluate as follows:</p>
         <emu-grammar>
-          CharacterEscape ::
+          CharacterEscape ::!
             ControlEscape
             `c` ControlLetter
             `0` [lookahead &notin; DecimalDigit]
             HexEscapeSequence
             RegExpUnicodeEscapeSequence
+            LegacyOctalEscapeSequence
             IdentityEscape
         </emu-grammar>
         <emu-alg>
@@ -46520,9 +46633,13 @@ THH:mm:ss.sss
     <emu-prodref name="Alternative"></emu-prodref>
     <emu-prodref name="Term"></emu-prodref>
     <emu-prodref name="Assertion"></emu-prodref>
+    <emu-prodref name="QuantifiableAssertion"></emu-prodref>
     <emu-prodref name="Quantifier"></emu-prodref>
     <emu-prodref name="QuantifierPrefix"></emu-prodref>
+    <emu-prodref name="ExtendedAtom"></emu-prodref>
     <emu-prodref name="Atom"></emu-prodref>
+    <emu-prodref name="InvalidBracedQuantifier"></emu-prodref>
+    <emu-prodref name="ExtendedPatternCharacter"></emu-prodref>
     <emu-prodref name="PatternCharacter"></emu-prodref>
     <emu-prodref name="SyntaxCharacter"></emu-prodref>
     <emu-prodref name="GroupSpecifier"></emu-prodref>
@@ -46539,6 +46656,7 @@ THH:mm:ss.sss
     <emu-prodref name="ClassAtom"></emu-prodref>
     <emu-prodref name="ClassAtomNoDash"></emu-prodref>
     <emu-prodref name="ClassEscape"></emu-prodref>
+    <emu-prodref name="ClassControlLetter"></emu-prodref>
     <emu-prodref name="AtomEscape"></emu-prodref>
     <emu-prodref name="DecimalEscape"></emu-prodref>
     <emu-prodref name="CharacterClassEscape"></emu-prodref>
@@ -46558,6 +46676,7 @@ THH:mm:ss.sss
     <emu-prodref name="HexTrailSurrogate"></emu-prodref>
     <emu-prodref name="HexNonSurrogate"></emu-prodref>
     <emu-prodref name="IdentityEscape"></emu-prodref>
+    <emu-prodref name="SourceCharacterIdentityEscape"></emu-prodref>
   </emu-annex>
 </emu-annex>
 
@@ -46579,252 +46698,7 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-regular-expressions-patterns">
       <h1>Regular Expressions Patterns</h1>
-      <p>The syntax of <emu-xref href="#sec-syntax-for-patterns"></emu-xref> is modified and extended as follows. These changes introduce ambiguities that are broken by the ordering of grammar productions and by contextual information. When parsing using the following grammar, each alternative is considered only if previous production alternatives do not match.</p>
-      <p>This alternative pattern grammar and semantics only changes the syntax and semantics of BMP patterns. The following grammar extensions include productions parameterized with the [UnicodeMode] parameter. However, none of these extensions change the syntax of Unicode patterns recognized when parsing with the [UnicodeMode] parameter present on the goal symbol.</p>
-      <h2>Syntax</h2>
-      <emu-grammar type="definition">
-        Term[UnicodeMode, N] ::
-          [+UnicodeMode] Assertion[+UnicodeMode, ?N]
-          [+UnicodeMode] Atom[+UnicodeMode, ?N] Quantifier
-          [+UnicodeMode] Atom[+UnicodeMode, ?N]
-          [~UnicodeMode] QuantifiableAssertion[?N] Quantifier
-          [~UnicodeMode] Assertion[~UnicodeMode, ?N]
-          [~UnicodeMode] ExtendedAtom[?N] Quantifier
-          [~UnicodeMode] ExtendedAtom[?N]
-
-        Assertion[UnicodeMode, N] ::
-          `^`
-          `$`
-          `\` `b`
-          `\` `B`
-          [+UnicodeMode] `(` `?` `=` Disjunction[+UnicodeMode, ?N] `)`
-          [+UnicodeMode] `(` `?` `!` Disjunction[+UnicodeMode, ?N] `)`
-          [~UnicodeMode] QuantifiableAssertion[?N]
-          `(` `?` `&lt;=` Disjunction[?UnicodeMode, ?N] `)`
-          `(` `?` `&lt;!` Disjunction[?UnicodeMode, ?N] `)`
-
-        QuantifiableAssertion[N] ::
-          `(` `?` `=` Disjunction[~UnicodeMode, ?N] `)`
-          `(` `?` `!` Disjunction[~UnicodeMode, ?N] `)`
-
-        ExtendedAtom[N] ::
-          `.`
-          `\` AtomEscape[~UnicodeMode, ?N]
-          `\` [lookahead == `c`]
-          CharacterClass[~UnicodeMode]
-          `(` Disjunction[~UnicodeMode, ?N] `)`
-          `(` `?` `:` Disjunction[~UnicodeMode, ?N] `)`
-          InvalidBracedQuantifier
-          ExtendedPatternCharacter
-
-        InvalidBracedQuantifier ::
-          `{` DecimalDigits[~Sep] `}`
-          `{` DecimalDigits[~Sep] `,` `}`
-          `{` DecimalDigits[~Sep] `,` DecimalDigits[~Sep] `}`
-
-        ExtendedPatternCharacter ::
-          SourceCharacter but not one of `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `|`
-
-        AtomEscape[UnicodeMode, N] ::
-          [+UnicodeMode] DecimalEscape
-          [~UnicodeMode] DecimalEscape [> but only if the CapturingGroupNumber of |DecimalEscape| is &le; _NcapturingParens_]
-          CharacterClassEscape[?UnicodeMode]
-          CharacterEscape[?UnicodeMode, ?N]
-          [+N] `k` GroupName[?UnicodeMode]
-
-        CharacterEscape[UnicodeMode, N] ::
-          ControlEscape
-          `c` ControlLetter
-          `0` [lookahead &notin; DecimalDigit]
-          HexEscapeSequence
-          RegExpUnicodeEscapeSequence[?UnicodeMode]
-          [~UnicodeMode] LegacyOctalEscapeSequence
-          IdentityEscape[?UnicodeMode, ?N]
-
-        IdentityEscape[UnicodeMode, N] ::
-          [+UnicodeMode] SyntaxCharacter
-          [+UnicodeMode] `/`
-          [~UnicodeMode] SourceCharacterIdentityEscape[?N]
-
-        SourceCharacterIdentityEscape[N] ::
-          [~N] SourceCharacter but not `c`
-          [+N] SourceCharacter but not one of `c` or `k`
-
-        ClassAtomNoDash[UnicodeMode, N] ::
-          SourceCharacter but not one of `\` or `]` or `-`
-          `\` ClassEscape[?UnicodeMode, ?N]
-          `\` [lookahead == `c`]
-
-        ClassEscape[UnicodeMode, N] ::
-          `b`
-          [+UnicodeMode] `-`
-          [~UnicodeMode] `c` ClassControlLetter
-          CharacterClassEscape[?UnicodeMode]
-          CharacterEscape[?UnicodeMode, ?N]
-
-        ClassControlLetter ::
-          DecimalDigit
-          `_`
-      </emu-grammar>
-      <emu-note>
-        <p>When the same left-hand sides occurs with both [+UnicodeMode] and [\~UnicodeMode] guards it is to control the disambiguation priority.</p>
-      </emu-note>
-
-      <emu-annex id="sec-patterns-static-semantics-early-errors-annexb">
-        <h1>Static Semantics: Early Errors</h1>
-        <p>The semantics of <emu-xref href="#sec-patterns-static-semantics-early-errors"></emu-xref> is extended as follows:</p>
-        <emu-grammar>ExtendedAtom :: InvalidBracedQuantifier</emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if any source text matches this rule.
-          </li>
-        </ul>
-        <p>Additionally, the rules for the following productions are modified with the addition of the <ins>highlighted</ins> text:</p>
-        <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *true* or IsCharacterClass of the second |ClassAtom| is *true* <ins>and this production has a <sub>[UnicodeMode]</sub> parameter</ins>.
-          </li>
-          <li>
-            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *false* and IsCharacterClass of the second |ClassAtom| is *false* and the CharacterValue of the first |ClassAtom| is larger than the CharacterValue of the second |ClassAtom|.
-          </li>
-        </ul>
-        <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *true* or IsCharacterClass of |ClassAtom| is *true* <ins>and this production has a <sub>[UnicodeMode]</sub> parameter</ins>.
-          </li>
-          <li>
-            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false* and IsCharacterClass of |ClassAtom| is *false* and the CharacterValue of |ClassAtomNoDash| is larger than the CharacterValue of |ClassAtom|.
-          </li>
-        </ul>
-      </emu-annex>
-
-      <emu-annex id="sec-patterns-static-semantics-is-character-class-annexb">
-        <h1>Static Semantics: IsCharacterClass</h1>
-        <p>The semantics of <emu-xref href="#sec-patterns-static-semantics-is-character-class"></emu-xref> is extended as follows:</p>
-        <emu-grammar>
-          ClassAtomNoDash :: `\` [lookahead == `c`]
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-      </emu-annex>
-
-      <emu-annex id="sec-patterns-static-semantics-character-value-annexb">
-        <h1>Static Semantics: CharacterValue</h1>
-        <p>The semantics of <emu-xref href="#sec-patterns-static-semantics-character-value"></emu-xref> is extended as follows:</p>
-        <emu-grammar>
-          ClassAtomNoDash :: `\` [lookahead == `c`]
-        </emu-grammar>
-        <emu-alg>
-          1. Return the code point value of U+005C (REVERSE SOLIDUS).
-        </emu-alg>
-        <emu-grammar>ClassEscape :: `c` ClassControlLetter</emu-grammar>
-        <emu-alg>
-          1. Let _ch_ be the code point matched by |ClassControlLetter|.
-          1. Let _i_ be _ch_'s code point value.
-          1. Return the remainder of dividing _i_ by 32.
-        </emu-alg>
-        <emu-grammar>CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar>
-        <emu-alg>
-          1. Return the MV of |LegacyOctalEscapeSequence| (see <emu-xref href="#sec-string-literals-static-semantics-mv"></emu-xref>).
-        </emu-alg>
-      </emu-annex>
-
-      <emu-annex id="sec-regular-expression-patterns-semantics">
-        <h1>Pattern Semantics</h1>
-        <p>The semantics of <emu-xref href="#sec-runtime-semantics-for-patterns"></emu-xref> is extended as follows:</p>
-        <p>Within <emu-xref href="#sec-term"></emu-xref> reference to &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar>ExtendedAtom :: `(` Disjunction `)`</emu-grammar> &rdquo;.</p>
-
-        <p>Term (<emu-xref href="#sec-term"></emu-xref>) includes the following additional evaluation rules:</p>
-        <p>The production <emu-grammar>Term :: QuantifiableAssertion Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
-        <p>The production <emu-grammar>Term :: ExtendedAtom Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
-        <p>The production <emu-grammar>Term :: ExtendedAtom</emu-grammar> evaluates the same as the production <emu-grammar>Term :: Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
-
-        <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>Assertion :: QuantifiableAssertion</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Evaluate |QuantifiableAssertion| to obtain a Matcher _m_.
-          1. Return _m_.
-        </emu-alg>
-
-        <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) evaluation rules for the <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
-
-        <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules, with parameter _direction_, are also added:</p>
-        <p>The production <emu-grammar>ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
-        </emu-alg>
-        <p>The production <emu-grammar>ExtendedAtom :: ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Let _ch_ be the character represented by |ExtendedPatternCharacter|.
-          1. Let _A_ be a one-element CharSet containing the character _ch_.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
-        </emu-alg>
-
-        <p>CharacterEscape (<emu-xref href="#sec-characterescape"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Let _cv_ be the CharacterValue of this |CharacterEscape|.
-          1. Return the character whose character value is _cv_.
-        </emu-alg>
-
-        <p>NonemptyClassRanges (<emu-xref href="#sec-nonemptyclassranges"></emu-xref>) modifies the following evaluation rule:</p>
-        <p>The production <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Evaluate the first |ClassAtom| to obtain a CharSet _A_.
-          1. Evaluate the second |ClassAtom| to obtain a CharSet _B_.
-          1. Evaluate |ClassRanges| to obtain a CharSet _C_.
-          1. Let _D_ be ! CharacterRangeOrUnion(_A_, _B_).
-          1. Return the union of _D_ and _C_.
-        </emu-alg>
-
-        <p>NonemptyClassRangesNoDash (<emu-xref href="#sec-nonemptyclassrangesnodash"></emu-xref>) modifies the following evaluation rule:</p>
-        <p>The production <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Evaluate |ClassAtomNoDash| to obtain a CharSet _A_.
-          1. Evaluate |ClassAtom| to obtain a CharSet _B_.
-          1. Evaluate |ClassRanges| to obtain a CharSet _C_.
-          1. Let _D_ be ! CharacterRangeOrUnion(_A_, _B_).
-          1. Return the union of _D_ and _C_.
-        </emu-alg>
-
-        <p>ClassEscape (<emu-xref href="#sec-classescape"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>ClassEscape :: `c` ClassControlLetter</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Let _cv_ be the CharacterValue of this |ClassEscape|.
-          1. Let _c_ be the character whose character value is _cv_.
-          1. Return the CharSet containing the single character _c_.
-        </emu-alg>
-
-        <p>ClassAtomNoDash (<emu-xref href="#sec-classatomnodash"></emu-xref>) includes the following additional evaluation rule:</p>
-        <p>The production <emu-grammar>ClassAtomNoDash :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
-        </emu-alg>
-
-        <emu-note>This production can only be reached from the sequence `\c` within a character class where it is not followed by an acceptable control character.</emu-note>
-
-        <emu-annex id="sec-runtime-semantics-characterrangeorunion-abstract-operation" type="abstract operation">
-          <h1>
-            CharacterRangeOrUnion (
-              _A_: a CharSet,
-              _B_: a CharSet,
-            )
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. If _Unicode_ is *false*, then
-              1. If _A_ does not contain exactly one character or _B_ does not contain exactly one character, then
-                1. Let _C_ be the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
-                1. Return the union of CharSets _A_, _B_ and _C_.
-            1. Return ! CharacterRange(_A_, _B_).
-          </emu-alg>
-        </emu-annex>
-      </emu-annex>
+      <p>Some of the syntax and semantics of BMP patterns ([~UnicodeMode]) used to be normative optional.</p>
     </emu-annex>
   </emu-annex>
 

--- a/spec.html
+++ b/spec.html
@@ -34243,7 +34243,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-syntax-for-patterns" oldids="sec-patterns">
       <h1>Syntax for Patterns</h1>
       <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
-      <h2>Syntax</h2>
+      <h2>Patterns</h2>
       <emu-grammar type="definition">
         Pattern[UnicodeMode, N] ::
           Disjunction[?UnicodeMode, ?N]
@@ -34291,33 +34291,15 @@ THH:mm:ss.sss
           `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[?UnicodeMode, ?N] `)`
 
-        SyntaxCharacter :: one of
-          `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `]` `{` `}` `|`
-
         PatternCharacter ::
           SourceCharacter but not SyntaxCharacter
 
-        AtomEscape[UnicodeMode, N] ::
-          DecimalEscape
-          CharacterClassEscape[?UnicodeMode]
-          CharacterEscape[?UnicodeMode]
-          [+N] `k` GroupName[?UnicodeMode]
+        SyntaxCharacter :: one of
+          `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `]` `{` `}` `|`
+      </emu-grammar>
 
-        CharacterEscape[UnicodeMode] ::
-          ControlEscape
-          `c` ControlLetter
-          `0` [lookahead &notin; DecimalDigit]
-          HexEscapeSequence
-          RegExpUnicodeEscapeSequence[?UnicodeMode]
-          IdentityEscape[?UnicodeMode]
-
-        ControlEscape :: one of
-          `f` `n` `r` `t` `v`
-
-        ControlLetter :: one of
-          `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
-          `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
-
+      <h2>Group Specifiers</h2>
+      <emu-grammar type="definition">
         GroupSpecifier[UnicodeMode] ::
           [empty]
           `?` GroupName[?UnicodeMode]
@@ -34339,35 +34321,55 @@ THH:mm:ss.sss
           `\` RegExpUnicodeEscapeSequence[+UnicodeMode]
           [~UnicodeMode] UnicodeLeadSurrogate UnicodeTrailSurrogate
 
-        RegExpUnicodeEscapeSequence[UnicodeMode] ::
-          [+UnicodeMode] `u` HexLeadSurrogate `\u` HexTrailSurrogate
-          [+UnicodeMode] `u` HexLeadSurrogate
-          [+UnicodeMode] `u` HexTrailSurrogate
-          [+UnicodeMode] `u` HexNonSurrogate
-          [~UnicodeMode] `u` Hex4Digits
-          [+UnicodeMode] `u{` CodePoint `}`
-
         UnicodeLeadSurrogate ::
           &gt; any Unicode code point in the inclusive range 0xD800 to 0xDBFF
 
         UnicodeTrailSurrogate ::
           &gt; any Unicode code point in the inclusive range 0xDC00 to 0xDFFF
       </emu-grammar>
-      <p>Each `\\u` |HexTrailSurrogate| for which the choice of associated `u` |HexLeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |HexLeadSurrogate| that would otherwise have no corresponding `\\u` |HexTrailSurrogate|.</p>
+
+      <h2>Character Classes</h2>
       <emu-grammar type="definition">
-        HexLeadSurrogate ::
-          Hex4Digits [> but only if the MV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
+        CharacterClass[UnicodeMode] ::
+          `[` [lookahead != `^`] ClassRanges[?UnicodeMode] `]`
+          `[` `^` ClassRanges[?UnicodeMode] `]`
 
-        HexTrailSurrogate ::
-          Hex4Digits [> but only if the MV of |Hex4Digits| is in the inclusive range 0xDC00 to 0xDFFF]
+        ClassRanges[UnicodeMode] ::
+          [empty]
+          NonemptyClassRanges[?UnicodeMode]
 
-        HexNonSurrogate ::
-          Hex4Digits [> but only if the MV of |Hex4Digits| is not in the inclusive range 0xD800 to 0xDFFF]
+        NonemptyClassRanges[UnicodeMode] ::
+          ClassAtom[?UnicodeMode]
+          ClassAtom[?UnicodeMode] NonemptyClassRangesNoDash[?UnicodeMode]
+          ClassAtom[?UnicodeMode] `-` ClassAtom[?UnicodeMode] ClassRanges[?UnicodeMode]
 
-        IdentityEscape[UnicodeMode] ::
-          [+UnicodeMode] SyntaxCharacter
-          [+UnicodeMode] `/`
-          [~UnicodeMode] SourceCharacter but not UnicodeIDContinue
+        NonemptyClassRangesNoDash[UnicodeMode] ::
+          ClassAtom[?UnicodeMode]
+          ClassAtomNoDash[?UnicodeMode] NonemptyClassRangesNoDash[?UnicodeMode]
+          ClassAtomNoDash[?UnicodeMode] `-` ClassAtom[?UnicodeMode] ClassRanges[?UnicodeMode]
+
+        ClassAtom[UnicodeMode] ::
+          `-`
+          ClassAtomNoDash[?UnicodeMode]
+
+        ClassAtomNoDash[UnicodeMode] ::
+          SourceCharacter but not one of `\` or `]` or `-`
+          `\` ClassEscape[?UnicodeMode]
+      </emu-grammar>
+
+      <h2>Escapes</h2>
+      <emu-grammar type="definition">
+        ClassEscape[UnicodeMode] ::
+          `b`
+          [+UnicodeMode] `-`
+          CharacterClassEscape[?UnicodeMode]
+          CharacterEscape[?UnicodeMode]
+
+        AtomEscape[UnicodeMode, N] ::
+          DecimalEscape
+          CharacterClassEscape[?UnicodeMode]
+          CharacterEscape[?UnicodeMode]
+          [+N] `k` GroupName[?UnicodeMode]
 
         DecimalEscape ::
           NonZeroDigit DecimalDigits[~Sep]? [lookahead &notin; DecimalDigit]
@@ -34409,37 +34411,44 @@ THH:mm:ss.sss
           ControlLetter
           `_`
 
-        CharacterClass[UnicodeMode] ::
-          `[` [lookahead != `^`] ClassRanges[?UnicodeMode] `]`
-          `[` `^` ClassRanges[?UnicodeMode] `]`
+        CharacterEscape[UnicodeMode] ::
+          ControlEscape
+          `c` ControlLetter
+          `0` [lookahead &notin; DecimalDigit]
+          HexEscapeSequence
+          RegExpUnicodeEscapeSequence[?UnicodeMode]
+          IdentityEscape[?UnicodeMode]
 
-        ClassRanges[UnicodeMode] ::
-          [empty]
-          NonemptyClassRanges[?UnicodeMode]
+        ControlEscape :: one of
+          `f` `n` `r` `t` `v`
 
-        NonemptyClassRanges[UnicodeMode] ::
-          ClassAtom[?UnicodeMode]
-          ClassAtom[?UnicodeMode] NonemptyClassRangesNoDash[?UnicodeMode]
-          ClassAtom[?UnicodeMode] `-` ClassAtom[?UnicodeMode] ClassRanges[?UnicodeMode]
+        ControlLetter :: one of
+          `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
+          `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
 
-        NonemptyClassRangesNoDash[UnicodeMode] ::
-          ClassAtom[?UnicodeMode]
-          ClassAtomNoDash[?UnicodeMode] NonemptyClassRangesNoDash[?UnicodeMode]
-          ClassAtomNoDash[?UnicodeMode] `-` ClassAtom[?UnicodeMode] ClassRanges[?UnicodeMode]
+        RegExpUnicodeEscapeSequence[UnicodeMode] ::
+          [+UnicodeMode] `u` HexLeadSurrogate `\u` HexTrailSurrogate
+          [+UnicodeMode] `u` HexLeadSurrogate
+          [+UnicodeMode] `u` HexTrailSurrogate
+          [+UnicodeMode] `u` HexNonSurrogate
+          [~UnicodeMode] `u` Hex4Digits
+          [+UnicodeMode] `u{` CodePoint `}`
+      </emu-grammar>
+      <p>Each `\\u` |HexTrailSurrogate| for which the choice of associated `u` |HexLeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |HexLeadSurrogate| that would otherwise have no corresponding `\\u` |HexTrailSurrogate|.</p>
+      <emu-grammar type="definition">
+        HexLeadSurrogate ::
+          Hex4Digits [> but only if the MV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
 
-        ClassAtom[UnicodeMode] ::
-          `-`
-          ClassAtomNoDash[?UnicodeMode]
+        HexTrailSurrogate ::
+          Hex4Digits [> but only if the MV of |Hex4Digits| is in the inclusive range 0xDC00 to 0xDFFF]
 
-        ClassAtomNoDash[UnicodeMode] ::
-          SourceCharacter but not one of `\` or `]` or `-`
-          `\` ClassEscape[?UnicodeMode]
+        HexNonSurrogate ::
+          Hex4Digits [> but only if the MV of |Hex4Digits| is not in the inclusive range 0xD800 to 0xDFFF]
 
-        ClassEscape[UnicodeMode] ::
-          `b`
-          [+UnicodeMode] `-`
-          CharacterClassEscape[?UnicodeMode]
-          CharacterEscape[?UnicodeMode]
+        IdentityEscape[UnicodeMode] ::
+          [+UnicodeMode] SyntaxCharacter
+          [+UnicodeMode] `/`
+          [~UnicodeMode] SourceCharacter but not UnicodeIDContinue
       </emu-grammar>
     </emu-clause>
 
@@ -34470,16 +34479,28 @@ THH:mm:ss.sss
             It is a Syntax Error if the MV of the first |DecimalDigits| is larger than the MV of the second |DecimalDigits|.
           </li>
         </ul>
-        <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
+        <emu-grammar>RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the enclosing |Pattern| does not contain a |GroupSpecifier| with an enclosed |RegExpIdentifierName| whose CapturingGroupName equals the CapturingGroupName of the |RegExpIdentifierName| of this production's |GroupName|.
+            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of some code point matched by the |IdentifierStartChar| lexical grammar production.
           </li>
         </ul>
-        <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar>
+        <emu-grammar>RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the CapturingGroupNumber of |DecimalEscape| is larger than _NcapturingParens_ (<emu-xref href="#sec-notation"></emu-xref>).
+            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of some code point matched by the |IdentifierPartChar| lexical grammar production.
+          </li>
+        </ul>
+        <emu-grammar>RegExpIdentifierStart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if RegExpIdentifierCodePoint of |RegExpIdentifierStart| is not matched by the |UnicodeIDStart| lexical grammar production.
+          </li>
+        </ul>
+        <emu-grammar>RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if RegExpIdentifierCodePoint of |RegExpIdentifierPart| is not matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar>
@@ -34500,28 +34521,16 @@ THH:mm:ss.sss
             It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false* and IsCharacterClass of |ClassAtom| is *false* and the CharacterValue of |ClassAtomNoDash| is larger than the CharacterValue of |ClassAtom|.
           </li>
         </ul>
-        <emu-grammar>RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
+        <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of some code point matched by the |IdentifierStartChar| lexical grammar production.
+            It is a Syntax Error if the CapturingGroupNumber of |DecimalEscape| is larger than _NcapturingParens_ (<emu-xref href="#sec-notation"></emu-xref>).
           </li>
         </ul>
-        <emu-grammar>RegExpIdentifierStart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
+        <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if RegExpIdentifierCodePoint of |RegExpIdentifierStart| is not matched by the |UnicodeIDStart| lexical grammar production.
-          </li>
-        </ul>
-        <emu-grammar>RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of some code point matched by the |IdentifierPartChar| lexical grammar production.
-          </li>
-        </ul>
-        <emu-grammar>RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if RegExpIdentifierCodePoint of |RegExpIdentifierPart| is not matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if the enclosing |Pattern| does not contain a |GroupSpecifier| with an enclosed |RegExpIdentifierName| whose CapturingGroupName equals the CapturingGroupName of the |RegExpIdentifierName| of this production's |GroupName|.
           </li>
         </ul>
         <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar>
@@ -34773,7 +34782,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the MV of |HexDigits|.
         </emu-alg>
-        <emu-grammar>CharacterEscape :: IdentityEscape</emu-grammar>
+        <emu-grammar>CharacterEscape ::! IdentityEscape</emu-grammar>
         <emu-alg>
           1. Let _ch_ be the code point matched by |IdentityEscape|.
           1. Return the code point value of _ch_.
@@ -35464,150 +35473,6 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-atomescape">
-        <h1>AtomEscape</h1>
-        <p>With parameter _direction_.</p>
-        <p>The production <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Evaluate |DecimalEscape| to obtain an integer _n_.
-          1. Assert: _n_ &le; _NcapturingParens_.
-          1. Return ! BackreferenceMatcher(_n_, _direction_).
-        </emu-alg>
-        <p>The production <emu-grammar>AtomEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Evaluate |CharacterEscape| to obtain a character _ch_.
-          1. Let _A_ be a one-element CharSet containing the character _ch_.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
-        </emu-alg>
-        <p>The production <emu-grammar>AtomEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Evaluate |CharacterClassEscape| to obtain a CharSet _A_.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
-        </emu-alg>
-        <emu-note>
-          <p>An escape sequence of the form `\\` followed by a non-zero decimal number _n_ matches the result of the _n_<sup>th</sup> set of capturing parentheses (<emu-xref href="#sec-notation"></emu-xref>). It is an error if the regular expression has fewer than _n_ capturing parentheses. If the regular expression has _n_ or more capturing parentheses but the _n_<sup>th</sup> one is *undefined* because it has not captured anything, then the backreference always succeeds.</p>
-        </emu-note>
-        <p>The production <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |RegExpIdentifierName| which has a CapturingGroupName equal to the CapturingGroupName of the |RegExpIdentifierName| contained in |GroupName|.
-          1. Assert: A unique such |GroupSpecifier| is found.
-          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of the located |GroupSpecifier|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing the located |GroupSpecifier|, including its immediately enclosing |Atom|.
-          1. Return ! BackreferenceMatcher(_parenIndex_, _direction_).
-        </emu-alg>
-
-        <emu-clause id="sec-backreference-matcher" type="abstract operation">
-          <h1>
-            BackreferenceMatcher (
-              _n_: a positive integer,
-              _direction_: 1 or -1,
-            )
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Assert: _n_ &ge; 1.
-            1. Return a new Matcher with parameters (_x_, _c_) that captures _n_ and _direction_ and performs the following steps when called:
-              1. Assert: _x_ is a State.
-              1. Assert: _c_ is a Continuation.
-              1. Let _cap_ be _x_'s _captures_ List.
-              1. Let _s_ be _cap_[_n_].
-              1. If _s_ is *undefined*, return _c_(_x_).
-              1. Let _e_ be _x_'s _endIndex_.
-              1. Let _len_ be the number of elements in _s_.
-              1. Let _f_ be _e_ + _direction_ &times; _len_.
-              1. If _f_ &lt; 0 or _f_ &gt; _InputLength_, return ~failure~.
-              1. Let _g_ be min(_e_, _f_).
-              1. If there exists an integer _i_ between 0 (inclusive) and _len_ (exclusive) such that Canonicalize(_s_[_i_]) is not the same character value as Canonicalize(_Input_[_g_ + _i_]), return ~failure~.
-              1. Let _y_ be the State (_f_, _cap_).
-              1. Return _c_(_y_).
-          </emu-alg>
-        </emu-clause>
-      </emu-clause>
-
-      <emu-clause id="sec-characterescape">
-        <h1>CharacterEscape</h1>
-        <p>The |CharacterEscape| productions evaluate as follows:</p>
-        <emu-grammar>
-          CharacterEscape ::
-            ControlEscape
-            `c` ControlLetter
-            `0` [lookahead &notin; DecimalDigit]
-            HexEscapeSequence
-            RegExpUnicodeEscapeSequence
-            IdentityEscape
-        </emu-grammar>
-        <emu-alg>
-          1. Let _cv_ be the CharacterValue of this |CharacterEscape|.
-          1. Return the character whose character value is _cv_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-decimalescape">
-        <h1>DecimalEscape</h1>
-        <p>The |DecimalEscape| productions evaluate as follows:</p>
-        <emu-grammar>DecimalEscape :: NonZeroDigit DecimalDigits?</emu-grammar>
-        <emu-alg>
-          1. Return the CapturingGroupNumber of this |DecimalEscape|.
-        </emu-alg>
-        <emu-note>
-          <p>If `\\` is followed by a decimal number _n_ whose first digit is not `0`, then the escape sequence is considered to be a backreference. It is an error if _n_ is greater than the total number of left-capturing parentheses in the entire regular expression.</p>
-        </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-characterclassescape">
-        <h1>CharacterClassEscape</h1>
-        <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the ten-element CharSet containing the characters `0` through `9` inclusive.
-        </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the CharSet containing all characters not in the CharSet returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> .
-        </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the CharSet containing all characters corresponding to a code point on the right-hand side of the |WhiteSpace| or |LineTerminator| productions.
-        </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the CharSet containing all characters not in the CharSet returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> .
-        </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return _WordCharacters_.
-        </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the CharSet containing all characters not in the CharSet returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> .
-        </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `p{` UnicodePropertyValueExpression `}`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the CharSet containing all Unicode code points included in the CharSet returned by |UnicodePropertyValueExpression|.
-        </emu-alg>
-        <p>The production <emu-grammar>CharacterClassEscape :: `P{` UnicodePropertyValueExpression `}`</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Return the CharSet containing all Unicode code points not included in the CharSet returned by |UnicodePropertyValueExpression|.
-        </emu-alg>
-        <p>The production <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Let _ps_ be SourceText of |UnicodePropertyName|.
-          1. Let _p_ be ! UnicodeMatchProperty(_ps_).
-          1. Assert: _p_ is a Unicode property name or property alias listed in the &ldquo;Property name and aliases&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
-          1. Let _vs_ be SourceText of |UnicodePropertyValue|.
-          1. Let _v_ be ! UnicodeMatchPropertyValue(_p_, _vs_).
-          1. Return the CharSet containing all Unicode code points whose character database definition includes the property _p_ with value _v_.
-        </emu-alg>
-        <p>The production <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Let _s_ be SourceText of |LoneUnicodePropertyNameOrValue|.
-          1. If ! UnicodeMatchPropertyValue(`General_Category`, _s_) is identical to a List of Unicode code points that is the name of a Unicode general category or general category alias listed in the &ldquo;Property value and aliases&rdquo; column of <emu-xref href="#table-unicode-general-category-values"></emu-xref>, then
-            1. Return the CharSet containing all Unicode code points whose character database definition includes the property &ldquo;General_Category&rdquo; with value _s_.
-          1. Let _p_ be ! UnicodeMatchProperty(_s_).
-          1. Assert: _p_ is a binary Unicode property or binary property alias listed in the &ldquo;Property name and aliases&rdquo; column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>.
-          1. Return the CharSet containing all Unicode code points whose character database definition includes the property _p_ with value &ldquo;True&rdquo;.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-characterclass">
         <h1>CharacterClass</h1>
         <p>The production <emu-grammar>CharacterClass :: `[` ClassRanges `]`</emu-grammar> evaluates as follows:</p>
@@ -35755,6 +35620,150 @@ THH:mm:ss.sss
         <emu-note>
           <p>A |ClassAtom| can use any of the escape sequences that are allowed in the rest of the regular expression except for `\\b`, `\\B`, and backreferences. Inside a |CharacterClass|, `\\b` means the backspace character, while `\\B` and backreferences raise errors. Using a backreference inside a |ClassAtom| causes an error.</p>
         </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-atomescape">
+        <h1>AtomEscape</h1>
+        <p>With parameter _direction_.</p>
+        <p>The production <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Evaluate |DecimalEscape| to obtain an integer _n_.
+          1. Assert: _n_ &le; _NcapturingParens_.
+          1. Return ! BackreferenceMatcher(_n_, _direction_).
+        </emu-alg>
+        <p>The production <emu-grammar>AtomEscape :: CharacterClassEscape</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Evaluate |CharacterClassEscape| to obtain a CharSet _A_.
+          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+        </emu-alg>
+        <emu-note>
+          <p>An escape sequence of the form `\\` followed by a non-zero decimal number _n_ matches the result of the _n_<sup>th</sup> set of capturing parentheses (<emu-xref href="#sec-notation"></emu-xref>). It is an error if the regular expression has fewer than _n_ capturing parentheses. If the regular expression has _n_ or more capturing parentheses but the _n_<sup>th</sup> one is *undefined* because it has not captured anything, then the backreference always succeeds.</p>
+        </emu-note>
+        <p>The production <emu-grammar>AtomEscape :: CharacterEscape</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Evaluate |CharacterEscape| to obtain a character _ch_.
+          1. Let _A_ be a one-element CharSet containing the character _ch_.
+          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+        </emu-alg>
+        <p>The production <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |RegExpIdentifierName| which has a CapturingGroupName equal to the CapturingGroupName of the |RegExpIdentifierName| contained in |GroupName|.
+          1. Assert: A unique such |GroupSpecifier| is found.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of the located |GroupSpecifier|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing the located |GroupSpecifier|, including its immediately enclosing |Atom|.
+          1. Return ! BackreferenceMatcher(_parenIndex_, _direction_).
+        </emu-alg>
+
+        <emu-clause id="sec-backreference-matcher" type="abstract operation">
+          <h1>
+            BackreferenceMatcher (
+              _n_: a positive integer,
+              _direction_: 1 or -1,
+            )
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Assert: _n_ &ge; 1.
+            1. Return a new Matcher with parameters (_x_, _c_) that captures _n_ and _direction_ and performs the following steps when called:
+              1. Assert: _x_ is a State.
+              1. Assert: _c_ is a Continuation.
+              1. Let _cap_ be _x_'s _captures_ List.
+              1. Let _s_ be _cap_[_n_].
+              1. If _s_ is *undefined*, return _c_(_x_).
+              1. Let _e_ be _x_'s _endIndex_.
+              1. Let _len_ be the number of elements in _s_.
+              1. Let _f_ be _e_ + _direction_ &times; _len_.
+              1. If _f_ &lt; 0 or _f_ &gt; _InputLength_, return ~failure~.
+              1. Let _g_ be min(_e_, _f_).
+              1. If there exists an integer _i_ between 0 (inclusive) and _len_ (exclusive) such that Canonicalize(_s_[_i_]) is not the same character value as Canonicalize(_Input_[_g_ + _i_]), return ~failure~.
+              1. Let _y_ be the State (_f_, _cap_).
+              1. Return _c_(_y_).
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-decimalescape">
+        <h1>DecimalEscape</h1>
+        <p>The |DecimalEscape| productions evaluate as follows:</p>
+        <emu-grammar>DecimalEscape :: NonZeroDigit DecimalDigits?</emu-grammar>
+        <emu-alg>
+          1. Return the CapturingGroupNumber of this |DecimalEscape|.
+        </emu-alg>
+        <emu-note>
+          <p>If `\\` is followed by a decimal number _n_ whose first digit is not `0`, then the escape sequence is considered to be a backreference. It is an error if _n_ is greater than the total number of left-capturing parentheses in the entire regular expression.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-characterclassescape">
+        <h1>CharacterClassEscape</h1>
+        <p>The production <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the ten-element CharSet containing the characters `0` through `9` inclusive.
+        </emu-alg>
+        <p>The production <emu-grammar>CharacterClassEscape :: `D`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing all characters not in the CharSet returned by <emu-grammar>CharacterClassEscape :: `d`</emu-grammar> .
+        </emu-alg>
+        <p>The production <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing all characters corresponding to a code point on the right-hand side of the |WhiteSpace| or |LineTerminator| productions.
+        </emu-alg>
+        <p>The production <emu-grammar>CharacterClassEscape :: `S`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing all characters not in the CharSet returned by <emu-grammar>CharacterClassEscape :: `s`</emu-grammar> .
+        </emu-alg>
+        <p>The production <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return _WordCharacters_.
+        </emu-alg>
+        <p>The production <emu-grammar>CharacterClassEscape :: `W`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing all characters not in the CharSet returned by <emu-grammar>CharacterClassEscape :: `w`</emu-grammar> .
+        </emu-alg>
+        <p>The production <emu-grammar>CharacterClassEscape :: `p{` UnicodePropertyValueExpression `}`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing all Unicode code points included in the CharSet returned by |UnicodePropertyValueExpression|.
+        </emu-alg>
+        <p>The production <emu-grammar>CharacterClassEscape :: `P{` UnicodePropertyValueExpression `}`</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Return the CharSet containing all Unicode code points not included in the CharSet returned by |UnicodePropertyValueExpression|.
+        </emu-alg>
+        <p>The production <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Let _ps_ be SourceText of |UnicodePropertyName|.
+          1. Let _p_ be ! UnicodeMatchProperty(_ps_).
+          1. Assert: _p_ is a Unicode property name or property alias listed in the &ldquo;Property name and aliases&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
+          1. Let _vs_ be SourceText of |UnicodePropertyValue|.
+          1. Let _v_ be ! UnicodeMatchPropertyValue(_p_, _vs_).
+          1. Return the CharSet containing all Unicode code points whose character database definition includes the property _p_ with value _v_.
+        </emu-alg>
+        <p>The production <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Let _s_ be SourceText of |LoneUnicodePropertyNameOrValue|.
+          1. If ! UnicodeMatchPropertyValue(`General_Category`, _s_) is identical to a List of Unicode code points that is the name of a Unicode general category or general category alias listed in the &ldquo;Property value and aliases&rdquo; column of <emu-xref href="#table-unicode-general-category-values"></emu-xref>, then
+            1. Return the CharSet containing all Unicode code points whose character database definition includes the property &ldquo;General_Category&rdquo; with value _s_.
+          1. Let _p_ be ! UnicodeMatchProperty(_s_).
+          1. Assert: _p_ is a binary Unicode property or binary property alias listed in the &ldquo;Property name and aliases&rdquo; column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>.
+          1. Return the CharSet containing all Unicode code points whose character database definition includes the property _p_ with value &ldquo;True&rdquo;.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-characterescape">
+        <h1>CharacterEscape</h1>
+        <p>The |CharacterEscape| productions evaluate as follows:</p>
+        <emu-grammar>
+          CharacterEscape ::
+            ControlEscape
+            `c` ControlLetter
+            `0` [lookahead &notin; DecimalDigit]
+            HexEscapeSequence
+            RegExpUnicodeEscapeSequence
+            IdentityEscape
+        </emu-grammar>
+        <emu-alg>
+          1. Let _cv_ be the CharacterValue of this |CharacterEscape|.
+          1. Return the character whose character value is _cv_.
+        </emu-alg>
       </emu-clause>
     </emu-clause>
 
@@ -46514,26 +46523,23 @@ THH:mm:ss.sss
     <emu-prodref name="Quantifier"></emu-prodref>
     <emu-prodref name="QuantifierPrefix"></emu-prodref>
     <emu-prodref name="Atom"></emu-prodref>
-    <emu-prodref name="SyntaxCharacter"></emu-prodref>
     <emu-prodref name="PatternCharacter"></emu-prodref>
-    <emu-prodref name="AtomEscape"></emu-prodref>
-    <emu-prodref name="CharacterEscape"></emu-prodref>
-    <emu-prodref name="ControlEscape"></emu-prodref>
-    <emu-prodref name="ControlLetter"></emu-prodref>
+    <emu-prodref name="SyntaxCharacter"></emu-prodref>
     <emu-prodref name="GroupSpecifier"></emu-prodref>
     <emu-prodref name="GroupName"></emu-prodref>
     <emu-prodref name="RegExpIdentifierName"></emu-prodref>
     <emu-prodref name="RegExpIdentifierStart"></emu-prodref>
     <emu-prodref name="RegExpIdentifierPart"></emu-prodref>
-    <emu-prodref name="RegExpUnicodeEscapeSequence"></emu-prodref>
     <emu-prodref name="UnicodeLeadSurrogate"></emu-prodref>
     <emu-prodref name="UnicodeTrailSurrogate"></emu-prodref>
-    <p>Each `\\u` |HexTrailSurrogate| for which the choice of associated `u` |HexLeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |HexLeadSurrogate| that would otherwise have no corresponding `\\u` |HexTrailSurrogate|.</p>
-    <p>&nbsp;</p>
-    <emu-prodref name="HexLeadSurrogate"></emu-prodref>
-    <emu-prodref name="HexTrailSurrogate"></emu-prodref>
-    <emu-prodref name="HexNonSurrogate"></emu-prodref>
-    <emu-prodref name="IdentityEscape"></emu-prodref>
+    <emu-prodref name="CharacterClass"></emu-prodref>
+    <emu-prodref name="ClassRanges"></emu-prodref>
+    <emu-prodref name="NonemptyClassRanges"></emu-prodref>
+    <emu-prodref name="NonemptyClassRangesNoDash"></emu-prodref>
+    <emu-prodref name="ClassAtom"></emu-prodref>
+    <emu-prodref name="ClassAtomNoDash"></emu-prodref>
+    <emu-prodref name="ClassEscape"></emu-prodref>
+    <emu-prodref name="AtomEscape"></emu-prodref>
     <emu-prodref name="DecimalEscape"></emu-prodref>
     <emu-prodref name="CharacterClassEscape"></emu-prodref>
     <emu-prodref name="UnicodePropertyValueExpression"></emu-prodref>
@@ -46544,13 +46550,14 @@ THH:mm:ss.sss
     <emu-prodref name="UnicodePropertyValueCharacters"></emu-prodref>
     <emu-prodref name="UnicodePropertyValueCharacter"></emu-prodref>
     <emu-prodref name="UnicodePropertyNameCharacter"></emu-prodref>
-    <emu-prodref name="CharacterClass"></emu-prodref>
-    <emu-prodref name="ClassRanges"></emu-prodref>
-    <emu-prodref name="NonemptyClassRanges"></emu-prodref>
-    <emu-prodref name="NonemptyClassRangesNoDash"></emu-prodref>
-    <emu-prodref name="ClassAtom"></emu-prodref>
-    <emu-prodref name="ClassAtomNoDash"></emu-prodref>
-    <emu-prodref name="ClassEscape"></emu-prodref>
+    <emu-prodref name="CharacterEscape"></emu-prodref>
+    <emu-prodref name="ControlEscape"></emu-prodref>
+    <emu-prodref name="ControlLetter"></emu-prodref>
+    <emu-prodref name="RegExpUnicodeEscapeSequence"></emu-prodref>
+    <emu-prodref name="HexLeadSurrogate"></emu-prodref>
+    <emu-prodref name="HexTrailSurrogate"></emu-prodref>
+    <emu-prodref name="HexNonSurrogate"></emu-prodref>
+    <emu-prodref name="IdentityEscape"></emu-prodref>
   </emu-annex>
 </emu-annex>
 

--- a/spec.html
+++ b/spec.html
@@ -34293,8 +34293,7 @@ THH:mm:ss.sss
           `\` AtomEscape[?UnicodeMode, ?N]
           [~UnicodeMode] `\` [lookahead == `c`]
           CharacterClass[?UnicodeMode]
-          [+UnicodeMode] `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
-          [~UnicodeMode] `(` Disjunction[?UnicodeMode, ?N] `)`
+          `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[?UnicodeMode, ?N] `)`
           [~UnicodeMode] InvalidBracedQuantifier
           [+UnicodeMode] PatternCharacter
@@ -34319,7 +34318,7 @@ THH:mm:ss.sss
       <emu-grammar type="definition">
         GroupSpecifier[UnicodeMode] ::
           [empty]
-          `?` GroupName[?UnicodeMode]
+          [+UnicodeMode] `?` GroupName[?UnicodeMode]
 
         GroupName[UnicodeMode] ::
           `&lt;` RegExpIdentifierName[?UnicodeMode] `&gt;`
@@ -35097,8 +35096,6 @@ THH:mm:ss.sss
             1. Assert: _c_ is a Continuation.
             1. Return ! RepeatMatcher(_m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_).
         </emu-alg>
-        <p>----</p>
-        <p>In the above algorithm, references to <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> are to be interpreted as meaning <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> or <emu-grammar>Atom ::! `(` Disjunction `)`</emu-grammar> .</p>
         <p>The production <emu-grammar>Term ::! QuantifiableAssertion Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term ::! Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
 
         <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -34292,7 +34292,7 @@ THH:mm:ss.sss
           `.`
           `\` AtomEscape[?UnicodeMode, ?N]
           [~UnicodeMode] `\` [lookahead == `c`]
-          CharacterClass[?UnicodeMode]
+          CharacterClass[?UnicodeMode, ?N]
           `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[?UnicodeMode, ?N] `)`
           [~UnicodeMode] InvalidBracedQuantifier
@@ -34303,9 +34303,9 @@ THH:mm:ss.sss
           `{` DecimalDigits[~Sep] `,` `}`
           `{` DecimalDigits[~Sep] `,` DecimalDigits[~Sep] `}`
 
-        PatternCharacter[U] ::
-          [+U] SourceCharacter but not SyntaxCharacter
-          [~U] SourceCharacter but not one of `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `|`
+        PatternCharacter[UnicodeMode] ::
+          [+UnicodeMode] SourceCharacter but not SyntaxCharacter
+          [~UnicodeMode] SourceCharacter but not one of `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `|`
 
         SyntaxCharacter :: one of
           `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `]` `{` `}` `|`
@@ -34343,27 +34343,27 @@ THH:mm:ss.sss
 
       <h2>Character Classes</h2>
       <emu-grammar type="definition">
-        CharacterClass[UnicodeMode] ::
-          `[` [lookahead != `^`] ClassRanges[?UnicodeMode] `]`
-          `[` `^` ClassRanges[?UnicodeMode] `]`
+        CharacterClass[UnicodeMode, N] ::
+          `[` [lookahead != `^`] ClassRanges[?UnicodeMode, ?N] `]`
+          `[` `^` ClassRanges[?UnicodeMode, ?N] `]`
 
-        ClassRanges[UnicodeMode] ::
+        ClassRanges[UnicodeMode, N] ::
           [empty]
-          NonemptyClassRanges[?UnicodeMode]
+          NonemptyClassRanges[?UnicodeMode, ?N]
 
-        NonemptyClassRanges[UnicodeMode] ::
-          ClassAtom[?UnicodeMode]
-          ClassAtom[?UnicodeMode] NonemptyClassRangesNoDash[?UnicodeMode]
-          ClassAtom[?UnicodeMode] `-` ClassAtom[?UnicodeMode] ClassRanges[?UnicodeMode]
+        NonemptyClassRanges[UnicodeMode, N] ::
+          ClassAtom[?UnicodeMode, ?N]
+          ClassAtom[?UnicodeMode, ?N] NonemptyClassRangesNoDash[?UnicodeMode, ?N]
+          ClassAtom[?UnicodeMode, ?N] `-` ClassAtom[?UnicodeMode, ?N] ClassRanges[?UnicodeMode, ?N]
 
-        NonemptyClassRangesNoDash[UnicodeMode] ::
-          ClassAtom[?UnicodeMode]
-          ClassAtomNoDash[?UnicodeMode] NonemptyClassRangesNoDash[?UnicodeMode]
-          ClassAtomNoDash[?UnicodeMode] `-` ClassAtom[?UnicodeMode] ClassRanges[?UnicodeMode]
+        NonemptyClassRangesNoDash[UnicodeMode, N] ::
+          ClassAtom[?UnicodeMode, ?N]
+          ClassAtomNoDash[?UnicodeMode, ?N] NonemptyClassRangesNoDash[?UnicodeMode, ?N]
+          ClassAtomNoDash[?UnicodeMode, ?N] `-` ClassAtom[?UnicodeMode, ?N] ClassRanges[?UnicodeMode, ?N]
 
-        ClassAtom[UnicodeMode] ::
+        ClassAtom[UnicodeMode, N] ::
           `-`
-          ClassAtomNoDash[?UnicodeMode]
+          ClassAtomNoDash[?UnicodeMode, ?N]
 
         ClassAtomNoDash[UnicodeMode, N] ::!
           SourceCharacter but not one of `\` or `]` or `-`

--- a/spec.html
+++ b/spec.html
@@ -34261,7 +34261,7 @@ THH:mm:ss.sss
           [+UnicodeMode] Assertion[+UnicodeMode, ?N]
           [+UnicodeMode] Atom[+UnicodeMode, ?N] Quantifier
           [+UnicodeMode] Atom[+UnicodeMode, ?N]
-          [~UnicodeMode] QuantifiableAssertion[?N] Quantifier
+          [~UnicodeMode] QuantifiableAssertion[~UnicodeMode, ?N] Quantifier
           [~UnicodeMode] Assertion[~UnicodeMode, ?N]
           [~UnicodeMode] ExtendedAtom[?N] Quantifier
           [~UnicodeMode] ExtendedAtom[?N]
@@ -34271,15 +34271,13 @@ THH:mm:ss.sss
           `$`
           `\` `b`
           `\` `B`
-          [+UnicodeMode] `(` `?` `=` Disjunction[+UnicodeMode, ?N] `)`
-          [+UnicodeMode] `(` `?` `!` Disjunction[+UnicodeMode, ?N] `)`
-          [~UnicodeMode] QuantifiableAssertion[?N]
+          QuantifiableAssertion[?UnicodeMode, ?N]
           `(` `?` `&lt;=` Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `&lt;!` Disjunction[?UnicodeMode, ?N] `)`
 
-        QuantifiableAssertion[N] ::
-          `(` `?` `=` Disjunction[~UnicodeMode, ?N] `)`
-          `(` `?` `!` Disjunction[~UnicodeMode, ?N] `)`
+        QuantifiableAssertion[UnicodeMode, N] ::
+          `(` `?` `=` Disjunction[?UnicodeMode, ?N] `)`
+          `(` `?` `!` Disjunction[?UnicodeMode, ?N] `)`
 
         Quantifier ::
           QuantifierPrefix
@@ -35240,7 +35238,7 @@ THH:mm:ss.sss
             1. If _a_ is *true* and _b_ is *true*, or if _a_ is *false* and _b_ is *false*, return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
-        <p>The production <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>QuantifiableAssertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
           1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
@@ -35257,7 +35255,7 @@ THH:mm:ss.sss
             1. Let _z_ be the State (_xe_, _cap_).
             1. Return _c_(_z_).
         </emu-alg>
-        <p>The production <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>QuantifiableAssertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
           1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
@@ -35305,8 +35303,6 @@ THH:mm:ss.sss
             1. If _r_ is not ~failure~, return ~failure~.
             1. Return _c_(_x_).
         </emu-alg>
-        <p>----</p>
-        <p>The evaluation rules for the <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
 
         <emu-clause id="sec-runtime-semantics-iswordchar-abstract-operation" type="abstract operation">
           <h1>

--- a/spec.html
+++ b/spec.html
@@ -34263,8 +34263,8 @@ THH:mm:ss.sss
           [+UnicodeMode] Atom[+UnicodeMode, ?N]
           [~UnicodeMode] QuantifiableAssertion[~UnicodeMode, ?N] Quantifier
           [~UnicodeMode] Assertion[~UnicodeMode, ?N]
-          [~UnicodeMode] ExtendedAtom[?N] Quantifier
-          [~UnicodeMode] ExtendedAtom[?N]
+          [~UnicodeMode] Atom[~UnicodeMode, ?N] Quantifier
+          [~UnicodeMode] Atom[~UnicodeMode, ?N]
 
         Assertion[UnicodeMode, N] ::
           `^`
@@ -34291,23 +34291,17 @@ THH:mm:ss.sss
           `{` DecimalDigits[~Sep] `,` `}`
           `{` DecimalDigits[~Sep] `,` DecimalDigits[~Sep] `}`
 
-        ExtendedAtom[N] ::!
-          `.`
-          `\` AtomEscape[~UnicodeMode, ?N]
-          `\` [lookahead == `c`]
-          CharacterClass[~UnicodeMode]
-          `(` Disjunction[~UnicodeMode, ?N] `)`
-          `(` `?` `:` Disjunction[~UnicodeMode, ?N] `)`
-          InvalidBracedQuantifier
-          ExtendedPatternCharacter
-
-        Atom[UnicodeMode, N] ::
-          PatternCharacter
+        Atom[UnicodeMode, N] ::!
           `.`
           `\` AtomEscape[?UnicodeMode, ?N]
+          [~UnicodeMode] `\` [lookahead == `c`]
           CharacterClass[?UnicodeMode]
-          `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
+          [+UnicodeMode] `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
+          [~UnicodeMode] `(` Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[?UnicodeMode, ?N] `)`
+          [~UnicodeMode] InvalidBracedQuantifier
+          [+UnicodeMode] PatternCharacter
+          [~UnicodeMode] ExtendedPatternCharacter
 
         InvalidBracedQuantifier ::
           `{` DecimalDigits[~Sep] `}`
@@ -34493,7 +34487,7 @@ THH:mm:ss.sss
         <emu-grammar>
           Term ::! QuantifiableAssertion Quantifier
 
-          ExtendedAtom ::! `\` [lookahead == `c`]
+          Atom ::! `\` [lookahead == `c`]
 
           ClassAtomNoDash ::! `\` [lookahead == `c`]
 
@@ -34524,7 +34518,7 @@ THH:mm:ss.sss
             It is a Syntax Error if the MV of the first |DecimalDigits| is larger than the MV of the second |DecimalDigits|.
           </li>
         </ul>
-        <emu-grammar>ExtendedAtom ::! InvalidBracedQuantifier</emu-grammar>
+        <emu-grammar>Atom ::! InvalidBracedQuantifier</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if any source text matches this rule.
@@ -34950,7 +34944,7 @@ THH:mm:ss.sss
             _InputLength_ is the number of characters in _Input_.
           </li>
           <li>
-            _NcapturingParens_ is the total number of left-capturing parentheses (i.e. the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes) in the pattern. A left-capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> production.
+            _NcapturingParens_ is the total number of left-capturing parentheses (i.e. the total number of <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes) in the pattern. A left-capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> production.
           </li>
           <li>
             _DotAll_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains *"s"* and otherwise is *false*.
@@ -35099,18 +35093,16 @@ THH:mm:ss.sss
           1. Evaluate |Atom| with argument _direction_ to obtain a Matcher _m_.
           1. Evaluate |Quantifier| to obtain the three results: a non-negative integer _min_, a non-negative integer (or +&infin;) _max_, and Boolean _greedy_.
           1. Assert: _min_ &le; _max_.
-          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Term|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Term|.
-          1. Let _parenCount_ be the number of left-capturing parentheses in |Atom|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes enclosed by |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Term|. This is the total number of <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Term|.
+          1. Let _parenCount_ be the number of left-capturing parentheses in |Atom|. This is the total number of <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes enclosed by |Atom|.
           1. Return a new Matcher with parameters (_x_, _c_) that captures _m_, _min_, _max_, _greedy_, _parenIndex_, and _parenCount_ and performs the following steps when called:
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
             1. Return ! RepeatMatcher(_m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_).
         </emu-alg>
         <p>----</p>
-        <p>In the above algorithm, references to <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> are to be interpreted as meaning <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> or <emu-grammar>ExtendedAtom ::! `(` Disjunction `)`</emu-grammar> .</p>
+        <p>In the above algorithm, references to <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> are to be interpreted as meaning <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> or <emu-grammar>Atom ::! `(` Disjunction `)`</emu-grammar> .</p>
         <p>The production <emu-grammar>Term ::! QuantifiableAssertion Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term ::! Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
-        <p>The production <emu-grammar>Term ::! ExtendedAtom Quantifier</emu-grammar> evaluates the same as the production <emu-grammar>Term ::! Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
-        <p>The production <emu-grammar>Term ::! ExtendedAtom</emu-grammar> evaluates the same as the production <emu-grammar>Term ::! Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
 
         <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" type="abstract operation">
           <h1>
@@ -35365,37 +35357,31 @@ THH:mm:ss.sss
       <emu-clause id="sec-atom">
         <h1>Atom</h1>
         <p>With parameter _direction_.</p>
-        <p>The production <emu-grammar>Atom :: PatternCharacter</emu-grammar> evaluates as follows:</p>
-        <emu-alg>
-          1. Let _ch_ be the character matched by |PatternCharacter|.
-          1. Let _A_ be a one-element CharSet containing the character _ch_.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
-        </emu-alg>
-        <p>The production <emu-grammar>Atom :: `.`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom ::! `.`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _A_ be the CharSet of all characters.
           1. If _DotAll_ is not *true*, then
             1. Remove from _A_ all characters corresponding to a code point on the right-hand side of the |LineTerminator| production.
           1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: `\` AtomEscape</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom ::! `\` AtomEscape</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |AtomEscape| with argument _direction_.
         </emu-alg>
-        <p>The production <emu-grammar>ExtendedAtom ::! `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom ::! `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
           1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: CharacterClass</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom ::! CharacterClass</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |CharacterClass| to obtain a CharSet _A_ and a Boolean _invert_.
           1. Return ! CharacterSetMatcher(_A_, _invert_, _direction_).
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Disjunction| with argument _direction_ to obtain a Matcher _m_.
-          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Atom|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Atom|. This is the total number of <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Atom|.
           1. Return a new Matcher with parameters (_x_, _c_) that captures _direction_, _m_, and _parenIndex_ and performs the following steps when called:
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
@@ -35416,18 +35402,22 @@ THH:mm:ss.sss
               1. Return _c_(_z_).
             1. Return _m_(_x_, _d_).
         </emu-alg>
-        <p>The production <emu-grammar>Atom :: `(` `?` `:` Disjunction `)`</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom ::! `(` `?` `:` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Return the Matcher that is the result of evaluating |Disjunction| with argument _direction_.
         </emu-alg>
-        <p>The production <emu-grammar>ExtendedAtom ::! ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
+        <p>The production <emu-grammar>Atom ::! ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character represented by |ExtendedPatternCharacter|.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
           1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
-        <p>----</p>
-        <p>The evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|.</p>
+        <p>The production <emu-grammar>Atom ::! PatternCharacter</emu-grammar> evaluates as follows:</p>
+        <emu-alg>
+          1. Let _ch_ be the character matched by |PatternCharacter|.
+          1. Let _A_ be a one-element CharSet containing the character _ch_.
+          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+        </emu-alg>
 
         <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" type="abstract operation">
           <h1>
@@ -35757,7 +35747,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |RegExpIdentifierName| which has a CapturingGroupName equal to the CapturingGroupName of the |RegExpIdentifierName| contained in |GroupName|.
           1. Assert: A unique such |GroupSpecifier| is found.
-          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of the located |GroupSpecifier|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing the located |GroupSpecifier|, including its immediately enclosing |Atom|.
+          1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of the located |GroupSpecifier|. This is the total number of <emu-grammar>Atom ::! `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing the located |GroupSpecifier|, including its immediately enclosing |Atom|.
           1. Return ! BackreferenceMatcher(_parenIndex_, _direction_).
         </emu-alg>
 
@@ -46632,7 +46622,6 @@ THH:mm:ss.sss
     <emu-prodref name="QuantifiableAssertion"></emu-prodref>
     <emu-prodref name="Quantifier"></emu-prodref>
     <emu-prodref name="QuantifierPrefix"></emu-prodref>
-    <emu-prodref name="ExtendedAtom"></emu-prodref>
     <emu-prodref name="Atom"></emu-prodref>
     <emu-prodref name="InvalidBracedQuantifier"></emu-prodref>
     <emu-prodref name="ExtendedPatternCharacter"></emu-prodref>


### PR DESCRIPTION
This PR was originally created to make all of B.1 "Additional Syntax" normative (incorporating it into the body of the spec, as part of the reform described in PR #1595).

But then I split off PR #1867 to handle:
- B.1.1 "Numeric Literals" and
- B.1.2 "String Literals"

So now this PR only handles:
- B.1.3 "HTML-like comments" and
- B.1.4 "Regular Expressions Patterns"

Notes:
* I've added "allowed but deprecated" notes. (should maybe be phrased in terms of "legacy")
* I dropped the entries in 16.2 "Forbidden Extensions", because the syntax is no longer an extension (although it's still disallowed in strict mode code, of course). [Later: See #1867 for some discussion of this topic.]
* I left placeholder summaries in B.1.* to keep section numbers in sync, and in case a tombstone is wanted. [Later: Not wanted in #1867, so probably not wanted here either.]
* It's possible that rebasing has done some damage, so I'll have to re-check everything if this PR goes forward.
