### PR TITLE
Editorial: Added more missing cases for ExpectedArgumentCount for FormalParameters and FormalParameterList

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18313,17 +18313,28 @@
     <emu-clause id="sec-function-definitions-static-semantics-expectedargumentcount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-grammar>FormalParameters :
+        [empty]
+        FunctionRestParameter
+      </emu-grammar>
       <emu-alg>
         1. Return 0.
       </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-grammar>FormalParameters :
+        FormalParameterList `,`
+        FormalParameterList `,` FunctionRestParameter
+      </emu-grammar>
       <emu-alg>
         1. Return ExpectedArgumentCount of |FormalParameterList|.
       </emu-alg>
       <emu-note>
         <p>The ExpectedArgumentCount of a |FormalParameterList| is the number of |FormalParameters| to the left of either the rest parameter or the first |FormalParameter| with an Initializer. A |FormalParameter| without an initializer is allowed after the first parameter with an initializer but such parameters are considered to be optional with *undefined* as their default value.</p>
       </emu-note>
+      <emu-grammar>FormalParameterList : FormalParameter</emu-grammar>
+      <emu-alg>
+        1. If HasInitializer of |FormalParameter| is *true*, return 0.
+        1. Return 1.
+      </emu-alg>
       <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. Let _count_ be ExpectedArgumentCount of |FormalParameterList|.


### PR DESCRIPTION
FormalParameterList is either 1) “FormalParamer" or 2) "FormalParameterList , FormalParameter”.
However, for ExpectedArgumentCount, only "FormalParameterList , FormalParameter” is defined
but “FormalParameter” is not defined. According to the NOTE, it might be 0 if it has initializer.
Otherwise, it might be 0. I think it also should be formally defined like other semantics.

In a similar way, there is no semantics of ExpectedArgumentCount for "FormalParameters : FormalRestParameter” and “FormalParameters : FormalParameterList , “. Thus, I changed the spec to cover all cases I mentioned above.

<img width="839" alt="PastedGraphic-2" src="https://user-images.githubusercontent.com/6766660/62751330-44993080-ba9e-11e9-836e-ed2b1705ffdc.png">

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
