### PR TITLE
Editorial: Use tildes for spec-internal values wherever possible.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -891,6 +891,11 @@
         <p><emu-eqn>floor<sub>_t_</sub>(_x_) = _x_ -<sub>_t_</sub> (_x_ modulo<sub>_t_</sub> 1<sub>_t_</sub>)</emu-eqn>.</p>
       </emu-note>
     </emu-clause>
+    <emu-clause id="sec-value-notation">
+      <h1>Value Notation</h1>
+      <p>In this specification, ECMAScript language values are displayed in *bold*. Examples include *null*, *true*, or *"hello"*. These are distinguished from longer ECMAScript code sequences such as `Function.prototype.apply` or `let n = 42;`.</p>
+      <p>Values which are internal to the specification and not directly observable from ECMAScript code are indicated with a ~sans-serif~ typeface. For instance, a Completion Record's [[Type]] field takes on values like ~normal~, ~return~, or ~throw~.</p>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -4365,7 +4370,7 @@
           1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _zero_ be &laquo; 0 &raquo;.
           1. For each index _i_ of _db_, do
-            1. Append WriteSharedMemory { [[Order]]: `"Init"`, [[NoTear]]: *true*, [[Block]]: _db_, [[ByteIndex]]: _i_, [[ElementSize]]: 1, [[Payload]]: _zero_ } to _eventList_.
+            1. Append WriteSharedMemory { [[Order]]: ~Init~, [[NoTear]]: *true*, [[Block]]: _db_, [[ByteIndex]]: _i_, [[ElementSize]]: 1, [[Payload]]: _zero_ } to _eventList_.
           1. Return _db_.
         </emu-alg>
       </emu-clause>
@@ -4386,11 +4391,11 @@
               1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
               1. Let _bytes_ be a List of length 1 that contains a nondeterministically chosen byte value.
               1. NOTE: In implementations, _bytes_ is the result of a non-atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
-              1. Let _readEvent_ be ReadSharedMemory { [[Order]]: `"Unordered"`, [[NoTear]]: *true*, [[Block]]: _fromBlock_, [[ByteIndex]]: _fromIndex_, [[ElementSize]]: 1 }.
+              1. Let _readEvent_ be ReadSharedMemory { [[Order]]: ~Unordered~, [[NoTear]]: *true*, [[Block]]: _fromBlock_, [[ByteIndex]]: _fromIndex_, [[ElementSize]]: 1 }.
               1. Append _readEvent_ to _eventList_.
               1. Append Chosen Value Record { [[Event]]: _readEvent_, [[ChosenValue]]: _bytes_ } to _execution_.[[ChosenValues]].
               1. If _toBlock_ is a Shared Data Block, then
-                1. Append WriteSharedMemory { [[Order]]: `"Unordered"`, [[NoTear]]: *true*, [[Block]]: _toBlock_, [[ByteIndex]]: _toIndex_, [[ElementSize]]: 1, [[Payload]]: _bytes_ } to _eventList_.
+                1. Append WriteSharedMemory { [[Order]]: ~Unordered~, [[NoTear]]: *true*, [[Block]]: _toBlock_, [[ByteIndex]]: _toIndex_, [[ElementSize]]: 1, [[Payload]]: _bytes_ } to _eventList_.
               1. Else,
                 1. Set _toBlock_[_toIndex_] to _bytes_[0].
             1. Else,
@@ -5714,15 +5719,15 @@
       <p>The abstract operation SetIntegrityLevel is used to fix the set of own properties of an object. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
-        1. Assert: _level_ is either `"sealed"` or `"frozen"`.
+        1. Assert: _level_ is either ~sealed~ or ~frozen~.
         1. Let _status_ be ? _O_.[[PreventExtensions]]().
         1. If _status_ is *false*, return *false*.
         1. Let _keys_ be ? _O_.[[OwnPropertyKeys]]().
-        1. If _level_ is `"sealed"`, then
+        1. If _level_ is ~sealed~, then
           1. For each element _k_ of _keys_, do
             1. Perform ? DefinePropertyOrThrow(_O_, _k_, PropertyDescriptor { [[Configurable]]: *false* }).
         1. Else,
-          1. Assert: _level_ is `"frozen"`.
+          1. Assert: _level_ is ~frozen~.
           1. For each element _k_ of _keys_, do
             1. Let _currentDesc_ be ? _O_.[[GetOwnProperty]](_k_).
             1. If _currentDesc_ is not *undefined*, then
@@ -5740,7 +5745,7 @@
       <p>The abstract operation TestIntegrityLevel is used to determine if the set of own properties of an object are fixed. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
-        1. Assert: _level_ is either `"sealed"` or `"frozen"`.
+        1. Assert: _level_ is either ~sealed~ or ~frozen~.
         1. Let _extensible_ be ? IsExtensible(_O_).
         1. If _extensible_ is *true*, return *false*.
         1. NOTE: If the object is extensible, none of its properties are examined.
@@ -5749,7 +5754,7 @@
           1. Let _currentDesc_ be ? _O_.[[GetOwnProperty]](_k_).
           1. If _currentDesc_ is not *undefined*, then
             1. If _currentDesc_.[[Configurable]] is *true*, return *false*.
-            1. If _level_ is `"frozen"` and IsDataDescriptor(_currentDesc_) is *true*, then
+            1. If _level_ is ~frozen~ and IsDataDescriptor(_currentDesc_) is *true*, then
               1. If _currentDesc_.[[Writable]] is *true*, return *false*.
         1. Return *true*.
       </emu-alg>
@@ -5851,7 +5856,7 @@
 
     <emu-clause id="sec-enumerableownpropertynames" aoid="EnumerableOwnPropertyNames" oldids="sec-enumerableownproperties">
       <h1>EnumerableOwnPropertyNames ( _O_, _kind_ )</h1>
-      <p>When the abstract operation EnumerableOwnPropertyNames is called with Object _O_ and String _kind_ the following steps are taken:</p>
+      <p>When the abstract operation EnumerableOwnPropertyNames is called with an Object _O_ and _kind_ which is one of (~key~, ~value~, ~key+value~), the following steps are taken:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Let _ownKeys_ be ? _O_.[[OwnPropertyKeys]]().
@@ -5860,12 +5865,12 @@
           1. If Type(_key_) is String, then
             1. Let _desc_ be ? _O_.[[GetOwnProperty]](_key_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
-              1. If _kind_ is `"key"`, append _key_ to _properties_.
+              1. If _kind_ is ~key~, append _key_ to _properties_.
               1. Else,
                 1. Let _value_ be ? Get(_O_, _key_).
-                1. If _kind_ is `"value"`, append _value_ to _properties_.
+                1. If _kind_ is ~value~, append _value_ to _properties_.
                 1. Else,
-                  1. Assert: _kind_ is `"key+value"`.
+                  1. Assert: _kind_ is ~key+value~.
                   1. Let _entry_ be ! CreateArrayFromList(&laquo; _key_, _value_ &raquo;).
                   1. Append _entry_ to _properties_.
         1. Order the elements of _properties_ so they are in the same relative order as would be produced by the Iterator that would be returned if the EnumerateObjectProperties internal method were invoked with _O_.
@@ -6455,10 +6460,10 @@
                 [[ThisBindingStatus]]
               </td>
               <td>
-                `"lexical"` | `"initialized"` | `"uninitialized"`
+                ~lexical~ | ~initialized~ | ~uninitialized~
               </td>
               <td>
-                If the value is `"lexical"`, this is an |ArrowFunction| and does not have a local *this* value.
+                If the value is ~lexical~, this is an |ArrowFunction| and does not have a local *this* value.
               </td>
             </tr>
             <tr>
@@ -6542,10 +6547,10 @@
           <h1>BindThisValue ( _V_ )</h1>
           <emu-alg>
             1. Let _envRec_ be the function Environment Record for which the method was invoked.
-            1. Assert: _envRec_.[[ThisBindingStatus]] is not `"lexical"`.
-            1. If _envRec_.[[ThisBindingStatus]] is `"initialized"`, throw a *ReferenceError* exception.
+            1. Assert: _envRec_.[[ThisBindingStatus]] is not ~lexical~.
+            1. If _envRec_.[[ThisBindingStatus]] is ~initialized~, throw a *ReferenceError* exception.
             1. Set _envRec_.[[ThisValue]] to _V_.
-            1. Set _envRec_.[[ThisBindingStatus]] to `"initialized"`.
+            1. Set _envRec_.[[ThisBindingStatus]] to ~initialized~.
             1. Return _V_.
           </emu-alg>
         </emu-clause>
@@ -6554,7 +6559,7 @@
           <h1>HasThisBinding ( )</h1>
           <emu-alg>
             1. Let _envRec_ be the function Environment Record for which the method was invoked.
-            1. If _envRec_.[[ThisBindingStatus]] is `"lexical"`, return *false*; otherwise, return *true*.
+            1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*; otherwise, return *true*.
           </emu-alg>
         </emu-clause>
 
@@ -6562,7 +6567,7 @@
           <h1>HasSuperBinding ( )</h1>
           <emu-alg>
             1. Let _envRec_ be the function Environment Record for which the method was invoked.
-            1. If _envRec_.[[ThisBindingStatus]] is `"lexical"`, return *false*.
+            1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*.
             1. If _envRec_.[[HomeObject]] has the value *undefined*, return *false*; otherwise, return *true*.
           </emu-alg>
         </emu-clause>
@@ -6571,8 +6576,8 @@
           <h1>GetThisBinding ( )</h1>
           <emu-alg>
             1. Let _envRec_ be the function Environment Record for which the method was invoked.
-            1. Assert: _envRec_.[[ThisBindingStatus]] is not `"lexical"`.
-            1. If _envRec_.[[ThisBindingStatus]] is `"uninitialized"`, throw a *ReferenceError* exception.
+            1. Assert: _envRec_.[[ThisBindingStatus]] is not ~lexical~.
+            1. If _envRec_.[[ThisBindingStatus]] is ~uninitialized~, throw a *ReferenceError* exception.
             1. Return _envRec_.[[ThisValue]].
           </emu-alg>
         </emu-clause>
@@ -7123,8 +7128,8 @@
           1. Let _env_ be a new Lexical Environment.
           1. Let _envRec_ be a new function Environment Record containing no bindings.
           1. Set _envRec_.[[FunctionObject]] to _F_.
-          1. If _F_.[[ThisMode]] is ~lexical~, set _envRec_.[[ThisBindingStatus]] to `"lexical"`.
-          1. Else, set _envRec_.[[ThisBindingStatus]] to `"uninitialized"`.
+          1. If _F_.[[ThisMode]] is ~lexical~, set _envRec_.[[ThisBindingStatus]] to ~lexical~.
+          1. Else, set _envRec_.[[ThisBindingStatus]] to ~uninitialized~.
           1. Let _home_ be _F_.[[HomeObject]].
           1. Set _envRec_.[[HomeObject]] to _home_.
           1. Set _envRec_.[[NewTarget]] to _newTarget_.
@@ -7822,7 +7827,7 @@
     </ul>
 
     <emu-note>
-      <p>This, along with the liveness guarantee in the memory model, ensures that all `"SeqCst"` writes eventually become observable to all agents.</p>
+      <p>This, along with the liveness guarantee in the memory model, ensures that all ~SeqCst~ writes eventually become observable to all agents.</p>
     </emu-note>
   </emu-clause>
 
@@ -8263,10 +8268,10 @@
             [[FunctionKind]]
           </td>
           <td>
-            String
+            ~normal~ | ~classConstructor~ | ~generator~ | ~async~ | ~asyncGenerator~
           </td>
           <td>
-            Either `"normal"`, `"classConstructor"`, `"generator"`, `"async"`, or `"async generator"`.
+            Whether the function is a class constructor, generator, or async function.
           </td>
         </tr>
         <tr>
@@ -8285,10 +8290,10 @@
             [[ConstructorKind]]
           </td>
           <td>
-            String
+            ~base~ | ~derived~
           </td>
           <td>
-            Either `"base"` or `"derived"`.
+            Whether or not the function is a derived class constructor.
           </td>
         </tr>
         <tr>
@@ -8318,7 +8323,7 @@
             [[ThisMode]]
           </td>
           <td>
-            (lexical, strict, global)
+            ~lexical~ | ~strict~ | ~global~
           </td>
           <td>
             Defines how `this` references are interpreted within the formal parameters and code body of the function. ~lexical~ means that `this` refers to the *this* value of a lexically enclosing function. ~strict~ means that the *this* value is used exactly as provided by an invocation of the function. ~global~ means that a *this* value of *undefined* is interpreted as a reference to the global object.
@@ -8367,7 +8372,7 @@
       <p>The [[Call]] internal method for an ECMAScript function object _F_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. If _F_.[[FunctionKind]] is `"classConstructor"`, throw a *TypeError* exception.
+        1. If _F_.[[FunctionKind]] is ~classConstructor~, throw a *TypeError* exception.
         1. Let _callerContext_ be the running execution context.
         1. Let _calleeContext_ be PrepareForOrdinaryCall(_F_, *undefined*).
         1. Assert: _calleeContext_ is now the running execution context.
@@ -8423,7 +8428,7 @@
               1. NOTE: ToObject produces wrapper objects using _calleeRealm_.
           1. Let _envRec_ be _localEnv_'s EnvironmentRecord.
           1. Assert: _envRec_ is a function Environment Record.
-          1. Assert: The next step never returns an abrupt completion because _envRec_.[[ThisBindingStatus]] is not `"initialized"`.
+          1. Assert: The next step never returns an abrupt completion because _envRec_.[[ThisBindingStatus]] is not ~initialized~.
           1. Return _envRec_.BindThisValue(_thisValue_).
         </emu-alg>
       </emu-clause>
@@ -8445,18 +8450,18 @@
         1. Assert: Type(_newTarget_) is Object.
         1. Let _callerContext_ be the running execution context.
         1. Let _kind_ be _F_.[[ConstructorKind]].
-        1. If _kind_ is `"base"`, then
+        1. If _kind_ is ~base~, then
           1. Let _thisArgument_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Object.prototype%"`).
         1. Let _calleeContext_ be PrepareForOrdinaryCall(_F_, _newTarget_).
         1. Assert: _calleeContext_ is now the running execution context.
-        1. If _kind_ is `"base"`, perform OrdinaryCallBindThis(_F_, _calleeContext_, _thisArgument_).
+        1. If _kind_ is ~base~, perform OrdinaryCallBindThis(_F_, _calleeContext_, _thisArgument_).
         1. Let _constructorEnv_ be the LexicalEnvironment of _calleeContext_.
         1. Let _envRec_ be _constructorEnv_'s EnvironmentRecord.
         1. Let _result_ be OrdinaryCallEvaluateBody(_F_, _argumentsList_).
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. If _result_.[[Type]] is ~return~, then
           1. If Type(_result_.[[Value]]) is Object, return NormalCompletion(_result_.[[Value]]).
-          1. If _kind_ is `"base"`, return NormalCompletion(_thisArgument_).
+          1. If _kind_ is ~base~, return NormalCompletion(_thisArgument_).
           1. If _result_.[[Value]] is not *undefined*, throw a *TypeError* exception.
         1. Else, ReturnIfAbrupt(_result_).
         1. Return ? _envRec_.GetThisBinding().
@@ -8468,16 +8473,16 @@
       <p>The abstract operation FunctionAllocate requires the two arguments _functionPrototype_ and _functionKind_. FunctionAllocate performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_functionPrototype_) is Object.
-        1. Assert: _functionKind_ is either `"normal"`, `"non-constructor"`, `"generator"`, `"async"`, or `"async generator"`.
-        1. If _functionKind_ is `"normal"`, let _needsConstruct_ be *true*.
+        1. Assert: _functionKind_ is either ~normal~, ~non-constructor~, ~generator~, ~async~, or ~asyncGenerator~.
+        1. If _functionKind_ is ~normal~, let _needsConstruct_ be *true*.
         1. Else, let _needsConstruct_ be *false*.
-        1. If _functionKind_ is `"non-constructor"`, set _functionKind_ to `"normal"`.
+        1. If _functionKind_ is ~non-constructor~, set _functionKind_ to ~normal~.
         1. Let _F_ be a newly created ECMAScript function object with the internal slots listed in <emu-xref href="#table-27"></emu-xref>.
         1. Set _F_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
         1. Set _F_.[[Call]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
         1. If _needsConstruct_ is *true*, then
           1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
-          1. Set _F_.[[ConstructorKind]] to `"base"`.
+          1. Set _F_.[[ConstructorKind]] to ~base~.
         1. Set _F_.[[FunctionKind]] to _functionKind_.
         1. Set _F_.[[Prototype]] to _functionPrototype_.
         1. Set _F_.[[Extensible]] to *true*.
@@ -8488,7 +8493,7 @@
 
     <emu-clause id="sec-functioninitialize" aoid="FunctionInitialize">
       <h1>FunctionInitialize ( _F_, _kind_, _ParameterList_, _Body_, _Scope_ )</h1>
-      <p>The abstract operation FunctionInitialize requires the arguments: a function object _F_, _kind_ which is one of (Normal, Method, Arrow), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. FunctionInitialize performs the following steps:</p>
+      <p>The abstract operation FunctionInitialize requires the arguments: a function object _F_, _kind_ which is one of (~Normal~, ~Method~, ~Arrow~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. FunctionInitialize performs the following steps:</p>
       <emu-alg>
         1. Let _len_ be the ExpectedArgumentCount of _ParameterList_.
         1. Perform ! SetFunctionLength(_F_, _len_).
@@ -8507,12 +8512,12 @@
 
     <emu-clause id="sec-functioncreate" aoid="FunctionCreate">
       <h1>FunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_ [ , _prototype_ ] )</h1>
-      <p>The abstract operation FunctionCreate requires the arguments: _kind_ which is one of (Normal, Method, Arrow), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, and optionally, an object _prototype_. FunctionCreate performs the following steps:</p>
+      <p>The abstract operation FunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~, ~Arrow~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, and optionally, an object _prototype_. FunctionCreate performs the following steps:</p>
       <emu-alg>
         1. If _prototype_ is not present, then
           1. Set _prototype_ to %Function.prototype%.
-        1. If _kind_ is not ~Normal~, let _allocKind_ be `"non-constructor"`.
-        1. Else, let _allocKind_ be `"normal"`.
+        1. If _kind_ is not ~Normal~, let _allocKind_ be ~non-constructor~.
+        1. Else, let _allocKind_ be ~normal~.
         1. Let _F_ be FunctionAllocate(_prototype_, _allocKind_).
         1. Return FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
@@ -8520,10 +8525,10 @@
 
     <emu-clause id="sec-generatorfunctioncreate" aoid="GeneratorFunctionCreate">
       <h1>GeneratorFunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_ )</h1>
-      <p>The abstract operation GeneratorFunctionCreate requires the arguments: _kind_ which is one of (Normal, Method), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. GeneratorFunctionCreate performs the following steps:</p>
+      <p>The abstract operation GeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. GeneratorFunctionCreate performs the following steps:</p>
       <emu-alg>
         1. Let _functionPrototype_ be %Generator%.
-        1. Let _F_ be FunctionAllocate(_functionPrototype_, `"generator"`).
+        1. Let _F_ be FunctionAllocate(_functionPrototype_, ~generator~).
         1. Return FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
     </emu-clause>
@@ -8533,7 +8538,7 @@
       <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_. AsyncGeneratorFunctionCreate performs the following steps:</p>
       <emu-alg>
         1. Let _functionPrototype_ be %AsyncGenerator%.
-        1. Let _F_ be ! FunctionAllocate(_functionPrototype_, `"generator"`).
+        1. Let _F_ be ! FunctionAllocate(_functionPrototype_, ~generator~).
         1. Return ! FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_).
       </emu-alg>
     </emu-clause>
@@ -8543,7 +8548,7 @@
       <p>The abstract operation AsyncFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~, ~Arrow~), a parameter list Parse Node specified by _parameters_, a body Parse Node specified by _body_, a Lexical Environment specified by _Scope_. AsyncFunctionCreate performs the following steps:</p>
       <emu-alg>
         1. Let _functionPrototype_ be %AsyncFunction.prototype%.
-        2. Let _F_ be ! FunctionAllocate(_functionPrototype_, `"async"`).
+        2. Let _F_ be ! FunctionAllocate(_functionPrototype_, ~async~).
         3. Return ! FunctionInitialize(_F_, _kind_, _parameters_, _body_, _Scope_).
       </emu-alg>
     </emu-clause>
@@ -8590,8 +8595,8 @@
       <p>The abstract operation MakeClassConstructor with argument _F_ performs the following steps:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
-        1. Assert: _F_.[[FunctionKind]] is `"normal"`.
-        1. Set _F_.[[FunctionKind]] to `"classConstructor"`.
+        1. Assert: _F_.[[FunctionKind]] is ~normal~.
+        1. Set _F_.[[FunctionKind]] to ~classConstructor~.
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
     </emu-clause>
@@ -8765,7 +8770,7 @@
     <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided function exotic objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
     <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such function exotic objects also have [[Prototype]], [[Extensible]], [[Realm]], and [[ScriptOrModule]] internal slots.</p>
     <p>Unless otherwise specified every built-in function object has the %Function.prototype% object as the initial value of its [[Prototype]] internal slot.</p>
-    <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value *"classConstructor"*.</p>
+    <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value ~classConstructor~.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
     <p>Built-in functions that are not constructors do not have a `"prototype"` property unless otherwise specified in the description of a particular function.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
@@ -9491,8 +9496,8 @@
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
-          1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-          1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, `"Unordered"`).
+          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~Unordered~).
         </emu-alg>
       </emu-clause>
 
@@ -9502,7 +9507,7 @@
         <emu-alg>
           1. Assert: Type(_index_) is Number.
           1. Assert: _O_ is an Object that has [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.
-          1. If _O_.[[ContentType]] is `"BigInt"`, let _numValue_ be ? ToBigInt(_value_).
+          1. If _O_.[[ContentType]] is ~BigInt~, let _numValue_ be ? ToBigInt(_value_).
           1. Otherwise, let _numValue_ be ? ToNumber(_value_).
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
@@ -9514,8 +9519,8 @@
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
-          1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-          1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _numValue_, *true*, `"Unordered"`).
+          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _numValue_, *true*, ~Unordered~).
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -13178,9 +13183,9 @@
             1. Let _rawValue_ be the String value _rawStrings_[_index_].
             1. Call _rawObj_.[[DefineOwnProperty]](_prop_, PropertyDescriptor { [[Value]]: _rawValue_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }).
             1. Set _index_ to _index_ + 1.
-          1. Perform SetIntegrityLevel(_rawObj_, `"frozen"`).
+          1. Perform SetIntegrityLevel(_rawObj_, ~frozen~).
           1. Call _template_.[[DefineOwnProperty]](`"raw"`, PropertyDescriptor { [[Value]]: _rawObj_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-          1. Perform SetIntegrityLevel(_template_, `"frozen"`).
+          1. Perform SetIntegrityLevel(_template_, ~frozen~).
           1. Append the Record { [[Site]]: _templateLiteral_, [[Array]]: _template_ } to _templateRegistry_.
           1. Return _template_.
         </emu-alg>
@@ -20833,7 +20838,7 @@
         1. Set the running execution context's LexicalEnvironment to _classScope_.
         1. Let _constructorInfo_ be ! DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_.
         1. Let _F_ be _constructorInfo_.[[Closure]].
-        1. If |ClassHeritage_opt| is present, set _F_.[[ConstructorKind]] to `"derived"`.
+        1. If |ClassHeritage_opt| is present, set _F_.[[ConstructorKind]] to ~derived~.
         1. Perform MakeConstructor(_F_, *false*, _proto_).
         1. Perform MakeClassConstructor(_F_).
         1. If _className_ is not *undefined*, then
@@ -22582,10 +22587,10 @@
                   [[Status]]
                 </td>
                 <td>
-                  String
+                  ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~ | ~evaluated~
                 </td>
                 <td>
-                  Initially `"unlinked"`. Transitions to `"linking"`, `"linked"`, `"evaluating"`, `"evaluated"` (in that order) as the module progresses throughout its lifecycle.
+                  Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, ~evaluated~ (in that order) as the module progresses throughout its lifecycle.
                 </td>
               </tr>
               <tr>
@@ -22596,7 +22601,7 @@
                   An abrupt completion | *undefined*
                 </td>
                 <td>
-                  A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not `"evaluated"`.
+                  A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not ~evaluated~.
                 </td>
               </tr>
               <tr>
@@ -22608,7 +22613,7 @@
                 </td>
                 <td>
                   Auxiliary field used during Link and Evaluate only.
-                  If [[Status]] is `"linking"` or `"evaluating"`, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
+                  If [[Status]] is ~linking~ or ~evaluating~, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
                 </td>
               </tr>
               <tr>
@@ -22619,7 +22624,7 @@
                   Integer | *undefined*
                 </td>
                 <td>
-                  Auxiliary field used during Link and Evaluate only. If [[Status]] is `"linking"` or `"evaluating"`, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+                  Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
                 </td>
               </tr>
               <tr>
@@ -22672,25 +22677,25 @@
           <h1>Link ( ) Concrete Method</h1>
 
           <p>The Link concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-          <p>On success, Link transitions this module's [[Status]] from `"unlinked"` to `"linked"`. On failure, an exception is thrown and this module's [[Status]] remains `"unlinked"`.</p>
+          <p>On success, Link transitions this module's [[Status]] from ~unlinked~ to ~linked~. On failure, an exception is thrown and this module's [[Status]] remains ~unlinked~.</p>
 
           <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleLinking):</p>
 
           <emu-alg>
             1. Let _module_ be this Cyclic Module Record.
-            1. Assert: _module_.[[Status]] is not `"linking"` or `"evaluating"`.
+            1. Assert: _module_.[[Status]] is not ~linking~ or ~evaluating~.
             1. Let _stack_ be a new empty List.
             1. Let _result_ be InnerModuleLinking(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion, then
               1. For each Cyclic Module Record _m_ in _stack_, do
-                1. Assert: _m_.[[Status]] is `"linking"`.
-                1. Set _m_.[[Status]] to `"unlinked"`.
+                1. Assert: _m_.[[Status]] is ~linking~.
+                1. Set _m_.[[Status]] to ~unlinked~.
                 1. Set _m_.[[Environment]] to *undefined*.
                 1. Set _m_.[[DFSIndex]] to *undefined*.
                 1. Set _m_.[[DFSAncestorIndex]] to *undefined*.
-              1. Assert: _module_.[[Status]] is `"unlinked"`.
+              1. Assert: _module_.[[Status]] is ~unlinked~.
               1. Return _result_.
-            1. Assert: _module_.[[Status]] is `"linked"` or `"evaluated"`.
+            1. Assert: _module_.[[Status]] is ~linked~ or ~evaluated~.
             1. Assert: _stack_ is empty.
             1. Return *undefined*.
           </emu-alg>
@@ -22698,7 +22703,7 @@
           <emu-clause id="sec-InnerModuleLinking" oldids="sec-innermoduleinstantiation" aoid="InnerModuleLinking">
             <h1>InnerModuleLinking ( _module_, _stack_, _index_ )</h1>
 
-            <p>The InnerModuleLinking abstract operation is used by Link to perform the actual linking process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to `"linked"` together.</p>
+            <p>The InnerModuleLinking abstract operation is used by Link to perform the actual linking process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together.</p>
 
             <p>This abstract operation performs the following steps:</p>
 
@@ -22706,10 +22711,10 @@
               1. If _module_ is not a Cyclic Module Record, then
                 1. Perform ? _module_.Link().
                 1. Return _index_.
-              1. If _module_.[[Status]] is `"linking"`, `"linked"`, or `"evaluated"`, then
+              1. If _module_.[[Status]] is ~linking~, ~linked~, or ~evaluated~, then
                 1. Return _index_.
-              1. Assert: _module_.[[Status]] is `"unlinked"`.
-              1. Set _module_.[[Status]] to `"linking"`.
+              1. Assert: _module_.[[Status]] is ~unlinked~.
+              1. Set _module_.[[Status]] to ~linking~.
               1. Set _module_.[[DFSIndex]] to _index_.
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Set _index_ to _index_ + 1.
@@ -22718,9 +22723,9 @@
                 1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
                 1. Set _index_ to ? InnerModuleLinking(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
-                  1. Assert: _requiredModule_.[[Status]] is either `"linking"`, `"linked"`, or `"evaluated"`.
-                  1. Assert: _requiredModule_.[[Status]] is `"linking"` if and only if _requiredModule_ is in _stack_.
-                  1. If _requiredModule_.[[Status]] is `"linking"`, then
+                  1. Assert: _requiredModule_.[[Status]] is either ~linking~, ~linked~, or ~evaluated~.
+                  1. Assert: _requiredModule_.[[Status]] is ~linking~ if and only if _requiredModule_ is in _stack_.
+                  1. If _requiredModule_.[[Status]] is ~linking~, then
                     1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? _module_.InitializeEnvironment().
               1. Assert: _module_ occurs exactly once in _stack_.
@@ -22731,7 +22736,7 @@
                   1. Let _requiredModule_ be the last element in _stack_.
                   1. Remove the last element of _stack_.
                   1. Assert: _requiredModule_ is a Cyclic Module Record.
-                  1. Set _requiredModule_.[[Status]] to `"linked"`.
+                  1. Set _requiredModule_.[[Status]] to ~linked~.
                   1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
               1. Return _index_.
             </emu-alg>
@@ -22742,7 +22747,7 @@
           <h1>Evaluate ( ) Concrete Method</h1>
 
           <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-          <p>Evaluate transitions this module's [[Status]] from `"linked"` to `"evaluated"`.</p>
+          <p>Evaluate transitions this module's [[Status]] from ~linked~ to ~evaluated~.</p>
 
           <p>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
 
@@ -22750,17 +22755,17 @@
 
           <emu-alg>
             1. Let _module_ be this Cyclic Module Record.
-            1. Assert: _module_.[[Status]] is `"linked"` or `"evaluated"`.
+            1. Assert: _module_.[[Status]] is ~linked~ or ~evaluated~.
             1. Let _stack_ be a new empty List.
             1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion, then
               1. For each Cyclic Module Record _m_ in _stack_, do
-                1. Assert: _m_.[[Status]] is `"evaluating"`.
-                1. Set _m_.[[Status]] to `"evaluated"`.
+                1. Assert: _m_.[[Status]] is ~evaluating~.
+                1. Set _m_.[[Status]] to ~evaluated~.
                 1. Set _m_.[[EvaluationError]] to _result_.
-              1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
+              1. Assert: _module_.[[Status]] is ~evaluated~ and _module_.[[EvaluationError]] is _result_.
               1. Return _result_.
-            1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is *undefined*.
+            1. Assert: _module_.[[Status]] is ~evaluated~ and _module_.[[EvaluationError]] is *undefined*.
             1. Assert: _stack_ is empty.
             1. Return *undefined*.
           </emu-alg>
@@ -22776,12 +22781,12 @@
               1. If _module_ is not a Cyclic Module Record, then
                 1. Perform ? _module_.Evaluate().
                 1. Return _index_.
-              1. If _module_.[[Status]] is `"evaluated"`, then
+              1. If _module_.[[Status]] is ~evaluated~, then
                 1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
                 1. Otherwise, return _module_.[[EvaluationError]].
-              1. If _module_.[[Status]] is `"evaluating"`, return _index_.
-              1. Assert: _module_.[[Status]] is `"linked"`.
-              1. Set _module_.[[Status]] to `"evaluating"`.
+              1. If _module_.[[Status]] is ~evaluating~, return _index_.
+              1. Assert: _module_.[[Status]] is ~linked~.
+              1. Set _module_.[[Status]] to ~evaluating~.
               1. Set _module_.[[DFSIndex]] to _index_.
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Set _index_ to _index_ + 1.
@@ -22791,9 +22796,9 @@
                 1. NOTE: Link must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
-                  1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
-                  1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
-                  1. If _requiredModule_.[[Status]] is `"evaluating"`, then
+                  1. Assert: _requiredModule_.[[Status]] is either ~evaluating~ or ~evaluated~.
+                  1. Assert: _requiredModule_.[[Status]] is ~evaluating~ if and only if _requiredModule_ is in _stack_.
+                  1. If _requiredModule_.[[Status]] is ~evaluating~, then
                     1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? _module_.ExecuteModule().
               1. Assert: _module_ occurs exactly once in _stack_.
@@ -22804,7 +22809,7 @@
                   1. Let _requiredModule_ be the last element in _stack_.
                   1. Remove the last element of _stack_.
                   1. Assert: _requiredModule_ is a Cyclic Module Record.
-                  1. Set _requiredModule_.[[Status]] to `"evaluated"`.
+                  1. Set _requiredModule_.[[Status]] to ~evaluated~.
                   1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
               1. Return _index_.
             </emu-alg>
@@ -22822,11 +22827,11 @@
             <img alt="A module graph in which module A depends on module B, and module B depends on module C" width="121" height="211" src="img/module-graph-simple.svg">
           </emu-figure>
 
-          <p>Let's first assume that there are no error conditions. When a host first calls _A_.Link(), this will complete successfully by assumption, and recursively link modules _B_ and _C_ as well, such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = `"linked"`. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be `"evaluated"`.</p>
+          <p>Let's first assume that there are no error conditions. When a host first calls _A_.Link(), this will complete successfully by assumption, and recursively link modules _B_ and _C_ as well, such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = ~linked~. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be ~evaluated~.</p>
 
-          <p>Consider then cases involving linking errors. If InnerModuleLinking of _C_ succeeds but, thereafter, fails for _B_, for example because it imports something that _C_ does not provide, then the original _A_.Link() will fail, and both _A_ and _B_'s [[Status]] remain `"unlinked"`. _C_'s [[Status]] has become `"linked"`, though.</p>
+          <p>Consider then cases involving linking errors. If InnerModuleLinking of _C_ succeeds but, thereafter, fails for _B_, for example because it imports something that _C_ does not provide, then the original _A_.Link() will fail, and both _A_ and _B_'s [[Status]] remain ~unlinked~. _C_'s [[Status]] has become ~linked~, though.</p>
 
-          <p>Finally, consider a case involving evaluation errors. If InnerModuleEvaluation of _C_ succeeds but, thereafter, fails for _B_, for example because _B_ contains code that throws an exception, then the original _A_.Evaluate() will fail. The resulting exception will be recorded in both _A_ and _B_'s [[EvaluationError]] fields, and their [[Status]] will become `"evaluated"`. _C_ will also become `"evaluated"` but, in contrast to _A_ and _B_, will remain without an [[EvaluationError]], as it successfully completed evaluation. Storing the exception ensures that any time a host tries to reuse _A_ or _B_ by calling their Evaluate() method, it will encounter the same exception. (Hosts are not required to reuse Cyclic Module Records; similarly, hosts are not required to expose the exception objects thrown by these  methods. However, the specification enables such uses.)</p>
+          <p>Finally, consider a case involving evaluation errors. If InnerModuleEvaluation of _C_ succeeds but, thereafter, fails for _B_, for example because _B_ contains code that throws an exception, then the original _A_.Evaluate() will fail. The resulting exception will be recorded in both _A_ and _B_'s [[EvaluationError]] fields, and their [[Status]] will become ~evaluated~. _C_ will also become ~evaluated~ but, in contrast to _A_ and _B_, will remain without an [[EvaluationError]], as it successfully completed evaluation. Storing the exception ensures that any time a host tries to reuse _A_ or _B_ by calling their Evaluate() method, it will encounter the same exception. (Hosts are not required to reuse Cyclic Module Records; similarly, hosts are not required to expose the exception objects thrown by these  methods. However, the specification enables such uses.)</p>
 
           <p>The difference here between linking and evaluation errors is due to how evaluation must be only performed once, as it can cause side effects; it is thus important to remember whether evaluation has already been performed, even if unsuccessfully. (In the error case, it makes sense to also remember the exception because otherwise subsequent Evaluate() calls would have to synthesize a new one.) Linking, on the other hand, is side-effect-free, and thus even if it fails, it can be retried at a later time with no issues.</p>
 
@@ -22836,7 +22841,7 @@
             <img alt="A module graph in which module A depends on a missing (unresolvable) module, represented by ???" width="121" height="121" src="img/module-graph-missing.svg">
           </emu-figure>
 
-          <p>In this scenario, module _A_ declares a dependency on some other module, but no Module Record exists for that module, i.e. HostResolveImportedModule throws an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule throwing an exception when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the exception they throw from HostResolveImportedModule. In any case, this exception causes a linking failure, which as before results in _A_'s [[Status]] remaining `"unlinked"`.</p>
+          <p>In this scenario, module _A_ declares a dependency on some other module, but no Module Record exists for that module, i.e. HostResolveImportedModule throws an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule throwing an exception when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the exception they throw from HostResolveImportedModule. In any case, this exception causes a linking failure, which as before results in _A_'s [[Status]] remaining ~unlinked~.</p>
 
           <p>Lastly, consider a module graph with a cycle:</p>
 
@@ -22844,13 +22849,13 @@
             <img alt="A module graph in which module A depends on module B and C, but module B also depends on module A" width="181" height="121" src="img/module-graph-cycle.svg">
           </emu-figure>
 
-          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Link(), which performs InnerModuleLinking on _A_. This in turn calls InnerModuleLinking on _B_. Because of the cycle, this again triggers InnerModuleLinking on _A_, but at this point it is a no-op since _A_.[[Status]] is already `"linking"`. _B_.[[Status]] itself remains `"linking"` when control gets back to _A_ and InnerModuleLinking is triggered on _C_. After this returns with _C_.[[Status]] being `"linked"` , both _A_ and _B_ transition from `"linking"` to `"linked"` together; this is by design, since they form a strongly connected component.</p>
+          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Link(), which performs InnerModuleLinking on _A_. This in turn calls InnerModuleLinking on _B_. Because of the cycle, this again triggers InnerModuleLinking on _A_, but at this point it is a no-op since _A_.[[Status]] is already ~linking~. _B_.[[Status]] itself remains ~linking~ when control gets back to _A_ and InnerModuleLinking is triggered on _C_. After this returns with _C_.[[Status]] being ~linked~ , both _A_ and _B_ transition from ~linking~ to ~linked~ together; this is by design, since they form a strongly connected component.</p>
 
           <p>An analogous story occurs for the evaluation phase of a cyclic module graph, in the success case.</p>
 
-          <p>Now consider a case where _A_ has an linking error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleLinking on _A_. However, once we unwind back to the original InnerModuleLinking on _A_, it fails during ModuleDeclarationEnvironmentSetup, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Link, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still `"linking"`). Hence both _A_ and _B_ become `"unlinked"`. Note that _C_ is left as `"linked"`.</p>
+          <p>Now consider a case where _A_ has an linking error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleLinking on _A_. However, once we unwind back to the original InnerModuleLinking on _A_, it fails during ModuleDeclarationEnvironmentSetup, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Link, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still ~linking~). Hence both _A_ and _B_ become ~unlinked~. Note that _C_ is left as ~linked~.</p>
 
-          <p>Finally, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate(), which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still `"evaluating"`). Hence both _A_ and _B_ become `"evaluated"` and the exception is recorded in both _A_ and _B_'s [[EvaluationError]] fields, while _C_ is left as `"evaluated"` with no [[EvaluationError]].</p>
+          <p>Finally, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate(), which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still ~evaluating~). Hence both _A_ and _B_ become ~evaluated~ and the exception is recorded in both _A_ and _B_'s [[EvaluationError]] fields, while _C_ is left as ~evaluated~ with no [[EvaluationError]].</p>
         </emu-clause>
       </emu-clause>
 
@@ -23373,7 +23378,7 @@
                 1. Append _ee_ to _starExportEntries_.
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
-            1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, [[Status]]: `"unlinked"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
+            1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, [[Status]]: ~unlinked~, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
           </emu-alg>
           <emu-note>
             <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -23651,7 +23656,7 @@
 
         <emu-alg>
           1. Assert: _module_ is an instance of a concrete subclass of Module Record.
-          1. Assert: If _module_ is a Cyclic Module Record, then _module_.[[Status]] is not `"unlinked"`.
+          1. Assert: If _module_ is a Cyclic Module Record, then _module_.[[Status]] is not ~unlinked~.
           1. Let _namespace_ be _module_.[[Namespace]].
           1. If _namespace_ is *undefined*, then
             1. Let _exportedNames_ be ? _module_.GetExportedNames().
@@ -24474,7 +24479,7 @@
             1. Let _F_ be _thisEnvRec_.[[FunctionObject]].
             1. Let _inFunction_ be *true*.
             1. Let _inMethod_ be _thisEnvRec_.HasSuperBinding().
-            1. If _F_.[[ConstructorKind]] is `"derived"`, let _inDerivedConstructor_ be *true*; otherwise, let _inDerivedConstructor_ be *false*.
+            1. If _F_.[[ConstructorKind]] is ~derived~, let _inDerivedConstructor_ be *true*; otherwise, let _inDerivedConstructor_ be *false*.
           1. Else,
             1. Let _inFunction_ be *false*.
             1. Let _inMethod_ be *false*.
@@ -24650,7 +24655,7 @@
       <p>The `parseFloat` function is the <dfn>%parseFloat%</dfn> intrinsic object. When the `parseFloat` function is called with one argument _string_, the following steps are taken:</p>
       <emu-alg>
         1. Let _inputString_ be ? ToString(_string_).
-        1. Let _trimmedString_ be ! TrimString(_inputString_, `"start"`).
+        1. Let _trimmedString_ be ! TrimString(_inputString_, ~start~).
         1. If neither _trimmedString_ nor any prefix of _trimmedString_ satisfies the syntax of a |StrDecimalLiteral| (see <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>), return *NaN*.
         1. Let _numberString_ be the longest prefix of _trimmedString_, which might be _trimmedString_ itself, that satisfies the syntax of a |StrDecimalLiteral|.
         1. Let _mathFloat_ be MV of _numberString_.
@@ -24670,7 +24675,7 @@
       <p>The `parseInt` function is the <dfn>%parseInt%</dfn> intrinsic object. When the `parseInt` function is called, the following steps are taken:</p>
       <emu-alg>
         1. Let _inputString_ be ? ToString(_string_).
-        1. Let _S_ be ! TrimString(_inputString_, `"start"`).
+        1. Let _S_ be ! TrimString(_inputString_, ~start~).
         1. Let _sign_ be 1.
         1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002D (HYPHEN-MINUS), set _sign_ to -1.
         1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), remove the first code unit from _S_.
@@ -25371,7 +25376,7 @@
         <p>When the `entries` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, `"key+value"`).
+          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~key+value~).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -25381,7 +25386,7 @@
         <p>When the `freeze` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return _O_.
-          1. Let _status_ be ? SetIntegrityLevel(_O_, `"frozen"`).
+          1. Let _status_ be ? SetIntegrityLevel(_O_, ~frozen~).
           1. If _status_ is *false*, throw a *TypeError* exception.
           1. Return _O_.
         </emu-alg>
@@ -25503,7 +25508,7 @@
         <p>When the `isFrozen` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return *true*.
-          1. Return ? TestIntegrityLevel(_O_, `"frozen"`).
+          1. Return ? TestIntegrityLevel(_O_, ~frozen~).
         </emu-alg>
       </emu-clause>
 
@@ -25512,7 +25517,7 @@
         <p>When the `isSealed` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return *true*.
-          1. Return ? TestIntegrityLevel(_O_, `"sealed"`).
+          1. Return ? TestIntegrityLevel(_O_, ~sealed~).
         </emu-alg>
       </emu-clause>
 
@@ -25521,7 +25526,7 @@
         <p>When the `keys` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, `"key"`).
+          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~key~).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -25548,7 +25553,7 @@
         <p>When the `seal` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return _O_.
-          1. Let _status_ be ? SetIntegrityLevel(_O_, `"sealed"`).
+          1. Let _status_ be ? SetIntegrityLevel(_O_, ~sealed~).
           1. If _status_ is *false*, throw a *TypeError* exception.
           1. Return _O_.
         </emu-alg>
@@ -25572,7 +25577,7 @@
         <p>When the `values` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, `"value"`).
+          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~value~).
           1. Return CreateArrayFromList(_nameList_).
         </emu-alg>
       </emu-clause>
@@ -25719,7 +25724,7 @@
         <emu-alg>
           1. Let _C_ be the active function object.
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, `"normal"`, _args_).
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~normal~, _args_).
         </emu-alg>
         <emu-note>
           <p>It is permissible but not necessary to have one argument for each formal parameter to be specified. For example, all three of the following expressions produce the same result:</p>
@@ -25732,7 +25737,7 @@
 
         <emu-clause id="sec-createdynamicfunction" aoid="CreateDynamicFunction">
           <h1>Runtime Semantics: CreateDynamicFunction ( _constructor_, _newTarget_, _kind_, _args_ )</h1>
-          <p>The abstract operation CreateDynamicFunction is called with arguments _constructor_, _newTarget_, _kind_, and _args_. _constructor_ is the constructor function that is performing this action, _newTarget_ is the constructor that `new` was initially applied to, _kind_ is either `"normal"`, `"generator"`, `"async"`, or `"async generator"`, and _args_ is a List containing the actual argument values that were passed to _constructor_. The following steps are taken:</p>
+          <p>The abstract operation CreateDynamicFunction is called with arguments _constructor_, _newTarget_, _kind_, and _args_. _constructor_ is the constructor function that is performing this action, _newTarget_ is the constructor that `new` was initially applied to, _kind_ is either ~normal~, ~generator~, ~async~, or ~asyncGenerator~, and _args_ is a List containing the actual argument values that were passed to _constructor_. The following steps are taken:</p>
           <emu-alg>
             1. Assert: The execution context stack has at least two elements.
             1. Let _callerContext_ be the second to top element of the execution context stack.
@@ -25740,20 +25745,20 @@
             1. Let _calleeRealm_ be the current Realm Record.
             1. Perform ? HostEnsureCanCompileStrings(_callerRealm_, _calleeRealm_).
             1. If _newTarget_ is *undefined*, set _newTarget_ to _constructor_.
-            1. If _kind_ is `"normal"`, then
+            1. If _kind_ is ~normal~, then
               1. Let _goal_ be the grammar symbol |FunctionBody[~Yield, ~Await]|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, ~Await]|.
               1. Let _fallbackProto_ be `"%Function.prototype%"`.
-            1. Else if _kind_ is `"generator"`, then
+            1. Else if _kind_ is ~generator~, then
               1. Let _goal_ be the grammar symbol |GeneratorBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, ~Await]|.
               1. Let _fallbackProto_ be `"%Generator%"`.
-            1. Else if _kind_ is `"async"`, then
+            1. Else if _kind_ is ~async~, then
               1. Let _goal_ be the grammar symbol |AsyncFunctionBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, +Await]|.
               1. Let _fallbackProto_ be `"%AsyncFunction.prototype%"`.
             1. Else,
-              1. Assert: _kind_ is `"async generator"`.
+              1. Assert: _kind_ is ~asyncGenerator~.
               1. Let _goal_ be the grammar symbol |AsyncGeneratorBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, +Await]|.
               1. Let _fallbackProto_ be `"%AsyncGenerator%"`.
@@ -25784,9 +25789,9 @@
               1. If _parameters_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
               1. If _body_ Contains |SuperProperty| is *true*, throw a *SyntaxError* exception.
               1. If _parameters_ Contains |SuperProperty| is *true*, throw a *SyntaxError* exception.
-              1. If _kind_ is `"generator"` or `"async generator"`, then
+              1. If _kind_ is ~generator~ or ~asyncGenerator~, then
                 1. If _parameters_ Contains |YieldExpression| is *true*, throw a *SyntaxError* exception.
-              1. If _kind_ is `"async"` or `"async generator"`, then
+              1. If _kind_ is ~async~ or ~asyncGenerator~, then
                 1. If _parameters_ Contains |AwaitExpression| is *true*, throw a *SyntaxError* exception.
               1. If _strict_ is *true*, then
                 1. If BoundNames of _parameters_ contains any duplicate elements, throw a *SyntaxError* exception.
@@ -25795,13 +25800,13 @@
             1. Let _realmF_ be _F_.[[Realm]].
             1. Let _scope_ be _realmF_.[[GlobalEnv]].
             1. Perform FunctionInitialize(_F_, ~Normal~, _parameters_, _body_, _scope_).
-            1. If _kind_ is `"generator"`, then
+            1. If _kind_ is ~generator~, then
               1. Let _prototype_ be ObjectCreate(%Generator.prototype%).
               1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-            1. Else if _kind_ is `"async generator"`, then
+            1. Else if _kind_ is ~asyncGenerator~, then
               1. Let _prototype_ be ObjectCreate(%AsyncGenerator.prototype%).
               1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-            1. Else if _kind_ is `"normal"`, perform MakeConstructor(_F_).
+            1. Else if _kind_ is ~normal~, perform MakeConstructor(_F_).
             1. NOTE: Async functions are not constructable and do not have a [[Construct]] internal method or a `"prototype"` property.
             1. Perform SetFunctionName(_F_, `"anonymous"`).
             1. Let _prefix_ be the prefix associated with _kind_ in <emu-xref href="#table-dynamic-function-sourcetext-prefixes"></emu-xref>.
@@ -25817,10 +25822,10 @@
             <table>
               <tbody>
                 <tr><th>Kind</th><th>Prefix</th></tr>
-                <tr><td>`"normal"`</td><td>`"function"`</td></tr>
-                <tr><td>`"generator"`</td><td>`"function*"`</td></tr>
-                <tr><td>`"async"`</td><td>`"async function"`</td></tr>
-                <tr><td>`"async generator"`</td><td>`"async function*"`</td></tr>
+                <tr><td>~normal~</td><td>`"function"`</td></tr>
+                <tr><td>~generator~</td><td>`"function*"`</td></tr>
+                <tr><td>~async~</td><td>`"async function"`</td></tr>
+                <tr><td>~asyncGenerator~</td><td>`"async function*"`</td></tr>
               </tbody>
             </table>
           </emu-table>
@@ -29027,7 +29032,7 @@ THH:mm:ss.sss
             1. Let _yv_ be YearFromTime(_tv_).
             1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be `"-"`.
             1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
-            1. Let _paddedYear_ be ! StringPad(_year_, 4, `"0"`, `"start"`).
+            1. Let _paddedYear_ be ! StringPad(_year_, 4, `"0"`, ~start~).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
@@ -29264,7 +29269,7 @@ THH:mm:ss.sss
           1. Let _yv_ be YearFromTime(_tv_).
           1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be `"-"`.
           1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
-          1. Let _paddedYear_ be ! StringPad(_year_, 4, `"0"`, `"start"`).
+          1. Let _paddedYear_ be ! StringPad(_year_, 4, `"0"`, ~start~).
           1. Return the string-concatenation of _weekday_, `","`, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
@@ -29714,7 +29719,7 @@ THH:mm:ss.sss
         <p>When the `padEnd` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
-          1. Return ? StringPad(_O_, _maxLength_, _fillString_, `"end"`).
+          1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~end~).
         </emu-alg>
       </emu-clause>
 
@@ -29723,14 +29728,14 @@ THH:mm:ss.sss
         <p>When the `padStart` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
-          1. Return ? StringPad(_O_, _maxLength_, _fillString_, `"start"`).
+          1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~start~).
         </emu-alg>
 
         <emu-clause id="sec-stringpad" aoid="StringPad">
           <h1>Runtime Semantics: StringPad ( _O_, _maxLength_, _fillString_, _placement_ )</h1>
           <p>When the abstract operation StringPad is called with arguments _O_, _maxLength_, _fillString_, and _placement_, the following steps are taken:</p>
           <emu-alg>
-            1. Assert: _placement_ is `"start"` or `"end"`.
+            1. Assert: _placement_ is ~start~ or ~end~.
             1. Let _S_ be ? ToString(_O_).
             1. Let _intMaxLength_ be ? ToLength(_maxLength_).
             1. Let _stringLength_ be the length of _S_.
@@ -29740,7 +29745,7 @@ THH:mm:ss.sss
             1. If _filler_ is the empty String, return _S_.
             1. Let _fillLen_ be _intMaxLength_ - _stringLength_.
             1. Let _truncatedStringFiller_ be the String value consisting of repeated concatenations of _filler_ truncated to length _fillLen_.
-            1. If _placement_ is `"start"`, return the string-concatenation of _truncatedStringFiller_ and _S_.
+            1. If _placement_ is ~start~, return the string-concatenation of _truncatedStringFiller_ and _S_.
             1. Else, return the string-concatenation of _S_ and _truncatedStringFiller_.
           </emu-alg>
           <emu-note>
@@ -30174,7 +30179,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? TrimString(_S_, `"start+end"`).
+          1. Return ? TrimString(_S_, ~start+end~).
         </emu-alg>
         <emu-note>
           <p>The `trim` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -30186,10 +30191,10 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _str_ be ? RequireObjectCoercible(_string_).
             1. Let _S_ be ? ToString(_str_).
-            1. If _where_ is `"start"`, let _T_ be the String value that is a copy of _S_ with leading white space removed.
-            1. Else if _where_ is `"end"`, let _T_ be the String value that is a copy of _S_ with trailing white space removed.
+            1. If _where_ is ~start~, let _T_ be the String value that is a copy of _S_ with leading white space removed.
+            1. Else if _where_ is ~end~, let _T_ be the String value that is a copy of _S_ with trailing white space removed.
             1. Else,
-              1. Assert: _where_ is `"start+end"`.
+              1. Assert: _where_ is ~start+end~.
               1. Let _T_ be the String value that is a copy of _S_ with both leading and trailing white space removed.
             1. Return _T_.
           </emu-alg>
@@ -30203,7 +30208,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? TrimString(_S_, `"end"`).
+          1. Return ? TrimString(_S_, ~end~).
         </emu-alg>
         <emu-note>
           <p>The `trimEnd` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -30216,7 +30221,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? TrimString(_S_, `"start"`).
+          1. Return ? TrimString(_S_, ~start~).
         </emu-alg>
         <emu-note>
           <p>The `trimStart` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -33008,7 +33013,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
-          1. Return CreateArrayIterator(_O_, `"key+value"`).
+          1. Return CreateArrayIterator(_O_, ~key+value~).
         </emu-alg>
         <p>This function is the <dfn>%ArrayProto_entries%</dfn> intrinsic object.</p>
       </emu-clause>
@@ -33357,7 +33362,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
-          1. Return CreateArrayIterator(_O_, `"key"`).
+          1. Return CreateArrayIterator(_O_, ~key~).
         </emu-alg>
         <p>This function is the <dfn>%ArrayProto_keys%</dfn> intrinsic object.</p>
       </emu-clause>
@@ -34001,7 +34006,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
-          1. Return CreateArrayIterator(_O_, `"value"`).
+          1. Return CreateArrayIterator(_O_, ~value~).
         </emu-alg>
         <p>This function is the <dfn>%ArrayProto_values%</dfn> intrinsic object.</p>
       </emu-clause>
@@ -34096,12 +34101,12 @@ THH:mm:ss.sss
               1. Set _O_.[[IteratedObject]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
             1. Set _O_.[[ArrayIteratorNextIndex]] to _index_ + 1.
-            1. If _itemKind_ is `"key"`, return CreateIterResultObject(_index_, *false*).
+            1. If _itemKind_ is ~key~, return CreateIterResultObject(_index_, *false*).
             1. Let _elementKey_ be ! ToString(_index_).
             1. Let _elementValue_ be ? Get(_a_, _elementKey_).
-            1. If _itemKind_ is `"value"`, let _result_ be _elementValue_.
+            1. If _itemKind_ is ~value~, let _result_ be _elementValue_.
             1. Else,
-              1. Assert: _itemKind_ is `"key+value"`.
+              1. Assert: _itemKind_ is ~key+value~.
               1. Let _result_ be ! CreateArrayFromList(&laquo; _index_, _elementValue_ &raquo;).
             1. Return CreateIterResultObject(_result_, *false*).
           </emu-alg>
@@ -34149,7 +34154,7 @@ THH:mm:ss.sss
                 [[ArrayIterationKind]]
               </td>
               <td>
-                A String value that identifies what is returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`.
+                A String value that identifies what is returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~.
               </td>
             </tr>
             </tbody>
@@ -34189,7 +34194,7 @@ THH:mm:ss.sss
             %Int8Array%
           </td>
           <td>
-            Int8
+            ~Int8~
           </td>
           <td>
             1
@@ -34208,7 +34213,7 @@ THH:mm:ss.sss
             %Uint8Array%
           </td>
           <td>
-            Uint8
+            ~Uint8~
           </td>
           <td>
             1
@@ -34227,7 +34232,7 @@ THH:mm:ss.sss
             %Uint8ClampedArray%
           </td>
           <td>
-            Uint8C
+            ~Uint8C~
           </td>
           <td>
             1
@@ -34246,7 +34251,7 @@ THH:mm:ss.sss
             %Int16Array%
           </td>
           <td>
-            Int16
+            ~Int16~
           </td>
           <td>
             2
@@ -34265,7 +34270,7 @@ THH:mm:ss.sss
             %Uint16Array%
           </td>
           <td>
-            Uint16
+            ~Uint16~
           </td>
           <td>
             2
@@ -34284,7 +34289,7 @@ THH:mm:ss.sss
             %Int32Array%
           </td>
           <td>
-            Int32
+            ~Int32~
           </td>
           <td>
             4
@@ -34303,7 +34308,7 @@ THH:mm:ss.sss
             %Uint32Array%
           </td>
           <td>
-            Uint32
+            ~Uint32~
           </td>
           <td>
             4
@@ -34322,7 +34327,7 @@ THH:mm:ss.sss
             %BigInt64Array%
           </td>
           <td>
-            BigInt64
+            ~BigInt64~
           </td>
           <td>
             8
@@ -34341,7 +34346,7 @@ THH:mm:ss.sss
             %BigUint64Array%
           </td>
           <td>
-            BigUint64
+            ~BigUint64~
           </td>
           <td>
             8
@@ -34360,7 +34365,7 @@ THH:mm:ss.sss
             %Float32Array%
           </td>
           <td>
-            Float32
+            ~Float32~
           </td>
           <td>
             4
@@ -34378,7 +34383,7 @@ THH:mm:ss.sss
             %Float64Array%
           </td>
           <td>
-            Float64
+            ~Float64~
           </td>
           <td>
             8
@@ -34612,8 +34617,8 @@ THH:mm:ss.sss
             1. Else,
               1. Let _direction_ be 1.
             1. Repeat, while _countBytes_ &gt; 0
-              1. Let _value_ be GetValueFromBuffer(_buffer_, _fromByteIndex_, `"Uint8"`, *true*, `"Unordered"`).
-              1. Perform SetValueInBuffer(_buffer_, _toByteIndex_, `"Uint8"`, _value_, *true*, `"Unordered"`).
+              1. Let _value_ be GetValueFromBuffer(_buffer_, _fromByteIndex_, ~Uint8~, *true*, ~Unordered~).
+              1. Perform SetValueInBuffer(_buffer_, _toByteIndex_, ~Uint8~, _value_, *true*, ~Unordered~).
               1. Set _fromByteIndex_ to _fromByteIndex_ + _direction_.
               1. Set _toByteIndex_ to _toByteIndex_ + _direction_.
               1. Set _countBytes_ to _countBytes_ - 1.
@@ -34639,7 +34644,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Return CreateArrayIterator(_O_, `"key+value"`).
+          1. Return CreateArrayIterator(_O_, ~key+value~).
         </emu-alg>
       </emu-clause>
 
@@ -34657,7 +34662,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. If _O_.[[ContentType]] is `"BigInt"`, set _value_ to ? ToBigInt(_value_).
+          1. If _O_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
           1. Otherwise, set _value_ to ? ToNumber(_value_).
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
@@ -34745,7 +34750,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Return CreateArrayIterator(_O_, `"key"`).
+          1. Return CreateArrayIterator(_O_, ~key~).
         </emu-alg>
       </emu-clause>
 
@@ -34831,7 +34836,7 @@ THH:mm:ss.sss
             1. Let _targetLength_ be _target_.[[ArrayLength]].
             1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
             1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
-            1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
+            1. Let _targetType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _src_ be ? ToObject(_array_).
             1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
@@ -34842,10 +34847,10 @@ THH:mm:ss.sss
             1. Repeat, while _targetByteIndex_ &lt; _limit_
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _value_ be ? Get(_src_, _Pk_).
-              1. If _target_.[[ContentType]] is `"BigInt"`, set _value_ to ? ToBigInt(_value_).
+              1. If _target_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
               1. Otherwise, set _value_ to ? ToNumber(_value_).
               1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, `"Unordered"`).
+              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
               1. Set _k_ to _k_ + 1.
               1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
             1. Return *undefined*.
@@ -34868,11 +34873,11 @@ THH:mm:ss.sss
             1. Let _srcBuffer_ be _typedArray_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
-            1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
+            1. Let _targetType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _targetName_.
             1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _srcName_ be the String value of _typedArray_.[[TypedArrayName]].
-            1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
+            1. Let _srcType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
             1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _srcName_.
             1. Let _srcLength_ be _typedArray_.[[ArrayLength]].
             1. Let _srcByteOffset_ be _typedArray_.[[ByteOffset]].
@@ -34889,17 +34894,17 @@ THH:mm:ss.sss
             1. Else, let _srcByteIndex_ be _srcByteOffset_.
             1. Let _targetByteIndex_ be _targetOffset_ &times; _targetElementSize_ + _targetByteOffset_.
             1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ &times; _srcLength_.
-            1. If SameValue(_srcType_, _targetType_) is *true*, then
+            1. If _srcType_ is the same as _targetType_, then
               1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
               1. Repeat, while _targetByteIndex_ &lt; _limit_
-                1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, `"Uint8"`, *true*, `"Unordered"`).
-                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, `"Uint8"`, _value_, *true*, `"Unordered"`).
+                1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, ~Uint8~, *true*, ~Unordered~).
+                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~Uint8~, _value_, *true*, ~Unordered~).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + 1.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + 1.
             1. Else,
               1. Repeat, while _targetByteIndex_ &lt; _limit_
-                1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, _srcType_, *true*, `"Unordered"`).
-                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, `"Unordered"`).
+                1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, _srcType_, *true*, ~Unordered~).
+                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
             1. Return *undefined*.
@@ -34921,10 +34926,10 @@ THH:mm:ss.sss
           1. Let _count_ be max(_final_ - _k_, 0).
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _count_ &raquo;).
           1. Let _srcName_ be the String value of _O_.[[TypedArrayName]].
-          1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
+          1. Let _srcType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
           1. Let _targetName_ be the String value of _A_.[[TypedArrayName]].
-          1. Let _targetType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
-          1. If SameValue(_srcType_, _targetType_) is *false*, then
+          1. Let _targetType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _targetName_.
+          1. If _srcType_ is different from _targetType_, then
             1. Let _n_ be 0.
             1. Repeat, while _k_ &lt; _final_
               1. Let _Pk_ be ! ToString(_k_).
@@ -34943,8 +34948,8 @@ THH:mm:ss.sss
             1. Let _srcByteIndex_ be (_k_ &times; _elementSize_) + _srcByteOffet_.
             1. Let _limit_ be _targetByteIndex_ + _count_ &times; _elementSize_.
             1. Repeat, while _targetByteIndex_ &lt; _limit_
-              1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, `"Uint8"`, *true*, `"Unordered"`).
-              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, `"Uint8"`, _value_, *true*, `"Unordered"`).
+              1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, ~Uint8~, *true*, ~Unordered~).
+              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~Uint8~, _value_, *true*, ~Unordered~).
               1. Set _srcByteIndex_ to _srcByteIndex_ + 1.
               1. Set _targetByteIndex_ to _targetByteIndex_ + 1.
           1. Return _A_.
@@ -35037,7 +35042,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
-          1. Return CreateArrayIterator(_O_, `"value"`).
+          1. Return CreateArrayIterator(_O_, ~value~).
         </emu-alg>
       </emu-clause>
 
@@ -35103,8 +35108,8 @@ THH:mm:ss.sss
             1. Let _obj_ be IntegerIndexedObjectCreate(_proto_, &laquo; [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;).
             1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
             1. Set _obj_.[[TypedArrayName]] to _constructorName_.
-            1. If _constructorName_ is `"BigInt64Array"` or `"BigUint64Array"`, set _obj_.[[ContentType]] to `"BigInt"`.
-            1. Otherwise, set _obj_.[[ContentType]] to `"Number"`.
+            1. If _constructorName_ is `"BigInt64Array"` or `"BigUint64Array"`, set _obj_.[[ContentType]] to ~BigInt~.
+            1. Otherwise, set _obj_.[[ContentType]] to ~Number~.
             1. If _length_ is not present, then
               1. Set _obj_.[[ByteLength]] to 0.
               1. Set _obj_.[[ByteOffset]] to 0.
@@ -35147,10 +35152,10 @@ THH:mm:ss.sss
           1. Let _srcArray_ be _typedArray_.
           1. Let _srcData_ be _srcArray_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-          1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
+          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
           1. Let _elementLength_ be _srcArray_.[[ArrayLength]].
           1. Let _srcName_ be the String value of _srcArray_.[[TypedArrayName]].
-          1. Let _srcType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
+          1. Let _srcType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
           1. Let _srcElementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _srcName_.
           1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
           1. Let _elementSize_ be the Element Size value in <emu-xref href="#table-49"></emu-xref> for _constructorName_.
@@ -35159,7 +35164,7 @@ THH:mm:ss.sss
             1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
           1. Else,
             1. Let _bufferConstructor_ be %ArrayBuffer%.
-          1. If SameValue(_elementType_, _srcType_) is *true*, then
+          1. If _elementType_ is the same as _srcType_, then
             1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).
           1. Else,
             1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
@@ -35169,8 +35174,8 @@ THH:mm:ss.sss
             1. Let _targetByteIndex_ be 0.
             1. Let _count_ be _elementLength_.
             1. Repeat, while _count_ &gt; 0
-              1. Let _value_ be GetValueFromBuffer(_srcData_, _srcByteIndex_, _srcType_, *true*, `"Unordered"`).
-              1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_, *true*, `"Unordered"`).
+              1. Let _value_ be GetValueFromBuffer(_srcData_, _srcByteIndex_, _srcType_, *true*, ~Unordered~).
+              1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_, *true*, ~Unordered~).
               1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
               1. Set _targetByteIndex_ to _targetByteIndex_ + _elementSize_.
               1. Set _count_ to _count_ - 1.
@@ -35471,7 +35476,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. Return ? CreateMapIterator(_M_, `"key+value"`).
+          1. Return ? CreateMapIterator(_M_, ~key+value~).
         </emu-alg>
       </emu-clause>
 
@@ -35528,7 +35533,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. Return ? CreateMapIterator(_M_, `"key"`).
+          1. Return ? CreateMapIterator(_M_, ~key~).
         </emu-alg>
       </emu-clause>
 
@@ -35569,7 +35574,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
-          1. Return ? CreateMapIterator(_M_, `"value"`).
+          1. Return ? CreateMapIterator(_M_, ~value~).
         </emu-alg>
       </emu-clause>
 
@@ -35636,10 +35641,10 @@ THH:mm:ss.sss
               1. Set _index_ to _index_ + 1.
               1. Set _O_.[[MapNextIndex]] to _index_.
               1. If _e_.[[Key]] is not ~empty~, then
-                1. If _itemKind_ is `"key"`, let _result_ be _e_.[[Key]].
-                1. Else if _itemKind_ is `"value"`, let _result_ be _e_.[[Value]].
+                1. If _itemKind_ is ~key~, let _result_ be _e_.[[Key]].
+                1. Else if _itemKind_ is ~value~, let _result_ be _e_.[[Value]].
                 1. Else,
-                  1. Assert: _itemKind_ is `"key+value"`.
+                  1. Assert: _itemKind_ is ~key+value~.
                   1. Let _result_ be ! CreateArrayFromList(&laquo; _e_.[[Key]], _e_.[[Value]] &raquo;).
                 1. Return CreateIterResultObject(_result_, *false*).
             1. Set _O_.[[Map]] to *undefined*.
@@ -35689,7 +35694,7 @@ THH:mm:ss.sss
                 [[MapIterationKind]]
               </td>
               <td>
-                A String value that identifies what is to be returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`.
+                A String value that identifies what is to be returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~.
               </td>
             </tr>
             </tbody>
@@ -35834,7 +35839,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateSetIterator(_S_, `"key+value"`).
+          1. Return ? CreateSetIterator(_S_, ~key+value~).
         </emu-alg>
         <emu-note>
           <p>For iteration purposes, a Set appears similar to a Map where each entry has the same value for its key and value.</p>
@@ -35905,7 +35910,7 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateSetIterator(_S_, `"value"`).
+          1. Return ? CreateSetIterator(_S_, ~value~).
         </emu-alg>
       </emu-clause>
 
@@ -35972,7 +35977,7 @@ THH:mm:ss.sss
               1. Set _index_ to _index_ + 1.
               1. Set _O_.[[SetNextIndex]] to _index_.
               1. If _e_ is not ~empty~, then
-                1. If _itemKind_ is `"key+value"`, then
+                1. If _itemKind_ is ~key+value~, then
                   1. Return CreateIterResultObject(CreateArrayFromList(&laquo; _e_, _e_ &raquo;), *false*).
                 1. Return CreateIterResultObject(_e_, *false*).
             1. Set _O_.[[IteratedSet]] to *undefined*.
@@ -36022,7 +36027,7 @@ THH:mm:ss.sss
                 [[SetIterationKind]]
               </td>
               <td>
-                A String value that identifies what is to be returned for each element of the iteration. The possible values are: `"key"`, `"value"`, `"key+value"`. `"key"` and `"value"` have the same meaning.
+                A String value that identifies what is to be returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~. ~key~ and ~value~ have the same meaning.
               </td>
             </tr>
             </tbody>
@@ -36383,16 +36388,16 @@ THH:mm:ss.sss
         <h1>IsUnsignedElementType ( _type_ )</h1>
         <p>The abstract operation IsUnsignedElementType verifies if the argument _type_ is an unsigned TypedArray element type. This operation performs the following steps:</p>
         <emu-alg>
-          1. If _type_ is `"Uint8"`, `"Uint8C"`, `"Uint16"`, `"Uint32"`, or `"BigUint64"`, return *true*.
+          1. If _type_ is ~Uint8~, ~Uint8C~, ~Uint16~, ~Uint32~, or ~BigUint64~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-isunclampedintegerelementtype" aoid="IsUnclampedIntegerElementType">
         <h1>IsUnclampedIntegerElementType ( _type_ )</h1>
-        <p>The abstract operation IsUnclampedIntegerElementType verifies if the argument _type_ is an Interger TypedArray element type not including `"Uint8C"`. This operation performs the following steps:</p>
+        <p>The abstract operation IsUnclampedIntegerElementType verifies if the argument _type_ is an Integer TypedArray element type not including ~Uint8C~. This operation performs the following steps:</p>
         <emu-alg>
-          1. If _type_ is `"Int8"`, `"Uint8"`, `"Int16"`, `"Uint16"`, `"Int32"`, or `"Uint32"`, return *true*.
+          1. If _type_ is ~Int8~, ~Uint8~, ~Int16~, ~Uint16~, ~Int32~, or ~Uint32~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -36401,7 +36406,7 @@ THH:mm:ss.sss
         <h1>IsBigIntElementType ( _type_ )</h1>
         <p>The abstract operation IsBigIntElementType verifies if the argument _type_ is a BigInt TypedArray element type. This operation performs the following steps:</p>
         <emu-alg>
-          1. If _type_ is `"BigUint64"` or `"BigInt64"`, return *true*.
+          1. If _type_ is ~BigUint64~ or ~BigInt64~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -36411,22 +36416,22 @@ THH:mm:ss.sss
         <p>The abstract operation IsNoTearConfiguration with arguments _type_ and _order_ performs the following steps:</p>
         <emu-alg>
           1. If ! IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
-          1. If ! IsBigIntElementType(_type_) is *true* and _order_ is not `"Init"` or `"Unordered"`, return *true*.
+          1. If ! IsBigIntElementType(_type_) is *true* and _order_ is not ~Init~ or ~Unordered~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-rawbytestonumeric" aoid="RawBytesToNumeric" oldids="sec-rawbytestonumber">
         <h1>RawBytesToNumeric ( _type_, _rawBytes_, _isLittleEndian_ )</h1>
-        <p>The abstract operation RawBytesToNumeric takes three parameters, a String _type_, a List _rawBytes_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation RawBytesToNumeric takes three parameters, a TypedArray element type _type_, a List _rawBytes_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is *false*, reverse the order of the elements of _rawBytes_.
-          1. If _type_ is `"Float32"`, then
+          1. If _type_ is ~Float32~, then
             1. Let _value_ be the byte elements of _rawBytes_ concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2008 binary32 value.
             1. If _value_ is an IEEE 754-2008 binary32 NaN value, return the *NaN* Number value.
             1. Return the Number value that corresponds to _value_.
-          1. If _type_ is `"Float64"`, then
+          1. If _type_ is ~Float64~, then
             1. Let _value_ be the byte elements of _rawBytes_ concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2008 binary64 value.
             1. If _value_ is an IEEE 754-2008 binary64 NaN value, return the *NaN* Number value.
             1. Return the Number value that corresponds to _value_.
@@ -36441,7 +36446,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-getvaluefrombuffer" aoid="GetValueFromBuffer">
         <h1>GetValueFromBuffer ( _arrayBuffer_, _byteIndex_, _type_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation GetValueFromBuffer takes six parameters, an ArrayBuffer or SharedArrayBuffer _arrayBuffer_, an integer _byteIndex_, a String _type_, a Boolean _isTypedArray_, a String _order_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation GetValueFromBuffer takes six parameters, an ArrayBuffer or SharedArrayBuffer _arrayBuffer_, an integer _byteIndex_, a TypedArray element type _type_, a Boolean _isTypedArray_, _order_ which is one of (~SeqCst~, ~Unordered~), and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -36465,11 +36470,11 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-numerictorawbytes" aoid="NumericToRawBytes" oldids="sec-numbertorawbytes">
         <h1>NumericToRawBytes ( _type_, _value_, _isLittleEndian_ )</h1>
-        <p>The abstract operation NumericToRawBytes takes three parameters, a String _type_, a BigInt or a Number _value_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation NumericToRawBytes takes three parameters, a TypedArray element type _type_, a BigInt or a Number _value_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
-          1. If _type_ is `"Float32"`, then
+          1. If _type_ is ~Float32~, then
             1. Let _rawBytes_ be a List containing the 4 bytes that are the result of converting _value_ to IEEE 754-2008 binary32 format using roundTiesToEven mode. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2008 binary32 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
-          1. Else if _type_ is `"Float64"`, then
+          1. Else if _type_ is ~Float64~, then
             1. Let _rawBytes_ be a List containing the 8 bytes that are the IEEE 754-2008 binary64 format encoding of _value_. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2008 binary64 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
           1. Else,
             1. Let _n_ be the Element Size specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
@@ -36485,7 +36490,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-setvalueinbuffer" aoid="SetValueInBuffer">
         <h1>SetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation SetValueInBuffer takes seven parameters, an ArrayBuffer or SharedArrayBuffer _arrayBuffer_, an integer _byteIndex_, a String _type_, a Number or BigInt _value_, a Boolean _isTypedArray_, a String _order_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation SetValueInBuffer takes seven parameters, an ArrayBuffer or SharedArrayBuffer _arrayBuffer_, an integer _byteIndex_, a TypedArray element type _type_, a Number or BigInt _value_, a Boolean _isTypedArray_, _order_ which is one of (~SeqCst~, ~Unordered~, ~Init~), and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -36507,7 +36512,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-getmodifysetvalueinbuffer" aoid="GetModifySetValueInBuffer">
         <h1>GetModifySetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_, _op_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation GetModifySetValueInBuffer takes six parameters, a SharedArrayBuffer _arrayBuffer_, a nonnegative integer _byteIndex_, a String _type_, a Number or BigInt _value_, a semantic function _op_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation GetModifySetValueInBuffer takes six parameters, a SharedArrayBuffer _arrayBuffer_, a nonnegative integer _byteIndex_, a TypedArray element type _type_, a Number or BigInt _value_, a semantic function _op_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
         <emu-alg>
           1. Assert: IsSharedArrayBuffer(_arrayBuffer_) is *true*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -36521,7 +36526,7 @@ THH:mm:ss.sss
           1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _rawBytesRead_ be a List of length _elementSize_ of nondeterministically chosen byte values.
           1. NOTE: In implementations, _rawBytesRead_ is the result of a load-link, of a load-exclusive, or of an operand of a read-modify-write instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
-          1. Let _rmwEvent_ be ReadModifyWriteSharedMemory { [[Order]]: `"SeqCst"`, [[NoTear]]: *true*, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_, [[ModifyOp]]: _op_ }.
+          1. Let _rmwEvent_ be ReadModifyWriteSharedMemory { [[Order]]: ~SeqCst~, [[NoTear]]: *true*, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_, [[ModifyOp]]: _op_ }.
           1. Append _rmwEvent_ to _eventList_.
           1. Append Chosen Value Record { [[Event]]: _rmwEvent_, [[ChosenValue]]: _rawBytesRead_ } to _execution_.[[ChosenValues]].
           1. Return RawBytesToNumeric(_type_, _rawBytesRead_, _isLittleEndian_).
@@ -36835,7 +36840,7 @@ THH:mm:ss.sss
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
-          1. Return GetValueFromBuffer(_buffer_, _bufferIndex_, _type_, *false*, `"Unordered"`, _isLittleEndian_).
+          1. Return GetValueFromBuffer(_buffer_, _bufferIndex_, _type_, *false*, ~Unordered~, _isLittleEndian_).
         </emu-alg>
       </emu-clause>
 
@@ -36856,7 +36861,7 @@ THH:mm:ss.sss
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
-          1. Return SetValueInBuffer(_buffer_, _bufferIndex_, _type_, _numberValue_, *false*, `"Unordered"`, _isLittleEndian_).
+          1. Return SetValueInBuffer(_buffer_, _bufferIndex_, _type_, _numberValue_, *false*, ~Unordered~, _isLittleEndian_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -36973,7 +36978,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *undefined*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"BigInt64"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~BigInt64~).
         </emu-alg>
       </emu-clause>
 
@@ -36983,7 +36988,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *undefined*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"BigUint64"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~BigUint64~).
         </emu-alg>
       </emu-clause>
 
@@ -36993,7 +36998,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Float32"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~Float32~).
         </emu-alg>
       </emu-clause>
 
@@ -37003,7 +37008,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Float64"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~Float64~).
         </emu-alg>
       </emu-clause>
 
@@ -37012,7 +37017,7 @@ THH:mm:ss.sss
         <p>When the `getInt8` method is called with argument _byteOffset_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
-          1. Return ? GetViewValue(_v_, _byteOffset_, *true*, `"Int8"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, *true*, ~Int8~).
         </emu-alg>
       </emu-clause>
 
@@ -37022,7 +37027,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int16"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~Int16~).
         </emu-alg>
       </emu-clause>
 
@@ -37032,7 +37037,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int32"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~Int32~).
         </emu-alg>
       </emu-clause>
 
@@ -37041,7 +37046,7 @@ THH:mm:ss.sss
         <p>When the `getUint8` method is called with argument _byteOffset_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
-          1. Return ? GetViewValue(_v_, _byteOffset_, *true*, `"Uint8"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, *true*, ~Uint8~).
         </emu-alg>
       </emu-clause>
 
@@ -37051,7 +37056,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint16"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~Uint16~).
         </emu-alg>
       </emu-clause>
 
@@ -37061,7 +37066,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint32"`).
+          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~Uint32~).
         </emu-alg>
       </emu-clause>
 
@@ -37071,7 +37076,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *undefined*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"BigInt64"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~BigInt64~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37081,7 +37086,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *undefined*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"BigUint64"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~BigUint64~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37091,7 +37096,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Float32"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~Float32~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37101,7 +37106,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Float64"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~Float64~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37110,7 +37115,7 @@ THH:mm:ss.sss
         <p>When the `setInt8` method is called with arguments _byteOffset_ and _value_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
-          1. Return ? SetViewValue(_v_, _byteOffset_, *true*, `"Int8"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, *true*, ~Int8~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37120,7 +37125,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int16"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~Int16~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37130,7 +37135,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Int32"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~Int32~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37139,7 +37144,7 @@ THH:mm:ss.sss
         <p>When the `setUint8` method is called with arguments _byteOffset_ and _value_, the following steps are taken:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
-          1. Return ? SetViewValue(_v_, _byteOffset_, *true*, `"Uint8"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, *true*, ~Uint8~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37149,7 +37154,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint16"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~Uint16~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37159,7 +37164,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, `"Uint32"`, _value_).
+          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~Uint32~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -37205,7 +37210,7 @@ THH:mm:ss.sss
           1. If _waitable_ is not present, set _waitable_ to *false*.
           1. Perform ? RequireInternalSlot(_typedArray_, [[TypedArrayName]]).
           1. Let _typeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _type_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _typeName_.
+          1. Let _type_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _typeName_.
           1. If _waitable_ is *true*, then
             1. If _typeName_ is not `"Int32Array"` or `"BigInt64Array"`, throw a *TypeError* exception.
           1. Else,
@@ -37349,10 +37354,10 @@ THH:mm:ss.sss
           1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
           1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. If _typedArray_.[[ContentType]] is `"BigInt"`, let _v_ be ? ToBigInt(_value_).
+          1. If _typedArray_.[[ContentType]] is ~BigInt~, let _v_ be ? ToBigInt(_value_).
           1. Otherwise, let _v_ be ? ToInteger(_value_).
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-          1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _offset_ be _typedArray_.[[ByteOffset]].
           1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
           1. Return GetModifySetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, _op_).
@@ -37367,10 +37372,10 @@ THH:mm:ss.sss
           1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-          1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
           1. Let _offset_ be _typedArray_.[[ByteOffset]].
           1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
-          1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, `"SeqCst"`).
+          1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -37400,13 +37405,13 @@ THH:mm:ss.sss
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. If _typedArray_.[[ContentType]] is `"BigInt"`, then
+        1. If _typedArray_.[[ContentType]] is ~BigInt~, then
           1. Let _expected_ be ? ToBigInt(_expectedValue_).
           1. Let _replacement_ be ? ToBigInt(_replacementValue_).
         1. Else,
           1. Let _expected_ be ? ToInteger(_expectedValue_).
           1. Let _replacement_ be ? ToInteger(_replacementValue_).
-        1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+        1. Let _elementType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
@@ -37471,10 +37476,10 @@ THH:mm:ss.sss
         1. If _arrayTypeName_ is `"BigUint64Array"` or `"BigInt64Array"`, let _v_ be ? ToBigInt(_value_).
         1. Otherwise, let _v_ be ? ToInteger(_value_).
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
-        1. Let _elementType_ be the String value of the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
+        1. Let _elementType_ be the Element Type value in <emu-xref href="#table-49"></emu-xref> for _arrayTypeName_.
         1. Let _offset_ be _typedArray_.[[ByteOffset]].
         1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
-        1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, *true*, `"SeqCst"`).
+        1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, *true*, ~SeqCst~).
         1. Return _v_.
       </emu-alg>
     </emu-clause>
@@ -37630,7 +37635,7 @@ THH:mm:ss.sss
                   1. NOTE: This algorithm intentionally does not throw an exception if CreateDataProperty returns *false*.
                 1. Set _I_ to _I_ + 1.
             1. Else,
-              1. Let _keys_ be ? EnumerableOwnPropertyNames(_val_, `"key"`).
+              1. Let _keys_ be ? EnumerableOwnPropertyNames(_val_, ~key~).
               1. For each String _P_ in _keys_, do
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_).
                 1. If _newElement_ is *undefined*, then
@@ -37903,7 +37908,7 @@ THH:mm:ss.sss
           1. If _PropertyList_ is not *undefined*, then
             1. Let _K_ be _PropertyList_.
           1. Else,
-            1. Let _K_ be ? EnumerableOwnPropertyNames(_value_, `"key"`).
+            1. Let _K_ be ? EnumerableOwnPropertyNames(_value_, ~key~).
           1. Let _partial_ be a new empty List.
           1. For each element _P_ of _K_, do
             1. Let _strP_ be ? SerializeJSONProperty(_P_, _value_).
@@ -38437,7 +38442,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the active function object.
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, `"generator"`, _args_).
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~generator~, _args_).
         </emu-alg>
         <emu-note>
           <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
@@ -38499,7 +38504,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-generatorfunction-instances">
       <h1>GeneratorFunction Instances</h1>
-      <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is `"generator"`.</p>
+      <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is ~generator~.</p>
       <p>Each GeneratorFunction instance has the following own properties:</p>
 
       <emu-clause id="sec-generatorfunction-instances-length">
@@ -38543,7 +38548,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the active function object.
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, `"async generator"`, _args_).
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~asyncGenerator~, _args_).
         </emu-alg>
         <emu-note>
           <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
@@ -38605,7 +38610,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-asyncgeneratorfunction-instances">
       <h1>AsyncGeneratorFunction Instances</h1>
-      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is `"generator"`.</p>
+      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is ~generator~.</p>
       <p>Each AsyncGeneratorFunction instance has the following own properties:</p>
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-length">
@@ -38708,7 +38713,7 @@ THH:mm:ss.sss
               [[GeneratorState]]
             </td>
             <td>
-              The current execution state of the generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, and `"completed"`.
+              The current execution state of the generator. The possible values are: *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, and ~completed~.
             </td>
           </tr>
           <tr>
@@ -38738,8 +38743,8 @@ THH:mm:ss.sss
             1. Let _result_ be the result of evaluating _generatorBody_.
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set _generator_.[[GeneratorState]] to `"completed"`.
-            1. Once a generator enters the `"completed"` state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
+            1. Set _generator_.[[GeneratorState]] to ~completed~.
+            1. Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
             1. If _result_.[[Type]] is ~normal~, let _resultValue_ be *undefined*.
             1. Else if _result_.[[Type]] is ~return~, let _resultValue_ be _result_.[[Value]].
             1. Else,
@@ -38747,7 +38752,7 @@ THH:mm:ss.sss
               1. Return Completion(_result_).
             1. Return CreateIterResultObject(_resultValue_, *true*).
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
-          1. Set _generator_.[[GeneratorState]] to `"suspendedStart"`.
+          1. Set _generator_.[[GeneratorState]] to ~suspendedStart~.
           1. Return NormalCompletion(*undefined*).
         </emu-alg>
       </emu-clause>
@@ -38759,7 +38764,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_generator_, [[GeneratorState]]).
           1. Assert: _generator_ also has a [[GeneratorContext]] internal slot.
           1. Let _state_ be _generator_.[[GeneratorState]].
-          1. If _state_ is `"executing"`, throw a *TypeError* exception.
+          1. If _state_ is ~executing~, throw a *TypeError* exception.
           1. Return _state_.
         </emu-alg>
       </emu-clause>
@@ -38769,12 +38774,12 @@ THH:mm:ss.sss
         <p>The abstract operation GeneratorResume with arguments _generator_ and _value_ performs the following steps:</p>
         <emu-alg>
           1. Let _state_ be ? GeneratorValidate(_generator_).
-          1. If _state_ is `"completed"`, return CreateIterResultObject(*undefined*, *true*).
-          1. Assert: _state_ is either `"suspendedStart"` or `"suspendedYield"`.
+          1. If _state_ is ~completed~, return CreateIterResultObject(*undefined*, *true*).
+          1. Assert: _state_ is either ~suspendedStart~ or ~suspendedYield~.
           1. Let _genContext_ be _generator_.[[GeneratorContext]].
           1. Let _methodContext_ be the running execution context.
           1. Suspend _methodContext_.
-          1. Set _generator_.[[GeneratorState]] to `"executing"`.
+          1. Set _generator_.[[GeneratorState]] to ~executing~.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
           1. Resume the suspended evaluation of _genContext_ using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
@@ -38787,19 +38792,19 @@ THH:mm:ss.sss
         <p>The abstract operation GeneratorResumeAbrupt with arguments _generator_ and _abruptCompletion_ performs the following steps:</p>
         <emu-alg>
           1. Let _state_ be ? GeneratorValidate(_generator_).
-          1. If _state_ is `"suspendedStart"`, then
-            1. Set _generator_.[[GeneratorState]] to `"completed"`.
-            1. Once a generator enters the `"completed"` state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
-            1. Set _state_ to `"completed"`.
-          1. If _state_ is `"completed"`, then
+          1. If _state_ is ~suspendedStart~, then
+            1. Set _generator_.[[GeneratorState]] to ~completed~.
+            1. Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
+            1. Set _state_ to ~completed~.
+          1. If _state_ is ~completed~, then
             1. If _abruptCompletion_.[[Type]] is ~return~, then
               1. Return CreateIterResultObject(_abruptCompletion_.[[Value]], *true*).
             1. Return Completion(_abruptCompletion_).
-          1. Assert: _state_ is `"suspendedYield"`.
+          1. Assert: _state_ is ~suspendedYield~.
           1. Let _genContext_ be _generator_.[[GeneratorContext]].
           1. Let _methodContext_ be the running execution context.
           1. Suspend _methodContext_.
-          1. Set _generator_.[[GeneratorState]] to `"executing"`.
+          1. Set _generator_.[[GeneratorState]] to ~executing~.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
           1. Resume the suspended evaluation of _genContext_ using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
@@ -38827,7 +38832,7 @@ THH:mm:ss.sss
           1. Assert: _genContext_ is the execution context of a generator.
           1. Let _generator_ be the value of the Generator component of _genContext_.
           1. Assert: GetGeneratorKind() is ~sync~.
-          1. Set _generator_.[[GeneratorState]] to `"suspendedYield"`.
+          1. Set _generator_.[[GeneratorState]] to ~suspendedYield~.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
             1. Return _resumptionValue_.
@@ -38910,7 +38915,7 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[AsyncGeneratorState]]</td>
-            <td>The current execution state of the async generator. The possible values are: *undefined*, `"suspendedStart"`, `"suspendedYield"`, `"executing"`, `"awaiting-return"`, and `"completed"`.</td>
+            <td>The current execution state of the async generator. The possible values are: *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, ~awaiting-return~, and ~completed~.</td>
           </tr>
           <tr>
             <td>[[AsyncGeneratorContext]]</td>
@@ -38965,7 +38970,7 @@ THH:mm:ss.sss
             1. Let _result_ be the result of evaluating _generatorBody_.
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set _generator_.[[AsyncGeneratorState]] to `"completed"`.
+            1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
             1. If _result_ is a normal completion, let _resultValue_ be *undefined*.
             1. Else,
               1. Let _resultValue_ be _result_.[[Value]].
@@ -38973,7 +38978,7 @@ THH:mm:ss.sss
                 1. Return ! AsyncGeneratorReject(_generator_, _resultValue_).
             1. Return ! AsyncGeneratorResolve(_generator_, _resultValue_, *true*).
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
-          1. Set _generator_.[[AsyncGeneratorState]] to `"suspendedStart"`.
+          1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedStart~.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return *undefined*.
         </emu-alg>
@@ -39013,20 +39018,20 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _generator_ is an AsyncGenerator instance.
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
-          1. Assert: _state_ is not `"executing"`.
-          1. If _state_ is `"awaiting-return"`, return *undefined*.
+          1. Assert: _state_ is not ~executing~.
+          1. If _state_ is ~awaiting-return~, return *undefined*.
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
           1. If _queue_ is an empty List, return *undefined*.
           1. Let _next_ be the value of the first element of _queue_.
           1. Assert: _next_ is an AsyncGeneratorRequest record.
           1. Let _completion_ be _next_.[[Completion]].
           1. If _completion_ is an abrupt completion, then
-            1. If _state_ is `"suspendedStart"`, then
-              1. Set _generator_.[[AsyncGeneratorState]] to `"completed"`.
-              1. Set _state_ to `"completed"`.
-            1. If _state_ is `"completed"`, then
+            1. If _state_ is ~suspendedStart~, then
+              1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
+              1. Set _state_ to ~completed~.
+            1. If _state_ is ~completed~, then
               1. If _completion_.[[Type]] is ~return~, then
-                1. Set _generator_.[[AsyncGeneratorState]] to `"awaiting-return"`.
+                1. Set _generator_.[[AsyncGeneratorState]] to ~awaiting-return~.
                 1. Let _promise_ be ? PromiseResolve(%Promise%, _completion_.[[Value]]).
                 1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
                 1. Let _onFulfilled_ be ! CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Generator]] &raquo;).
@@ -39040,12 +39045,12 @@ THH:mm:ss.sss
                 1. Assert: _completion_.[[Type]] is ~throw~.
                 1. Perform ! AsyncGeneratorReject(_generator_, _completion_.[[Value]]).
                 1. Return *undefined*.
-          1. Else if _state_ is `"completed"`, return ! AsyncGeneratorResolve(_generator_, *undefined*, *true*).
-          1. Assert: _state_ is either `"suspendedStart"` or `"suspendedYield"`.
+          1. Else if _state_ is ~completed~, return ! AsyncGeneratorResolve(_generator_, *undefined*, *true*).
+          1. Assert: _state_ is either ~suspendedStart~ or ~suspendedYield~.
           1. Let _genContext_ be _generator_.[[AsyncGeneratorContext]].
           1. Let _callerContext_ be the running execution context.
           1. Suspend _callerContext_.
-          1. Set _generator_.[[AsyncGeneratorState]] to `"executing"`.
+          1. Set _generator_.[[AsyncGeneratorState]] to ~executing~.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
           1. Resume the suspended evaluation of _genContext_ using _completion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
           1. Assert: _result_ is never an abrupt completion.
@@ -39062,7 +39067,7 @@ THH:mm:ss.sss
 
           <emu-alg>
             1. Let _F_ be the active function object.
-            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to `"completed"`.
+            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to ~completed~.
             1. Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
           </emu-alg>
 
@@ -39078,7 +39083,7 @@ THH:mm:ss.sss
 
           <emu-alg>
             1. Let _F_ be the active function object.
-            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to `"completed"`.
+            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to ~completed~.
             1. Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
           </emu-alg>
 
@@ -39099,7 +39104,7 @@ THH:mm:ss.sss
           1. Let _request_ be AsyncGeneratorRequest { [[Completion]]: _completion_, [[Capability]]: _promiseCapability_ }.
           1. Append _request_ to the end of _queue_.
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
-          1. If _state_ is not `"executing"`, then
+          1. If _state_ is not ~executing~, then
             1. Perform ! AsyncGeneratorResumeNext(_generator_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
@@ -39114,7 +39119,7 @@ THH:mm:ss.sss
           1. Let _generator_ be the value of the Generator component of _genContext_.
           1. Assert: GetGeneratorKind() is ~async~.
           1. Set _value_ to ? Await(_value_).
-          1. Set _generator_.[[AsyncGeneratorState]] to `"suspendedYield"`.
+          1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedYield~.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
             1. If _resumptionValue_.[[Type]] is not ~return~, return Completion(_resumptionValue_).
@@ -39256,7 +39261,7 @@ THH:mm:ss.sss
                 [[Type]]
               </td>
               <td>
-                Either `"Fulfill"` or `"Reject"`.
+                ~Fulfill~ | ~Reject~
               </td>
               <td>
                 The [[Type]] is used when [[Handler]] is *undefined* to allow for behaviour specific to the settlement type.
@@ -39343,12 +39348,12 @@ THH:mm:ss.sss
         <h1>FulfillPromise ( _promise_, _value_ )</h1>
         <p>When the FulfillPromise abstract operation is called with arguments _promise_ and _value_, the following steps are taken:</p>
         <emu-alg>
-          1. Assert: The value of _promise_.[[PromiseState]] is `"pending"`.
+          1. Assert: The value of _promise_.[[PromiseState]] is ~pending~.
           1. Let _reactions_ be _promise_.[[PromiseFulfillReactions]].
           1. Set _promise_.[[PromiseResult]] to _value_.
           1. Set _promise_.[[PromiseFulfillReactions]] to *undefined*.
           1. Set _promise_.[[PromiseRejectReactions]] to *undefined*.
-          1. Set _promise_.[[PromiseState]] to `"fulfilled"`.
+          1. Set _promise_.[[PromiseState]] to ~fulfilled~.
           1. Return TriggerPromiseReactions(_reactions_, _value_).
         </emu-alg>
       </emu-clause>
@@ -39405,12 +39410,12 @@ THH:mm:ss.sss
         <h1>RejectPromise ( _promise_, _reason_ )</h1>
         <p>When the RejectPromise abstract operation is called with arguments _promise_ and _reason_, the following steps are taken:</p>
         <emu-alg>
-          1. Assert: The value of _promise_.[[PromiseState]] is `"pending"`.
+          1. Assert: The value of _promise_.[[PromiseState]] is ~pending~.
           1. Let _reactions_ be _promise_.[[PromiseRejectReactions]].
           1. Set _promise_.[[PromiseResult]] to _reason_.
           1. Set _promise_.[[PromiseFulfillReactions]] to *undefined*.
           1. Set _promise_.[[PromiseRejectReactions]] to *undefined*.
-          1. Set _promise_.[[PromiseState]] to `"rejected"`.
+          1. Set _promise_.[[PromiseState]] to ~rejected~.
           1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
           1. Return TriggerPromiseReactions(_reactions_, _reason_).
         </emu-alg>
@@ -39462,9 +39467,9 @@ THH:mm:ss.sss
           1. Let _type_ be _reaction_.[[Type]].
           1. Let _handler_ be _reaction_.[[Handler]].
           1. If _handler_ is *undefined*, then
-            1. If _type_ is `"Fulfill"`, let _handlerResult_ be NormalCompletion(_argument_).
+            1. If _type_ is ~Fulfill~, let _handlerResult_ be NormalCompletion(_argument_).
             1. Else,
-              1. Assert: _type_ is `"Reject"`.
+              1. Assert: _type_ is ~Reject~.
               1. Let _handlerResult_ be ThrowCompletion(_argument_).
           1. Else, let _handlerResult_ be Call(_handler_, *undefined*, &laquo; _argument_ &raquo;).
           1. If _promiseCapability_ is *undefined*, then
@@ -39513,7 +39518,7 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
           1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Promise.prototype%"`, &laquo; [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] &raquo;).
-          1. Set _promise_.[[PromiseState]] to `"pending"`.
+          1. Set _promise_.[[PromiseState]] to ~pending~.
           1. Set _promise_.[[PromiseFulfillReactions]] to a new empty List.
           1. Set _promise_.[[PromiseRejectReactions]] to a new empty List.
           1. Set _promise_.[[PromiseIsHandled]] to *false*.
@@ -39958,16 +39963,16 @@ THH:mm:ss.sss
               1. Set _onFulfilled_ to *undefined*.
             1. If IsCallable(_onRejected_) is *false*, then
               1. Set _onRejected_ to *undefined*.
-            1. Let _fulfillReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
-            1. Let _rejectReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
-            1. If _promise_.[[PromiseState]] is `"pending"`, then
+            1. Let _fulfillReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: ~Fulfill~, [[Handler]]: _onFulfilled_ }.
+            1. Let _rejectReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: ~Reject~, [[Handler]]: _onRejected_ }.
+            1. If _promise_.[[PromiseState]] is ~pending~, then
               1. Append _fulfillReaction_ as the last element of the List that is _promise_.[[PromiseFulfillReactions]].
               1. Append _rejectReaction_ as the last element of the List that is _promise_.[[PromiseRejectReactions]].
-            1. Else if _promise_.[[PromiseState]] is `"fulfilled"`, then
+            1. Else if _promise_.[[PromiseState]] is ~fulfilled~, then
               1. Let _value_ be _promise_.[[PromiseResult]].
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _fulfillReaction_, _value_ &raquo;).
             1. Else,
-              1. Assert: The value of _promise_.[[PromiseState]] is `"rejected"`.
+              1. Assert: The value of _promise_.[[PromiseState]] is ~rejected~.
               1. Let _reason_ be _promise_.[[PromiseResult]].
               1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
               1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _rejectReaction_, _reason_ &raquo;).
@@ -40006,7 +40011,7 @@ THH:mm:ss.sss
               [[PromiseState]]
             </td>
             <td>
-              A String value that governs how a promise will react to incoming calls to its `then` method. The possible values are: `"pending"`, `"fulfilled"`, and `"rejected"`.
+              One of ~pending~, ~fulfilled~, or ~rejected~. Governs how a promise will react to incoming calls to its `then` method.
             </td>
           </tr>
           <tr>
@@ -40014,7 +40019,7 @@ THH:mm:ss.sss
               [[PromiseResult]]
             </td>
             <td>
-              The value with which the promise has been fulfilled or rejected, if any. Only meaningful if [[PromiseState]] is not `"pending"`.
+              The value with which the promise has been fulfilled or rejected, if any. Only meaningful if [[PromiseState]] is not ~pending~.
             </td>
           </tr>
           <tr>
@@ -40022,7 +40027,7 @@ THH:mm:ss.sss
               [[PromiseFulfillReactions]]
             </td>
             <td>
-              A List of PromiseReaction records to be processed when/if the promise transitions from the `"pending"` state to the `"fulfilled"` state.
+              A List of PromiseReaction records to be processed when/if the promise transitions from the ~pending~ state to the ~fulfilled~ state.
             </td>
           </tr>
           <tr>
@@ -40030,7 +40035,7 @@ THH:mm:ss.sss
               [[PromiseRejectReactions]]
             </td>
             <td>
-              A List of PromiseReaction records to be processed when/if the promise transitions from the `"pending"` state to the `"rejected"` state.
+              A List of PromiseReaction records to be processed when/if the promise transitions from the ~pending~ state to the ~rejected~ state.
             </td>
           </tr>
           <tr>
@@ -40072,7 +40077,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the active function object.
           2. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          3. Return CreateDynamicFunction(_C_, NewTarget, `"async"`, _args_).
+          3. Return CreateDynamicFunction(_C_, NewTarget, ~async~, _args_).
         </emu-alg>
 
         <emu-note>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</emu-note>
@@ -40132,7 +40137,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-async-function-instances">
       <h1>AsyncFunction Instances</h1>
 
-      <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is `"async"`. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructable.</p>
+      <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[FunctionKind]] internal slot for all such instances is ~async~. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructable.</p>
       <p>Each AsyncFunction instance has the following own properties:</p>
       <emu-clause id="sec-async-function-instances-length">
         <h1>length</h1>
@@ -40436,7 +40441,7 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[Order]]</td>
-            <td>`"SeqCst"` or `"Unordered"`</td>
+            <td>~SeqCst~ | ~Unordered~</td>
             <td>The weakest ordering guaranteed by the memory model for the event.</td>
           </tr>
           <tr>
@@ -40473,7 +40478,7 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[Order]]</td>
-            <td>`"SeqCst"`, `"Unordered"`, or `"Init"`</td>
+            <td>~SeqCst~ | ~Unordered~ | ~Init~</td>
             <td>The weakest ordering guaranteed by the memory model for the event.</td>
           </tr>
           <tr>
@@ -40515,7 +40520,7 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[Order]]</td>
-            <td>`"SeqCst"`</td>
+            <td>~SeqCst~</td>
             <td>Read-modify-write events are always sequentially consistent.</td>
           </tr>
           <tr>
@@ -40810,7 +40815,7 @@ THH:mm:ss.sss
       <p>For a candidate execution _execution_, _execution_.[[SynchronizesWith]] is the least Relation on events that satisfies the following.</p>
       <ul>
         <li>
-          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if _R_.[[Order]] is `"SeqCst"`, _W_.[[Order]] is `"SeqCst"`, and _R_ and _W_ have equal ranges.
+          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if _R_.[[Order]] is ~SeqCst~, _W_.[[Order]] is ~SeqCst~, and _R_ and _W_ have equal ranges.
         </li>
         <li>
           For each element _eventsRecord_ of _execution_.[[EventsRecords]], the following is true.
@@ -40826,11 +40831,11 @@ THH:mm:ss.sss
       </emu-note>
 
       <emu-note>
-        <p>`"Init"` events do not participate in synchronizes-with, and are instead constrained directly by happens-before.</p>
+        <p>~Init~ events do not participate in synchronizes-with, and are instead constrained directly by happens-before.</p>
       </emu-note>
 
       <emu-note>
-        <p>Not all `"SeqCst"` events related by reads-from are related by synchronizes-with. Only events that also have equal ranges are related by synchronizes-with.</p>
+        <p>Not all ~SeqCst~ events related by reads-from are related by synchronizes-with. Only events that also have equal ranges are related by synchronizes-with.</p>
       </emu-note>
 
       <emu-note>
@@ -40845,7 +40850,7 @@ THH:mm:ss.sss
       <ul>
         <li>For each pair (_E_, _D_) in _execution_.[[AgentOrder]], (_E_, _D_) is in _execution_.[[HappensBefore]].</li>
         <li>For each pair (_E_, _D_) in _execution_.[[SynchronizesWith]], (_E_, _D_) is in _execution_.[[HappensBefore]].</li>
-        <li>For each pair (_E_, _D_) in SharedDataBlockEventSet(_execution_), (_E_, _D_) is in _execution_.[[HappensBefore]] if _E_.[[Order]] is `"Init"` and _E_ and _D_ have overlapping ranges.</li>
+        <li>For each pair (_E_, _D_) in SharedDataBlockEventSet(_execution_), (_E_, _D_) is in _execution_.[[HappensBefore]] if _E_.[[Order]] is ~Init~ and _E_ and _D_ have overlapping ranges.</li>
         <li>For each pair (_E_, _D_) in EventSet(_execution_), (_E_, _D_) is in _execution_.[[HappensBefore]] if there is an event _F_ such that the pairs (_E_, _F_) and (_F_, _D_) are in _execution_.[[HappensBefore]].</li>
       </ul>
 
@@ -40917,20 +40922,20 @@ THH:mm:ss.sss
       <ul>
         <li>For each pair (_E_, _D_) in _execution_.[[HappensBefore]], (_E_, _D_) is in memory-order.</li>
         <li>
-          <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ in SharedDataBlockEventSet(_execution_) such that _V_.[[Order]] is `"SeqCst"`, the pairs (_W_, _V_) and (_V_, _R_) are in memory-order, and any of the following conditions are true.</p>
+          <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ in SharedDataBlockEventSet(_execution_) such that _V_.[[Order]] is ~SeqCst~, the pairs (_W_, _V_) and (_V_, _R_) are in memory-order, and any of the following conditions are true.</p>
           <ul>
             <li>The pair (_W_, _R_) is in _execution_.[[SynchronizesWith]], and _V_ and _R_ have equal ranges.</li>
-            <li>The pairs (_W_, _R_) and (_V_, _R_) are in _execution_.[[HappensBefore]], _W_.[[Order]] is `"SeqCst"`, and _W_ and _V_ have equal ranges.</li>
-            <li>The pairs (_W_, _R_) and (_W_, _V_) are in _execution_.[[HappensBefore]], _R_.[[Order]] is `"SeqCst"`, and _V_ and _R_ have equal ranges.</li>
+            <li>The pairs (_W_, _R_) and (_V_, _R_) are in _execution_.[[HappensBefore]], _W_.[[Order]] is ~SeqCst~, and _W_ and _V_ have equal ranges.</li>
+            <li>The pairs (_W_, _R_) and (_W_, _V_) are in _execution_.[[HappensBefore]], _R_.[[Order]] is ~SeqCst~, and _V_ and _R_ have equal ranges.</li>
           </ul>
           <emu-note>
-            <p>This clause additionally constrains `"SeqCst"` events on equal ranges.</p>
+            <p>This clause additionally constrains ~SeqCst~ events on equal ranges.</p>
           </emu-note>
         </li>
         <li>
-          <p>For each WriteSharedMemory or ReadModifyWriteSharedMemory event _W_ in SharedDataBlockEventSet(_execution_), if _W_.[[Order]] is `"SeqCst"`, then it is not the case that there is an infinite number of ReadSharedMemory or ReadModifyWriteSharedMemory events in SharedDataBlockEventSet(_execution_) with equal range that is memory-order before _W_.</p>
+          <p>For each WriteSharedMemory or ReadModifyWriteSharedMemory event _W_ in SharedDataBlockEventSet(_execution_), if _W_.[[Order]] is ~SeqCst~, then it is not the case that there is an infinite number of ReadSharedMemory or ReadModifyWriteSharedMemory events in SharedDataBlockEventSet(_execution_) with equal range that is memory-order before _W_.</p>
           <emu-note>
-            <p>This clause together with the forward progress guarantee on agents ensure the liveness condition that `"SeqCst"` writes become visible to `"SeqCst"` reads with equal range in finite time.</p>
+            <p>This clause together with the forward progress guarantee on agents ensure the liveness condition that ~SeqCst~ writes become visible to ~SeqCst~ reads with equal range in finite time.</p>
           </emu-note>
         </li>
       </ul>
@@ -40975,7 +40980,7 @@ THH:mm:ss.sss
     <p>For an execution _execution_, two events _E_ and _D_ in SharedDataBlockEventSet(_execution_) are in a data race if the following abstract operation returns *true*.</p>
     <emu-alg>
       1. If _E_ and _D_ are in a race in _execution_, then
-        1. If _E_.[[Order]] is not `"SeqCst"` or _D_.[[Order]] is not `"SeqCst"`, then
+        1. If _E_.[[Order]] is not ~SeqCst~ or _D_.[[Order]] is not ~SeqCst~, then
           1. Return *true*.
         1. If _E_ and _D_ have overlapping ranges, then
           1. Return *true*.
@@ -41006,8 +41011,8 @@ THH:mm:ss.sss
       <p>Any transformation of an agent-order slice that is valid in the absence of shared memory is valid in the presence of shared memory, with the following exceptions.</p>
       <ul>
         <li>
-          <p><em>Atomics are carved in stone</em>: Program transformations must not cause the <code>"SeqCst"</code> events in an agent-order slice to be reordered with its <code>"Unordered"</code> operations, nor its <code>"SeqCst"</code> operations to be reordered with each other, nor may a program transformation remove a <code>"SeqCst"</code> operation from the agent-order.</p>
-          <p>(In practice, the prohibition on reorderings forces a compiler to assume that every <code>"SeqCst"</code> operation is a synchronization and included in the final memory-order, which it would usually have to assume anyway in the absence of inter-agent program analysis. It also forces the compiler to assume that every call where the callee's effects on the memory-order are unknown may contain <code>"SeqCst"</code> operations.)</p>
+          <p><em>Atomics are carved in stone</em>: Program transformations must not cause the ~SeqCst~ events in an agent-order slice to be reordered with its ~Unordered~ operations, nor its ~SeqCst~ operations to be reordered with each other, nor may a program transformation remove a ~SeqCst~ operation from the agent-order.</p>
+          <p>(In practice, the prohibition on reorderings forces a compiler to assume that every ~SeqCst~ operation is a synchronization and included in the final memory-order, which it would usually have to assume anyway in the absence of inter-agent program analysis. It also forces the compiler to assume that every call where the callee's effects on the memory-order are unknown may contain ~SeqCst~ operations.)</p>
         </li>
         <li>
           <p><em>Reads must be stable</em>: Any given shared memory read must only observe a single value in an execution.</p>
@@ -41019,7 +41024,7 @@ THH:mm:ss.sss
         </li>
         <li>
           <p><em>Possible read values must be nonempty</em>: Program transformations cannot cause the possible read values of a shared memory read to become empty.</p>
-          <p>(Counterintuitively, this rule in effect restricts transformations on writes, because writes have force in memory model insofar as to be read by read events. For example, writes may be moved and coalesced and sometimes reordered between two <code>"SeqCst"</code> operations, but the transformation may not remove every write that updates a location; some write must be preserved.)</p>
+          <p>(Counterintuitively, this rule in effect restricts transformations on writes, because writes have force in memory model insofar as to be read by read events. For example, writes may be moved and coalesced and sometimes reordered between two ~SeqCst~ operations, but the transformation may not remove every write that updates a location; some write must be preserved.)</p>
         </li>
       </ul>
       <p>Examples of transformations that remain valid are: merging multiple non-atomic reads from the same location, reordering non-atomic reads, introducing speculative non-atomic reads, merging multiple non-atomic writes to the same location, reordering non-atomic writes to different locations, and hoisting non-atomic reads out of loops even if that affects termination. Note in general that aliased TypedArrays make it hard to prove that locations are different.</p>


### PR DESCRIPTION
Follow-up to #1302, prerequisite for the <code>\`"foo"\`</code> → <code>\*"foo"\*</code> update.

This patch aims to change all non-observable magic strings into `~foo~`-style spec-internal values.