### PR TITLE
Editorial: remove context copy from AsyncFunctionStart

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40123,8 +40123,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-async-functions-abstract-operations-async-function-start" aoid="AsyncFunctionStart">
         <h1>AsyncFunctionStart ( _promiseCapability_, _asyncFunctionBody_ )</h1>
         <emu-alg>
-          1. Let _runningContext_ be the running execution context.
-          1. Let _asyncContext_ be a copy of _runningContext_.
+          1. Let _asyncContext_ be the running execution context.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. Let _result_ be the result of evaluating _asyncFunctionBody_.
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
@@ -40139,7 +40138,9 @@ THH:mm:ss.sss
             1. Return.
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.
-          1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
+          1. Assert: When we return here, _asyncContext_ has been removed from the execution context stack.
+          1. Push _asyncContext_ onto the execution context stack.
+          1. NOTE: Pushing _asyncContext_ onto the execution context stack is needed to fulfill invariants of <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist">Function [[Call]]</a>.
           1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, the step 3.g above.
           1. Return.
         </emu-alg>


### PR DESCRIPTION
In AsyncFunctionStart, the context created by PrepareForOrdinaryCall is copied, and the copied context is used as the context for future evaluation with the async function. The context created by PrepareForOrdinaryCall is never used, and doesn't seem to (observably) exist in most implementations:

![](https://gc.gy/35188265.png)

<sub>Only engine262 shows the original context from PrepareForOrdinaryCall (the one with no location on it)</sub>

After some light experimentation, I found that removing the context doesn't result in any test262 failures, so I am assuming for now that this is a safe change to make.