### PR TITLE
Editorial: Spell out fairness requirements of EnterCriticalSection

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36079,6 +36079,7 @@ THH:mm:ss.sss
           1. Assert: The calling agent is not in the critical section for any WaiterList.
           1. Wait until no agent is in the critical section for _WL_, then enter the critical section for _WL_ (without allowing any other agent to enter).
         </emu-alg>
+        <p>EnterCriticalSection has <dfn>contention</dfn> when an agent attempting to enter the critical section must wait for another agent to leave it. When there is no contention, FIFO order of EnterCriticalSection calls is observable. When there is contention, an implementation may choose an arbitrary order but may not cause an agent to wait indefinitely.</p>
       </emu-clause>
 
       <emu-clause id="sec-leavecriticalsection" aoid="LeaveCriticalSection">


### PR DESCRIPTION
Codify the existing fairness requirements that came up during https://github.com/tc39/proposal-atomics-wait-async/issues/12.

This is editorial because the bounded fairness is already implied by the forward progress guarantee.