### PR TITLE
Editorial: use `! CreateDataPropertyOrThrow` instead of `CreateDataProperty` and an assert

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4255,18 +4255,17 @@
           1. Let _obj_ be ObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. If _Desc_ has a [[Value]] field, then
-            1. Perform CreateDataProperty(_obj_, `"value"`, _Desc_.[[Value]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"value"`, _Desc_.[[Value]]).
           1. If _Desc_ has a [[Writable]] field, then
-            1. Perform CreateDataProperty(_obj_, `"writable"`, _Desc_.[[Writable]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"writable"`, _Desc_.[[Writable]]).
           1. If _Desc_ has a [[Get]] field, then
-            1. Perform CreateDataProperty(_obj_, `"get"`, _Desc_.[[Get]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"get"`, _Desc_.[[Get]]).
           1. If _Desc_ has a [[Set]] field, then
-            1. Perform CreateDataProperty(_obj_, `"set"`, _Desc_.[[Set]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"set"`, _Desc_.[[Set]]).
           1. If _Desc_ has an [[Enumerable]] field, then
-            1. Perform CreateDataProperty(_obj_, `"enumerable"`, _Desc_.[[Enumerable]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"enumerable"`, _Desc_.[[Enumerable]]).
           1. If _Desc_ has a [[Configurable]] field, then
-            1. Perform CreateDataProperty(_obj_, `"configurable"`, _Desc_.[[Configurable]]).
-          1. Assert: All of the above CreateDataProperty operations return *true*.
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"configurable"`, _Desc_.[[Configurable]]).
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -5761,8 +5760,7 @@
         1. Let _array_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each element _e_ of _elements_, do
-          1. Let _status_ be CreateDataProperty(_array_, ! ToString(_n_), _e_).
-          1. Assert: _status_ is *true*.
+          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(_n_), _e_).
           1. Set _n_ to _n_ + 1.
         1. Return _array_.
       </emu-alg>
@@ -5911,7 +5909,7 @@
             1. Let _desc_ be ? _from_.[[GetOwnProperty]](_nextKey_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
               1. Let _propValue_ be ? Get(_from_, _nextKey_).
-              1. Perform ! CreateDataProperty(_target_, _nextKey_, _propValue_).
+              1. Perform ! CreateDataPropertyOrThrow(_target_, _nextKey_, _propValue_).
         1. Return _target_.
       </emu-alg>
       <emu-note>
@@ -6030,8 +6028,8 @@
       <emu-alg>
         1. Assert: Type(_done_) is Boolean.
         1. Let _obj_ be ObjectCreate(%Object.prototype%).
-        1. Perform CreateDataProperty(_obj_, `"value"`, _value_).
-        1. Perform CreateDataProperty(_obj_, `"done"`, _done_).
+        1. Perform ! CreateDataPropertyOrThrow(_obj_, `"value"`, _value_).
+        1. Perform ! CreateDataPropertyOrThrow(_obj_, `"done"`, _done_).
         1. Return _obj_.
       </emu-alg>
     </emu-clause>
@@ -9257,7 +9255,7 @@
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
             1. Let _val_ be _argumentsList_[_index_].
-            1. Perform CreateDataProperty(_obj_, ! ToString(_index_), _val_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(_index_), _val_).
             1. Set _index_ to _index_ + 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, `"callee"`, PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
@@ -9287,9 +9285,9 @@
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
             1. Let _val_ be _argumentsList_[_index_].
-            1. Perform CreateDataProperty(_obj_, ! ToString(_index_), _val_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(_index_), _val_).
             1. Set _index_ to _index_ + 1.
-          1. Perform DefinePropertyOrThrow(_obj_, `"length"`, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, `"length"`, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _mappedNames_ be a new empty List.
           1. Let _index_ be _numberOfParameters_ - 1.
           1. Repeat, while _index_ &ge; 0,
@@ -12699,11 +12697,11 @@
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _nextIndex_.
             1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Let _status_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(_nextIndex_), _nextValue_).
+            1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(_nextIndex_), _nextValue_).
             1. Set _nextIndex_ to _nextIndex_ + 1.
         </emu-alg>
         <emu-note>
-          <p>CreateDataProperty is used to ensure that own properties are defined for the array even if the standard built-in Array prototype object has been modified in a manner that would preclude the creation of new own properties using [[Set]].</p>
+          <p>CreateDataPropertyOrThrow is used to ensure that own properties are defined for the array even if the standard built-in Array prototype object has been modified in a manner that would preclude the creation of new own properties using [[Set]].</p>
         </emu-note>
       </emu-clause>
 
@@ -15464,8 +15462,7 @@
               1. Let _nextValue_ be IteratorValue(_next_).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
-              1. Let _status_ be CreateDataProperty(_A_, ! ToString(_n_), _nextValue_).
-              1. Assert: _status_ is *true*.
+              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _nextValue_).
               1. Set _n_ to _n_ + 1.
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Return ? PutValue(_lref_, _A_).
@@ -16764,8 +16761,7 @@
             1. Let _nextValue_ be IteratorValue(_next_).
             1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_nextValue_).
-            1. Let _status_ be CreateDataProperty(_A_, ! ToString(_n_), _nextValue_).
-            1. Assert: _status_ is *true*.
+            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _nextValue_).
             1. Set _n_ to _n_ + 1.
         </emu-alg>
         <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
@@ -16783,8 +16779,7 @@
             1. Let _nextValue_ be IteratorValue(_next_).
             1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_nextValue_).
-            1. Let _status_ be CreateDataProperty(_A_, ! ToString(_n_), _nextValue_).
-            1. Assert: _status_ is *true*.
+            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _nextValue_).
             1. Set _n_ to _n_ + 1.
         </emu-alg>
       </emu-clause>
@@ -25485,7 +25480,7 @@
           1. For each element _key_ of _ownKeys_ in List order, do
             1. Let _desc_ be ? _obj_.[[GetOwnProperty]](_key_).
             1. Let _descriptor_ be ! FromPropertyDescriptor(_desc_).
-            1. If _descriptor_ is not *undefined*, perform ! CreateDataProperty(_descriptors_, _key_, _descriptor_).
+            1. If _descriptor_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_descriptors_, _key_, _descriptor_).
           1. Return _descriptors_.
         </emu-alg>
       </emu-clause>
@@ -30055,12 +30050,12 @@ THH:mm:ss.sss
           1. Let _R_ be ? ToString(_separator_).
           1. If _lim_ = 0, return _A_.
           1. If _separator_ is *undefined*, then
-            1. Perform ! CreateDataProperty(_A_, `"0"`, _S_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, `"0"`, _S_).
             1. Return _A_.
           1. If _s_ = 0, then
             1. Let _z_ be SplitMatch(_S_, 0, _R_).
             1. If _z_ is not *false*, return _A_.
-            1. Perform ! CreateDataProperty(_A_, `"0"`, _S_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, `"0"`, _S_).
             1. Return _A_.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &ne; _s_
@@ -30071,13 +30066,13 @@ THH:mm:ss.sss
               1. If _e_ = _p_, set _q_ to _q_ + 1.
               1. Else,
                 1. Let _T_ be the String value equal to the substring of _S_ consisting of the code units at indices _p_ (inclusive) through _q_ (exclusive).
-                1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
+                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
                 1. Set _lengthA_ to _lengthA_ + 1.
                 1. If _lengthA_ = _lim_, return _A_.
                 1. Set _p_ to _e_.
                 1. Set _q_ to _p_.
           1. Let _T_ be the String value equal to the substring of _S_ consisting of the code units at indices _p_ (inclusive) through _s_ (exclusive).
-          1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -32211,15 +32206,15 @@ THH:mm:ss.sss
             1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
             1. Let _A_ be ! ArrayCreate(_n_ + 1).
             1. Assert: The value of _A_'s `"length"` property is _n_ + 1.
-            1. Perform ! CreateDataProperty(_A_, `"index"`, _lastIndex_).
-            1. Perform ! CreateDataProperty(_A_, `"input"`, _S_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, `"index"`, _lastIndex_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, `"input"`, _S_).
             1. Let _matchedSubstr_ be the matched substring (i.e. the portion of _S_ between offset _lastIndex_ inclusive and offset _e_ exclusive).
-            1. Perform ! CreateDataProperty(_A_, `"0"`, _matchedSubstr_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, `"0"`, _matchedSubstr_).
             1. If _R_ contains any |GroupName|, then
               1. Let _groups_ be ObjectCreate(*null*).
             1. Else,
               1. Let _groups_ be *undefined*.
-            1. Perform ! CreateDataProperty(_A_, `"groups"`, _groups_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, `"groups"`, _groups_).
             1. For each integer _i_ such that _i_ &gt; 0 and _i_ &le; _n_, do
               1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
@@ -32230,10 +32225,10 @@ THH:mm:ss.sss
                 1. Assert: _fullUnicode_ is *false*.
                 1. Assert: _captureI_ is a List of code units.
                 1. Let _capturedValue_ be the String value consisting of the code units of _captureI_.
-              1. Perform ! CreateDataProperty(_A_, ! ToString(_i_), _capturedValue_).
+              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_i_), _capturedValue_).
               1. If the _i_<sup>th</sup> capture of _R_ was defined with a |GroupName|, then
                 1. Let _s_ be the StringValue of the corresponding |RegExpIdentifierName|.
-                1. Perform ! CreateDataProperty(_groups_, _s_, _capturedValue_).
+                1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
             1. Return _A_.
           </emu-alg>
         </emu-clause>
@@ -32345,8 +32340,7 @@ THH:mm:ss.sss
                 1. Return _A_.
               1. Else,
                 1. Let _matchStr_ be ? ToString(? Get(_result_, `"0"`)).
-                1. Let _status_ be CreateDataProperty(_A_, ! ToString(_n_), _matchStr_).
-                1. Assert: _status_ is *true*.
+                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _matchStr_).
                 1. If _matchStr_ is the empty String, then
                   1. Let _thisIndex_ be ? ToLength(? Get(_rx_, `"lastIndex"`)).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
@@ -32553,7 +32547,7 @@ THH:mm:ss.sss
           1. If _size_ = 0, then
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is not *null*, return _A_.
-            1. Perform ! CreateDataProperty(_A_, `"0"`, _S_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, `"0"`, _S_).
             1. Return _A_.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &lt; _size_
@@ -32566,7 +32560,7 @@ THH:mm:ss.sss
               1. If _e_ = _p_, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
               1. Else,
                 1. Let _T_ be the String value equal to the substring of _S_ consisting of the code units at indices _p_ (inclusive) through _q_ (exclusive).
-                1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
+                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
                 1. Set _lengthA_ to _lengthA_ + 1.
                 1. If _lengthA_ = _lim_, return _A_.
                 1. Set _p_ to _e_.
@@ -32575,13 +32569,13 @@ THH:mm:ss.sss
                 1. Let _i_ be 1.
                 1. Repeat, while _i_ &le; _numberOfCaptures_,
                   1. Let _nextCapture_ be ? Get(_z_, ! ToString(_i_)).
-                  1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _nextCapture_).
+                  1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _nextCapture_).
                   1. Set _i_ to _i_ + 1.
                   1. Set _lengthA_ to _lengthA_ + 1.
                   1. If _lengthA_ = _lim_, return _A_.
                 1. Set _q_ to _p_.
           1. Let _T_ be the String value equal to the substring of _S_ consisting of the code units at indices _p_ (inclusive) through _size_ (exclusive).
-          1. Perform ! CreateDataProperty(_A_, ! ToString(_lengthA_), _T_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
           1. Return _A_.
         </emu-alg>
         <p>The value of the `name` property of this function is `"[Symbol.split]"`.</p>
@@ -32793,8 +32787,7 @@ THH:mm:ss.sss
           1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%Array.prototype%"`).
           1. Let _array_ be ! ArrayCreate(0, _proto_).
           1. If Type(_len_) is not Number, then
-            1. Let _defineStatus_ be CreateDataProperty(_array_, `"0"`, _len_).
-            1. Assert: _defineStatus_ is *true*.
+            1. Perform ! CreateDataPropertyOrThrow(_array_, `"0"`, _len_).
             1. Let _intLen_ be 1.
           1. Else,
             1. Let _intLen_ be ToUint32(_len_).
@@ -32819,8 +32812,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _numberOfArgs_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _itemK_ be _items_[_k_].
-            1. Let _defineStatus_ be CreateDataProperty(_array_, _Pk_, _itemK_).
-            1. Assert: _defineStatus_ is *true*.
+            1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
             1. Set _k_ to _k_ + 1.
           1. Assert: The value of _array_'s `"length"` property is _numberOfArgs_.
           1. Return _array_.
@@ -34077,17 +34069,16 @@ THH:mm:ss.sss
         <p>The initial value of the @@unscopables data property is an object created by the following steps:</p>
         <emu-alg>
           1. Let _unscopableList_ be ObjectCreate(*null*).
-          1. Perform CreateDataProperty(_unscopableList_, `"copyWithin"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"entries"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"fill"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"find"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"findIndex"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"flat"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"flatMap"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"includes"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"keys"`, *true*).
-          1. Perform CreateDataProperty(_unscopableList_, `"values"`, *true*).
-          1. Assert: Each of the above calls returns *true*.
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"copyWithin"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"entries"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"fill"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"find"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"findIndex"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"flat"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"flatMap"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"includes"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"keys"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"values"`, *true*).
           1. Return _unscopableList_.
         </emu-alg>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -37659,8 +37650,7 @@ THH:mm:ss.sss
         1. If IsCallable(_reviver_) is *true*, then
           1. Let _root_ be ObjectCreate(%Object.prototype%).
           1. Let _rootName_ be the empty String.
-          1. Let _status_ be CreateDataProperty(_root_, _rootName_, _unfiltered_).
-          1. Assert: _status_ is *true*.
+          1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
           1. Return ? InternalizeJSONProperty(_root_, _rootName_).
         1. Else,
           1. Return _unfiltered_.
@@ -37749,8 +37739,7 @@ THH:mm:ss.sss
         1. Else,
           1. Let _gap_ be the empty String.
         1. Let _wrapper_ be ObjectCreate(%Object.prototype%).
-        1. Let _status_ be CreateDataProperty(_wrapper_, the empty String, _value_).
-        1. Assert: _status_ is *true*.
+        1. Perform ! CreateDataPropertyOrThrow(_wrapper_, the empty String, _value_).
         1. Return ? SerializeJSONProperty(the empty String, _wrapper_).
       </emu-alg>
       <p>The `"length"` property of the `stringify` function is 3.</p>
@@ -39766,8 +39755,8 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be _F_.[[Capability]].
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Let _obj_ be ! ObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataProperty(_obj_, `"status"`, `"fulfilled"`).
-            1. Perform ! CreateDataProperty(_obj_, `"value"`, _x_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"status"`, `"fulfilled"`).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"value"`, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
@@ -39792,8 +39781,8 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be _F_.[[Capability]].
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Let _obj_ be ! ObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataProperty(_obj_, `"status"`, `"rejected"`).
-            1. Perform ! CreateDataProperty(_obj_, `"reason"`, _x_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"status"`, `"rejected"`).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"reason"`, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
@@ -40433,8 +40422,8 @@ THH:mm:ss.sss
           1. Let _revoker_ be ! CreateBuiltinFunction(_steps_, &laquo; [[RevocableProxy]] &raquo;).
           1. Set _revoker_.[[RevocableProxy]] to _p_.
           1. Let _result_ be ObjectCreate(%Object.prototype%).
-          1. Perform CreateDataProperty(_result_, `"proxy"`, _p_).
-          1. Perform CreateDataProperty(_result_, `"revoke"`, _revoker_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, `"proxy"`, _p_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, `"revoke"`, _revoker_).
           1. Return _result_.
         </emu-alg>
 


### PR DESCRIPTION
This commit contains two kinds of changes:
 1. usage of CreateDataProperty, with an assert that it returns `true`,
converted to "Perform ! CreateDataPropertyOrThrow"
 2. usage of CreateDataProperty, but with what I believe to be a
*missing* assertion that it returns true, converted to the same