### PR TITLE
Editorial: Changing 'SetViewValue' to use 'ToNumber' instead of 'ToInteger'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36846,7 +36846,7 @@ THH:mm:ss.sss
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. If ! IsBigIntElementType(_type_) is *true*, let _numberValue_ be ? ToBigInt(_value_).
-          1. Otherwise, let _numberValue_ be ? ToInteger(_value_).
+          1. Otherwise, let _numberValue_ be ? ToNumber(_value_).
           1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.


### PR DESCRIPTION
PR #1515 changed this step to `ToInteger` wrongly. We need to change it back to `ToNumber`.