### PR TITLE
Normative: Fix bogus assert in NotifyWaiter

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37332,7 +37332,6 @@ THH:mm:ss.sss
         <p>The abstract operation NotifyWaiter takes two arguments, a WaiterList _WL_ and an agent signifier _W_. It performs the following steps:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
-          1. Assert: _W_ is on the list of waiters in _WL_.
           1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
           1. Let _eventsRecord_ be the Agent Events Record in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _agentSynchronizesWith_ be _eventsRecord_.[[AgentSynchronizesWith]].


### PR DESCRIPTION
NotifyWaiter is always called immediately after W is removed from the waiter list.