### PR TITLE
Editorial: Add missing _direction_ parameter in extended regexp pattern evaluate semantics in annex b

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42014,17 +42014,17 @@ THH:mm:ss.sss
 
         <p>Assertion (<emu-xref href="#sec-assertion"></emu-xref>) evaluation rules for the <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
 
-        <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules are also added:</p>
+        <p>Atom (<emu-xref href="#sec-atom"></emu-xref>) evaluation rules for the |Atom| productions except for <emu-grammar>Atom :: PatternCharacter</emu-grammar> are also used for the |ExtendedAtom| productions, but with |ExtendedAtom| substituted for |Atom|. The following evaluation rules, with parameter _direction_, are also added:</p>
         <p>The production <emu-grammar>ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
-          1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
+          1. Call CharacterSetMatcher(_A_, *false*, _direction_) and return its Matcher result.
         </emu-alg>
         <p>The production <emu-grammar>ExtendedAtom :: ExtendedPatternCharacter</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _ch_ be the character represented by |ExtendedPatternCharacter|.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
-          1. Call CharacterSetMatcher(_A_, *false*) and return its Matcher result.
+          1. Call CharacterSetMatcher(_A_, *false*, _direction_) and return its Matcher result.
         </emu-alg>
 
         <p>CharacterEscape (<emu-xref href="#sec-characterescape"></emu-xref>) includes the following additional evaluation rule:</p>


### PR DESCRIPTION
Simple bugfix. When lookbehind assertions were introduced (PR #1029), a _direction_ parameter was added in the evaluate semantics of some productions of the RegExp grammar. Additional productions found in Annex B were overlooked.

Fixes #1674.