### PR TITLE
Editorial: Added a missing case of IsFunctionDefinition for FunctionExpression

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18382,7 +18382,10 @@
     <emu-clause id="sec-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>
+        FunctionExpression :
+          `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+      </emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>


### PR DESCRIPTION
According to other rules (e.g. 13.7.4.2 Static Semantics: ContainsDuplicateLabels),
the “opt” subscript is attached to represent both absent and present cases for optional terms.
Thus, the following case does not represent the case when BindingIdentifier is absent.
Then, there is no definition of IsFunctionDefinition for “function ( FormalParameters ) { FunctionBody }” case. I think that the “opt” subscript should be attached into BindingIdentifier to resolve misunderstandings.

Note) I think that there is an error in rewriting system in specification for single line grammar. The problem is resolved when I changed into the single line grammar into multi-line grammar.

<img width="733" alt="PastedGraphic-3" src="https://user-images.githubusercontent.com/6766660/62751450-abb6e500-ba9e-11e9-89ff-6fe9fadca91a.png">

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
