### PR TITLE
Editorial: Reference DecimalDigit rather than duplicating its RHS

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30549,16 +30549,7 @@ THH:mm:ss.sss
 
         UnicodePropertyValueCharacter ::
           UnicodePropertyNameCharacter
-          `0`
-          `1`
-          `2`
-          `3`
-          `4`
-          `5`
-          `6`
-          `7`
-          `8`
-          `9`
+          DecimalDigit
 
         UnicodePropertyNameCharacter ::
           ControlLetter


### PR DESCRIPTION
Simple improvement noticed while working on #1727.