### PR TITLE
Editorial: Remove redundant definitions of ComputedPropertyContains.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20854,14 +20854,6 @@
         1. If _inList_ is *true*, return *true*.
         1. Return the result of ComputedPropertyContains for |ClassElement| with argument _symbol_.
       </emu-alg>
-      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
-      <emu-alg>
-        1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
-      </emu-alg>
-      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
-      <emu-alg>
-        1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
-      </emu-alg>
       <emu-grammar>ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.


### PR DESCRIPTION
These are already covered by the chain productions rule.