### PR TITLE
Normative: Add two missing Early Error rules for productions covering an AssignmentPattern

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15397,18 +15397,25 @@
     <emu-clause id="sec-assignment-operators-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
+      <p>If |LeftHandSideExpression| is an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
       <ul>
         <li>
-          It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and |LeftHandSideExpression| is not covering an |AssignmentPattern|.
+          It is a Syntax Error if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
         </li>
         <li>
-          It is an early Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          All Early Error rules for |AssignmentPattern| and its derived productions also apply to the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
+        </li>
+      </ul>
+      <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
+      <ul>
+        <li>
+          It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <ul>
         <li>
-          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
     </emu-clause>
@@ -15550,12 +15557,19 @@
           </li>
         </ul>
         <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
+        <p>If |LeftHandSideExpression| is an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
         <ul>
           <li>
-            It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
+            It is a Syntax Error if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
           </li>
           <li>
-            It is a Syntax Error if |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral| and AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            All Early Error rules for |AssignmentPattern| and its derived productions also apply to the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
+          </li>
+        </ul>
+        <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
+        <ul>
+          <li>
+            It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
       </emu-clause>
@@ -17723,23 +17737,21 @@
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
         </emu-grammar>
+        <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
         <ul>
           <li>
-            It is a Syntax Error if |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
+            It is a Syntax Error if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
+          </li>
+          <li>
+            All Early Error rules for |AssignmentPattern| and its derived productions also apply to the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
           </li>
         </ul>
-        <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral| and if |LeftHandSideExpression| is covering an |AssignmentPattern| then the following rules are not applied. Instead, the Early Error rules for |AssignmentPattern| are used.</p>
+        <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
         <ul>
           <li>
             It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
-          <li>
-            It is a Syntax Error if the |LeftHandSideExpression| is <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar> and |Expression| derives a phrase that would produce a Syntax Error according to these rules if that phrase were substituted for |LeftHandSideExpression|. This rule is recursively applied.
-          </li>
         </ul>
-        <emu-note>
-          <p>The last rule means that the other rules are applied even if parentheses surround |Expression|.</p>
-        </emu-note>
         <emu-grammar>
           IterationStatement :
             `for` `(` ForDeclaration `in` Expression `)` Statement


### PR DESCRIPTION
Refactor and correct Early Error rules for LeftHandSideExpression productions potentially covering an AssignmentPattern:

* Add two missing early error rules  “All Early Error rules for |AssignmentPattern| ... are applied to the |AssignmentPattern| covered by ...”

* Removes an early error rule “... derives a phrase that would produce a Syntax Error ...”, because it is implied by the previous rule.