### PR TITLE
Editorial: Improve %JSONStringify% intrinsic definition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37735,6 +37735,7 @@ THH:mm:ss.sss
         1. Perform ! CreateDataPropertyOrThrow(_wrapper_, the empty String, _value_).
         1. Return ? SerializeJSONProperty(the empty String, _wrapper_).
       </emu-alg>
+      <p>This function is the <dfn>%JSONStringify%</dfn> intrinsic object.</p>
       <p>The `"length"` property of the `stringify` function is 3.</p>
       <emu-note>
         <p>JSON structures are allowed to be nested to any depth, but they must be acyclic. If _value_ is or contains a cyclic structure, then the stringify function must throw a *TypeError* exception. This is an example of a value that cannot be stringified:</p>


### PR DESCRIPTION
This change makes `%JSONStringify%` in [Well-Known Intrinsic Objects](https://tc39.es/ecma262/#table-7) table a link to [JSON.stringify](https://tc39.es/ecma262/#sec-json.stringify).

Follow-up of #1272.