### PR TITLE
Editorial: Simplify AssignmentTargetType values.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12244,7 +12244,7 @@
       <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
-        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is *"eval"* or *"arguments"*, return ~strict~.
+        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is *"eval"* or *"arguments"*, return ~invalid~.
         1. Return ~simple~.
       </emu-alg>
       <emu-grammar>IdentifierReference : `yield`</emu-grammar>
@@ -15172,7 +15172,7 @@
             It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
           </li>
           <li>
-            It is a Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType(|LeftHandSideExpression|) is not ~simple~.
+            It is a Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
       </emu-clause>


### PR DESCRIPTION
Resolves #1643.

As expressed there, boolean seems best if `nonsimple` is the best enum value we can come up with. I've also taken the opportunity to simplify the name to `IsSimpleAssignmentTarget` since I'm not sure that "valid" really serves to clarify anything (but feel free to disagree).