### PR TITLE
Normative: make String.prototype.matchAll throw for non-global regular expressions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29725,6 +29725,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _regexp_ is neither *undefined* nor *null*, then
+            1. Let _isRegExp_ be ? IsRegExp(_regexp_).
+            1. If _isRegExp_ is true, then
+              1. Let _flags_ be ? Get(_regexp_, *"flags"*).
+              1. Perform ? RequireObjectCoercible(_flags_).
+              1. If ? ToString(_flags_) does not contain *"g"*, throw a *TypeError* exception.
             1. Let _matcher_ be ? GetMethod(_regexp_, @@matchAll).
             1. If _matcher_ is not *undefined*, then
               1. Return ? Call(_matcher_, _regexp_, &laquo; _O_ &raquo;).


### PR DESCRIPTION
Per October 2 2019 TC39 meeting consensus.

#### Tracking issues

- [V8](https://bugs.chromium.org/p/v8/issues/detail?id=9800)