### PR TITLE
Editorial: simplify ArraySetLength truncation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8989,11 +8989,10 @@
             1. Set _newLenDesc_.[[Writable]] to *true*.
           1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
           1. If _succeeded_ is *false*, return *false*.
-          1. Repeat, while _newLen_ &lt; _oldLen_,
-            1. Set _oldLen_ to _oldLen_ - 1.
-            1. Let _deleteSucceeded_ be ! _A_.[[Delete]](! ToString(_oldLen_)).
+          1. For each own property key _P_ of _A_ that is an array index, whose numeric value is greater than or equal to _newLen_, in descending numeric index order, do
+            1. Let _deleteSucceeded_ be ! _A_.[[Delete]](_P_).
             1. If _deleteSucceeded_ is *false*, then
-              1. Set _newLenDesc_.[[Value]] to _oldLen_ + 1.
+              1. Set _newLenDesc_.[[Value]] to ! ToUint32(_P_) + 1.
               1. If _newWritable_ is *false*, set _newLenDesc_.[[Writable]] to *false*.
               1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
               1. Return *false*.


### PR DESCRIPTION
This change iterates over the existing keys of an array when truncating it instead of every possible key between `newLen` and `oldLen`, clarifying the observable behaviour of the loop.

https://deploy-preview-1702--ecma262-snapshots.netlify.com/#sec-arraysetlength

The behaviour of this change has been verified in engine262.