### PR TITLE
Editorial: Fixed error for already unwrapped completion records

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31759,7 +31759,6 @@ THH:mm:ss.sss
               1. If _mapping_ is *true*, then
                 1. Let _mappedValue_ be Call(_mapfn_, _T_, &laquo; _nextValue_, _k_ &raquo;).
                 1. If _mappedValue_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _mappedValue_).
-                1. Set _mappedValue_ to _mappedValue_.[[Value]].
               1. Else, let _mappedValue_ be _nextValue_.
               1. Let _defineStatus_ be CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
               1. If _defineStatus_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _defineStatus_).
@@ -34285,7 +34284,7 @@ THH:mm:ss.sss
             1. If _k_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _k_).
             1. Let _v_ be Get(_nextItem_, `"1"`).
             1. If _v_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _v_).
-            1. Let _status_ be Call(_adder_, _target_, &laquo; _k_.[[Value]], _v_.[[Value]] &raquo;).
+            1. Let _status_ be Call(_adder_, _target_, &laquo; _k_, _v_ &raquo;).
             1. If _status_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _status_).
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
The Get and Call function always return abrupt completion or non-completion values
because the ReturnIfAbrupt(?) is applied right before return the result in Get and Call.
Thus, in the following cases, _mappedValue_ in Array.from and _k_ and _v_ in AddEntriesFromIterable are not completion but just non-completion values because the abrupt completion cases are already filtered previous conditions. Thus, I suggest to remove access of [[Value]] for _mappedValue_, _k_, and _v_.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
