### PR TITLE
Normative: Prevent DFS invariants from being broken

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23162,6 +23162,7 @@
           <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
 
           <emu-alg>
+            1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
             1. Let _module_ be this Cyclic Module Record.
             1. Assert: _module_.[[Status]] is ~linked~ or ~evaluated~.
             1. Let _stack_ be a new empty List.


### PR DESCRIPTION
An implementation of HostImportModuleDynamically, could, in theory, call
Evaluate() in the same tick as the call to HostImportModuleDynamically.
If that call to HostImportModuleDynamically was the direct result of
another call to Evaluate(), this may eagerly evaluate a module that
is already queued to be run at a later time.

cc @guybedford 
