### PR TITLE
Editorial: Resolved ambiguous VarScopedDeclarations for IterationStatement

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16689,7 +16689,6 @@
         <emu-grammar>
           IterationStatement :
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.


### PR DESCRIPTION
I think that the following two highlighted lines are duplicated. I think the first one is not correct because VarScopedDeclarations collects all declarations with "var". Thus, I propose to remove the first one in the spec.

<img width="725" alt="PastedGraphic-1" src="https://user-images.githubusercontent.com/6766660/62751084-6f36b980-ba9d-11e9-9c69-172cf3db97fe.png">

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
