### PR TITLE
meta: make "new feature" issue template clearer

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F680 Feature request is not here"
+name: "\U0001F680 Feature request is here?"
 about: Suggest an idea for ECMA-262
 
 ---

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -6,7 +6,7 @@ about: Suggest an idea for ECMA-262
 
 This repository is only for handling issues with the specification itself.
 
-New ideas, suggestions and discussions about future versions of ECMAScript should not be made in this repository.   
+New ideas, suggestions, and discussions about future versions of ECMAScript should not be made in this repository.
 
 Feature Requests are developed in separate GitHub repositories,
 which are then merged into the main repository once they have received "Stage 4". 

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -15,4 +15,4 @@ This four-stage process is documented in the [TC39 process document](https://tc3
 
 TC39 is open to accepting new feature requests for ECMAScript, referred to as "proposals". 
 
-To contribute visit [CONTRIBUTING.md](/CONTRIBUTING.md) for more details.
+To contribute visit [CONTRIBUTING.md](/CONTRIBUTING.md#new-feature-proposals) for more details.

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,15 +1,18 @@
 ---
-name: "\U0001F680 Feature request"
+name: "\U0001F680 Feature request is not here"
 about: Suggest an idea for ECMA-262
 
 ---
 
-TC39 is open to accepting new feature requests for ECMAScript, referred to as
-"proposals". Proposals go through a four-stage process which is documented in
-the [TC39 process document](https://tc39.es/process-document/).
+This repository is only for handling issues with the specification itself.
 
-Feature requests for future versions of ECMAScript should not be made in this
-repository. Instead, they are developed in separate GitHub repositories, which
-are then merged into the main repository once they have received "Stage 4".
+New ideas, suggestions and discussions about future versions of ECMAScript should not be made in this repository.   
 
-Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for more details.
+Feature Requests are developed in separate GitHub repositories,
+which are then merged into the main repository once they have received "Stage 4". 
+
+This four-stage process is documented in the [TC39 process document](https://tc39.es/process-document/).
+
+TC39 is open to accepting new feature requests for ECMAScript, referred to as "proposals". 
+
+To contribute visit [CONTRIBUTING.md](/CONTRIBUTING.md) for more details.


### PR DESCRIPTION
Make this more clearer can help to prevent the 'close issues' from recurring.

Better is not assume that the error is always from the user who has not read or not interpret properly.

If the number of 'close issues' does not decrease, we will have data to say that the text is still bad and could improve even further.

To learn more: https://en.wikipedia.org/wiki/Copywriting

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
