### PR TITLE
Editorial: Remove assertion in InitializeBinding of Object Environment Record

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6535,15 +6535,13 @@
 
         <emu-clause id="sec-object-environment-records-initializebinding-n-v">
           <h1>InitializeBinding ( _N_, _V_ )</h1>
-          <p>The concrete Environment Record method InitializeBinding for object Environment Records is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</p>
+          <p>The concrete Environment Record method InitializeBinding for object Environment Records is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_.</p>
           <emu-alg>
             1. Let _envRec_ be the object Environment Record for which the method was invoked.
-            1. Assert: _envRec_ must have an uninitialized binding for _N_.
-            1. <emu-not-ref>Record</emu-not-ref> that the binding for _N_ in _envRec_ has been initialized.
             1. Return ? _envRec_.SetMutableBinding(_N_, _V_, *false*).
           </emu-alg>
           <emu-note>
-            <p>In this specification, all uses of CreateMutableBinding for object Environment Records are immediately followed by a call to InitializeBinding for the same name. Hence, implementations do not need to explicitly track the initialization state of individual object Environment Record bindings.</p>
+            <p>In this specification, all uses of CreateMutableBinding for object Environment Records are immediately followed by a call to InitializeBinding for the same name. Hence, this specification does not explicitly track the initialization state of bindings in object Environment Records.</p>
           </emu-note>
         </emu-clause>
 
@@ -7145,7 +7143,6 @@
             1. Else,
               1. Let _desc_ be the PropertyDescriptor { [[Value]]: _V_ }.
             1. Perform ? DefinePropertyOrThrow(_globalObject_, _N_, _desc_).
-            1. [id="step-createglobalfunctionbinding-record-initialized"] <emu-not-ref>Record</emu-not-ref> that the binding for _N_ in _ObjRec_ has been initialized.
             1. [id="step-createglobalfunctionbinding-set"] Perform ? Set(_globalObject_, _N_, _V_, *false*).
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
             1. If _varDeclaredNames_ does not contain _N_, then
@@ -7153,7 +7150,7 @@
             1. Return NormalCompletion(~empty~).
           </emu-alg>
           <emu-note>
-            <p>Global function declarations are always represented as own properties of the global object. If possible, an existing own property is reconfigured to have a standard set of attribute values. Steps <emu-xref href="#step-createglobalfunctionbinding-record-initialized"></emu-xref>-<emu-xref href="#step-createglobalfunctionbinding-set"></emu-xref> are equivalent to what calling the InitializeBinding concrete method would do and if _globalObject_ is a Proxy will produce the same sequence of Proxy trap calls.</p>
+            <p>Global function declarations are always represented as own properties of the global object. If possible, an existing own property is reconfigured to have a standard set of attribute values. Step <emu-xref href="#step-createglobalfunctionbinding-set"></emu-xref> is equivalent to what calling the InitializeBinding concrete method would do and if _globalObject_ is a Proxy will produce the same sequence of Proxy trap calls.</p>
           </emu-note>
         </emu-clause>
       </emu-clause>


### PR DESCRIPTION
In declarative environment records, CreateMutableBinding and CreateImmutableBinding creates uninitialized bindings. Unlike declarative environment records, in object environment records, such internal methods does not create uninitialized bindings. They just creates a new property for the binding object with `undefined` value and there is no mention about uninitialized bindings. However, in InitializeBinding of object environment records, it requires uninitialized bindings. I think that it is better to remove the following highlighted assertion.

<img width="832" alt="PastedGraphic-4" src="https://user-images.githubusercontent.com/6766660/62750968-e9b30980-ba9c-11e9-8ae2-0ab45dbcadbe.png">


<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
