### PR TITLE
Normative: `ValidateAndApplyPropertyDescriptor`: fix bug that bypasses "apply"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7017,13 +7017,11 @@
             1. If _current_.[[Configurable]] is *false* and _current_.[[Writable]] is *false*, then
               1. If _Desc_.[[Writable]] is present and _Desc_.[[Writable]] is *true*, return *false*.
               1. If _Desc_.[[Value]] is present and SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*, return *false*.
-              1. Return *true*.
           1. Else,
             1. Assert: ! IsAccessorDescriptor(_current_) and ! IsAccessorDescriptor(_Desc_) are both *true*.
             1. If _current_.[[Configurable]] is *false*, then
               1. If _Desc_.[[Set]] is present and SameValue(_Desc_.[[Set]], _current_.[[Set]]) is *false*, return *false*.
               1. If _Desc_.[[Get]] is present and SameValue(_Desc_.[[Get]], _current_.[[Get]]) is *false*, return *false*.
-              1. Return *true*.
           1. If _O_ is not *undefined*, then
             1. For each field of _Desc_ that is present, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
           1. Return *true*.


### PR DESCRIPTION
This bug was introduced in https://github.com/tc39/ecma262/pull/353/ - it prevents the change from actually being applied.

I believe the confusion was trying to be consistent with the `return true` above, but that one is in the "current is undefined" section, in which the change is not applied anyways.

I discovered this while implementing `ArraySetLength` in https://npmjs.com/es-abstract, which invoked my implementation of `ValidateAndApplyPropertyDescriptor`.