### PR TITLE
Editorial: Stylize strings as values.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -162,14 +162,14 @@
 
     <emu-clause id="sec-objects">
       <h1>Objects</h1>
-      <p>Even though ECMAScript includes syntax for class definitions, ECMAScript objects are not fundamentally class-based such as those in C++, Smalltalk, or Java. Instead objects may be created in various ways including via a literal notation or via <em>constructors</em> which create objects and then execute code that initializes all or part of them by assigning initial values to their properties. Each constructor is a function that has a property named `"prototype"` that is used to implement <em>prototype-based inheritance</em> and <em>shared properties</em>. Objects are created by using constructors in <b>new</b> expressions; for example, `new Date(2009, 11)` creates a new Date object. Invoking a constructor without using <b>new</b> has consequences that depend on the constructor. For example, `Date()` produces a string representation of the current date and time rather than an object.</p>
-      <p>Every object created by a constructor has an implicit reference (called the object's <em>prototype</em>) to the value of its constructor's `"prototype"` property. Furthermore, a prototype may have a non-null implicit reference to its prototype, and so on; this is called the <em>prototype chain</em>. When a reference is made to a property in an object, that reference is to the property of that name in the first object in the prototype chain that contains a property of that name. In other words, first the object mentioned directly is examined for such a property; if that object contains the named property, that is the property to which the reference refers; if that object does not contain the named property, the prototype for that object is examined next; and so on.</p>
+      <p>Even though ECMAScript includes syntax for class definitions, ECMAScript objects are not fundamentally class-based such as those in C++, Smalltalk, or Java. Instead objects may be created in various ways including via a literal notation or via <em>constructors</em> which create objects and then execute code that initializes all or part of them by assigning initial values to their properties. Each constructor is a function that has a property named *"prototype"* that is used to implement <em>prototype-based inheritance</em> and <em>shared properties</em>. Objects are created by using constructors in <b>new</b> expressions; for example, `new Date(2009, 11)` creates a new Date object. Invoking a constructor without using <b>new</b> has consequences that depend on the constructor. For example, `Date()` produces a string representation of the current date and time rather than an object.</p>
+      <p>Every object created by a constructor has an implicit reference (called the object's <em>prototype</em>) to the value of its constructor's *"prototype"* property. Furthermore, a prototype may have a non-null implicit reference to its prototype, and so on; this is called the <em>prototype chain</em>. When a reference is made to a property in an object, that reference is to the property of that name in the first object in the prototype chain that contains a property of that name. In other words, first the object mentioned directly is examined for such a property; if that object contains the named property, that is the property to which the reference refers; if that object does not contain the named property, the prototype for that object is examined next; and so on.</p>
       <emu-figure id="figure-1" caption="Object/Prototype Relationships">
         <object data="img/figure-1.svg" height="354" type="image/svg+xml" width="719"> <img alt="An image of lots of boxes and arrows." height="354" src="img/figure-1.png" width="719"> </object>
       </emu-figure>
       <p>In a class-based object-oriented language, in general, state is carried by instances, methods are carried by classes, and inheritance is only of structure and behaviour. In ECMAScript, the state and methods are carried by objects, while structure, behaviour, and state are all inherited.</p>
       <p>All objects that do not directly contain a particular property that their prototype contains share that property and its value. Figure 1 illustrates this:</p>
-      <p><b>CF</b> is a constructor (and also an object). Five objects have been created by using `new` expressions: <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b>. Each of these objects contains properties named `"q1"` and `"q2"`. The dashed lines represent the implicit prototype relationship; so, for example, <b>cf<sub>3</sub></b>'s prototype is <b>CF<sub>p</sub></b>. The constructor, <b>CF</b>, has two properties itself, named `"P1"` and `"P2"`, which are not visible to <b>CF<sub>p</sub></b>, <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, or <b>cf<sub>5</sub></b>. The property named `"CFP1"` in <b>CF<sub>p</sub></b> is shared by <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> (but not by <b>CF</b>), as are any properties found in <b>CF<sub>p</sub></b>'s implicit prototype chain that are not named `"q1"`, `"q2"`, or `"CFP1"`. Notice that there is no implicit prototype link between <b>CF</b> and <b>CF<sub>p</sub></b>.</p>
+      <p><b>CF</b> is a constructor (and also an object). Five objects have been created by using `new` expressions: <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b>. Each of these objects contains properties named *"q1"* and *"q2"*. The dashed lines represent the implicit prototype relationship; so, for example, <b>cf<sub>3</sub></b>'s prototype is <b>CF<sub>p</sub></b>. The constructor, <b>CF</b>, has two properties itself, named *"P1"* and *"P2"*, which are not visible to <b>CF<sub>p</sub></b>, <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, or <b>cf<sub>5</sub></b>. The property named *"CFP1"* in <b>CF<sub>p</sub></b> is shared by <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> (but not by <b>CF</b>), as are any properties found in <b>CF<sub>p</sub></b>'s implicit prototype chain that are not named *"q1"*, *"q2"*, or *"CFP1"*. Notice that there is no implicit prototype link between <b>CF</b> and <b>CF<sub>p</sub></b>.</p>
       <p>Unlike most class-based object languages, properties can be added to objects dynamically by assigning values to them. That is, constructors are not required to name or assign values to all or any of the constructed object's properties. In the above diagram, one could add a new shared property for <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> by assigning a new value to the property in <b>CF<sub>p</sub></b>.</p>
       <p>Although ECMAScript objects are not inherently class-based, it is often convenient to define class-like abstractions based upon a common pattern of constructor functions, prototype objects, and methods. The ECMAScript built-in objects themselves follow such a class-like pattern. Beginning with ECMAScript 2015, the ECMAScript language includes syntactic class definitions that permit programmers to concisely define objects that conform to the same class-like abstraction pattern used by the built-in objects.</p>
     </emu-clause>
@@ -211,7 +211,7 @@
       <h1>constructor</h1>
       <p>function object that creates and initializes objects</p>
       <emu-note>
-        <p>The value of a constructor's `"prototype"` property is a prototype object that is used to implement inheritance and shared properties.</p>
+        <p>The value of a constructor's *"prototype"* property is a prototype object that is used to implement inheritance and shared properties.</p>
       </emu-note>
     </emu-clause>
 
@@ -219,7 +219,7 @@
       <h1>prototype</h1>
       <p>object that provides shared properties for other objects</p>
       <emu-note>
-        <p>When a constructor creates an object, that object implicitly references the constructor's `"prototype"` property for the purpose of resolving property references. The constructor's `"prototype"` property can be referenced by the program expression <code><var>constructor</var>.prototype</code>, and properties added to an object's prototype are shared, through inheritance, by all objects sharing the prototype. Alternatively, a new object may be created with an explicitly specified prototype by using the `Object.create` built-in function.</p>
+        <p>When a constructor creates an object, that object implicitly references the constructor's *"prototype"* property for the purpose of resolving property references. The constructor's *"prototype"* property can be referenced by the program expression <code><var>constructor</var>.prototype</code>, and properties added to an object's prototype are shared, through inheritance, by all objects sharing the prototype. Alternatively, a new object may be created with an explicitly specified prototype by using the `Object.create` built-in function.</p>
       </emu-note>
     </emu-clause>
 
@@ -730,7 +730,7 @@
         1. Let _status_ be SyntaxDirectedOperation of |SomeNonTerminal|.
         2. Let _someParseNode_ be the parse of some source text.
         2. Perform SyntaxDirectedOperation of _someParseNode_.
-        2. Perform SyntaxDirectedOperation of _someParseNode_ passing `"value"` as the argument.
+        2. Perform SyntaxDirectedOperation of _someParseNode_ passing *"value"* as the argument.
       </emu-alg>
       <p>Unless explicitly specified otherwise, all chain productions have an implicit definition for every operation that might be applied to that production's left-hand side nonterminal. The implicit definition simply reapplies the same operation with the same parameters, if any, to the chain production's sole right-hand side nonterminal and then returns the result. For example, assume that some algorithm has a step of the form: &ldquo;Return the result of evaluating |Block|&rdquo; and that there is a production:</p>
       <emu-grammar type="example">
@@ -752,11 +752,11 @@
         <h1>Implicit Completion Values</h1>
         <p>The algorithms of this specification often implicitly return Completion Records whose [[Type]] is ~normal~. Unless it is otherwise obvious from the context, an algorithm statement that returns a value that is not a Completion Record, such as:</p>
         <emu-alg>
-          1. Return `"Infinity"`.
+          1. Return *"Infinity"*.
         </emu-alg>
         <p>means the same thing as:</p>
         <emu-alg>
-          1. Return NormalCompletion(`"Infinity"`).
+          1. Return NormalCompletion(*"Infinity"*).
         </emu-alg>
         <p>However, if the value expression of a &ldquo;return&rdquo; statement is a Completion Record construction literal, the resulting Completion Record is returned. If the value expression is a call to an abstract operation, the &ldquo;return&rdquo; statement simply returns the Completion Record produced by the abstract operation.</p>
         <p>The abstract operation Completion(_completionRecord_) is used to emphasize that a previously computed Completion Record is being returned. The Completion abstract operation takes a single argument, _completionRecord_, and performs the following steps:</p>
@@ -974,7 +974,7 @@
                 @@asyncIterator
               </td>
               <td>
-                `"Symbol.asyncIterator"`
+                *"Symbol.asyncIterator"*
               </td>
               <td>
                 A method that returns the default AsyncIterator for an object. Called by the semantics of the `for`-`await`-`of` statement.
@@ -985,7 +985,7 @@
                 @@hasInstance
               </td>
               <td>
-                `"Symbol.hasInstance"`
+                *"Symbol.hasInstance"*
               </td>
               <td>
                 A method that determines if a constructor object recognizes an object as one of the constructor's instances. Called by the semantics of the `instanceof` operator.
@@ -996,7 +996,7 @@
                 @@isConcatSpreadable
               </td>
               <td>
-                `"Symbol.isConcatSpreadable"`
+                *"Symbol.isConcatSpreadable"*
               </td>
               <td>
                 A Boolean valued property that if true indicates that an object should be flattened to its array elements by <emu-xref href="#sec-array.prototype.concat">`Array.prototype.concat`</emu-xref>.
@@ -1007,7 +1007,7 @@
                 @@iterator
               </td>
               <td>
-                `"Symbol.iterator"`
+                *"Symbol.iterator"*
               </td>
               <td>
                 A method that returns the default Iterator for an object. Called by the semantics of the for-of statement.
@@ -1018,7 +1018,7 @@
                 @@match
               </td>
               <td>
-                `"Symbol.match"`
+                *"Symbol.match"*
               </td>
               <td>
                 A regular expression method that matches the regular expression against a string. Called by the <emu-xref href="#sec-string.prototype.match">`String.prototype.match`</emu-xref> method.
@@ -1029,7 +1029,7 @@
                 @@matchAll
               </td>
               <td>
-                `"Symbol.matchAll"`
+                *"Symbol.matchAll"*
               </td>
               <td>
                 A regular expression method that returns an iterator, that yields matches of the regular expression against a string. Called by the <emu-xref href="#sec-string.prototype.matchall">`String.prototype.matchAll`</emu-xref> method.
@@ -1040,7 +1040,7 @@
                 @@replace
               </td>
               <td>
-                `"Symbol.replace"`
+                *"Symbol.replace"*
               </td>
               <td>
                 A regular expression method that replaces matched substrings of a string. Called by the <emu-xref href="#sec-string.prototype.replace">`String.prototype.replace`</emu-xref> method.
@@ -1051,7 +1051,7 @@
                 @@search
               </td>
               <td>
-                `"Symbol.search"`
+                *"Symbol.search"*
               </td>
               <td>
                 A regular expression method that returns the index within a string that matches the regular expression. Called by the <emu-xref href="#sec-string.prototype.search">`String.prototype.search`</emu-xref> method.
@@ -1062,7 +1062,7 @@
                 @@species
               </td>
               <td>
-                `"Symbol.species"`
+                *"Symbol.species"*
               </td>
               <td>
                 A function valued property that is the constructor function that is used to create derived objects.
@@ -1073,7 +1073,7 @@
                 @@split
               </td>
               <td>
-                `"Symbol.split"`
+                *"Symbol.split"*
               </td>
               <td>
                 A regular expression method that splits a string at the indices that match the regular expression. Called by the <emu-xref href="#sec-string.prototype.split">`String.prototype.split`</emu-xref> method.
@@ -1084,7 +1084,7 @@
                 @@toPrimitive
               </td>
               <td>
-                `"Symbol.toPrimitive"`
+                *"Symbol.toPrimitive"*
               </td>
               <td>
                 A method that converts an object to a corresponding primitive value. Called by the ToPrimitive abstract operation.
@@ -1095,7 +1095,7 @@
                 @@toStringTag
               </td>
               <td>
-                `"Symbol.toStringTag"`
+                *"Symbol.toStringTag"*
               </td>
               <td>
                 A String valued property that is used in the creation of the default string description of an object. Accessed by the built-in method <emu-xref href="#sec-object.prototype.tostring">`Object.prototype.toString`</emu-xref>.
@@ -1106,7 +1106,7 @@
                 @@unscopables
               </td>
               <td>
-                `"Symbol.unscopables"`
+                *"Symbol.unscopables"*
               </td>
               <td>
                 An object valued property whose own and inherited property names are property names that are excluded from the `with` environment bindings of the associated object.
@@ -1744,10 +1744,10 @@
           <h1>Number::toString ( _x_ )</h1>
           <p>The abstract operation Number::toString converts a Number _x_ to String format as follows:</p>
           <emu-alg>
-            1. If _x_ is *NaN*, return the String `"NaN"`.
-            1. If _x_ is *+0* or *-0*, return the String `"0"`.
-            1. If _x_ is less than zero, return the string-concatenation of `"-"` and ! Number::toString(-_x_).
-            1. If _x_ is *+&infin;*, return the String `"Infinity"`.
+            1. If _x_ is *NaN*, return the String *"NaN"*.
+            1. If _x_ is *+0* or *-0*, return the String *"0"*.
+            1. If _x_ is less than zero, return the string-concatenation of *"-"* and ! Number::toString(-_x_).
+            1. If _x_ is *+&infin;*, return the String *"Infinity"*.
             1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10<sub>ℝ</sub>, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
             1. If _k_ &le; _n_ &le; 21, return the string-concatenation of:
               * the code units of the _k_ digits of the decimal representation of _s_ (in order, with no leading zeroes)
@@ -1955,24 +1955,24 @@
         <emu-clause id="sec-bigintbitwiseop" aoid="BigIntBitwiseOp">
           <h1>BigIntBitwiseOp ( _op_, _x_, _y_ )</h1>
           <emu-alg>
-            1. Assert: _op_ is `"&amp;"`, `"|"`, or `"^"`.
+            1. Assert: _op_ is *"&amp;"*, *"|"*, or *"^"*.
             1. Let _result_ be *0n*.
             1. Let _shift_ be 0.
             1. Repeat, until (_x_ = 0 or _x_ = -1) and (_y_ = 0 or _y_ = -1),
               1. Let _xDigit_ be _x_ modulo 2.
               1. Let _yDigit_ be _y_ modulo 2.
-              1. If _op_ is `"&amp;"`, set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryAnd(_xDigit_, _yDigit_).
-              1. Else if _op_ is `"|"`, set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryOr(_xDigit_, _yDigit_).
+              1. If _op_ is *"&amp;"*, set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryAnd(_xDigit_, _yDigit_).
+              1. Else if _op_ is *"|"*, set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryOr(_xDigit_, _yDigit_).
               1. Else,
-                1. Assert: _op_ is `"^"`.
+                1. Assert: _op_ is *"^"*.
                 1. Set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryXor(_xDigit_, _yDigit_).
               1. Set _shift_ to _shift_ + 1.
               1. Set _x_ to (_x_ - _xDigit_) / 2.
               1. Set _y_ to (_y_ - _yDigit_) / 2.
-            1. If _op_ is `"&amp;"`, let _tmp_ be BinaryAnd(_x_ modulo 2, _y_ modulo 2).
-            1. Else if _op_ is `"|"`, let _tmp_ be BinaryOr(_x_ modulo 2, _y_ modulo 2).
+            1. If _op_ is *"&amp;"*, let _tmp_ be BinaryAnd(_x_ modulo 2, _y_ modulo 2).
+            1. Else if _op_ is *"|"*, let _tmp_ be BinaryOr(_x_ modulo 2, _y_ modulo 2).
             1. Else,
-              1. Assert: _op_ is `"^"`.
+              1. Assert: _op_ is *"^"*.
               1. Let _tmp_ be BinaryXor(_x_ modulo 2, _y_ modulo 2).
             1. If _tmp_ &ne; 0, then
               1. Set _result_ to _result_ - 2<sup>_shift_</sup>. NOTE: This extends the sign.
@@ -1983,21 +1983,21 @@
         <emu-clause id="sec-numeric-types-bigint-bitwiseAND">
           <h1>BigInt::bitwiseAND ( _x_, _y_ )</h1>
           <emu-alg>
-            1. Return BigIntBitwiseOp(`"&amp;"`, _x_, _y_).
+            1. Return BigIntBitwiseOp(*"&amp;"*, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-bitwiseXOR">
           <h1>BigInt::bitwiseXOR ( _x_, _y_ )</h1>
           <emu-alg>
-            1. Return BigIntBitwiseOp(`"^"`, _x_, _y_).
+            1. Return BigIntBitwiseOp(*"^"*, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-bitwiseOR">
           <h1>BigInt::bitwiseOR ( _x_, _y_ )</h1>
           <emu-alg>
-            1. Return BigIntBitwiseOp(`"|"`, _x_, _y_).
+            1. Return BigIntBitwiseOp(*"|"*, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
@@ -2005,7 +2005,7 @@
           <h1>BigInt::toString ( _x_ )</h1>
           <p>The abstract operation BigInt::toString converts a BigInt _x_ to String format as follows:</p>
           <emu-alg>
-            1. If _x_ is less than zero, return the string-concatenation of the String `"-"` and ! BigInt::toString(-_x_).
+            1. If _x_ is less than zero, return the string-concatenation of the String *"-"* and ! BigInt::toString(-_x_).
             1. Return the String value consisting of the code units of the digits of the decimal representation of _x_.
           </emu-alg>
         </emu-clause>
@@ -2644,7 +2644,7 @@
                 `ArrayBuffer.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %ArrayBuffer%; i.e., %ArrayBuffer.prototype%
+                The initial value of the *"prototype"* data property of %ArrayBuffer%; i.e., %ArrayBuffer.prototype%
               </td>
             </tr>
             <tr>
@@ -2665,7 +2665,7 @@
                 `Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>); i.e., %Array.prototype%
+                The initial value of the *"prototype"* data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>); i.e., %Array.prototype%
               </td>
             </tr>
             <tr>
@@ -2676,7 +2676,7 @@
                 `Array.prototype.entries`
               </td>
               <td>
-                The initial value of the `"entries"` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>); i.e., %Array.prototype.entries%
+                The initial value of the *"entries"* data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>); i.e., %Array.prototype.entries%
               </td>
             </tr>
             <tr>
@@ -2687,7 +2687,7 @@
                 `Array.prototype.forEach`
               </td>
               <td>
-                The initial value of the `"forEach"` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>); i.e., %Array.prototype.forEach%
+                The initial value of the *"forEach"* data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>); i.e., %Array.prototype.forEach%
               </td>
             </tr>
             <tr>
@@ -2698,7 +2698,7 @@
                 `Array.prototype.keys`
               </td>
               <td>
-                The initial value of the `"keys"` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>); i.e., %Array.prototype.keys%
+                The initial value of the *"keys"* data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>); i.e., %Array.prototype.keys%
               </td>
             </tr>
             <tr>
@@ -2709,7 +2709,7 @@
                 `Array.prototype.values`
               </td>
               <td>
-                The initial value of the `"values"` data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>); i.e., %Array.prototype.values%
+                The initial value of the *"values"* data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>); i.e., %Array.prototype.values%
               </td>
             </tr>
             <tr>
@@ -2739,7 +2739,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %AsyncFunction%; i.e., %AsyncFunction.prototype%
+                The initial value of the *"prototype"* data property of %AsyncFunction%; i.e., %AsyncFunction.prototype%
               </td>
             </tr>
             <tr>
@@ -2749,7 +2749,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `"prototype"` property of %AsyncGeneratorFunction%; i.e., %AsyncGeneratorFunction.prototype%
+                The initial value of the *"prototype"* property of %AsyncGeneratorFunction%; i.e., %AsyncGeneratorFunction.prototype%
               </td>
             </tr>
             <tr>
@@ -2769,7 +2769,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `"prototype"` property of %AsyncGenerator%; i.e., %AsyncGenerator.prototype%
+                The initial value of the *"prototype"* property of %AsyncGenerator%; i.e., %AsyncGenerator.prototype%
               </td>
             </tr>
             <tr>
@@ -2845,7 +2845,7 @@
                 `Boolean.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>); i.e., %Boolean.prototype%
+                The initial value of the *"prototype"* data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>); i.e., %Boolean.prototype%
               </td>
             </tr>
             <tr>
@@ -2867,7 +2867,7 @@
                 `DataView.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %DataView%; i.e., %DataView.prototype%
+                The initial value of the *"prototype"* data property of %DataView%; i.e., %DataView.prototype%
               </td>
             </tr>
             <tr>
@@ -2889,7 +2889,7 @@
                 `Date.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Date%.; i.e., %Date.prototype%
+                The initial value of the *"prototype"* data property of %Date%.; i.e., %Date.prototype%
               </td>
             </tr>
             <tr>
@@ -2955,7 +2955,7 @@
                 `Error.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Error%; i.e., %Error.prototype%
+                The initial value of the *"prototype"* data property of %Error%; i.e., %Error.prototype%
               </td>
             </tr>
             <tr>
@@ -2988,7 +2988,7 @@
                 `EvalError.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %EvalError%; i.e., %EvalError.prototype%
+                The initial value of the *"prototype"* data property of %EvalError%; i.e., %EvalError.prototype%
               </td>
             </tr>
             <tr>
@@ -3010,7 +3010,7 @@
                 `Float32Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Float32Array%; i.e., %Float32Array.prototype%
+                The initial value of the *"prototype"* data property of %Float32Array%; i.e., %Float32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3032,7 +3032,7 @@
                 `Float64Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Float64Array%; i.e., %Float64Array.prototype%
+                The initial value of the *"prototype"* data property of %Float64Array%; i.e., %Float64Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3054,7 +3054,7 @@
                 `Function.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Function%; i.e., %Function.prototype%
+                The initial value of the *"prototype"* data property of %Function%; i.e., %Function.prototype%
               </td>
             </tr>
             <tr>
@@ -3064,7 +3064,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %GeneratorFunction%
+                The initial value of the *"prototype"* data property of %GeneratorFunction%
               </td>
             </tr>
             <tr>
@@ -3084,7 +3084,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Generator%; i.e., %Generator.prototype%
+                The initial value of the *"prototype"* data property of %Generator%; i.e., %Generator.prototype%
               </td>
             </tr>
             <tr>
@@ -3106,7 +3106,7 @@
                 `Int8Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Int8Array%; i.e., %Int8Array.prototype%
+                The initial value of the *"prototype"* data property of %Int8Array%; i.e., %Int8Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3128,7 +3128,7 @@
                 `Int16Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Int16Array%; i.e., %Int16Array.prototype%
+                The initial value of the *"prototype"* data property of %Int16Array%; i.e., %Int16Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3150,7 +3150,7 @@
                 `Int32Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Int32Array%; i.e., %Int32Array.prototype%
+                The initial value of the *"prototype"* data property of %Int32Array%; i.e., %Int32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3204,7 +3204,7 @@
                 `JSON.parse`
               </td>
               <td>
-                The initial value of the `"parse"` data property of %JSON%; i.e., %JSON.parse%
+                The initial value of the *"parse"* data property of %JSON%; i.e., %JSON.parse%
               </td>
             </tr>
             <tr>
@@ -3215,7 +3215,7 @@
                 `JSON.stringify`
               </td>
               <td>
-                The initial value of the `"stringify"` data property of %JSON%; i.e., %JSON.stringify%
+                The initial value of the *"stringify"* data property of %JSON%; i.e., %JSON.stringify%
               </td>
             </tr>
             <tr>
@@ -3247,7 +3247,7 @@
                 `Map.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Map%; i.e., %Map.prototype%
+                The initial value of the *"prototype"* data property of %Map%; i.e., %Map.prototype%
               </td>
             </tr>
             <tr>
@@ -3280,7 +3280,7 @@
                 `Number.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Number%; i.e., %Number.prototype%
+                The initial value of the *"prototype"* data property of %Number%; i.e., %Number.prototype%
               </td>
             </tr>
             <tr>
@@ -3302,7 +3302,7 @@
                 `Object.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>); i.e., %Object.prototype%
+                The initial value of the *"prototype"* data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>); i.e., %Object.prototype%
               </td>
             </tr>
             <tr>
@@ -3313,7 +3313,7 @@
                 `Object.prototype.toString`
               </td>
               <td>
-                The initial value of the `"toString"` data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>); i.e., %Object.prototype.toString%
+                The initial value of the *"toString"* data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>); i.e., %Object.prototype.toString%
               </td>
             </tr>
             <tr>
@@ -3324,7 +3324,7 @@
                 `Object.prototype.valueOf`
               </td>
               <td>
-                The initial value of the `"valueOf"` data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>); i.e., %Object.prototype.valueOf%
+                The initial value of the *"valueOf"* data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>); i.e., %Object.prototype.valueOf%
               </td>
             </tr>
             <tr>
@@ -3368,7 +3368,7 @@
                 `Promise.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Promise%; i.e., %Promise.prototype%
+                The initial value of the *"prototype"* data property of %Promise%; i.e., %Promise.prototype%
               </td>
             </tr>
             <tr>
@@ -3379,7 +3379,7 @@
                 `Promise.prototype.then`
               </td>
               <td>
-                The initial value of the `"then"` data property of %Promise.prototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>); i.e., %Promise.prototype.then%
+                The initial value of the *"then"* data property of %Promise.prototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>); i.e., %Promise.prototype.then%
               </td>
             </tr>
             <tr>
@@ -3390,7 +3390,7 @@
                 `Promise.all`
               </td>
               <td>
-                The initial value of the `"all"` data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>); i.e., %Promise.all%
+                The initial value of the *"all"* data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>); i.e., %Promise.all%
               </td>
             </tr>
             <tr>
@@ -3401,7 +3401,7 @@
                 `Promise.reject`
               </td>
               <td>
-                The initial value of the `"reject"` data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>); i.e., %Promise.reject%
+                The initial value of the *"reject"* data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>); i.e., %Promise.reject%
               </td>
             </tr>
             <tr>
@@ -3412,7 +3412,7 @@
                 `Promise.resolve`
               </td>
               <td>
-                The initial value of the `"resolve"` data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>); i.e., %Promise.resolve%
+                The initial value of the *"resolve"* data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>); i.e., %Promise.resolve%
               </td>
             </tr>
             <tr>
@@ -3445,7 +3445,7 @@
                 `RangeError.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %RangeError%; i.e., %RangeError.prototype%
+                The initial value of the *"prototype"* data property of %RangeError%; i.e., %RangeError.prototype%
               </td>
             </tr>
             <tr>
@@ -3467,7 +3467,7 @@
                 `ReferenceError.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %ReferenceError%; i.e., %ReferenceError.prototype%
+                The initial value of the *"prototype"* data property of %ReferenceError%; i.e., %ReferenceError.prototype%
               </td>
             </tr>
             <tr>
@@ -3500,7 +3500,7 @@
                 `RegExp.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %RegExp%; i.e., %RegExp.prototype%
+                The initial value of the *"prototype"* data property of %RegExp%; i.e., %RegExp.prototype%
               </td>
             </tr>
             <tr>
@@ -3542,7 +3542,7 @@
                 `Set.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Set%; i.e., %Set.prototype%
+                The initial value of the *"prototype"* data property of %Set%; i.e., %Set.prototype%
               </td>
             </tr>
             <tr>
@@ -3564,7 +3564,7 @@
                 `SharedArrayBuffer.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %SharedArrayBuffer%; i.e., %SharedArrayBuffer.prototype%
+                The initial value of the *"prototype"* data property of %SharedArrayBuffer%; i.e., %SharedArrayBuffer.prototype%
               </td>
             </tr>
             <tr>
@@ -3596,7 +3596,7 @@
                 `String.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %String%; i.e., %String.prototype%
+                The initial value of the *"prototype"* data property of %String%; i.e., %String.prototype%
               </td>
             </tr>
             <tr>
@@ -3618,7 +3618,7 @@
                 `Symbol.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>); i.e., %Symbol.prototype%
+                The initial value of the *"prototype"* data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>); i.e., %Symbol.prototype%
               </td>
             </tr>
             <tr>
@@ -3640,7 +3640,7 @@
                 `SyntaxError.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %SyntaxError%; i.e., %SyntaxError.prototype%
+                The initial value of the *"prototype"* data property of %SyntaxError%; i.e., %SyntaxError.prototype%
               </td>
             </tr>
             <tr>
@@ -3670,7 +3670,7 @@
               <td>
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %TypedArray%; i.e., %TypedArray.prototype%
+                The initial value of the *"prototype"* data property of %TypedArray%; i.e., %TypedArray.prototype%
               </td>
             </tr>
             <tr>
@@ -3692,7 +3692,7 @@
                 `TypeError.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %TypeError%; i.e., %TypeError.prototype%
+                The initial value of the *"prototype"* data property of %TypeError%; i.e., %TypeError.prototype%
               </td>
             </tr>
             <tr>
@@ -3714,7 +3714,7 @@
                 `Uint8Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Uint8Array%; i.e., %Uint8Array.prototype%
+                The initial value of the *"prototype"* data property of %Uint8Array%; i.e., %Uint8Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3736,7 +3736,7 @@
                 `Uint8ClampedArray.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Uint8ClampedArray%; i.e., %Uint8ClampedArray.prototype%
+                The initial value of the *"prototype"* data property of %Uint8ClampedArray%; i.e., %Uint8ClampedArray.prototype%
               </td>
             </tr>
             <tr>
@@ -3758,7 +3758,7 @@
                 `Uint16Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Uint16Array%; i.e., %Uint16Array.prototype%
+                The initial value of the *"prototype"* data property of %Uint16Array%; i.e., %Uint16Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3780,7 +3780,7 @@
                 `Uint32Array.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %Uint32Array%; i.e., %Uint32Array.prototype%
+                The initial value of the *"prototype"* data property of %Uint32Array%; i.e., %Uint32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3802,7 +3802,7 @@
                 `URIError.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %URIError%; i.e., %URIError.prototype%
+                The initial value of the *"prototype"* data property of %URIError%; i.e., %URIError.prototype%
               </td>
             </tr>
             <tr>
@@ -3824,7 +3824,7 @@
                 `WeakMap.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %WeakMap%; i.e., %WeakMap.prototype%
+                The initial value of the *"prototype"* data property of %WeakMap%; i.e., %WeakMap.prototype%
               </td>
             </tr>
             <tr>
@@ -3846,7 +3846,7 @@
                 `WeakSet.prototype`
               </td>
               <td>
-                The initial value of the `"prototype"` data property of %WeakSet%; i.e., %WeakSet.prototype%
+                The initial value of the *"prototype"* data property of %WeakSet%; i.e., %WeakSet.prototype%
               </td>
             </tr>
             </tbody>
@@ -4021,7 +4021,7 @@
             1. Return *undefined*.
           </emu-alg>
 
-          <p>The `"length"` property of an Await fulfilled function is 1.</p>
+          <p>The *"length"* property of an Await fulfilled function is 1.</p>
         </emu-clause>
 
         <emu-clause id="await-rejected">
@@ -4042,7 +4042,7 @@
             1. Return *undefined*.
           </emu-alg>
 
-          <p>The `"length"` property of an Await rejected function is 1.</p>
+          <p>The *"length"* property of an Await rejected function is 1.</p>
         </emu-clause>
       </emu-clause>
 
@@ -4263,17 +4263,17 @@
           1. Let _obj_ be ObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. If _Desc_ has a [[Value]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"value"`, _Desc_.[[Value]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _Desc_.[[Value]]).
           1. If _Desc_ has a [[Writable]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"writable"`, _Desc_.[[Writable]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"writable"*, _Desc_.[[Writable]]).
           1. If _Desc_ has a [[Get]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"get"`, _Desc_.[[Get]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"get"*, _Desc_.[[Get]]).
           1. If _Desc_ has a [[Set]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"set"`, _Desc_.[[Set]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"set"*, _Desc_.[[Set]]).
           1. If _Desc_ has an [[Enumerable]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"enumerable"`, _Desc_.[[Enumerable]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"enumerable"*, _Desc_.[[Enumerable]]).
           1. If _Desc_ has a [[Configurable]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"configurable"`, _Desc_.[[Configurable]]).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"configurable"*, _Desc_.[[Configurable]]).
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -4284,30 +4284,30 @@
         <emu-alg>
           1. If Type(_Obj_) is not Object, throw a *TypeError* exception.
           1. Let _desc_ be a new Property Descriptor that initially has no fields.
-          1. Let _hasEnumerable_ be ? HasProperty(_Obj_, `"enumerable"`).
+          1. Let _hasEnumerable_ be ? HasProperty(_Obj_, *"enumerable"*).
           1. If _hasEnumerable_ is *true*, then
-            1. Let _enumerable_ be ! ToBoolean(? Get(_Obj_, `"enumerable"`)).
+            1. Let _enumerable_ be ! ToBoolean(? Get(_Obj_, *"enumerable"*)).
             1. Set _desc_.[[Enumerable]] to _enumerable_.
-          1. Let _hasConfigurable_ be ? HasProperty(_Obj_, `"configurable"`).
+          1. Let _hasConfigurable_ be ? HasProperty(_Obj_, *"configurable"*).
           1. If _hasConfigurable_ is *true*, then
-            1. Let _configurable_ be ! ToBoolean(? Get(_Obj_, `"configurable"`)).
+            1. Let _configurable_ be ! ToBoolean(? Get(_Obj_, *"configurable"*)).
             1. Set _desc_.[[Configurable]] to _configurable_.
-          1. Let _hasValue_ be ? HasProperty(_Obj_, `"value"`).
+          1. Let _hasValue_ be ? HasProperty(_Obj_, *"value"*).
           1. If _hasValue_ is *true*, then
-            1. Let _value_ be ? Get(_Obj_, `"value"`).
+            1. Let _value_ be ? Get(_Obj_, *"value"*).
             1. Set _desc_.[[Value]] to _value_.
-          1. Let _hasWritable_ be ? HasProperty(_Obj_, `"writable"`).
+          1. Let _hasWritable_ be ? HasProperty(_Obj_, *"writable"*).
           1. If _hasWritable_ is *true*, then
-            1. Let _writable_ be ! ToBoolean(? Get(_Obj_, `"writable"`)).
+            1. Let _writable_ be ! ToBoolean(? Get(_Obj_, *"writable"*)).
             1. Set _desc_.[[Writable]] to _writable_.
-          1. Let _hasGet_ be ? HasProperty(_Obj_, `"get"`).
+          1. Let _hasGet_ be ? HasProperty(_Obj_, *"get"*).
           1. If _hasGet_ is *true*, then
-            1. Let _getter_ be ? Get(_Obj_, `"get"`).
+            1. Let _getter_ be ? Get(_Obj_, *"get"*).
             1. If IsCallable(_getter_) is *false* and _getter_ is not *undefined*, throw a *TypeError* exception.
             1. Set _desc_.[[Get]] to _getter_.
-          1. Let _hasSet_ be ? HasProperty(_Obj_, `"set"`).
+          1. Let _hasSet_ be ? HasProperty(_Obj_, *"set"*).
           1. If _hasSet_ is *true*, then
-            1. Let _setter_ be ? Get(_Obj_, `"set"`).
+            1. Let _setter_ be ? Get(_Obj_, *"set"*).
             1. If IsCallable(_setter_) is *false* and _setter_ is not *undefined*, throw a *TypeError* exception.
             1. Set _desc_.[[Set]] to _setter_.
           1. If _desc_.[[Get]] is present or _desc_.[[Set]] is present, then
@@ -4426,17 +4426,17 @@
       <emu-alg>
         1. Assert: _input_ is an ECMAScript language value.
         1. If Type(_input_) is Object, then
-          1. If _PreferredType_ is not present, let _hint_ be `"default"`.
-          1. Else if _PreferredType_ is hint String, let _hint_ be `"string"`.
+          1. If _PreferredType_ is not present, let _hint_ be *"default"*.
+          1. Else if _PreferredType_ is hint String, let _hint_ be *"string"*.
           1. Else,
             1. Assert: _PreferredType_ is hint Number.
-            1. Let _hint_ be `"number"`.
+            1. Let _hint_ be *"number"*.
           1. Let _exoticToPrim_ be ? GetMethod(_input_, @@toPrimitive).
           1. If _exoticToPrim_ is not *undefined*, then
             1. Let _result_ be ? Call(_exoticToPrim_, _input_, &laquo; _hint_ &raquo;).
             1. If Type(_result_) is not Object, return _result_.
             1. Throw a *TypeError* exception.
-          1. If _hint_ is `"default"`, set _hint_ to `"number"`.
+          1. If _hint_ is *"default"*, set _hint_ to *"number"*.
           1. Return ? OrdinaryToPrimitive(_input_, _hint_).
         1. Return _input_.
       </emu-alg>
@@ -4449,11 +4449,11 @@
         <p>When the abstract operation OrdinaryToPrimitive is called with arguments _O_ and _hint_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: Type(_O_) is Object.
-          1. Assert: Type(_hint_) is String and its value is either `"string"` or `"number"`.
-          1. If _hint_ is `"string"`, then
-            1. Let _methodNames_ be &laquo; `"toString"`, `"valueOf"` &raquo;.
+          1. Assert: Type(_hint_) is String and its value is either *"string"* or *"number"*.
+          1. If _hint_ is *"string"*, then
+            1. Let _methodNames_ be &laquo; *"toString"*, *"valueOf"* &raquo;.
           1. Else,
-            1. Let _methodNames_ be &laquo; `"valueOf"`, `"toString"` &raquo;.
+            1. Let _methodNames_ be &laquo; *"valueOf"*, *"toString"* &raquo;.
           1. For each _name_ in _methodNames_ in List order, do
             1. Let _method_ be ? Get(_O_, _name_).
             1. If IsCallable(_method_) is *true*, then
@@ -5046,7 +5046,7 @@
               Undefined
             </td>
             <td>
-              Return `"undefined"`.
+              Return *"undefined"*.
             </td>
           </tr>
           <tr>
@@ -5054,7 +5054,7 @@
               Null
             </td>
             <td>
-              Return `"null"`.
+              Return *"null"*.
             </td>
           </tr>
           <tr>
@@ -5062,8 +5062,8 @@
               Boolean
             </td>
             <td>
-              <p>If _argument_ is *true*, return `"true"`.</p>
-              <p>If _argument_ is *false*, return `"false"`.</p>
+              <p>If _argument_ is *true*, return *"true"*.</p>
+              <p>If _argument_ is *false*, return *"false"*.</p>
             </td>
           </tr>
           <tr>
@@ -5221,10 +5221,10 @@
 
     <emu-clause id="sec-canonicalnumericindexstring" aoid="CanonicalNumericIndexString">
       <h1>CanonicalNumericIndexString ( _argument_ )</h1>
-      <p>The abstract operation CanonicalNumericIndexString returns _argument_ converted to a numeric value if it is a String representation of a Number that would be produced by ToString, or the string `"-0"`. Otherwise, it returns *undefined*. This abstract operation functions as follows:</p>
+      <p>The abstract operation CanonicalNumericIndexString returns _argument_ converted to a numeric value if it is a String representation of a Number that would be produced by ToString, or the string *"-0"*. Otherwise, it returns *undefined*. This abstract operation functions as follows:</p>
       <emu-alg>
         1. Assert: Type(_argument_) is String.
-        1. If _argument_ is `"-0"`, return *-0*.
+        1. If _argument_ is *"-0"*, return *-0*.
         1. Let _n_ be ! ToNumber(_argument_).
         1. If SameValue(! ToString(_n_), _argument_) is *false*, return *undefined*.
         1. Return _n_.
@@ -5776,10 +5776,10 @@
 
     <emu-clause id="sec-lengthofarraylike" aoid="LengthOfArrayLike">
       <h1>LengthOfArrayLike ( _obj_ )</h1>
-      <p>The abstract operation LengthOfArrayLike returns the value of the `"length"` property of an array-like object.</p>
+      <p>The abstract operation LengthOfArrayLike returns the value of the *"length"* property of an array-like object.</p>
       <emu-alg>
         1. Assert: Type(_obj_) is Object.
-        1. Return ? ToLength(? Get(_obj_, `"length"`)).
+        1. Return ? ToLength(? Get(_obj_, *"length"*)).
       </emu-alg>
       <p>An <dfn>array-like object</dfn> is any object for which this operation returns an integer rather than an abrupt completion.</p>
       <emu-note>
@@ -5830,7 +5830,7 @@
           1. Let _BC_ be _C_.[[BoundTargetFunction]].
           1. Return ? InstanceofOperator(_O_, _BC_).
         1. If Type(_O_) is not Object, return *false*.
-        1. Let _P_ be ? Get(_C_, `"prototype"`).
+        1. Let _P_ be ? Get(_C_, *"prototype"*).
         1. If Type(_P_) is not Object, throw a *TypeError* exception.
         1. Repeat,
           1. Set _O_ to ? _O_.[[GetPrototypeOf]]().
@@ -5844,7 +5844,7 @@
       <p>The abstract operation SpeciesConstructor is used to retrieve the constructor that should be used to create new objects that are derived from the argument object _O_. The _defaultConstructor_ argument is the constructor to use if a constructor @@species property cannot be found starting from _O_. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
-        1. Let _C_ be ? Get(_O_, `"constructor"`).
+        1. Let _C_ be ? Get(_O_, *"constructor"*).
         1. If _C_ is *undefined*, return _defaultConstructor_.
         1. If Type(_C_) is not Object, throw a *TypeError* exception.
         1. Let _S_ be ? Get(_C_, @@species).
@@ -5947,7 +5947,7 @@
           1. Otherwise, set _method_ to ? GetMethod(_obj_, @@iterator).
         1. Let _iterator_ be ? Call(_method_, _obj_).
         1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
-        1. Let _nextMethod_ be ? GetV(_iterator_, `"next"`).
+        1. Let _nextMethod_ be ? GetV(_iterator_, *"next"*).
         1. Let _iteratorRecord_ be the Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
         1. Return _iteratorRecord_.
       </emu-alg>
@@ -5971,7 +5971,7 @@
       <p>The abstract operation IteratorComplete with argument _iterResult_ performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_iterResult_) is Object.
-        1. Return ! ToBoolean(? Get(_iterResult_, `"done"`)).
+        1. Return ! ToBoolean(? Get(_iterResult_, *"done"*)).
       </emu-alg>
     </emu-clause>
 
@@ -5980,7 +5980,7 @@
       <p>The abstract operation IteratorValue with argument _iterResult_ performs the following steps:</p>
       <emu-alg>
         1. Assert: Type(_iterResult_) is Object.
-        1. Return ? Get(_iterResult_, `"value"`).
+        1. Return ? Get(_iterResult_, *"value"*).
       </emu-alg>
     </emu-clause>
 
@@ -6002,7 +6002,7 @@
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Assert: _completion_ is a Completion Record.
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
-        1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
+        1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
         1. If _return_ is *undefined*, return Completion(_completion_).
         1. Let _innerResult_ be Call(_return_, _iterator_).
         1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
@@ -6019,7 +6019,7 @@
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Assert: _completion_ is a Completion Record.
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
-        1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
+        1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
         1. If _return_ is *undefined*, return Completion(_completion_).
         1. Let _innerResult_ be Call(_return_, _iterator_).
         1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
@@ -6036,8 +6036,8 @@
       <emu-alg>
         1. Assert: Type(_done_) is Boolean.
         1. Let _obj_ be ObjectCreate(%Object.prototype%).
-        1. Perform ! CreateDataPropertyOrThrow(_obj_, `"value"`, _value_).
-        1. Perform ! CreateDataPropertyOrThrow(_obj_, `"done"`, _done_).
+        1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _value_).
+        1. Perform ! CreateDataPropertyOrThrow(_obj_, *"done"*, _done_).
         1. Return _obj_.
       </emu-alg>
     </emu-clause>
@@ -6072,7 +6072,7 @@
           1. Set _O_.[[ListIteratorNextIndex]] to _index_ + 1.
           1. Return CreateIterResultObject(_list_[_index_], *false*).
         </emu-alg>
-        <p>The `"length"` property of a ListIteratorNext function is 0.</p>
+        <p>The *"length"* property of a ListIteratorNext function is 0.</p>
       </emu-clause>
     </emu-clause>
   </emu-clause>
@@ -6900,7 +6900,7 @@
             1. Return *true*.
           </emu-alg>
           <emu-note>
-            <p>Properties may exist upon a global object that were directly created rather than being declared using a var or function declaration. A global lexical binding may not be created that has the same name as a non-configurable property of the global object. The global property `"undefined"` is an example of such a property.</p>
+            <p>Properties may exist upon a global object that were directly created rather than being declared using a var or function declaration. A global lexical binding may not be created that has the same name as a non-configurable property of the global object. The global property *"undefined"* is an example of such a property.</p>
           </emu-note>
         </emu-clause>
 
@@ -7648,10 +7648,10 @@
       1. Perform ? InitializeHostDefinedRealm().
       1. In an implementation-dependent manner, obtain the ECMAScript source texts (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>) and any associated host-defined values for zero or more ECMAScript scripts and/or ECMAScript modules. For each such _sourceText_ and _hostDefined_, do
         1. If _sourceText_ is the source code of a script, then
-          1. Perform EnqueueJob(`"ScriptJobs"`, ScriptEvaluationJob, &laquo; _sourceText_, _hostDefined_ &raquo;).
+          1. Perform EnqueueJob(*"ScriptJobs"*, ScriptEvaluationJob, &laquo; _sourceText_, _hostDefined_ &raquo;).
         1. Else,
           1. Assert: _sourceText_ is the source code of a module.
-          1. Perform EnqueueJob(`"ScriptJobs"`, TopLevelModuleEvaluationJob, &laquo; _sourceText_, _hostDefined_ &raquo;).
+          1. Perform EnqueueJob(*"ScriptJobs"*, TopLevelModuleEvaluationJob, &laquo; _sourceText_, _hostDefined_ &raquo;).
       1. Repeat,
         1. Suspend the running execution context and remove it from the execution context stack.
         1. Assert: The execution context stack is now empty.
@@ -8188,7 +8188,7 @@
 
     <emu-clause id="sec-ordinarycreatefromconstructor" aoid="OrdinaryCreateFromConstructor">
       <h1>OrdinaryCreateFromConstructor ( _constructor_, _intrinsicDefaultProto_ [ , _internalSlotsList_ ] )</h1>
-      <p>The abstract operation OrdinaryCreateFromConstructor creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's `"prototype"` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. The optional _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
+      <p>The abstract operation OrdinaryCreateFromConstructor creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. The optional _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Let _proto_ be ? GetPrototypeFromConstructor(_constructor_, _intrinsicDefaultProto_).
@@ -8198,11 +8198,11 @@
 
     <emu-clause id="sec-getprototypefromconstructor" aoid="GetPrototypeFromConstructor">
       <h1>GetPrototypeFromConstructor ( _constructor_, _intrinsicDefaultProto_ )</h1>
-      <p>The abstract operation GetPrototypeFromConstructor determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's `"prototype"` property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. This abstract operation performs the following steps:</p>
+      <p>The abstract operation GetPrototypeFromConstructor determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Assert: IsCallable(_constructor_) is *true*.
-        1. Let _proto_ be ? Get(_constructor_, `"prototype"`).
+        1. Let _proto_ be ? Get(_constructor_, *"prototype"*).
         1. If Type(_proto_) is not Object, then
           1. Let _realm_ be ? GetFunctionRealm(_constructor_).
           1. Set _proto_ to _realm_'s intrinsic object named _intrinsicDefaultProto_.
@@ -8451,7 +8451,7 @@
         1. Let _callerContext_ be the running execution context.
         1. Let _kind_ be _F_.[[ConstructorKind]].
         1. If _kind_ is ~base~, then
-          1. Let _thisArgument_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Object.prototype%"`).
+          1. Let _thisArgument_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Object.prototype%"*).
         1. Let _calleeContext_ be PrepareForOrdinaryCall(_F_, _newTarget_).
         1. Assert: _calleeContext_ is now the running execution context.
         1. If _kind_ is ~base~, perform OrdinaryCallBindThis(_F_, _calleeContext_, _thisArgument_).
@@ -8559,8 +8559,8 @@
       <emu-alg>
         1. Assert: _realm_.[[Intrinsics]].[[%ThrowTypeError%]] exists and has been initialized.
         1. Let _thrower_ be _realm_.[[Intrinsics]].[[%ThrowTypeError%]].
-        1. Perform ! DefinePropertyOrThrow(_F_, `"caller"`, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
-        1. Return ! DefinePropertyOrThrow(_F_, `"arguments"`, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"caller"*, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Return ! DefinePropertyOrThrow(_F_, *"arguments"*, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
       </emu-alg>
 
       <emu-clause id="sec-%throwtypeerror%">
@@ -8570,22 +8570,22 @@
           1. Throw a *TypeError* exception.
         </emu-alg>
         <p>The value of the [[Extensible]] internal slot of a %ThrowTypeError% function is *false*.</p>
-        <p>The `"length"` property of a %ThrowTypeError% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <p>The *"length"* property of a %ThrowTypeError% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-makeconstructor" aoid="MakeConstructor">
       <h1>MakeConstructor ( _F_ [ , _writablePrototype_ [ , _prototype_ ] ] )</h1>
-      <p>The abstract operation MakeConstructor requires a Function argument _F_ and optionally, a Boolean _writablePrototype_ and an object _prototype_. If _prototype_ is provided it is assumed to already contain, if needed, a `"constructor"` property whose value is _F_. This operation converts _F_ into a constructor by performing the following steps:</p>
+      <p>The abstract operation MakeConstructor requires a Function argument _F_ and optionally, a Boolean _writablePrototype_ and an object _prototype_. If _prototype_ is provided it is assumed to already contain, if needed, a *"constructor"* property whose value is _F_. This operation converts _F_ into a constructor by performing the following steps:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: IsConstructor(_F_) is *true*.
-        1. Assert: _F_ is an extensible object that does not have a `"prototype"` own property.
+        1. Assert: _F_ is an extensible object that does not have a *"prototype"* own property.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then
           1. Set _prototype_ to ObjectCreate(%Object.prototype%).
-          1. Perform ! DefinePropertyOrThrow(_prototype_, `"constructor"`, PropertyDescriptor { [[Value]]: _F_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
-        1. Perform ! DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ! DefinePropertyOrThrow(_prototype_, *"constructor"*, PropertyDescriptor { [[Value]]: _F_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
     </emu-clause>
@@ -8614,29 +8614,29 @@
 
     <emu-clause id="sec-setfunctionname" aoid="SetFunctionName">
       <h1>SetFunctionName ( _F_, _name_ [ , _prefix_ ] )</h1>
-      <p>The abstract operation SetFunctionName requires a Function argument _F_, a String or Symbol argument _name_ and optionally a String argument _prefix_. This operation adds a `"name"` property to _F_ by performing the following steps:</p>
+      <p>The abstract operation SetFunctionName requires a Function argument _F_, a String or Symbol argument _name_ and optionally a String argument _prefix_. This operation adds a *"name"* property to _F_ by performing the following steps:</p>
       <emu-alg>
-        1. Assert: _F_ is an extensible object that does not have a `"name"` own property.
+        1. Assert: _F_ is an extensible object that does not have a *"name"* own property.
         1. Assert: Type(_name_) is either Symbol or String.
         1. Assert: If _prefix_ is present, then Type(_prefix_) is String.
         1. If Type(_name_) is Symbol, then
           1. Let _description_ be _name_'s [[Description]] value.
           1. If _description_ is *undefined*, set _name_ to the empty String.
-          1. Else, set _name_ to the string-concatenation of `"["`, _description_, and `"]"`.
+          1. Else, set _name_ to the string-concatenation of *"["*, _description_, and *"]"*.
         1. If _prefix_ is present, then
           1. Set _name_ to the string-concatenation of _prefix_, the code unit 0x0020 (SPACE), and _name_.
-        1. Return ! DefinePropertyOrThrow(_F_, `"name"`, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Return ! DefinePropertyOrThrow(_F_, *"name"*, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-setfunctionlength" aoid="SetFunctionLength">
       <h1>SetFunctionLength ( _F_, _length_ )</h1>
-      <p>The abstract operation SetFunctionLength requires a Function argument _F_ and a Number argument _length_. This operation adds a `"length"` property to _F_ by performing the following steps:</p>
+      <p>The abstract operation SetFunctionLength requires a Function argument _F_ and a Number argument _length_. This operation adds a *"length"* property to _F_ by performing the following steps:</p>
       <emu-alg>
-        1. Assert: _F_ is an extensible object that does not have a `"length"` own property.
+        1. Assert: _F_ is an extensible object that does not have a *"length"* own property.
         1. Assert: Type(_length_) is Number.
         1. Assert: _length_ &ge; 0 and ! IsInteger(_length_) is *true*.
-        1. Return ! DefinePropertyOrThrow(_F_, `"length"`, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Return ! DefinePropertyOrThrow(_F_, *"length"*, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
       </emu-alg>
     </emu-clause>
 
@@ -8679,10 +8679,10 @@
         1. If _func_.[[ThisMode]] is ~lexical~, then
           1. NOTE: Arrow functions never have an arguments objects.
           1. Set _argumentsObjectNeeded_ to *false*.
-        1. Else if `"arguments"` is an element of _parameterNames_, then
+        1. Else if *"arguments"* is an element of _parameterNames_, then
           1. Set _argumentsObjectNeeded_ to *false*.
         1. Else if _hasParameterExpressions_ is *false*, then
-          1. If `"arguments"` is an element of _functionNames_ or if `"arguments"` is an element of _lexicalNames_, then
+          1. If *"arguments"* is an element of _functionNames_ or if *"arguments"* is an element of _lexicalNames_, then
             1. Set _argumentsObjectNeeded_ to *false*.
         1. For each String _paramName_ in _parameterNames_, do
           1. Let _alreadyDeclared_ be _envRec_.HasBinding(_paramName_).
@@ -8698,11 +8698,11 @@
             1. NOTE: mapped argument object is only provided for non-strict functions that don't have a rest parameter, any parameter default value initializers, or any destructured parameters.
             1. Let _ao_ be CreateMappedArgumentsObject(_func_, _formals_, _argumentsList_, _envRec_).
           1. If _strict_ is *true*, then
-            1. Perform ! _envRec_.CreateImmutableBinding(`"arguments"`, *false*).
+            1. Perform ! _envRec_.CreateImmutableBinding(*"arguments"*, *false*).
           1. Else,
-            1. Perform ! _envRec_.CreateMutableBinding(`"arguments"`, *false*).
-          1. Call _envRec_.InitializeBinding(`"arguments"`, _ao_).
-          1. Let _parameterBindings_ be a new List of _parameterNames_ with `"arguments"` appended.
+            1. Perform ! _envRec_.CreateMutableBinding(*"arguments"*, *false*).
+          1. Call _envRec_.InitializeBinding(*"arguments"*, _ao_).
+          1. Let _parameterBindings_ be a new List of _parameterNames_ with *"arguments"* appended.
         1. Else,
           1. Let _parameterBindings_ be _parameterNames_.
         1. Let _iteratorRecord_ be CreateListIteratorRecord(_argumentsList_).
@@ -8772,7 +8772,7 @@
     <p>Unless otherwise specified every built-in function object has the %Function.prototype% object as the initial value of its [[Prototype]] internal slot.</p>
     <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[FunctionKind]] internal slot to have the value ~classConstructor~.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
-    <p>Built-in functions that are not constructors do not have a `"prototype"` property unless otherwise specified in the description of a particular function.</p>
+    <p>Built-in functions that are not constructors do not have a *"prototype"* property unless otherwise specified in the description of a particular function.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
 
     <emu-clause id="sec-built-in-function-objects-call-thisargument-argumentslist">
@@ -8932,7 +8932,7 @@
 
     <emu-clause id="sec-array-exotic-objects">
       <h1>Array Exotic Objects</h1>
-      <p>An <em>Array object</em> is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array object has a non-configurable `"length"` property whose value is always a nonnegative integer less than 2<sup>32</sup>. The value of the `"length"` property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array object is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the `"length"` property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the `"length"` property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array object and is unaffected by `"length"` or array index properties that may be inherited from its prototypes.</p>
+      <p>An <em>Array object</em> is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array object has a non-configurable *"length"* property whose value is always a nonnegative integer less than 2<sup>32</sup>. The value of the *"length"* property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array object is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the *"length"* property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the *"length"* property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array object and is unaffected by *"length"* or array index properties that may be inherited from its prototypes.</p>
       <emu-note>
         <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) is equal to _P_ and ToUint32(_P_) is not equal to <emu-eqn>2<sup>32</sup> - 1</emu-eqn>.</p>
       </emu-note>
@@ -8943,10 +8943,10 @@
         <p>When the [[DefineOwnProperty]] internal method of an Array exotic object _A_ is called with property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. If _P_ is `"length"`, then
+          1. If _P_ is *"length"*, then
             1. Return ? ArraySetLength(_A_, _Desc_).
           1. Else if _P_ is an array index, then
-            1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, `"length"`).
+            1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
             1. Assert: _oldLenDesc_ will never be *undefined* or an accessor descriptor because Array objects are created with a length data property that cannot be deleted or reconfigured.
             1. Let _oldLen_ be _oldLenDesc_.[[Value]].
             1. Let _index_ be ! ToUint32(_P_).
@@ -8955,7 +8955,7 @@
             1. If _succeeded_ is *false*, return *false*.
             1. If _index_ &ge; _oldLen_, then
               1. Set _oldLenDesc_.[[Value]] to _index_ + 1.
-              1. Let _succeeded_ be OrdinaryDefineOwnProperty(_A_, `"length"`, _oldLenDesc_).
+              1. Let _succeeded_ be OrdinaryDefineOwnProperty(_A_, *"length"*, _oldLenDesc_).
               1. Assert: _succeeded_ is *true*.
             1. Return *true*.
           1. Return OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
@@ -8975,7 +8975,7 @@
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _A_.[[Prototype]] to _proto_.
           1. Set _A_.[[Extensible]] to *true*.
-          1. Perform ! OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _A_.
         </emu-alg>
       </emu-clause>
@@ -8988,7 +8988,7 @@
           1. If _length_ is *-0*, set _length_ to *+0*.
           1. Let _isArray_ be ? IsArray(_originalArray_).
           1. If _isArray_ is *false*, return ? ArrayCreate(_length_).
-          1. Let _C_ be ? Get(_originalArray_, `"constructor"`).
+          1. Let _C_ be ? Get(_originalArray_, *"constructor"*).
           1. If IsConstructor(_C_) is *true*, then
             1. Let _thisRealm_ be the current Realm Record.
             1. Let _realmC_ be ? GetFunctionRealm(_C_).
@@ -9011,24 +9011,24 @@
         <p>When the abstract operation ArraySetLength is called with an Array exotic object _A_, and Property Descriptor _Desc_, the following steps are taken:</p>
         <emu-alg>
           1. If _Desc_.[[Value]] is absent, then
-            1. Return OrdinaryDefineOwnProperty(_A_, `"length"`, _Desc_).
+            1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _Desc_).
           1. Let _newLenDesc_ be a copy of _Desc_.
           1. Let _newLen_ be ? ToUint32(_Desc_.[[Value]]).
           1. Let _numberLen_ be ? ToNumber(_Desc_.[[Value]]).
           1. If _newLen_ &ne; _numberLen_, throw a *RangeError* exception.
           1. Set _newLenDesc_.[[Value]] to _newLen_.
-          1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, `"length"`).
+          1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
           1. Assert: _oldLenDesc_ will never be *undefined* or an accessor descriptor because Array objects are created with a length data property that cannot be deleted or reconfigured.
           1. Let _oldLen_ be _oldLenDesc_.[[Value]].
           1. If _newLen_ &ge; _oldLen_, then
-            1. Return OrdinaryDefineOwnProperty(_A_, `"length"`, _newLenDesc_).
+            1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
           1. If _oldLenDesc_.[[Writable]] is *false*, return *false*.
           1. If _newLenDesc_.[[Writable]] is absent or has the value *true*, let _newWritable_ be *true*.
           1. Else,
             1. Need to defer setting the [[Writable]] attribute to *false* in case any elements cannot be deleted.
             1. Let _newWritable_ be *false*.
             1. Set _newLenDesc_.[[Writable]] to *true*.
-          1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, `"length"`, _newLenDesc_).
+          1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
           1. If _succeeded_ is *false*, return *false*.
           1. Repeat, while _newLen_ &lt; _oldLen_,
             1. Set _oldLen_ to _oldLen_ - 1.
@@ -9036,10 +9036,10 @@
             1. If _deleteSucceeded_ is *false*, then
               1. Set _newLenDesc_.[[Value]] to _oldLen_ + 1.
               1. If _newWritable_ is *false*, set _newLenDesc_.[[Writable]] to *false*.
-              1. Perform ! OrdinaryDefineOwnProperty(_A_, `"length"`, _newLenDesc_).
+              1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
               1. Return *false*.
           1. If _newWritable_ is *false*, then
-            1. Return OrdinaryDefineOwnProperty(_A_, `"length"`, PropertyDescriptor { [[Writable]]: *false* }). This call will always return *true*.
+            1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Writable]]: *false* }). This call will always return *true*.
           1. Return *true*.
         </emu-alg>
         <emu-note>
@@ -9050,7 +9050,7 @@
 
     <emu-clause id="sec-string-exotic-objects">
       <h1>String Exotic Objects</h1>
-      <p>A <em>String object</em> is an exotic object that encapsulates a String value and exposes virtual integer-indexed data properties corresponding to the individual code unit elements of the String value. String exotic objects always have a data property named `"length"` whose value is the number of code unit elements in the encapsulated String value. Both the code unit data properties and the `"length"` property are non-writable and non-configurable.</p>
+      <p>A <em>String object</em> is an exotic object that encapsulates a String value and exposes virtual integer-indexed data properties corresponding to the individual code unit elements of the String value. String exotic objects always have a data property named *"length"* whose value is the number of code unit elements in the encapsulated String value. Both the code unit data properties and the *"length"* property are non-writable and non-configurable.</p>
       <p>String exotic objects have the same internal slots as ordinary objects. They also have a [[StringData]] internal slot.</p>
       <p>String exotic objects provide alternative definitions for the following internal methods. All of the other String exotic object essential internal methods that are not defined below are as specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</p>
 
@@ -9112,7 +9112,7 @@
           1. Set _S_.[[Prototype]] to _prototype_.
           1. Set _S_.[[Extensible]] to *true*.
           1. Let _length_ be the number of code unit elements in _value_.
-          1. Perform ! DefinePropertyOrThrow(_S_, `"length"`, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ! DefinePropertyOrThrow(_S_, *"length"*, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _S_.
         </emu-alg>
       </emu-clause>
@@ -9150,10 +9150,10 @@
         <p>The ParameterMap object and its property values are used as a device for specifying the arguments object correspondence to argument bindings. The ParameterMap object and the objects that are the values of its properties are not directly observable from ECMAScript code. An ECMAScript implementation does not need to actually create or use such objects to implement the specified semantics.</p>
       </emu-note>
       <emu-note>
-        <p>Ordinary arguments objects define a non-configurable accessor property named `"callee"` which throws a *TypeError* exception on access. The `"callee"` property has a more specific meaning for arguments exotic objects, which are created only for some class of non-strict functions. The definition of this property in the ordinary variant exists to ensure that it is not defined in any other manner by conforming ECMAScript implementations.</p>
+        <p>Ordinary arguments objects define a non-configurable accessor property named *"callee"* which throws a *TypeError* exception on access. The *"callee"* property has a more specific meaning for arguments exotic objects, which are created only for some class of non-strict functions. The definition of this property in the ordinary variant exists to ensure that it is not defined in any other manner by conforming ECMAScript implementations.</p>
       </emu-note>
       <emu-note>
-        <p>ECMAScript implementations of arguments exotic objects have historically contained an accessor property named `"caller"`. Prior to ECMAScript 2017, this specification included the definition of a throwing `"caller"` property on ordinary arguments objects. Since implementations do not contain this extension any longer, ECMAScript 2017 dropped the requirement for a throwing `"caller"` accessor.</p>
+        <p>ECMAScript implementations of arguments exotic objects have historically contained an accessor property named *"caller"*. Prior to ECMAScript 2017, this specification included the definition of a throwing *"caller"* property on ordinary arguments objects. Since implementations do not contain this extension any longer, ECMAScript 2017 dropped the requirement for a throwing *"caller"* accessor.</p>
       </emu-note>
 
       <emu-clause id="sec-arguments-exotic-objects-getownproperty-p">
@@ -9251,14 +9251,14 @@
           1. Let _len_ be the number of elements in _argumentsList_.
           1. Let _obj_ be ObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
           1. Set _obj_.[[ParameterMap]] to *undefined*.
-          1. Perform DefinePropertyOrThrow(_obj_, `"length"`, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
             1. Let _val_ be _argumentsList_[_index_].
             1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(_index_), _val_).
             1. Set _index_ to _index_ + 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
-          1. Perform ! DefinePropertyOrThrow(_obj_, `"callee"`, PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -9287,7 +9287,7 @@
             1. Let _val_ be _argumentsList_[_index_].
             1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(_index_), _val_).
             1. Set _index_ to _index_ + 1.
-          1. Perform ! DefinePropertyOrThrow(_obj_, `"length"`, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _mappedNames_ be a new empty List.
           1. Let _index_ be _numberOfParameters_ - 1.
           1. Repeat, while _index_ &ge; 0,
@@ -9300,7 +9300,7 @@
                 1. Perform _map_.[[DefineOwnProperty]](! ToString(_index_), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
             1. Set _index_ to _index_ - 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
-          1. Perform ! DefinePropertyOrThrow(_obj_, `"callee"`, PropertyDescriptor { [[Value]]: _func_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Value]]: _func_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Return _obj_.
         </emu-alg>
 
@@ -9659,7 +9659,7 @@
           1. Assert: _binding_ is a ResolvedBinding Record.
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.
-          1. If _binding_.[[BindingName]] is `"*namespace*"`, then
+          1. If _binding_.[[BindingName]] is *"\*namespace\*"*, then
             1. Return ? GetModuleNamespace(_targetModule_).
           1. Let _targetEnv_ be _targetModule_.[[Environment]].
           1. If _targetEnv_ is *undefined*, throw a *ReferenceError* exception.
@@ -9883,7 +9883,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"getPrototypeOf"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"getPrototypeOf"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[GetPrototypeOf]]().
         1. Let _handlerProto_ be ? Call(_trap_, _handler_, &laquo; _target_ &raquo;).
@@ -9916,7 +9916,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"setPrototypeOf"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"setPrototypeOf"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[SetPrototypeOf]](_V_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _V_ &raquo;)).
@@ -9948,7 +9948,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"isExtensible"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"isExtensible"*).
         1. If _trap_ is *undefined*, then
           1. Return ? IsExtensible(_target_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
@@ -9977,7 +9977,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"preventExtensions"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"preventExtensions"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[PreventExtensions]]().
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
@@ -10008,7 +10008,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"getOwnPropertyDescriptor"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"getOwnPropertyDescriptor"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[GetOwnProperty]](_P_).
         1. Let _trapResultObj_ be ? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;).
@@ -10061,7 +10061,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"defineProperty"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"defineProperty"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[DefineOwnProperty]](_P_, _Desc_).
         1. Let _descObj_ be FromPropertyDescriptor(_Desc_).
@@ -10108,7 +10108,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"has"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"has"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[HasProperty]](_P_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
@@ -10145,7 +10145,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"get"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"get"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Get]](_P_, _Receiver_).
         1. Let _trapResult_ be ? Call(_trap_, _handler_, &laquo; _target_, _P_, _Receiver_ &raquo;).
@@ -10179,7 +10179,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"set"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"set"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Set]](_P_, _V_, _Receiver_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _V_, _Receiver_ &raquo;)).
@@ -10217,7 +10217,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"deleteProperty"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"deleteProperty"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[Delete]](_P_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
@@ -10248,7 +10248,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"ownKeys"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"ownKeys"*).
         1. If _trap_ is *undefined*, then
           1. Return ? _target_.[[OwnPropertyKeys]]().
         1. Let _trapResultArray_ be ? Call(_trap_, _handler_, &laquo; _target_ &raquo;).
@@ -10309,7 +10309,7 @@
         1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
-        1. Let _trap_ be ? GetMethod(_handler_, `"apply"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"apply"*).
         1. If _trap_ is *undefined*, then
           1. Return ? Call(_target_, _thisArgument_, _argumentsList_).
         1. Let _argArray_ be ! CreateArrayFromList(_argumentsList_).
@@ -10329,7 +10329,7 @@
         1. Assert: Type(_handler_) is Object.
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Assert: IsConstructor(_target_) is *true*.
-        1. Let _trap_ be ? GetMethod(_handler_, `"construct"`).
+        1. Let _trap_ be ? GetMethod(_handler_, *"construct"*).
         1. If _trap_ is *undefined*, then
           1. Return ? Construct(_target_, _argumentsList_, _newTarget_).
         1. Let _argArray_ be ! CreateArrayFromList(_argumentsList_).
@@ -10922,13 +10922,13 @@
         <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of *"$"*, or *"_"*, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if SV(|UnicodeEscapeSequence|) is none of *"$"*, or *"_"*, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
       </emu-clause>
@@ -12189,7 +12189,7 @@
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the code matched by this production is contained in strict mode code and the StringValue of |Identifier| is `"arguments"` or `"eval"`.
+          It is a Syntax Error if the code matched by this production is contained in strict mode code and the StringValue of |Identifier| is *"arguments"* or *"eval"*.
         </li>
       </ul>
       <emu-grammar>
@@ -12241,19 +12241,19 @@
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if this production has a <sub>[Yield]</sub> parameter and StringValue of |Identifier| is `"yield"`.
+          It is a Syntax Error if this production has a <sub>[Yield]</sub> parameter and StringValue of |Identifier| is *"yield"*.
         </li>
         <li>
-          It is a Syntax Error if this production has an <sub>[Await]</sub> parameter and StringValue of |Identifier| is `"await"`.
+          It is a Syntax Error if this production has an <sub>[Await]</sub> parameter and StringValue of |Identifier| is *"await"*.
         </li>
       </ul>
       <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, `"static"`, or `"yield"`.
+          It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is: *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, *"static"*, or *"yield"*.
         </li>
         <li>
-          It is a Syntax Error if the goal symbol of the syntactic grammar is |Module| and the StringValue of |IdentifierName| is `"await"`.
+          It is a Syntax Error if the goal symbol of the syntactic grammar is |Module| and the StringValue of |IdentifierName| is *"await"*.
         </li>
         <li>
           It is a Syntax Error if StringValue of |IdentifierName| is the same String value as the StringValue of any |ReservedWord| except for `yield` or `await`.
@@ -12273,11 +12273,11 @@
       </emu-alg>
       <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
       <emu-alg>
-        1. Return a new List containing `"yield"`.
+        1. Return a new List containing *"yield"*.
       </emu-alg>
       <emu-grammar>BindingIdentifier : `await`</emu-grammar>
       <emu-alg>
-        1. Return a new List containing `"await"`.
+        1. Return a new List containing *"await"*.
       </emu-alg>
     </emu-clause>
 
@@ -12286,7 +12286,7 @@
       <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
-        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is `"eval"` or `"arguments"`, return ~strict~.
+        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is *"eval"* or *"arguments"*, return ~strict~.
         1. Return ~simple~.
       </emu-alg>
       <emu-grammar>IdentifierReference : `yield`</emu-grammar>
@@ -12310,7 +12310,7 @@
         LabelIdentifier : `yield`
       </emu-grammar>
       <emu-alg>
-        1. Return `"yield"`.
+        1. Return *"yield"*.
       </emu-alg>
       <emu-grammar>
         IdentifierReference : `await`
@@ -12320,7 +12320,7 @@
         LabelIdentifier : `await`
       </emu-grammar>
       <emu-alg>
-        1. Return `"await"`.
+        1. Return *"await"*.
       </emu-alg>
       <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
       <emu-alg>
@@ -12342,11 +12342,11 @@
       </emu-alg>
       <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
       <emu-alg>
-        1. Return ? InitializeBoundName(`"yield"`, _value_, _environment_).
+        1. Return ? InitializeBoundName(*"yield"*, _value_, _environment_).
       </emu-alg>
       <emu-grammar>BindingIdentifier : `await`</emu-grammar>
       <emu-alg>
-        1. Return ? InitializeBoundName(`"await"`, _value_, _environment_).
+        1. Return ? InitializeBoundName(*"await"*, _value_, _environment_).
       </emu-alg>
 
       <emu-clause id="sec-initializeboundname" aoid="InitializeBoundName">
@@ -12372,11 +12372,11 @@
       </emu-alg>
       <emu-grammar>IdentifierReference : `yield`</emu-grammar>
       <emu-alg>
-        1. Return ? ResolveBinding(`"yield"`).
+        1. Return ? ResolveBinding(*"yield"*).
       </emu-alg>
       <emu-grammar>IdentifierReference : `await`</emu-grammar>
       <emu-alg>
-        1. Return ? ResolveBinding(`"await"`).
+        1. Return ? ResolveBinding(*"await"*).
       </emu-alg>
       <emu-note>
         <p>The result of evaluating an |IdentifierReference| is always a value of type Reference.</p>
@@ -12609,7 +12609,7 @@
         <emu-grammar>Elision : `,`</emu-grammar>
         <emu-alg>
           1. Let _len_ be _nextIndex_ + 1.
-          1. Perform ? Set(_array_, `"length"`, _len_, *true*).
+          1. Perform ? Set(_array_, *"length"*, _len_, *true*).
           1. NOTE: The above Set throws if _len_ exceeds 2<sup>32</sup>-1.
           1. Return _len_.
         </emu-alg>
@@ -13151,7 +13151,7 @@
             1. Call _rawObj_.[[DefineOwnProperty]](_prop_, PropertyDescriptor { [[Value]]: _rawValue_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }).
             1. Set _index_ to _index_ + 1.
           1. Perform SetIntegrityLevel(_rawObj_, ~frozen~).
-          1. Call _template_.[[DefineOwnProperty]](`"raw"`, PropertyDescriptor { [[Value]]: _rawObj_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Call _template_.[[DefineOwnProperty]](*"raw"*, PropertyDescriptor { [[Value]]: _rawObj_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Perform SetIntegrityLevel(_template_, ~frozen~).
           1. Append the Record { [[Site]]: _templateLiteral_, [[Array]]: _template_ } to _templateRegistry_.
           1. Return _template_.
@@ -13643,7 +13643,7 @@
           1. Let _arguments_ be the |Arguments| of _expr_.
           1. Let _ref_ be the result of evaluating _memberExpr_.
           1. Let _func_ be ? GetValue(_ref_).
-          1. If Type(_ref_) is Reference and IsPropertyReference(_ref_) is *false* and GetReferencedName(_ref_) is `"eval"`, then
+          1. If Type(_ref_) is Reference and IsPropertyReference(_ref_) is *false* and GetReferencedName(_ref_) is *"eval"*, then
             1. If SameValue(_func_, %eval%) is *true*, then
               1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
               1. If _argList_ has no elements, return *undefined*.
@@ -14128,7 +14128,7 @@
         <emu-alg>
           1. Let _val_ be the result of evaluating |UnaryExpression|.
           1. If Type(_val_) is Reference, then
-            1. If IsUnresolvableReference(_val_) is *true*, return `"undefined"`.
+            1. If IsUnresolvableReference(_val_) is *true*, return *"undefined"*.
           1. Set _val_ to ? GetValue(_val_).
           1. Return a String according to <emu-xref href="#table-35"></emu-xref>.
         </emu-alg>
@@ -14148,7 +14148,7 @@
                 Undefined
               </td>
               <td>
-                `"undefined"`
+                *"undefined"*
               </td>
             </tr>
             <tr>
@@ -14156,7 +14156,7 @@
                 Null
               </td>
               <td>
-                `"object"`
+                *"object"*
               </td>
             </tr>
             <tr>
@@ -14164,7 +14164,7 @@
                 Boolean
               </td>
               <td>
-                `"boolean"`
+                *"boolean"*
               </td>
             </tr>
             <tr>
@@ -14172,7 +14172,7 @@
                 Number
               </td>
               <td>
-                `"number"`
+                *"number"*
               </td>
             </tr>
             <tr>
@@ -14180,7 +14180,7 @@
                 String
               </td>
               <td>
-                `"string"`
+                *"string"*
               </td>
             </tr>
             <tr>
@@ -14188,7 +14188,7 @@
                 Symbol
               </td>
               <td>
-                `"symbol"`
+                *"symbol"*
               </td>
             </tr>
             <tr>
@@ -14196,7 +14196,7 @@
                 BigInt
               </td>
               <td>
-                `"bigint"`
+                *"bigint"*
               </td>
             </tr>
             <tr>
@@ -14204,7 +14204,7 @@
                 Object (does not implement [[Call]])
               </td>
               <td>
-                `"object"`
+                *"object"*
               </td>
             </tr>
             <tr>
@@ -14212,7 +14212,7 @@
                 Object (implements [[Call]])
               </td>
               <td>
-                `"function"`
+                *"function"*
               </td>
             </tr>
             </tbody>
@@ -14708,7 +14708,7 @@
 
     <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
       <h1>Runtime Semantics: InstanceofOperator ( _V_, _target_ )</h1>
-      <p>The abstract operation InstanceofOperator(_V_, _target_) implements the generic algorithm for determining if  ECMAScript value _V_ is an instance of object _target_ either by consulting _target_'s @@hasinstance method or, if absent, determining whether the value of _target_'s `"prototype"` property is present in _V_'s prototype chain. This abstract operation performs the following steps:</p>
+      <p>The abstract operation InstanceofOperator(_V_, _target_) implements the generic algorithm for determining if  ECMAScript value _V_ is an instance of object _target_ either by consulting _target_'s @@hasinstance method or, if absent, determining whether the value of _target_'s *"prototype"* property is present in _V_'s prototype chain. This abstract operation performs the following steps:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _instOfHandler_ be ? GetMethod(_target_, @@hasInstance).
@@ -16103,7 +16103,7 @@
         <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the BoundNames of |BindingList| contains `"let"`.
+            It is a Syntax Error if the BoundNames of |BindingList| contains *"let"*.
           </li>
           <li>
             It is a Syntax Error if the BoundNames of |BindingList| contains any duplicate entries.
@@ -17383,7 +17383,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the BoundNames of |ForDeclaration| contains `"let"`.
+            It is a Syntax Error if the BoundNames of |ForDeclaration| contains *"let"*.
           </li>
           <li>
             It is a Syntax Error if any element of the BoundNames of |ForDeclaration| also occurs in the VarDeclaredNames of |Statement|.
@@ -19013,7 +19013,7 @@
           If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
+          If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -19081,10 +19081,10 @@
       </emu-alg>
       <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Return &laquo; `"*default*"` &raquo;.
+        1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
       <emu-note>
-        <p>`"*default*"` is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
       </emu-note>
       <emu-grammar>FormalParameters : [empty]</emu-grammar>
       <emu-alg>
@@ -19390,7 +19390,7 @@
       <emu-alg>
         1. Let _F_ be FunctionCreate(~Normal~, |FormalParameters|, |FunctionBody|, _scope_).
         1. Perform MakeConstructor(_F_).
-        1. Perform SetFunctionName(_F_, `"default"`).
+        1. Perform SetFunctionName(_F_, *"default"*).
         1. Set _F_.[[SourceText]] to the source text matched by |FunctionDeclaration|.
         1. Return _F_.
       </emu-alg>
@@ -19449,7 +19449,7 @@
         <p>The |BindingIdentifier| in a |FunctionExpression| can be referenced from inside the |FunctionExpression|'s |FunctionBody| to allow the function to call itself recursively. However, unlike in a |FunctionDeclaration|, the |BindingIdentifier| in a |FunctionExpression| cannot be referenced from and does not affect the scope enclosing the |FunctionExpression|.</p>
       </emu-note>
       <emu-note>
-        <p>A `"prototype"` property is automatically created for every function defined using a |FunctionDeclaration| or |FunctionExpression|, to allow for the possibility that the function will be used as a constructor.</p>
+        <p>A *"prototype"* property is automatically created for every function defined using a |FunctionDeclaration| or |FunctionExpression|, to allow for the possibility that the function will be used as a constructor.</p>
       </emu-note>
       <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
@@ -19869,7 +19869,7 @@
         1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. Let _closure_ be FunctionCreate(~Method~, _formalParameterList_, |FunctionBody|, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
-        1. Perform SetFunctionName(_closure_, _propKey_, `"get"`).
+        1. Perform SetFunctionName(_closure_, _propKey_, *"get"*).
         1. Set _closure_.[[SourceText]] to the source text matched by |MethodDefinition|.
         1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
@@ -19881,7 +19881,7 @@
         1. Let _scope_ be the running execution context's LexicalEnvironment.
         1. Let _closure_ be FunctionCreate(~Method~, |PropertySetParameterList|, |FunctionBody|, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
-        1. Perform SetFunctionName(_closure_, _propKey_, `"set"`).
+        1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
         1. Set _closure_.[[SourceText]] to the source text matched by |MethodDefinition|.
         1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
@@ -19950,7 +19950,7 @@
           If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.
+          If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -19985,10 +19985,10 @@
       </emu-alg>
       <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Return &laquo; `"*default*"` &raquo;.
+        1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
       <emu-note>
-        <p>`"*default*"` is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
       </emu-note>
     </emu-clause>
 
@@ -20082,7 +20082,7 @@
       <emu-grammar>GeneratorBody : FunctionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, `"%Generator.prototype%"`, &laquo; [[GeneratorState]], [[GeneratorContext]] &raquo;).
+        1. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%Generator.prototype%"*, &laquo; [[GeneratorState]], [[GeneratorContext]] &raquo;).
         1. Perform GeneratorStart(_G_, |FunctionBody|).
         1. Return Completion { [[Type]]: ~return~, [[Value]]: _G_, [[Target]]: ~empty~ }.
       </emu-alg>
@@ -20097,7 +20097,7 @@
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Let _F_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_).
         1. Let _prototype_ be ObjectCreate(%Generator.prototype%).
-        1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform SetFunctionName(_F_, _name_).
         1. Set _F_.[[SourceText]] to the source text matched by |GeneratorDeclaration|.
         1. Return _F_.
@@ -20106,8 +20106,8 @@
       <emu-alg>
         1. Let _F_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_).
         1. Let _prototype_ be ObjectCreate(%Generator.prototype%).
-        1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Perform SetFunctionName(_F_, `"default"`).
+        1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform SetFunctionName(_F_, *"default"*).
         1. Set _F_.[[SourceText]] to the source text matched by |GeneratorDeclaration|.
         1. Return _F_.
       </emu-alg>
@@ -20128,7 +20128,7 @@
         1. Let _closure_ be GeneratorFunctionCreate(~Method~, |UniqueFormalParameters|, |GeneratorBody|, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Let _prototype_ be ObjectCreate(%Generator.prototype%).
-        1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform SetFunctionName(_closure_, _propKey_).
         1. Set _closure_.[[SourceText]] to the source text matched by |GeneratorMethod|.
         1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
@@ -20154,7 +20154,7 @@
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _closure_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_).
         1. Let _prototype_ be ObjectCreate(%Generator.prototype%).
-        1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Set _closure_.[[SourceText]] to the source text matched by |GeneratorExpression|.
         1. Return _closure_.
       </emu-alg>
@@ -20167,7 +20167,7 @@
         1. Perform _envRec_.CreateImmutableBinding(_name_, *false*).
         1. Let _closure_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _funcEnv_).
         1. Let _prototype_ be ObjectCreate(%Generator.prototype%).
-        1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Perform _envRec_.InitializeBinding(_name_, _closure_).
         1. Set _closure_.[[SourceText]] to the source text matched by |GeneratorExpression|.
@@ -20209,7 +20209,7 @@
             1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
             1. Else, set _received_ to GeneratorYield(_innerResult_).
           1. Else if _received_.[[Type]] is ~throw~, then
-            1. Let _throw_ be ? GetMethod(_iterator_, `"throw"`).
+            1. Let _throw_ be ? GetMethod(_iterator_, *"throw"*).
             1. If _throw_ is not *undefined*, then
               1. Let _innerResult_ be ? Call(_throw_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
               1. If _generatorKind_ is ~async~, then set _innerResult_ to ? Await(_innerResult_).
@@ -20229,7 +20229,7 @@
               1. Throw a *TypeError* exception.
           1. Else,
             1. Assert: _received_.[[Type]] is ~return~.
-            1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
+            1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
             1. If _return_ is *undefined*, then
               1. If _generatorKind_ is ~async~, then set _received_.[[Value]] to ? Await(_received_.[[Value]]).
               1. Return Completion(_received_).
@@ -20289,7 +20289,7 @@
       </emu-grammar>
       <ul>
         <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
+        <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if ContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |YieldExpression| is *true*.</li>
@@ -20310,10 +20310,10 @@
       </emu-alg>
       <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Return &laquo; `"*default*"` &raquo;.
+        1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
       <emu-note>
-        <p>`"*default*"` is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
       </emu-note>
     </emu-clause>
 
@@ -20408,7 +20408,7 @@
       </emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, `"%AsyncGenerator.prototype%"`, &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]] &raquo;).
+        1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%AsyncGenerator.prototype%"*, &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]] &raquo;).
         1. Perform ! AsyncGeneratorStart(_generator_, |FunctionBody|).
         1. Return Completion { [[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~ }.
       </emu-alg>
@@ -20424,7 +20424,7 @@
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Let _F_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_).
         1. Let _prototype_ be ! ObjectCreate(%AsyncGenerator.prototype%).
-        1. Perform ! DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform ! SetFunctionName(_F_, _name_).
         1. Set _F_.[[SourceText]] to the source text matched by |AsyncGeneratorDeclaration|.
         1. Return _F_.
@@ -20436,8 +20436,8 @@
       <emu-alg>
         1. Let _F_ be AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_).
         1. Let _prototype_ be ObjectCreate(%AsyncGenerator.prototype%).
-        1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Perform SetFunctionName(_F_, `"default"`).
+        1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform SetFunctionName(_F_, *"default"*).
         1. Set _F_.[[SourceText]] to the source text matched by |AsyncGeneratorDeclaration|.
         1. Return _F_.
       </emu-alg>
@@ -20459,7 +20459,7 @@
         1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Method~, |UniqueFormalParameters|, |AsyncGeneratorBody|, _scope_).
         1. Perform ! MakeMethod(_closure_, _object_).
         1. Let _prototype_ be ! ObjectCreate(%AsyncGenerator.prototype%).
-        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform ! SetFunctionName(_closure_, _propKey_).
         1. Set _closure_.[[SourceText]] to the source text matched by |AsyncGeneratorMethod|.
         1. Let _desc_ be PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
@@ -20490,7 +20490,7 @@
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_).
         1. Let _prototype_ be ! ObjectCreate(%AsyncGenerator.prototype%).
-        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Set _closure_.[[SourceText]] to the source text matched by |AsyncGeneratorExpression|.
         1. Return _closure_.
       </emu-alg>
@@ -20506,7 +20506,7 @@
         1. Perform ! _envRec_.CreateImmutableBinding(_name_).
         1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _funcEnv_).
         1. Let _prototype_ be ! ObjectCreate(%AsyncGenerator.prototype%).
-        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform ! SetFunctionName(_closure_, _name_).
         1. Perform ! _envRec_.InitializeBinding(_name_, _closure_).
         1. Set _closure_.[[SourceText]] to the source text matched by |AsyncGeneratorExpression|.
@@ -20567,16 +20567,16 @@
       <emu-grammar>ClassBody : ClassElementList</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PrototypePropertyNameList of |ClassElementList| contains more than one occurrence of `"constructor"`.
+          It is a Syntax Error if PrototypePropertyNameList of |ClassElementList| contains more than one occurrence of *"constructor"*.
         </li>
       </ul>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PropName of |MethodDefinition| is not `"constructor"` and HasDirectSuper of |MethodDefinition| is *true*.
+          It is a Syntax Error if PropName of |MethodDefinition| is not *"constructor"* and HasDirectSuper of |MethodDefinition| is *true*.
         </li>
         <li>
-          It is a Syntax Error if PropName of |MethodDefinition| is `"constructor"` and SpecialMethod of |MethodDefinition| is *true*.
+          It is a Syntax Error if PropName of |MethodDefinition| is *"constructor"* and SpecialMethod of |MethodDefinition| is *true*.
         </li>
       </ul>
       <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
@@ -20585,7 +20585,7 @@
           It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
         </li>
         <li>
-          It is a Syntax Error if PropName of |MethodDefinition| is `"prototype"`.
+          It is a Syntax Error if PropName of |MethodDefinition| is *"prototype"*.
         </li>
       </ul>
     </emu-clause>
@@ -20599,7 +20599,7 @@
       </emu-alg>
       <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Return &laquo; `"*default*"` &raquo;.
+        1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
     </emu-clause>
 
@@ -20609,7 +20609,7 @@
       <emu-alg>
         1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return ~empty~.
         1. If IsStatic of |ClassElement| is *true*, return ~empty~.
-        1. If PropName of |ClassElement| is not `"constructor"`, return ~empty~.
+        1. If PropName of |ClassElement| is not *"constructor"*, return ~empty~.
         1. Return |ClassElement|.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
@@ -20618,11 +20618,11 @@
         1. If _head_ is not ~empty~, return _head_.
         1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return ~empty~.
         1. If IsStatic of |ClassElement| is *true*, return ~empty~.
-        1. If PropName of |ClassElement| is not `"constructor"`, return ~empty~.
+        1. If PropName of |ClassElement| is not *"constructor"*, return ~empty~.
         1. Return |ClassElement|.
       </emu-alg>
       <emu-note>
-        <p>Early Error rules ensure that there is only one method definition named `"constructor"` and that it is not an accessor property or generator definition.</p>
+        <p>Early Error rules ensure that there is only one method definition named *"constructor"* and that it is not an accessor property or generator definition.</p>
       </emu-note>
     </emu-clause>
 
@@ -20724,14 +20724,14 @@
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
         1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return a new empty List.
-        1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is `"constructor"`, return a new empty List.
+        1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is *"constructor"*, return a new empty List.
         1. Return a List containing |ClassElement|.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _list_ be NonConstructorMethodDefinitions of |ClassElementList|.
         1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return _list_.
-        1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is `"constructor"`, return _list_.
+        1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is *"constructor"*, return _list_.
         1. Append |ClassElement| to the end of _list_.
         1. Return _list_.
       </emu-alg>
@@ -20787,7 +20787,7 @@
             1. Let _constructorParent_ be %Function.prototype%.
           1. Else if IsConstructor(_superclass_) is *false*, throw a *TypeError* exception.
           1. Else,
-            1. Let _protoParent_ be ? Get(_superclass_, `"prototype"`).
+            1. Let _protoParent_ be ? Get(_superclass_, *"prototype"*).
             1. If Type(_protoParent_) is neither Object nor Null, throw a *TypeError* exception.
             1. Let _constructorParent_ be _superclass_.
         1. Let _proto_ be ObjectCreate(_protoParent_).
@@ -20810,7 +20810,7 @@
         1. Perform MakeClassConstructor(_F_).
         1. If _className_ is not *undefined*, then
           1. Perform SetFunctionName(_F_, _className_).
-        1. Perform CreateMethodProperty(_proto_, `"constructor"`, _F_).
+        1. Perform CreateMethodProperty(_proto_, *"constructor"*, _F_).
         1. If |ClassBody_opt| is not present, let _methods_ be a new empty List.
         1. Else, let _methods_ be NonConstructorMethodDefinitions of |ClassBody|.
         1. For each |ClassElement| _m_ in order from _methods_, do
@@ -20841,7 +20841,7 @@
       </emu-alg>
       <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and `"default"`.
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and *"default"*.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassDeclaration|.
         1. Return _value_.
       </emu-alg>
@@ -20946,7 +20946,7 @@
         <li>It is a Syntax Error if ContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
         <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is `"eval"` or `"arguments"`.</li>
+        <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperProperty| is *true*.</li>
@@ -20967,9 +20967,9 @@
         AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return &laquo; `"*default*"` &raquo;.
+        1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
-      <emu-note>"`*default*`" is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</emu-note>
+      <emu-note>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-async-function-definitions-static-semantics-ComputedPropertyContains">
@@ -21079,7 +21079,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _F_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_).
-        1. Perform ! SetFunctionName(_F_, `"default"`).
+        1. Perform ! SetFunctionName(_F_, *"default"*).
         1. Set _F_.[[SourceText]] to the source text matched by |AsyncFunctionDeclaration|.
         1. Return _F_.
       </emu-alg>
@@ -22514,7 +22514,7 @@
                 ResolveExport(_exportName_ [, _resolveSet_])
               </td>
               <td>
-                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to `"*namespace*"`. Return *null* if the name cannot be resolved, or `"ambiguous"` if multiple bindings were found.</p>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to *"\*namespace\*"*. Return *null* if the name cannot be resolved, or *"ambiguous"* if multiple bindings were found.</p>
                 <p>This operation must be idempotent if it completes normally. Each time it is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result.</p>
               </td>
             </tr>
@@ -22960,7 +22960,7 @@
                 String
               </td>
               <td>
-                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value *"*"* indicates that the import request is for the target module's namespace object.
+                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value *"\*"* indicates that the import request is for the target module's namespace object.
               </td>
             </tr>
             <tr>
@@ -23001,13 +23001,13 @@
                   `import v from "mod";`
                 </td>
                 <td>
-                  `"mod"`
+                  *"mod"*
                 </td>
                 <td>
-                  `"default"`
+                  *"default"*
                 </td>
                 <td>
-                  `"v"`
+                  *"v"*
                 </td>
               </tr>
               <tr>
@@ -23015,13 +23015,13 @@
                   `import * as ns from "mod";`
                 </td>
                 <td>
-                  `"mod"`
+                  *"mod"*
                 </td>
                 <td>
-                  `"*"`
+                  *"\*"*
                 </td>
                 <td>
-                  `"ns"`
+                  *"ns"*
                 </td>
               </tr>
               <tr>
@@ -23029,13 +23029,13 @@
                   `import {x} from "mod";`
                 </td>
                 <td>
-                  `"mod"`
+                  *"mod"*
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
               </tr>
               <tr>
@@ -23043,13 +23043,13 @@
                   `import {x as v} from "mod";`
                 </td>
                 <td>
-                  `"mod"`
+                  *"mod"*
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
                 <td>
-                  `"v"`
+                  *"v"*
                 </td>
               </tr>
               <tr>
@@ -23109,7 +23109,7 @@
                 String | null
               </td>
               <td>
-                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|. `"*"` indicates that the export request is for all exported bindings.
+                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|. *"\*"* indicates that the export request is for all exported bindings.
               </td>
             </tr>
             <tr>
@@ -23153,7 +23153,7 @@
                   `export var v;`
                 </td>
                 <td>
-                  `"v"`
+                  *"v"*
                 </td>
                 <td>
                   *null*
@@ -23162,7 +23162,7 @@
                   *null*
                 </td>
                 <td>
-                  `"v"`
+                  *"v"*
                 </td>
               </tr>
               <tr>
@@ -23170,7 +23170,7 @@
                   `export default function f() {}`
                 </td>
                 <td>
-                  `"default"`
+                  *"default"*
                 </td>
                 <td>
                   *null*
@@ -23179,7 +23179,7 @@
                   *null*
                 </td>
                 <td>
-                  `"f"`
+                  *"f"*
                 </td>
               </tr>
               <tr>
@@ -23187,7 +23187,7 @@
                   `export default function () {}`
                 </td>
                 <td>
-                  `"default"`
+                  *"default"*
                 </td>
                 <td>
                   *null*
@@ -23196,7 +23196,7 @@
                   *null*
                 </td>
                 <td>
-                  `"*default*"`
+                  *"\*default\*"*
                 </td>
               </tr>
               <tr>
@@ -23204,7 +23204,7 @@
                   `export default 42;`
                 </td>
                 <td>
-                  `"default"`
+                  *"default"*
                 </td>
                 <td>
                   *null*
@@ -23213,7 +23213,7 @@
                   *null*
                 </td>
                 <td>
-                  `"*default*"`
+                  *"\*default\*"*
                 </td>
               </tr>
               <tr>
@@ -23221,7 +23221,7 @@
                   `export {x};`
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
                 <td>
                   *null*
@@ -23230,7 +23230,7 @@
                   *null*
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
               </tr>
               <tr>
@@ -23238,7 +23238,7 @@
                   `export {v as x};`
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
                 <td>
                   *null*
@@ -23247,7 +23247,7 @@
                   *null*
                 </td>
                 <td>
-                  `"v"`
+                  *"v"*
                 </td>
               </tr>
               <tr>
@@ -23255,13 +23255,13 @@
                   `export {x} from "mod";`
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
                 <td>
-                  `"mod"`
+                  *"mod"*
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
                 <td>
                   *null*
@@ -23272,13 +23272,13 @@
                   `export {v as x} from "mod";`
                 </td>
                 <td>
-                  `"x"`
+                  *"x"*
                 </td>
                 <td>
-                  `"mod"`
+                  *"mod"*
                 </td>
                 <td>
-                  `"v"`
+                  *"v"*
                 </td>
                 <td>
                   *null*
@@ -23292,10 +23292,10 @@
                   *null*
                 </td>
                 <td>
-                  `"mod"`
+                  *"mod"*
                 </td>
                 <td>
-                  `"*"`
+                  *"\*"*
                 </td>
                 <td>
                   *null*
@@ -23306,13 +23306,13 @@
                   `export * as ns from "mod";`
                 </td>
                 <td>
-                  `"ns"`
+                  *"ns"*
                 </td>
                 <td>
-                  `"mod"`
+                  *"mod"*
                 </td>
                 <td>
-                  `"*"`
+                  *"\*"*
                 </td>
                 <td>
                   *null*
@@ -23344,13 +23344,13 @@
                   1. Append _ee_ to _localExportEntries_.
                 1. Else,
                   1. Let _ie_ be the element of _importEntries_ whose [[LocalName]] is the same as _ee_.[[LocalName]].
-                  1. If _ie_.[[ImportName]] is `"*"`, then
+                  1. If _ie_.[[ImportName]] is *"\*"*, then
                     1. NOTE: This is a re-export of an imported module namespace object.
                     1. Append _ee_ to _localExportEntries_.
                   1. Else,
                     1. NOTE: This is a re-export of a single name.
                     1. Append the ExportEntry Record { [[ModuleRequest]]: _ie_.[[ModuleRequest]], [[ImportName]]: _ie_.[[ImportName]], [[LocalName]]: *null*, [[ExportName]]: _ee_.[[ExportName]] } to _indirectExportEntries_.
-              1. Else if _ee_.[[ImportName]] is `"*"` and _ee_.[[ExportName]] is *null*, then
+              1. Else if _ee_.[[ImportName]] is *"\*"* and _ee_.[[ExportName]] is *null*, then
                 1. Append _ee_ to _starExportEntries_.
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
@@ -23384,7 +23384,7 @@
               1. Let _requestedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _starNames_ be ? _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
-                1. If SameValue(_n_, `"default"`) is *false*, then
+                1. If SameValue(_n_, *"default"*) is *false*, then
                   1. If _n_ is not an element of _exportedNames_, then
                     1. Append _n_ to _exportedNames_.
             1. Return _exportedNames_.
@@ -23400,7 +23400,7 @@
 
           <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
 
-          <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to `"*namespace*"`. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string `"ambiguous"` is returned.</p>
+          <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to *"\*namespace\*"*. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string *"ambiguous"* is returned.</p>
 
           <p>This abstract method performs the following steps:</p>
 
@@ -23420,13 +23420,13 @@
             1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-                1. If _e_.[[ImportName]] is `"*"`, then
+                1. If _e_.[[ImportName]] is *"\*"*, then
                   1. Assert: _module_ does not provide the direct binding for this export.
-                  1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: `"*namespace*"` }.
+                  1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: *"\*namespace\*"* }.
                 1. Else,
                   1. Assert: _module_ imports a specific binding for this export.
                   1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
-            1. If SameValue(_exportName_, `"default"`) is *true*, then
+            1. If SameValue(_exportName_, *"default"*) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
               1. Return *null*.
               1. NOTE: A `default` export cannot be provided by an `export *` or `export * from "mod"` declaration.
@@ -23434,13 +23434,13 @@
             1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
-              1. If _resolution_ is `"ambiguous"`, return `"ambiguous"`.
+              1. If _resolution_ is *"ambiguous"*, return *"ambiguous"*.
               1. If _resolution_ is not *null*, then
                 1. Assert: _resolution_ is a ResolvedBinding Record.
                 1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
-                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return `"ambiguous"`.
+                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return *"ambiguous"*.
             1. Return _starResolution_.
           </emu-alg>
         </emu-clause>
@@ -23456,7 +23456,7 @@
             1. Let _module_ be this Source Text Module Record.
             1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
               1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]]).
-              1. If _resolution_ is *null* or `"ambiguous"`, throw a *SyntaxError* exception.
+              1. If _resolution_ is *null* or *"ambiguous"*, throw a *SyntaxError* exception.
               1. Assert: _resolution_ is a ResolvedBinding Record.
             1. Assert: All named exports from _module_ are resolvable.
             1. Let _realm_ be _module_.[[Realm]].
@@ -23467,14 +23467,14 @@
             1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
               1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
               1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
-              1. If _in_.[[ImportName]] is `"*"`, then
+              1. If _in_.[[ImportName]] is *"\*"*, then
                 1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
                 1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                 1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
               1. Else,
                 1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]]).
-                1. If _resolution_ is *null* or `"ambiguous"`, throw a *SyntaxError* exception.
-                1. If _resolution_.[[BindingName]] is `"*namespace*"`, then
+                1. If _resolution_ is *null* or *"ambiguous"*, throw a *SyntaxError* exception.
+                1. If _resolution_.[[BindingName]] is *"\*namespace\*"*, then
                   1. Let _namespace_ be ? GetModuleNamespace(_resolution_.[[Module]]).
                   1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
@@ -23822,13 +23822,13 @@
         <emu-grammar>ImportedDefaultBinding : ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
-          1. Let _defaultEntry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: `"default"`, [[LocalName]]: _localName_ }.
+          1. Let _defaultEntry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"default"*, [[LocalName]]: _localName_ }.
           1. Return a new List containing _defaultEntry_.
         </emu-alg>
         <emu-grammar>NameSpaceImport : `*` `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the StringValue of |ImportedBinding|.
-          1. Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: `"*"`, [[LocalName]]: _localName_ }.
+          1. Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: _localName_ }.
           1. Return a new List containing _entry_.
         </emu-alg>
         <emu-grammar>NamedImports : `{` `}`</emu-grammar>
@@ -23907,7 +23907,7 @@
         <emu-grammar>ExportDeclaration : `export` NamedExports `;`</emu-grammar>
         <ul>
           <li>
-            For each |IdentifierName| _n_ in ReferencedBindings of |NamedExports|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or if the StringValue of _n_ is one of: `"implements"`, `"interface"`, `"let"`, `"package"`, `"private"`, `"protected"`, `"public"`, or `"static"`.
+            For each |IdentifierName| _n_ in ReferencedBindings of |NamedExports|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or if the StringValue of _n_ is one of: *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, or *"static"*.
           </li>
         </ul>
         <emu-note>
@@ -23937,18 +23937,18 @@
         <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Let _declarationNames_ be the BoundNames of |HoistableDeclaration|.
-          1. If _declarationNames_ does not include the element `"*default*"`, append `"*default*"` to _declarationNames_.
+          1. If _declarationNames_ does not include the element *"\*default\*"*, append *"\*default\*"* to _declarationNames_.
           1. Return _declarationNames_.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _declarationNames_ be the BoundNames of |ClassDeclaration|.
-          1. If _declarationNames_ does not include the element `"*default*"`, append `"*default*"` to _declarationNames_.
+          1. If _declarationNames_ does not include the element *"\*default\*"*, append *"\*default\*"* to _declarationNames_.
           1. Return _declarationNames_.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
-          1. Return &laquo; `"*default*"` &raquo;.
+          1. Return &laquo; *"\*default\*"* &raquo;.
         </emu-alg>
       </emu-clause>
 
@@ -24039,7 +24039,7 @@
           ExportDeclaration : `export` `default` AssignmentExpression `;`
         </emu-grammar>
         <emu-alg>
-          1. Return &laquo; `"default"` &raquo;.
+          1. Return &laquo; *"default"* &raquo;.
         </emu-alg>
         <emu-grammar>NamedExports : `{` `}`</emu-grammar>
         <emu-alg>
@@ -24093,21 +24093,21 @@
         <emu-alg>
           1. Let _names_ be BoundNames of |HoistableDeclaration|.
           1. Let _localName_ be the sole element of _names_.
-          1. Return a new List containing the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: `"default"` }.
+          1. Return a new List containing the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |ClassDeclaration|.
           1. Let _localName_ be the sole element of _names_.
-          1. Return a new List containing the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: `"default"` }.
+          1. Return a new List containing the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
-          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: `"*default*"`, [[ExportName]]: `"default"` }.
+          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: *"\*default\*"*, [[ExportName]]: *"default"* }.
           1. Return a new List containing _entry_.
         </emu-alg>
         <emu-note>
-          <p>`"*default*"` is used within this specification as a synthetic name for anonymous default export values.</p>
+          <p>*"\*default\*"* is used within this specification as a synthetic name for anonymous default export values.</p>
         </emu-note>
       </emu-clause>
 
@@ -24116,13 +24116,13 @@
         <p>With parameter _module_.</p>
         <emu-grammar>ExportFromClause : `*`</emu-grammar>
         <emu-alg>
-          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: `"*"`, [[LocalName]]: *null*, [[ExportName]]: *null* }.
+          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: *null*, [[ExportName]]: *null* }.
           1. Return a new List containing _entry_.
         </emu-alg>
         <emu-grammar>ExportFromClause : `*` `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _exportName_ be the StringValue of |IdentifierName|.
-          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: `"*"`, [[LocalName]]: *null*, [[ExportName]]: _exportName_ }.
+          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: *null*, [[ExportName]]: _exportName_ }.
           1. Return a new List containing _entry_.
         </emu-alg>
         <emu-grammar>NamedExports : `{` `}`</emu-grammar>
@@ -24278,20 +24278,20 @@
         <emu-alg>
           1. Let _value_ be ? BindingClassDeclarationEvaluation of |ClassDeclaration|.
           1. Let _className_ be the sole element of BoundNames of |ClassDeclaration|.
-          1. If _className_ is `"*default*"`, then
+          1. If _className_ is *"\*default\*"*, then
             1. Let _env_ be the running execution context's LexicalEnvironment.
-            1. Perform ? InitializeBoundName(`"*default*"`, _value_, _env_).
+            1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
-            1. Let _value_ be NamedEvaluation of |AssignmentExpression| with argument `"default"`.
+            1. Let _value_ be NamedEvaluation of |AssignmentExpression| with argument *"default"*.
           1. Else,
             1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
-          1. Perform ? InitializeBoundName(`"*default*"`, _value_, _env_).
+          1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-clause>
@@ -24331,13 +24331,13 @@
     <p>An implementation must not extend this specification in the following ways:</p>
     <ul>
       <li>
-        ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named `"caller"` or `"arguments"`. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
+        ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named *"caller"* or *"arguments"*. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
       </li>
       <li>
-        If an implementation extends any function object with an own property named `"caller"` the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
+        If an implementation extends any function object with an own property named *"caller"* the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
       </li>
       <li>
-        Neither mapped nor unmapped arguments objects may be created with an own property named `"caller"`.
+        Neither mapped nor unmapped arguments objects may be created with an own property named *"caller"*.
       </li>
       <li>
         The behaviour of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, %TypedArray%`.prototype.toLocaleString`.
@@ -24382,13 +24382,13 @@
   <p>Unless otherwise specified every built-in prototype object has the Object prototype object, which is the initial value of the expression `Object.prototype` (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>), as the value of its [[Prototype]] internal slot, except the Object prototype object itself.</p>
   <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function.</p>
   <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>).</p>
-  <p>Every built-in function object, including constructors, has a `"length"` property whose value is an integer. Unless otherwise specified, this value is equal to the largest number of named arguments shown in the subclause headings for the function description. Optional parameters (which are indicated with brackets: `[` `]`) or rest parameters (which are shown using the form &laquo;...name&raquo;) are not included in the default argument count.</p>
+  <p>Every built-in function object, including constructors, has a *"length"* property whose value is an integer. Unless otherwise specified, this value is equal to the largest number of named arguments shown in the subclause headings for the function description. Optional parameters (which are indicated with brackets: `[` `]`) or rest parameters (which are shown using the form &laquo;...name&raquo;) are not included in the default argument count.</p>
   <emu-note>
-    <p>For example, the function object that is the initial value of the `"map"` property of the Array prototype object is described under the subclause heading &laquo;Array.prototype.map (callbackFn [ , thisArg])&raquo; which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the `"length"` property of that function object is 1.</p>
+    <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading &laquo;Array.prototype.map (callbackFn [ , thisArg])&raquo; which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is 1.</p>
   </emu-note>
-  <p>Unless otherwise specified, the `"length"` property of a built-in function object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-  <p>Every built-in function object, including constructors, that is not identified as an anonymous function has a `"name"` property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. For functions that are specified as properties of objects, the name value is the property name string used to access the function. Functions that are specified as get or set accessor functions of built-in properties have `"get "` or `"set "` prepended to the property name string. The value of the `"name"` property is explicitly specified for each built-in functions whose property key is a Symbol value.</p>
-  <p>Unless otherwise specified, the `"name"` property of a built-in function object, if it exists, has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+  <p>Unless otherwise specified, the *"length"* property of a built-in function object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+  <p>Every built-in function object, including constructors, that is not identified as an anonymous function has a *"name"* property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. For functions that are specified as properties of objects, the name value is the property name string used to access the function. Functions that are specified as get or set accessor functions of built-in properties have *"get "* or *"set "* prepended to the property name string. The value of the *"name"* property is explicitly specified for each built-in functions whose property key is a Symbol value.</p>
+  <p>Unless otherwise specified, the *"name"* property of a built-in function object, if it exists, has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   <p>Every other data property described in clauses 18 through 26 and in Annex <emu-xref href="#sec-additional-built-in-properties"></emu-xref> has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* } unless otherwise specified.</p>
   <p>Every accessor property described in clauses 18 through 26 and in Annex <emu-xref href="#sec-additional-built-in-properties"></emu-xref> has the attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, *undefined*. If only a set accessor is described the get accessor is the default value, *undefined*.</p>
 </emu-clause>
@@ -24409,7 +24409,7 @@
 
     <emu-clause id="sec-globalthis">
       <h1>globalThis</h1>
-      <p>The initial value of the `"globalThis"` property of the global object in a Realm Record _realm_ is _realm_.[[GlobalEnv]]'s EnvironmentRecord's [[GlobalThisValue]].</p>
+      <p>The initial value of the *"globalThis"* property of the global object in a Realm Record _realm_ is _realm_.[[GlobalEnv]]'s EnvironmentRecord's [[GlobalThisValue]].</p>
       <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
 
@@ -24663,7 +24663,7 @@
         1. Else,
           1. Set _R_ to 10.
         1. If _stripPrefix_ is *true*, then
-          1. If the length of _S_ is at least 2 and the first two code units of _S_ are either `"0x"` or `"0X"`, then
+          1. If the length of _S_ is at least 2 and the first two code units of _S_ are either *"0x"* or *"0X"*, then
             1. Remove the first two code units from _S_.
             1. Set _R_ to 16.
         1. If _S_ contains a code unit that is not a radix-_R_ digit, let _Z_ be the substring of _S_ consisting of all code units before the first such code unit; otherwise, let _Z_ be _S_.
@@ -24730,7 +24730,7 @@
           <p>The above syntax is based upon RFC 2396 and does not reflect changes introduced by the more recent RFC 3986.</p>
         </emu-note>
         <h2>Runtime Semantics</h2>
-        <p>When a code unit to be included in a URI is not listed above or is not intended to have the special meaning sometimes given to the reserved code units, that code unit must be encoded. The code unit is transformed into its UTF-8 encoding, with <emu-xref href="#surrogate-pair">surrogate pairs</emu-xref> first converted from UTF-16 to the corresponding code point value. (Note that for code units in the range [0, 127] this results in a single octet with the same value.) The resulting sequence of octets is then transformed into a String with each octet represented by an escape sequence of the form `"%xx"`.</p>
+        <p>When a code unit to be included in a URI is not listed above or is not intended to have the special meaning sometimes given to the reserved code units, that code unit must be encoded. The code unit is transformed into its UTF-8 encoding, with <emu-xref href="#surrogate-pair">surrogate pairs</emu-xref> first converted from UTF-16 to the corresponding code point value. (Note that for code units in the range [0, 127] this results in a single octet with the same value.) The resulting sequence of octets is then transformed into a String with each octet represented by an escape sequence of the form *"%xx"*.</p>
 
         <emu-clause id="sec-encode" aoid="Encode">
           <h1>Runtime Semantics: Encode ( _string_, _unescapedSet_ )</h1>
@@ -24753,7 +24753,7 @@
                 1. For each element _octet_ of _Octets_ in List order, do
                   1. Set _R_ to the string-concatenation of:
                     * the previous value of _R_
-                    * `"%"`
+                    * *"%"*
                     * the String representation of _octet_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
           </emu-alg>
         </emu-clause>
@@ -24988,7 +24988,7 @@
         <p>The `decodeURI` function is the <dfn>%decodeURI%</dfn> intrinsic object. When the `decodeURI` function is called with one argument _encodedURI_, the following steps are taken:</p>
         <emu-alg>
           1. Let _uriString_ be ? ToString(_encodedURI_).
-          1. Let _reservedURISet_ be a String containing one instance of each code unit valid in |uriReserved| plus `"#"`.
+          1. Let _reservedURISet_ be a String containing one instance of each code unit valid in |uriReserved| plus *"#"*.
           1. Return ? Decode(_uriString_, _reservedURISet_).
         </emu-alg>
         <emu-note>
@@ -25013,7 +25013,7 @@
         <p>The `encodeURI` function is the <dfn>%encodeURI%</dfn> intrinsic object. When the `encodeURI` function is called with one argument _uri_, the following steps are taken:</p>
         <emu-alg>
           1. Let _uriString_ be ? ToString(_uri_).
-          1. Let _unescapedURISet_ be a String containing one instance of each code unit valid in |uriReserved| and |uriUnescaped| plus `"#"`.
+          1. Let _unescapedURISet_ be a String containing one instance of each code unit valid in |uriReserved| and |uriUnescaped| plus *"#"*.
           1. Return ? Encode(_uriString_, _unescapedURISet_).
         </emu-alg>
         <emu-note>
@@ -25244,7 +25244,7 @@
       <p>The Object constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Object%</dfn>.</li>
-        <li>is the initial value of the `"Object"` property of the global object.</li>
+        <li>is the initial value of the *"Object"* property of the global object.</li>
         <li>creates a new ordinary object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition.</li>
@@ -25255,11 +25255,11 @@
         <p>When the `Object` function is called with optional argument _value_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is neither *undefined* nor the active function, then
-            1. Return ? OrdinaryCreateFromConstructor(NewTarget, `"%Object.prototype%"`).
+            1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
           1. If _value_ is *null*, *undefined* or not supplied, return ObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
-        <p>The `"length"` property of the `Object` constructor function is 1.</p>
+        <p>The *"length"* property of the `Object` constructor function is 1.</p>
       </emu-clause>
     </emu-clause>
 
@@ -25268,7 +25268,7 @@
       <p>The Object constructor:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>has a `"length"` property.</li>
+        <li>has a *"length"* property.</li>
         <li>has the following additional properties:</li>
       </ul>
 
@@ -25290,7 +25290,7 @@
                   1. Perform ? Set(_to_, _nextKey_, _propValue_, *true*).
           1. Return _to_.
         </emu-alg>
-        <p>The `"length"` property of the `assign` function is 2.</p>
+        <p>The *"length"* property of the `assign` function is 2.</p>
       </emu-clause>
 
       <emu-clause id="sec-object.create">
@@ -25625,7 +25625,7 @@
         <p>When the `toLocaleString` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. Return ? Invoke(_O_, `"toString"`).
+          1. Return ? Invoke(_O_, *"toString"*).
         </emu-alg>
         <p>The optional parameters to this function are not used but are intended to correspond to the parameter pattern used by ECMA-402 `toLocaleString` functions. Implementations that do not include ECMA-402 support must not use those parameter positions for other purposes.</p>
         <emu-note>
@@ -25640,23 +25640,23 @@
         <h1>Object.prototype.toString ( )</h1>
         <p>When the `toString` method is called, the following steps are taken:</p>
         <emu-alg>
-          1. If the *this* value is *undefined*, return `"[object Undefined]"`.
-          1. If the *this* value is *null*, return `"[object Null]"`.
+          1. If the *this* value is *undefined*, return *"[object Undefined]"*.
+          1. If the *this* value is *null*, return *"[object Null]"*.
           1. Let _O_ be ! ToObject(*this* value).
           1. Let _isArray_ be ? IsArray(_O_).
-          1. If _isArray_ is *true*, let _builtinTag_ be `"Array"`.
-          1. Else if _O_ has a [[ParameterMap]] internal slot, let _builtinTag_ be `"Arguments"`.
-          1. Else if _O_ has a [[Call]] internal method, let _builtinTag_ be `"Function"`.
-          1. Else if _O_ has an [[ErrorData]] internal slot, let _builtinTag_ be `"Error"`.
-          1. Else if _O_ has a [[BooleanData]] internal slot, let _builtinTag_ be `"Boolean"`.
-          1. Else if _O_ has a [[NumberData]] internal slot, let _builtinTag_ be `"Number"`.
-          1. Else if _O_ has a [[StringData]] internal slot, let _builtinTag_ be `"String"`.
-          1. Else if _O_ has a [[DateValue]] internal slot, let _builtinTag_ be `"Date"`.
-          1. Else if _O_ has a [[RegExpMatcher]] internal slot, let _builtinTag_ be `"RegExp"`.
-          1. Else, let _builtinTag_ be `"Object"`.
+          1. If _isArray_ is *true*, let _builtinTag_ be *"Array"*.
+          1. Else if _O_ has a [[ParameterMap]] internal slot, let _builtinTag_ be *"Arguments"*.
+          1. Else if _O_ has a [[Call]] internal method, let _builtinTag_ be *"Function"*.
+          1. Else if _O_ has an [[ErrorData]] internal slot, let _builtinTag_ be *"Error"*.
+          1. Else if _O_ has a [[BooleanData]] internal slot, let _builtinTag_ be *"Boolean"*.
+          1. Else if _O_ has a [[NumberData]] internal slot, let _builtinTag_ be *"Number"*.
+          1. Else if _O_ has a [[StringData]] internal slot, let _builtinTag_ be *"String"*.
+          1. Else if _O_ has a [[DateValue]] internal slot, let _builtinTag_ be *"Date"*.
+          1. Else if _O_ has a [[RegExpMatcher]] internal slot, let _builtinTag_ be *"RegExp"*.
+          1. Else, let _builtinTag_ be *"Object"*.
           1. Let _tag_ be ? Get(_O_, @@toStringTag).
           1. If Type(_tag_) is not String, set _tag_ to _builtinTag_.
-          1. Return the string-concatenation of `"[object "`, _tag_, and `"]"`.
+          1. Return the string-concatenation of *"[object "*, _tag_, and *"]"*.
         </emu-alg>
         <p>This function is the <dfn>%ObjProto_toString%</dfn> intrinsic object.</p>
         <emu-note>
@@ -25688,7 +25688,7 @@
       <p>The Function constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Function%</dfn>.</li>
-        <li>is the initial value of the `"Function"` property of the global object.</li>
+        <li>is the initial value of the *"Function"* property of the global object.</li>
         <li>creates and initializes a new function object when called as a function rather than as a constructor. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction`, `AsyncFunction`, and `AsyncGeneratorFunction` subclasses.</li>
       </ul>
@@ -25724,20 +25724,20 @@
             1. If _kind_ is ~normal~, then
               1. Let _goal_ be the grammar symbol |FunctionBody[~Yield, ~Await]|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, ~Await]|.
-              1. Let _fallbackProto_ be `"%Function.prototype%"`.
+              1. Let _fallbackProto_ be *"%Function.prototype%"*.
             1. Else if _kind_ is ~generator~, then
               1. Let _goal_ be the grammar symbol |GeneratorBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, ~Await]|.
-              1. Let _fallbackProto_ be `"%Generator%"`.
+              1. Let _fallbackProto_ be *"%Generator%"*.
             1. Else if _kind_ is ~async~, then
               1. Let _goal_ be the grammar symbol |AsyncFunctionBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, +Await]|.
-              1. Let _fallbackProto_ be `"%AsyncFunction.prototype%"`.
+              1. Let _fallbackProto_ be *"%AsyncFunction.prototype%"*.
             1. Else,
               1. Assert: _kind_ is ~asyncGenerator~.
               1. Let _goal_ be the grammar symbol |AsyncGeneratorBody|.
               1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, +Await]|.
-              1. Let _fallbackProto_ be `"%AsyncGenerator%"`.
+              1. Let _fallbackProto_ be *"%AsyncGenerator%"*.
             1. Let _argCount_ be the number of elements in _args_.
             1. Let _P_ be the empty String.
             1. If _argCount_ = 0, let _bodyText_ be the empty String.
@@ -25750,7 +25750,7 @@
               1. Repeat, while _k_ &lt; _argCount_ - 1
                 1. Let _nextArg_ be _args_[_k_].
                 1. Let _nextArgString_ be ? ToString(_nextArg_).
-                1. Set _P_ to the string-concatenation of the previous value of _P_, `","` (a comma), and _nextArgString_.
+                1. Set _P_ to the string-concatenation of the previous value of _P_, *","* (a comma), and _nextArgString_.
                 1. Set _k_ to _k_ + 1.
               1. Let _bodyText_ be _args_[_k_].
             1. Set _bodyText_ to ? ToString(_bodyText_).
@@ -25778,30 +25778,30 @@
             1. Perform FunctionInitialize(_F_, ~Normal~, _parameters_, _body_, _scope_).
             1. If _kind_ is ~generator~, then
               1. Let _prototype_ be ObjectCreate(%Generator.prototype%).
-              1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+              1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~asyncGenerator~, then
               1. Let _prototype_ be ObjectCreate(%AsyncGenerator.prototype%).
-              1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+              1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~normal~, perform MakeConstructor(_F_).
-            1. NOTE: Async functions are not constructable and do not have a [[Construct]] internal method or a `"prototype"` property.
-            1. Perform SetFunctionName(_F_, `"anonymous"`).
+            1. NOTE: Async functions are not constructable and do not have a [[Construct]] internal method or a *"prototype"* property.
+            1. Perform SetFunctionName(_F_, *"anonymous"*).
             1. Let _prefix_ be the prefix associated with _kind_ in <emu-xref href="#table-dynamic-function-sourcetext-prefixes"></emu-xref>.
-            1. Let _sourceText_ be the string-concatenation of _prefix_, `" anonymous("`, _P_, 0x000A (LINE FEED), `") {"`, 0x000A (LINE FEED), _bodyText_, 0x000A (LINE FEED), and `"}"`.
+            1. Let _sourceText_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, 0x000A (LINE FEED), _bodyText_, 0x000A (LINE FEED), and *"}"*.
             1. Set _F_.[[SourceText]] to _sourceText_.
             1. Return _F_.
           </emu-alg>
           <emu-note>
-            <p>A `"prototype"` property is created for every non-async function created using CreateDynamicFunction to provide for the possibility that the function will be used as a constructor.</p>
+            <p>A *"prototype"* property is created for every non-async function created using CreateDynamicFunction to provide for the possibility that the function will be used as a constructor.</p>
           </emu-note>
 
           <emu-table id="table-dynamic-function-sourcetext-prefixes" caption="Dynamic Function SourceText Prefixes">
             <table>
               <tbody>
                 <tr><th>Kind</th><th>Prefix</th></tr>
-                <tr><td>~normal~</td><td>`"function"`</td></tr>
-                <tr><td>~generator~</td><td>`"function*"`</td></tr>
-                <tr><td>~async~</td><td>`"async function"`</td></tr>
-                <tr><td>~asyncGenerator~</td><td>`"async function*"`</td></tr>
+                <tr><td>~normal~</td><td>*"function"*</td></tr>
+                <tr><td>~generator~</td><td>*"function\*"*</td></tr>
+                <tr><td>~async~</td><td>*"async function"*</td></tr>
+                <tr><td>~asyncGenerator~</td><td>*"async function\*"*</td></tr>
               </tbody>
             </table>
           </emu-table>
@@ -25839,9 +25839,9 @@
         <li>accepts any arguments and returns *undefined* when invoked.</li>
         <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
-        <li>does not have a `"prototype"` property.</li>
-        <li>has a `"length"` property whose value is 0.</li>
-        <li>has a `"name"` property whose value is the empty String.</li>
+        <li>does not have a *"prototype"* property.</li>
+        <li>has a *"length"* property whose value is 0.</li>
+        <li>has a *"name"* property whose value is the empty String.</li>
       </ul>
       <emu-note>
         <p>The Function prototype object is specified to be a function object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
@@ -25876,22 +25876,22 @@
           1. If IsCallable(_Target_) is *false*, throw a *TypeError* exception.
           1. Let _args_ be a new (possibly empty) List consisting of all of the argument values provided after _thisArg_ in order.
           1. Let _F_ be ? BoundFunctionCreate(_Target_, _thisArg_, _args_).
-          1. Let _targetHasLength_ be ? HasOwnProperty(_Target_, `"length"`).
+          1. Let _targetHasLength_ be ? HasOwnProperty(_Target_, *"length"*).
           1. If _targetHasLength_ is *true*, then
-            1. Let _targetLen_ be ? Get(_Target_, `"length"`).
+            1. Let _targetLen_ be ? Get(_Target_, *"length"*).
             1. If Type(_targetLen_) is not Number, let _L_ be 0.
             1. Else,
               1. Set _targetLen_ to ! ToInteger(_targetLen_).
               1. Let _L_ be the larger of 0 and the result of _targetLen_ minus the number of elements of _args_.
           1. Else, let _L_ be 0.
           1. Perform ! SetFunctionLength(_F_, _L_).
-          1. Let _targetName_ be ? Get(_Target_, `"name"`).
+          1. Let _targetName_ be ? Get(_Target_, *"name"*).
           1. If Type(_targetName_) is not String, set _targetName_ to the empty string.
-          1. Perform SetFunctionName(_F_, _targetName_, `"bound"`).
+          1. Perform SetFunctionName(_F_, _targetName_, *"bound"*).
           1. Return _F_.
         </emu-alg>
         <emu-note>
-          <p>Function objects created using `Function.prototype.bind` are exotic objects. They also do not have a `"prototype"` property.</p>
+          <p>Function objects created using `Function.prototype.bind` are exotic objects. They also do not have a *"prototype"* property.</p>
         </emu-note>
         <emu-note>
           <p>If _Target_ is an arrow function or a bound function then the _thisArg_ passed to this method will not be used by subsequent calls to _F_.</p>
@@ -25927,7 +25927,7 @@
         <p>When the `toString` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If _func_ is a <emu-xref href="#sec-bound-function-exotic-objects">Bound Function exotic object</emu-xref> or a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ is a <emu-xref href="#sec-well-known-intrinsic-objects">Well-known Intrinsic Object</emu-xref> and is not identified as an anonymous function, the portion of the returned String that would be matched by |PropertyName| must be the initial value of the `"name"` property of _func_.
+          1. If _func_ is a <emu-xref href="#sec-bound-function-exotic-objects">Bound Function exotic object</emu-xref> or a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ is a <emu-xref href="#sec-well-known-intrinsic-objects">Well-known Intrinsic Object</emu-xref> and is not identified as an anonymous function, the portion of the returned String that would be matched by |PropertyName| must be the initial value of the *"name"* property of _func_.
           1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and Type(_func_.[[SourceText]]) is String and ! HostHasSourceTextAvailable(_func_) is *true*, then return _func_.[[SourceText]].
           1. If Type(_func_) is Object and IsCallable(_func_) is *true*, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
           1. Throw a *TypeError* exception.
@@ -25946,7 +25946,7 @@
           1. Let _F_ be the *this* value.
           1. Return ? OrdinaryHasInstance(_F_, _V_).
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.hasInstance]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.hasInstance]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>This is the default implementation of `@@hasInstance` that most functions inherit. `@@hasInstance` is called by the `instanceof` operator to determine whether a value is an instance of a specific constructor. An expression such as</p>
@@ -25970,21 +25970,21 @@
 
       <emu-clause id="sec-function-instances-length">
         <h1>length</h1>
-        <p>The value of the `"length"` property is an integer that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a function when invoked on a number of arguments other than the number specified by its `"length"` property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The value of the *"length"* property is an integer that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a function when invoked on a number of arguments other than the number specified by its *"length"* property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-function-instances-name">
         <h1>name</h1>
-        <p>The value of the `"name"` property is a String that is descriptive of the function. The name has no semantic significance but is typically a variable or property name that is used to refer to the function at its point of definition in ECMAScript code. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-        <p>Anonymous functions objects that do not have a contextual name associated with them by this specification do not have a `"name"` own property but inherit the `"name"` property of %Function.prototype%.</p>
+        <p>The value of the *"name"* property is a String that is descriptive of the function. The name has no semantic significance but is typically a variable or property name that is used to refer to the function at its point of definition in ECMAScript code. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>Anonymous functions objects that do not have a contextual name associated with them by this specification do not have a *"name"* own property but inherit the *"name"* property of %Function.prototype%.</p>
       </emu-clause>
 
       <emu-clause id="sec-function-instances-prototype">
         <h1>prototype</h1>
-        <p>Function instances that can be used as a constructor have a `"prototype"` property. Whenever such a Function instance is created another ordinary object is also created and is the initial value of the function's `"prototype"` property. Unless otherwise specified, the value of the `"prototype"` property is used to initialize the [[Prototype]] internal slot of the object created when that function is invoked as a constructor.</p>
+        <p>Function instances that can be used as a constructor have a *"prototype"* property. Whenever such a Function instance is created another ordinary object is also created and is the initial value of the function's *"prototype"* property. Unless otherwise specified, the value of the *"prototype"* property is used to initialize the [[Prototype]] internal slot of the object created when that function is invoked as a constructor.</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Function objects created using `Function.prototype.bind`, or by evaluating a |MethodDefinition| (that is not a |GeneratorMethod| or |AsyncGeneratorMethod|) or an |ArrowFunction| do not have a `"prototype"` property.</p>
+          <p>Function objects created using `Function.prototype.bind`, or by evaluating a |MethodDefinition| (that is not a |GeneratorMethod| or |AsyncGeneratorMethod|) or an |ArrowFunction| do not have a *"prototype"* property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -26004,7 +26004,7 @@
       <p>The Boolean constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Boolean%</dfn>.</li>
-        <li>is the initial value of the `"Boolean"` property of the global object.</li>
+        <li>is the initial value of the *"Boolean"* property of the global object.</li>
         <li>creates and initializes a new Boolean object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behaviour must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</li>
@@ -26016,7 +26016,7 @@
         <emu-alg>
           1. Let _b_ be ! ToBoolean(_value_).
           1. If NewTarget is *undefined*, return _b_.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Boolean.prototype%"`, &laquo; [[BooleanData]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Boolean.prototype%"*, &laquo; [[BooleanData]] &raquo;).
           1. Set _O_.[[BooleanData]] to _b_.
           1. Return _O_.
         </emu-alg>
@@ -26068,7 +26068,7 @@
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _b_ be ? thisBooleanValue(*this* value).
-          1. If _b_ is *true*, return `"true"`; else return `"false"`.
+          1. If _b_ is *true*, return *"true"*; else return *"false"*.
         </emu-alg>
       </emu-clause>
 
@@ -26095,7 +26095,7 @@
       <p>The Symbol constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Symbol%</dfn>.</li>
-        <li>is the initial value of the `"Symbol"` property of the global object.</li>
+        <li>is the initial value of the *"Symbol"* property of the global object.</li>
         <li>returns a new Symbol value when called as a function.</li>
         <li>is not intended to be used with the `new` operator.</li>
         <li>is not intended to be subclassed.</li>
@@ -26324,7 +26324,7 @@
             1. Let _desc_ be _sym_'s [[Description]] value.
             1. If _desc_ is *undefined*, set _desc_ to the empty string.
             1. Assert: Type(_desc_) is String.
-            1. Return the string-concatenation of `"Symbol("`, _desc_, and `")"`.
+            1. Return the string-concatenation of *"Symbol("*, _desc_, and *")"*.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -26339,12 +26339,12 @@
 
       <emu-clause id="sec-symbol.prototype-@@toprimitive">
         <h1>Symbol.prototype [ @@toPrimitive ] ( _hint_ )</h1>
-        <p>This function is called by ECMAScript language operators to convert a Symbol object to a primitive value. The allowed values for _hint_ are `"default"`, `"number"`, and `"string"`.</p>
+        <p>This function is called by ECMAScript language operators to convert a Symbol object to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*.</p>
         <p>When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:</p>
         <emu-alg>
           1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.toPrimitive]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -26370,7 +26370,7 @@
       <p>The Error constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Error%</dfn>.</li>
-        <li>is the initial value of the `"Error"` property of the global object.</li>
+        <li>is the initial value of the *"Error"* property of the global object.</li>
         <li>creates and initializes a new Error object when called as a function rather than as a constructor. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
       </ul>
@@ -26380,11 +26380,11 @@
         <p>When the `Error` function is called with argument _message_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Error.prototype%"`, &laquo; [[ErrorData]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Error.prototype%"*, &laquo; [[ErrorData]] &raquo;).
           1. If _message_ is not *undefined*, then
             1. Let _msg_ be ? ToString(_message_).
             1. Let _msgDesc_ be the PropertyDescriptor { [[Value]]: _msg_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-            1. Perform ! DefinePropertyOrThrow(_O_, `"message"`, _msgDesc_).
+            1. Perform ! DefinePropertyOrThrow(_O_, *"message"*, _msgDesc_).
           1. Return _O_.
         </emu-alg>
       </emu-clause>
@@ -26427,7 +26427,7 @@
 
       <emu-clause id="sec-error.prototype.name">
         <h1>Error.prototype.name</h1>
-        <p>The initial value of `Error.prototype.name` is `"Error"`.</p>
+        <p>The initial value of `Error.prototype.name` is *"Error"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-error.prototype.tostring">
@@ -26436,9 +26436,9 @@
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. Let _name_ be ? Get(_O_, `"name"`).
-          1. If _name_ is *undefined*, set _name_ to `"Error"`; otherwise set _name_ to ? ToString(_name_).
-          1. Let _msg_ be ? Get(_O_, `"message"`).
+          1. Let _name_ be ? Get(_O_, *"name"*).
+          1. If _name_ is *undefined*, set _name_ to *"Error"*; otherwise set _name_ to ? ToString(_name_).
+          1. Let _msg_ be ? Get(_O_, *"message"*).
           1. If _msg_ is *undefined*, set _msg_ to the empty String; otherwise set _msg_ to ? ToString(_msg_).
           1. If _name_ is the empty String, return _msg_.
           1. If _msg_ is the empty String, return _name_.
@@ -26489,7 +26489,7 @@
 
     <emu-clause id="sec-nativeerror-object-structure">
       <h1>_NativeError_ Object Structure</h1>
-      <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the `"name"` property of the prototype object, and in the implementation-defined `"message"` property of the prototype object.</p>
+      <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the *"name"* property of the prototype object, and in the implementation-defined *"message"* property of the prototype object.</p>
       <p>For each error object, references to _NativeError_ in the definition should be replaced with the appropriate error object name from <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>.</p>
 
       <emu-clause id="sec-nativeerror-constructors">
@@ -26509,10 +26509,10 @@
             1. If _message_ is not *undefined*, then
               1. Let _msg_ be ? ToString(_message_).
               1. Let _msgDesc_ be the PropertyDescriptor { [[Value]]: _msg_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-              1. Perform ! DefinePropertyOrThrow(_O_, `"message"`, _msgDesc_).
+              1. Perform ! DefinePropertyOrThrow(_O_, *"message"*, _msgDesc_).
             1. Return _O_.
           </emu-alg>
-          <p>The actual value of the string passed in step 2 is either `"%EvalError.prototype%"`, `"%RangeError.prototype%"`, `"%ReferenceError.prototype%"`, `"%SyntaxError.prototype%"`, `"%TypeError.prototype%"`, or `"%URIError.prototype%"` corresponding to which _NativeError_ constructor is being defined.</p>
+          <p>The actual value of the string passed in step 2 is either *"%EvalError.prototype%"*, *"%RangeError.prototype%"*, *"%ReferenceError.prototype%"*, *"%SyntaxError.prototype%"*, *"%TypeError.prototype%"*, or *"%URIError.prototype%"* corresponding to which _NativeError_ constructor is being defined.</p>
         </emu-clause>
       </emu-clause>
 
@@ -26521,7 +26521,7 @@
         <p>Each _NativeError_ constructor:</p>
         <ul>
           <li>has a [[Prototype]] internal slot whose value is %Error%.</li>
-          <li>has a `"name"` property whose value is the String value *"NativeError"*.</li>
+          <li>has a *"name"* property whose value is the String value *"NativeError"*.</li>
           <li>has the following properties:</li>
         </ul>
 
@@ -26543,17 +26543,17 @@
 
         <emu-clause id="sec-nativeerror.prototype.constructor">
           <h1>_NativeError_.prototype.constructor</h1>
-          <p>The initial value of the `"constructor"` property of the prototype for a given _NativeError_ constructor is the corresponding intrinsic object %_NativeError_% (<emu-xref href="#sec-nativeerror-constructors"></emu-xref>).</p>
+          <p>The initial value of the *"constructor"* property of the prototype for a given _NativeError_ constructor is the corresponding intrinsic object %_NativeError_% (<emu-xref href="#sec-nativeerror-constructors"></emu-xref>).</p>
         </emu-clause>
 
         <emu-clause id="sec-nativeerror.prototype.message">
           <h1>_NativeError_.prototype.message</h1>
-          <p>The initial value of the `"message"` property of the prototype for a given _NativeError_ constructor is the empty String.</p>
+          <p>The initial value of the *"message"* property of the prototype for a given _NativeError_ constructor is the empty String.</p>
         </emu-clause>
 
         <emu-clause id="sec-nativeerror.prototype.name">
           <h1>_NativeError_.prototype.name</h1>
-          <p>The initial value of the `"name"` property of the prototype for a given _NativeError_ constructor is the String value consisting of the name of the constructor (the name used instead of _NativeError_).</p>
+          <p>The initial value of the *"name"* property of the prototype for a given _NativeError_ constructor is the String value consisting of the name of the constructor (the name used instead of _NativeError_).</p>
         </emu-clause>
       </emu-clause>
 
@@ -26576,7 +26576,7 @@
       <p>The Number constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Number%</dfn>.</li>
-        <li>is the initial value of the `"Number"` property of the global object.</li>
+        <li>is the initial value of the *"Number"* property of the global object.</li>
         <li>creates and initializes a new Number object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behaviour must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</li>
@@ -26589,7 +26589,7 @@
           1. If no arguments were passed to this function invocation, let _n_ be *+0*.
           1. Else, let _n_ be ? ToNumber(_value_).
           1. If NewTarget is *undefined*, return _n_.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Number.prototype%"`, &laquo; [[NumberData]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Number.prototype%"*, &laquo; [[NumberData]] &raquo;).
           1. Set _O_.[[NumberData]] to _n_.
           1. Return _O_.
         </emu-alg>
@@ -26696,12 +26696,12 @@
 
       <emu-clause id="sec-number.parsefloat">
         <h1>Number.parseFloat ( _string_ )</h1>
-        <p>The value of the `Number.parseFloat` data property is the same built-in function object that is the value of the `"parseFloat"` property of the global object defined in <emu-xref href="#sec-parsefloat-string"></emu-xref>.</p>
+        <p>The value of the `Number.parseFloat` data property is the same built-in function object that is the value of the *"parseFloat"* property of the global object defined in <emu-xref href="#sec-parsefloat-string"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.parseint">
         <h1>Number.parseInt ( _string_, _radix_ )</h1>
-        <p>The value of the `Number.parseInt` data property is the same built-in function object that is the value of the `"parseInt"` property of the global object defined in <emu-xref href="#sec-parseint-string-radix"></emu-xref>.</p>
+        <p>The value of the `Number.parseInt` data property is the same built-in function object that is the value of the *"parseInt"* property of the global object defined in <emu-xref href="#sec-parseint-string-radix"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.positive_infinity">
@@ -26750,13 +26750,13 @@
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToInteger(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
-          1. If _x_ is *NaN*, return the String `"NaN"`.
+          1. If _x_ is *NaN*, return the String *"NaN"*.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
-            1. Set _s_ to `"-"`.
+            1. Set _s_ to *"-"*.
             1. Set _x_ to -_x_.
           1. If _x_ = *+&infin;*, then
-            1. Return the string-concatenation of _s_ and `"Infinity"`.
+            1. Return the string-concatenation of _s_ and *"Infinity"*.
           1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ = 0, then
             1. Let _m_ be the String value consisting of _f_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
@@ -26769,18 +26769,18 @@
             1. Let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. If _f_ &ne; 0, then
             1. Let _a_ be the first code unit of _m_, and let _b_ be the remaining _f_ code units of _m_.
-            1. Set _m_ to the string-concatenation of _a_, `"."`, and _b_.
+            1. Set _m_ to the string-concatenation of _a_, *"."*, and _b_.
           1. If _e_ = 0, then
-            1. Let _c_ be `"+"`.
-            1. Let _d_ be `"0"`.
+            1. Let _c_ be *"+"*.
+            1. Let _d_ be *"0"*.
           1. Else,
-            1. If _e_ &gt; 0, let _c_ be `"+"`.
+            1. If _e_ &gt; 0, let _c_ be *"+"*.
             1. Else,
               1. Assert: _e_ &lt; 0.
-              1. Let _c_ be `"-"`.
+              1. Let _c_ be *"-"*.
               1. Set _e_ to -_e_.
             1. Let _d_ be the String value consisting of the digits of the decimal representation of _e_ (in order, with no leading zeroes).
-          1. Set _m_ to the string-concatenation of _m_, `"e"`, _c_, and _d_.
+          1. Set _m_ to the string-concatenation of _m_, *"e"*, _c_, and _d_.
           1. Return the string-concatenation of _s_ and _m_.
         </emu-alg>
         <emu-note>
@@ -26802,16 +26802,16 @@
           1. Let _f_ be ? ToInteger(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
           1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
-          1. If _x_ is *NaN*, return the String `"NaN"`.
+          1. If _x_ is *NaN*, return the String *"NaN"*.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
-            1. Set _s_ to `"-"`.
+            1. Set _s_ to *"-"*.
             1. Set _x_ to -_x_.
           1. If _x_ &ge; 10<sup>21</sup>, then
             1. Let _m_ be ! ToString(_x_).
           1. Else,
             1. Let _n_ be an integer for which ℝ(_n_) &divide; 10<sub>ℝ</sub><sup>ℝ(_f_)</sup> - ℝ(_x_) is as close to zero as possible. If there are two such _n_, pick the larger _n_.
-            1. If _n_ = 0, let _m_ be the String `"0"`. Otherwise, let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
+            1. If _n_ = 0, let _m_ be the String *"0"*. Otherwise, let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _f_ &ne; 0, then
               1. Let _k_ be the length of _m_.
               1. If _k_ &le; _f_, then
@@ -26819,14 +26819,14 @@
                 1. Set _m_ to the string-concatenation of _z_ and _m_.
                 1. Set _k_ to _f_ + 1.
               1. Let _a_ be the first _k_ - _f_ code units of _m_, and let _b_ be the remaining _f_ code units of _m_.
-              1. Set _m_ to the string-concatenation of _a_, `"."`, and _b_.
+              1. Set _m_ to the string-concatenation of _a_, *"."*, and _b_.
           1. Return the string-concatenation of _s_ and _m_.
         </emu-alg>
         <emu-note>
           <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent number values. For example,</p>
-          <p>`(1000000000000000128).toString()` returns `"1000000000000000100"`, while
+          <p>`(1000000000000000128).toString()` returns *"1000000000000000100"*, while
             <br>
-            `(1000000000000000128).toFixed(0)` returns `"1000000000000000128"`.</p>
+            `(1000000000000000128).toFixed(0)` returns *"1000000000000000128"*.</p>
         </emu-note>
       </emu-clause>
 
@@ -26844,13 +26844,13 @@
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. If _precision_ is *undefined*, return ! ToString(_x_).
           1. Let _p_ be ? ToInteger(_precision_).
-          1. If _x_ is *NaN*, return the String `"NaN"`.
+          1. If _x_ is *NaN*, return the String *"NaN"*.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
             1. Set _s_ to the code unit 0x002D (HYPHEN-MINUS).
             1. Set _x_ to -_x_.
           1. If _x_ = *+&infin;*, then
-            1. Return the string-concatenation of _s_ and `"Infinity"`.
+            1. Return the string-concatenation of _s_ and *"Infinity"*.
           1. If _p_ &lt; 1 or _p_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ = 0, then
             1. Let _m_ be the String value consisting of _p_ occurrences of the code unit 0x0030 (DIGIT ZERO).
@@ -26862,7 +26862,7 @@
               1. Assert: _e_ &ne; 0.
               1. If _p_ &ne; 1, then
                 1. Let _a_ be the first code unit of _m_, and let _b_ be the remaining _p_ - 1 code units of _m_.
-                1. Set _m_ to the string-concatenation of _a_, `"."`, and _b_.
+                1. Set _m_ to the string-concatenation of _a_, *"."*, and _b_.
               1. If _e_ &gt; 0, then
                 1. Let _c_ be the code unit 0x002B (PLUS SIGN).
               1. Else,
@@ -26896,7 +26896,7 @@
           1. Return the String representation of this Number value using the radix specified by _radixNumber_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-dependent, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-number-tostring"></emu-xref>.
         </emu-alg>
         <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Number or a Number object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
-        <p>The `"length"` property of the `toString` method is 1.</p>
+        <p>The *"length"* property of the `toString` method is 1.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.prototype.valueof">
@@ -26920,7 +26920,7 @@
       <p>The BigInt constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%BigInt%</dfn>.</li>
-        <li>is the initial value of the `"BigInt"` property of the global object.</li>
+        <li>is the initial value of the *"BigInt"* property of the global object.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is not intended to be used with the `new` operator or to be subclassed. It may be used as the value of an `extends` clause of a class definition but a `super` call to the `BigInt` constructor will cause an exception.</li>
       </ul>
@@ -27047,7 +27047,7 @@
     <p>The Math object:</p>
     <ul>
       <li>is the intrinsic object <dfn>%Math%</dfn>.</li>
-      <li>is the initial value of the `"Math"` property of the global object.</li>
+      <li>is the initial value of the *"Math"* property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>is not a function object.</li>
@@ -28145,7 +28145,7 @@
                 `YYYY`
               </td>
               <td>
-                is the year in the proleptic Gregorian calendar as four decimal digits from 0000 to 9999, or as an <emu-xref href="#sec-expanded-years">expanded year</emu-xref> of `"+"` or `"-"` followed by six decimal digits.
+                is the year in the proleptic Gregorian calendar as four decimal digits from 0000 to 9999, or as an <emu-xref href="#sec-expanded-years">expanded year</emu-xref> of *"+"* or *"-"* followed by six decimal digits.
               </td>
             </tr>
             <tr>
@@ -28153,7 +28153,7 @@
                 `-`
               </td>
               <td>
-                `"-"` (hyphen) appears literally twice in the string.
+                *"-"* (hyphen) appears literally twice in the string.
               </td>
             </tr>
             <tr>
@@ -28177,7 +28177,7 @@
                 `T`
               </td>
               <td>
-                `"T"` appears literally in the string, to indicate the beginning of the time element.
+                *"T"* appears literally in the string, to indicate the beginning of the time element.
               </td>
             </tr>
             <tr>
@@ -28193,7 +28193,7 @@
                 `:`
               </td>
               <td>
-                `":"` (colon) appears literally twice in the string.
+                *":"* (colon) appears literally twice in the string.
               </td>
             </tr>
             <tr>
@@ -28217,7 +28217,7 @@
                 `.`
               </td>
               <td>
-                `"."` (dot) appears literally in the string.
+                *"."* (dot) appears literally in the string.
               </td>
             </tr>
             <tr>
@@ -28233,7 +28233,7 @@
                 `Z`
               </td>
               <td>
-                is the UTC offset representation specified as `"Z"` (for UTC with no offset) or an offset of either `"+"` or `"-"` followed by a time expression `HH:mm` (indicating local time ahead of or behind UTC, respectively)
+                is the UTC offset representation specified as *"Z"* (for UTC with no offset) or an offset of either *"+"* or *"-"* followed by a time expression `HH:mm` (indicating local time ahead of or behind UTC, respectively)
               </td>
             </tr>
             </tbody>
@@ -28308,12 +28308,12 @@ THH:mm:ss.sss
       <p>The Date constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Date%</dfn>.</li>
-        <li>is the initial value of the `"Date"` property of the global object.</li>
+        <li>is the initial value of the *"Date"* property of the global object.</li>
         <li>creates and initializes a new Date object when called as a constructor.</li>
         <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
         <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behaviour must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
-        <li>has a `"length"` property whose value is 7.</li>
+        <li>has a *"length"* property whose value is 7.</li>
       </ul>
 
       <emu-clause id="sec-date-year-month-date-hours-minutes-seconds-ms">
@@ -28339,7 +28339,7 @@ THH:mm:ss.sss
               1. Let _yi_ be ! ToInteger(_y_).
               1. If 0 &le; _yi_ &le; 99, let _yr_ be 1900 + _yi_; otherwise, let _yr_ be _y_.
             1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Date.prototype%"`, &laquo; [[DateValue]] &raquo;).
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
             1. Set _O_.[[DateValue]] to TimeClip(UTC(_finalDate_)).
             1. Return _O_.
         </emu-alg>
@@ -28365,7 +28365,7 @@ THH:mm:ss.sss
                 1. Let _tv_ be the result of parsing _v_ as a date, in exactly the same manner as for the `parse` method (<emu-xref href="#sec-date.parse"></emu-xref>).
               1. Else,
                 1. Let _tv_ be ? ToNumber(_v_).
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Date.prototype%"`, &laquo; [[DateValue]] &raquo;).
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
             1. Set _O_.[[DateValue]] to TimeClip(_tv_).
             1. Return _O_.
         </emu-alg>
@@ -28382,7 +28382,7 @@ THH:mm:ss.sss
             1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
             1. Return ToDateString(_now_).
           1. Else,
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Date.prototype%"`, &laquo; [[DateValue]] &raquo;).
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
             1. Set _O_.[[DateValue]] to the time value (UTC) identifying the current time.
             1. Return _O_.
         </emu-alg>
@@ -28405,7 +28405,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-date.parse">
         <h1>Date.parse ( _string_ )</h1>
         <p>The `parse` function applies the ToString operator to its argument. If ToString results in an abrupt completion the Completion Record is immediately returned. Otherwise, `parse` interprets the resulting String as a date and time; it returns a Number, the UTC time value corresponding to the date and time. The String may be interpreted as a local time, a UTC time, or a time in some other time zone, depending on the contents of the String. The function first attempts to parse the String according to the format described in Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>), including expanded years. If the String does not conform to that format the function may fall back to any implementation-specific heuristics or implementation-specific date formats. Strings that are unrecognizable or contain out-of-bounds format element values shall cause `Date.parse` to return *NaN*.</p>
-        <p>If the String conforms to the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, substitute values take the place of absent format elements. When the `MM` or `DD` elements are absent, `"01"` is used. When the `HH`, `mm`, or `ss` elements are absent, `"00"` is used. When the `sss` element is absent, `"000"` is used. When the UTC offset representation is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time.</p>
+        <p>If the String conforms to the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, substitute values take the place of absent format elements. When the `MM` or `DD` elements are absent, *"01"* is used. When the `HH`, `mm`, or `ss` elements are absent, *"00"* is used. When the `sss` element is absent, *"000"* is used. When the UTC offset representation is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time.</p>
         <p>If `x` is any Date object whose milliseconds amount is zero within a particular implementation of ECMAScript, then all of the following expressions should produce the same numeric value in that implementation, if all the properties referenced have their initial values:</p>
         <pre><code class="javascript">
           x.valueOf()
@@ -28443,7 +28443,7 @@ THH:mm:ss.sss
             1. If 0 &le; _yi_ &le; 99, let _yr_ be 1900 + _yi_; otherwise, let _yr_ be _y_.
           1. Return TimeClip(MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_))).
         </emu-alg>
-        <p>The `"length"` property of the `UTC` function is 7.</p>
+        <p>The *"length"* property of the `UTC` function is 7.</p>
         <emu-note>
           <p>The `UTC` function differs from the `Date` constructor in two ways: it returns a time value as a Number, rather than creating a Date object, and it interprets the arguments in UTC rather than as local time.</p>
         </emu-note>
@@ -28678,7 +28678,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The `"length"` property of the `setFullYear` method is 3.</p>
+        <p>The *"length"* property of the `setFullYear` method is 3.</p>
         <emu-note>
           <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getDate()`.</p>
         </emu-note>
@@ -28698,7 +28698,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The `"length"` property of the `setHours` method is 4.</p>
+        <p>The *"length"* property of the `setHours` method is 4.</p>
         <emu-note>
           <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -28730,7 +28730,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The `"length"` property of the `setMinutes` method is 3.</p>
+        <p>The *"length"* property of the `setMinutes` method is 3.</p>
         <emu-note>
           <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, this behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -28748,7 +28748,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The `"length"` property of the `setMonth` method is 2.</p>
+        <p>The *"length"* property of the `setMonth` method is 2.</p>
         <emu-note>
           <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getDate()`.</p>
         </emu-note>
@@ -28766,7 +28766,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The `"length"` property of the `setSeconds` method is 2.</p>
+        <p>The *"length"* property of the `setSeconds` method is 2.</p>
         <emu-note>
           <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -28811,7 +28811,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The `"length"` property of the `setUTCFullYear` method is 3.</p>
+        <p>The *"length"* property of the `setUTCFullYear` method is 3.</p>
         <emu-note>
           <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getUTCMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getUTCDate()`.</p>
         </emu-note>
@@ -28831,7 +28831,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The `"length"` property of the `setUTCHours` method is 4.</p>
+        <p>The *"length"* property of the `setUTCHours` method is 4.</p>
         <emu-note>
           <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getUTCMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -28867,7 +28867,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The `"length"` property of the `setUTCMinutes` method is 3.</p>
+        <p>The *"length"* property of the `setUTCMinutes` method is 3.</p>
         <emu-note>
           <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it function behaves as if _ms_ was present with the value return by `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -28887,7 +28887,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The `"length"` property of the `setUTCMonth` method is 2.</p>
+        <p>The *"length"* property of the `setUTCMonth` method is 2.</p>
         <emu-note>
           <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getUTCDate()`.</p>
         </emu-note>
@@ -28907,7 +28907,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The `"length"` property of the `setUTCSeconds` method is 2.</p>
+        <p>The *"length"* property of the `setUTCSeconds` method is 2.</p>
         <emu-note>
           <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -28919,7 +28919,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
-          1. If _tv_ is *NaN*, return `"Invalid Date"`.
+          1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _t_ be LocalTime(_tv_).
           1. Return DateString(_t_).
         </emu-alg>
@@ -28927,7 +28927,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toisostring">
         <h1>Date.prototype.toISOString ( )</h1>
-        <p>If this time value is not a finite Number or if it corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, this function throws a *RangeError* exception. Otherwise, it returns a String representation of this time value in that format on the UTC time scale, including all format elements and the UTC offset representation `"Z"`.</p>
+        <p>If this time value is not a finite Number or if it corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, this function throws a *RangeError* exception. Otherwise, it returns a String representation of this time value in that format on the UTC time scale, including all format elements and the UTC offset representation *"Z"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tojson">
@@ -28938,7 +28938,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _tv_ be ? ToPrimitive(_O_, hint Number).
           1. If Type(_tv_) is Number and _tv_ is not finite, return *null*.
-          1. Return ? Invoke(_O_, `"toISOString"`).
+          1. Return ? Invoke(_O_, *"toISOString"*).
         </emu-alg>
         <emu-note>
           <p>The argument is ignored.</p>
@@ -28992,7 +28992,7 @@ THH:mm:ss.sss
             1. Let _hour_ be the String representation of HourFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _minute_ be the String representation of MinFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _second_ be the String representation of SecFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-            1. Return the string-concatenation of _hour_, `":"`, _minute_, `":"`, _second_, the code unit 0x0020 (SPACE), and `"GMT"`.
+            1. Return the string-concatenation of _hour_, *":"*, _minute_, *":"*, _second_, the code unit 0x0020 (SPACE), and *"GMT"*.
           </emu-alg>
         </emu-clause>
 
@@ -29006,9 +29006,9 @@ THH:mm:ss.sss
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
             1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _yv_ be YearFromTime(_tv_).
-            1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be `"-"`.
+            1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be *"-"*.
             1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
-            1. Let _paddedYear_ be ! StringPad(_year_, 4, `"0"`, ~start~).
+            1. Let _paddedYear_ be ! StringPad(_year_, 4, *"0"*, ~start~).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
@@ -29027,7 +29027,7 @@ THH:mm:ss.sss
                   0
                 </td>
                 <td>
-                  `"Sun"`
+                  *"Sun"*
                 </td>
               </tr>
               <tr>
@@ -29035,7 +29035,7 @@ THH:mm:ss.sss
                   1
                 </td>
                 <td>
-                  `"Mon"`
+                  *"Mon"*
                 </td>
               </tr>
               <tr>
@@ -29043,7 +29043,7 @@ THH:mm:ss.sss
                   2
                 </td>
                 <td>
-                  `"Tue"`
+                  *"Tue"*
                 </td>
               </tr>
               <tr>
@@ -29051,7 +29051,7 @@ THH:mm:ss.sss
                   3
                 </td>
                 <td>
-                  `"Wed"`
+                  *"Wed"*
                 </td>
               </tr>
               <tr>
@@ -29059,7 +29059,7 @@ THH:mm:ss.sss
                   4
                 </td>
                 <td>
-                  `"Thu"`
+                  *"Thu"*
                 </td>
               </tr>
               <tr>
@@ -29067,7 +29067,7 @@ THH:mm:ss.sss
                   5
                 </td>
                 <td>
-                  `"Fri"`
+                  *"Fri"*
                 </td>
               </tr>
               <tr>
@@ -29075,7 +29075,7 @@ THH:mm:ss.sss
                   6
                 </td>
                 <td>
-                  `"Sat"`
+                  *"Sat"*
                 </td>
               </tr>
               </tbody>
@@ -29097,7 +29097,7 @@ THH:mm:ss.sss
                   0
                 </td>
                 <td>
-                  `"Jan"`
+                  *"Jan"*
                 </td>
               </tr>
               <tr>
@@ -29105,7 +29105,7 @@ THH:mm:ss.sss
                   1
                 </td>
                 <td>
-                  `"Feb"`
+                  *"Feb"*
                 </td>
               </tr>
               <tr>
@@ -29113,7 +29113,7 @@ THH:mm:ss.sss
                   2
                 </td>
                 <td>
-                  `"Mar"`
+                  *"Mar"*
                 </td>
               </tr>
               <tr>
@@ -29121,7 +29121,7 @@ THH:mm:ss.sss
                   3
                 </td>
                 <td>
-                  `"Apr"`
+                  *"Apr"*
                 </td>
               </tr>
               <tr>
@@ -29129,7 +29129,7 @@ THH:mm:ss.sss
                   4
                 </td>
                 <td>
-                  `"May"`
+                  *"May"*
                 </td>
               </tr>
               <tr>
@@ -29137,7 +29137,7 @@ THH:mm:ss.sss
                   5
                 </td>
                 <td>
-                  `"Jun"`
+                  *"Jun"*
                 </td>
               </tr>
               <tr>
@@ -29145,7 +29145,7 @@ THH:mm:ss.sss
                   6
                 </td>
                 <td>
-                  `"Jul"`
+                  *"Jul"*
                 </td>
               </tr>
               <tr>
@@ -29153,7 +29153,7 @@ THH:mm:ss.sss
                   7
                 </td>
                 <td>
-                  `"Aug"`
+                  *"Aug"*
                 </td>
               </tr>
               <tr>
@@ -29161,7 +29161,7 @@ THH:mm:ss.sss
                   8
                 </td>
                 <td>
-                  `"Sep"`
+                  *"Sep"*
                 </td>
               </tr>
               <tr>
@@ -29169,7 +29169,7 @@ THH:mm:ss.sss
                   9
                 </td>
                 <td>
-                  `"Oct"`
+                  *"Oct"*
                 </td>
               </tr>
               <tr>
@@ -29177,7 +29177,7 @@ THH:mm:ss.sss
                   10
                 </td>
                 <td>
-                  `"Nov"`
+                  *"Nov"*
                 </td>
               </tr>
               <tr>
@@ -29185,7 +29185,7 @@ THH:mm:ss.sss
                   11
                 </td>
                 <td>
-                  `"Dec"`
+                  *"Dec"*
                 </td>
               </tr>
               </tbody>
@@ -29200,7 +29200,7 @@ THH:mm:ss.sss
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
             1. Let _offset_ be LocalTZA(_tv_, *true*).
-            1. If _offset_ &ge; 0, let _offsetSign_ be `"+"`; otherwise, let _offsetSign_ be `"-"`.
+            1. If _offset_ &ge; 0, let _offsetSign_ be *"+"*; otherwise, let _offsetSign_ be *"-"*.
             1. Let _offsetMin_ be the String representation of MinFromTime(abs(_offset_)), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _offsetHour_ be the String representation of HourFromTime(abs(_offset_)), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _tzName_ be an implementation-defined string that is either the empty string or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-dependent timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
@@ -29213,7 +29213,7 @@ THH:mm:ss.sss
           <p>The following steps are performed:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
-            1. If _tv_ is *NaN*, return `"Invalid Date"`.
+            1. If _tv_ is *NaN*, return *"Invalid Date"*.
             1. Let _t_ be LocalTime(_tv_).
             1. Return the string-concatenation of DateString(_t_), the code unit 0x0020 (SPACE), TimeString(_t_), and TimeZoneString(_tv_).
           </emu-alg>
@@ -29226,7 +29226,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
-          1. If _tv_ is *NaN*, return `"Invalid Date"`.
+          1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _t_ be LocalTime(_tv_).
           1. Return the string-concatenation of TimeString(_t_) and TimeZoneString(_tv_).
         </emu-alg>
@@ -29238,15 +29238,15 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
-          1. If _tv_ is *NaN*, return `"Invalid Date"`.
+          1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
           1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
           1. Let _yv_ be YearFromTime(_tv_).
-          1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be `"-"`.
+          1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be *"-"*.
           1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
-          1. Let _paddedYear_ be ! StringPad(_year_, 4, `"0"`, ~start~).
-          1. Return the string-concatenation of _weekday_, `","`, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
+          1. Let _paddedYear_ be ! StringPad(_year_, 4, *"0"*, ~start~).
+          1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
 
@@ -29260,7 +29260,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype-@@toprimitive">
         <h1>Date.prototype [ @@toPrimitive ] ( _hint_ )</h1>
-        <p>This function is called by ECMAScript language operators to convert a Date object to a primitive value. The allowed values for _hint_ are `"default"`, `"number"`, and `"string"`. Date objects, are unique among built-in ECMAScript object in that they treat `"default"` as being equivalent to `"string"`, All other built-in ECMAScript objects treat `"default"` as being equivalent to `"number"`.</p>
+        <p>This function is called by ECMAScript language operators to convert a Date object to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*. Date objects, are unique among built-in ECMAScript object in that they treat *"default"* as being equivalent to *"string"*, All other built-in ECMAScript objects treat *"default"* as being equivalent to *"number"*.</p>
         <p>When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -29272,7 +29272,7 @@ THH:mm:ss.sss
           1. Else, throw a *TypeError* exception.
           1. Return ? OrdinaryToPrimitive(_O_, _tryFirst_).
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.toPrimitive]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
@@ -29295,7 +29295,7 @@ THH:mm:ss.sss
       <p>The String constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%String%</dfn>.</li>
-        <li>is the initial value of the `"String"` property of the global object.</li>
+        <li>is the initial value of the *"String"* property of the global object.</li>
         <li>creates and initializes a new String object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behaviour must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</li>
@@ -29305,12 +29305,12 @@ THH:mm:ss.sss
         <h1>String ( _value_ )</h1>
         <p>When `String` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
-          1. If no arguments were passed to this function invocation, let _s_ be `""`.
+          1. If no arguments were passed to this function invocation, let _s_ be *""*.
           1. Else,
             1. If NewTarget is *undefined* and Type(_value_) is Symbol, return SymbolDescriptiveString(_value_).
             1. Let _s_ be ? ToString(_value_).
           1. If NewTarget is *undefined*, return _s_.
-          1. Return ! StringCreate(_s_, ? GetPrototypeFromConstructor(NewTarget, `"%String.prototype%"`)).
+          1. Return ! StringCreate(_s_, ? GetPrototypeFromConstructor(NewTarget, *"%String.prototype%"*)).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -29338,7 +29338,7 @@ THH:mm:ss.sss
             1. Set _nextIndex_ to _nextIndex_ + 1.
           1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty string is returned.
         </emu-alg>
-        <p>The `"length"` property of the `fromCharCode` function is 1.</p>
+        <p>The *"length"* property of the `fromCharCode` function is 1.</p>
       </emu-clause>
 
       <emu-clause id="sec-string.fromcodepoint">
@@ -29358,7 +29358,7 @@ THH:mm:ss.sss
             1. Set _nextIndex_ to _nextIndex_ + 1.
           1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty string is returned.
         </emu-alg>
-        <p>The `"length"` property of the `fromCodePoint` function is 1.</p>
+        <p>The *"length"* property of the `fromCodePoint` function is 1.</p>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype">
@@ -29374,7 +29374,7 @@ THH:mm:ss.sss
           1. Let _substitutions_ be a List consisting of all of the arguments passed to this function, starting with the second argument. If fewer than two arguments were passed, the List is empty.
           1. Let _numberOfSubstitutions_ be the number of elements in _substitutions_.
           1. Let _cooked_ be ? ToObject(_template_).
-          1. Let _raw_ be ? ToObject(? Get(_cooked_, `"raw"`)).
+          1. Let _raw_ be ? ToObject(? Get(_cooked_, *"raw"*)).
           1. Let _literalSegments_ be ? LengthOfArrayLike(_raw_).
           1. If _literalSegments_ &le; 0, return the empty string.
           1. Let _stringElements_ be a new empty List.
@@ -29404,7 +29404,7 @@ THH:mm:ss.sss
         <li>is the intrinsic object <dfn>%StringPrototype%</dfn>.</li>
         <li>is a String exotic object and has the internal methods specified for such objects.</li>
         <li>has a [[StringData]] internal slot whose value is the empty String.</li>
-        <li>has a `"length"` property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
+        <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
@@ -29494,7 +29494,7 @@ THH:mm:ss.sss
             1. Set _R_ to the string-concatenation of the previous value of _R_ and _nextString_.
           1. Return _R_.
         </emu-alg>
-        <p>The `"length"` property of the `concat` method is 1.</p>
+        <p>The *"length"* property of the `concat` method is 1.</p>
         <emu-note>
           <p>The `concat` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29666,7 +29666,7 @@ THH:mm:ss.sss
             1. If _matcher_ is not *undefined*, then
               1. Return ? Call(_matcher_, _regexp_, &laquo; _O_ &raquo;).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _rx_ be ? RegExpCreate(_regexp_, `"g"`).
+          1. Let _rx_ be ? RegExpCreate(_regexp_, *"g"*).
           1. Return ? Invoke(_rx_, @@matchAll, &laquo; _S_ &raquo;).
         </emu-alg>
         <emu-note>The `matchAll` function is intentionally generic, it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</emu-note>
@@ -29679,9 +29679,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. If _form_ is not present or _form_ is *undefined*, set _form_ to `"NFC"`.
+          1. If _form_ is not present or _form_ is *undefined*, set _form_ to *"NFC"*.
           1. Let _f_ be ? ToString(_form_).
-          1. If _f_ is not one of `"NFC"`, `"NFD"`, `"NFKC"`, or `"NFKD"`, throw a *RangeError* exception.
+          1. If _f_ is not one of *"NFC"*, *"NFD"*, *"NFKC"*, or *"NFKD"*, throw a *RangeError* exception.
           1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="https://unicode.org/reports/tr15/">https://unicode.org/reports/tr15/</a>.
           1. Return _ns_.
         </emu-alg>
@@ -29728,7 +29728,7 @@ THH:mm:ss.sss
             <p>The argument _maxLength_ will be clamped such that it can be no smaller than the length of _S_.</p>
           </emu-note>
           <emu-note>
-            <p>The argument _fillString_ defaults to `" "` (the String value consisting of the code unit 0x0020 SPACE).</p>
+            <p>The argument _fillString_ defaults to *" "* (the String value consisting of the code unit 0x0020 SPACE).</p>
           </emu-note>
         </emu-clause>
       </emu-clause>
@@ -29902,10 +29902,10 @@ THH:mm:ss.sss
                 </td>
                 <td>
                   <emu-alg>
-                    1. If _namedCaptures_ is *undefined*, the replacement text is the String `"$&lt;"`.
+                    1. If _namedCaptures_ is *undefined*, the replacement text is the String *"$&lt;"*.
                     1. Else,
                       1. Scan until the next `>` U+003E (GREATER-THAN SIGN).
-                      1. If none is found, the replacement text is the String `"$&lt;"`.
+                      1. If none is found, the replacement text is the String *"$&lt;"*.
                       1. Else,
                         1. Let _groupName_ be the enclosed substring.
                         1. Let _capture_ be ? Get(_namedCaptures_, _groupName_).
@@ -29987,12 +29987,12 @@ THH:mm:ss.sss
           1. Let _R_ be ? ToString(_separator_).
           1. If _lim_ = 0, return _A_.
           1. If _separator_ is *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_A_, `"0"`, _S_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
             1. Return _A_.
           1. If _s_ = 0, then
             1. Let _z_ be SplitMatch(_S_, 0, _R_).
             1. If _z_ is not *false*, return _A_.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, `"0"`, _S_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
             1. Return _A_.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &ne; _s_
@@ -30220,14 +30220,14 @@ THH:mm:ss.sss
           1. Let _S_ be ? ToString(_O_).
           1. Return CreateStringIterator(_S_).
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.iterator]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.iterator]"*.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-string-instances">
       <h1>Properties of String Instances</h1>
       <p>String instances are String exotic objects and have the internal methods specified for such objects. String instances inherit properties from the String prototype object. String instances also have a [[StringData]] internal slot.</p>
-      <p>String instances have a `"length"` property, and a set of enumerable properties with integer-indexed names.</p>
+      <p>String instances have a *"length"* property, and a set of enumerable properties with integer-indexed names.</p>
 
       <emu-clause id="sec-properties-of-string-instances-length">
         <h1>length</h1>
@@ -30582,13 +30582,13 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierStart[U] :: `\` RegExpUnicodeEscapeSequence[?U]</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if SV(|RegExpUnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if SV(|RegExpUnicodeEscapeSequence|) is none of *"$"*, or *"_"*, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierPart[U] :: `\` RegExpUnicodeEscapeSequence[?U]</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if SV(|RegExpUnicodeEscapeSequence|) is none of `"$"`, or `"_"`, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if SV(|RegExpUnicodeEscapeSequence|) is none of *"$"*, or *"_"*, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar>
@@ -30895,16 +30895,16 @@ THH:mm:ss.sss
             _NcapturingParens_ is the total number of left-capturing parentheses (i.e. the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes) in the pattern. A left-capturing parenthesis is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> production.
           </li>
           <li>
-            _DotAll_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains `"s"` and otherwise is *false*.
+            _DotAll_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains *"s"* and otherwise is *false*.
           </li>
           <li>
-            _IgnoreCase_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains `"i"` and otherwise is *false*.
+            _IgnoreCase_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains *"i"* and otherwise is *false*.
           </li>
           <li>
-            _Multiline_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains `"m"` and otherwise is *false*.
+            _Multiline_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains *"m"* and otherwise is *false*.
           </li>
           <li>
-            _Unicode_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains `"u"` and otherwise is *false*.
+            _Unicode_ is *true* if the RegExp object's [[OriginalFlags]] internal slot contains *"u"* and otherwise is *false*.
           </li>
         </ul>
         <p>Furthermore, the descriptions below use the following internal data structures:</p>
@@ -30970,7 +30970,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The `|` regular expression operator separates two alternatives. The pattern first tries to match the left |Alternative| (followed by the sequel of the regular expression); if it fails, it tries to match the right |Disjunction| (followed by the sequel of the regular expression). If the left |Alternative|, the right |Disjunction|, and the sequel all have choice points, all choices in the sequel are tried before moving on to the next choice in the left |Alternative|. If choices in the left |Alternative| are exhausted, the right |Disjunction| is tried instead of the left |Alternative|. Any capturing parentheses inside a portion of the pattern skipped by `|` produce *undefined* values instead of Strings. Thus, for example,</p>
           <pre><code class="javascript">/a|ab/.exec("abc")</code></pre>
-          <p>returns the result `"a"` and not `"ab"`. Moreover,</p>
+          <p>returns the result *"a"* and not *"ab"*. Moreover,</p>
           <pre><code class="javascript">/((a)|(ab))((c)|(bc))/.exec("abc")</code></pre>
           <p>returns the array</p>
           <pre><code class="javascript">["abc", "a", "a", undefined, "bc", undefined, "bc"]</code></pre>
@@ -31065,9 +31065,9 @@ THH:mm:ss.sss
             <p>If the |Atom| and the sequel of the regular expression all have choice points, the |Atom| is first matched as many (or as few, if non-greedy) times as possible. All choices in the sequel are tried before moving on to the next choice in the last repetition of |Atom|. All choices in the last (n<sup>th</sup>) repetition of |Atom| are tried before moving on to the next choice in the next-to-last (n - 1)<sup>st</sup> repetition of |Atom|; at which point it may turn out that more or fewer repetitions of |Atom| are now possible; these are exhausted (again, starting with either as few or as many as possible) before moving on to the next choice in the (n - 1)<sup>st</sup> repetition of |Atom| and so on.</p>
             <p>Compare</p>
             <pre><code class="javascript">/a[a-z]{2,4}/.exec("abcdefghi")</code></pre>
-            <p>which returns `"abcde"` with</p>
+            <p>which returns *"abcde"* with</p>
             <pre><code class="javascript">/a[a-z]{2,4}?/.exec("abcdefghi")</code></pre>
-            <p>which returns `"abc"`.</p>
+            <p>which returns *"abc"*.</p>
             <p>Consider also</p>
             <pre><code class="javascript">/(aa|aabaac|ba|b|c)*/.exec("aabaac")</code></pre>
             <p>which, by the choice point ordering above, returns the array</p>
@@ -31079,7 +31079,7 @@ THH:mm:ss.sss
             </code></pre>
             <p>The above ordering of choice points can be used to write a regular expression that calculates the greatest common divisor of two numbers (represented in unary notation). The following example calculates the gcd of 10 and 15:</p>
             <pre><code class="javascript">"aaaaaaaaaa,aaaaaaaaaaaaaaa".replace(/^(a+)\1*,\1+$/, "$1")</code></pre>
-            <p>which returns the gcd in unary notation `"aaaaa"`.</p>
+            <p>which returns the gcd in unary notation *"aaaaa"*.</p>
           </emu-note>
           <emu-note>
             <p>Step 4 of the RepeatMatcher clears |Atom|'s captures each time |Atom| is repeated. We can see its behaviour in the regular expression</p>
@@ -31926,7 +31926,7 @@ THH:mm:ss.sss
       <p>The RegExp constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%RegExp%</dfn>.</li>
-        <li>is the initial value of the `"RegExp"` property of the global object.</li>
+        <li>is the initial value of the *"RegExp"* property of the global object.</li>
         <li>creates and initializes a new RegExp object when called as a function rather than as a constructor. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behaviour must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</li>
       </ul>
@@ -31939,7 +31939,7 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, then
             1. Let _newTarget_ be the active function object.
             1. If _patternIsRegExp_ is *true* and _flags_ is *undefined*, then
-              1. Let _patternConstructor_ be ? Get(_pattern_, `"constructor"`).
+              1. Let _patternConstructor_ be ? Get(_pattern_, *"constructor"*).
               1. If SameValue(_newTarget_, _patternConstructor_) is *true*, return _pattern_.
           1. Else, let _newTarget_ be NewTarget.
           1. If Type(_pattern_) is Object and _pattern_ has a [[RegExpMatcher]] internal slot, then
@@ -31947,9 +31947,9 @@ THH:mm:ss.sss
             1. If _flags_ is *undefined*, let _F_ be _pattern_.[[OriginalFlags]].
             1. Else, let _F_ be _flags_.
           1. Else if _patternIsRegExp_ is *true*, then
-            1. Let _P_ be ? Get(_pattern_, `"source"`).
+            1. Let _P_ be ? Get(_pattern_, *"source"*).
             1. If _flags_ is *undefined*, then
-              1. Let _F_ be ? Get(_pattern_, `"flags"`).
+              1. Let _F_ be ? Get(_pattern_, *"flags"*).
             1. Else, let _F_ be _flags_.
           1. Else,
             1. Let _P_ be _pattern_.
@@ -31969,8 +31969,8 @@ THH:mm:ss.sss
           <h1>Runtime Semantics: RegExpAlloc ( _newTarget_ )</h1>
           <p>When the abstract operation RegExpAlloc with argument _newTarget_ is called, the following steps are taken:</p>
           <emu-alg>
-            1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%RegExp.prototype%"`, &laquo; [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] &raquo;).
-            1. Perform ! DefinePropertyOrThrow(_obj_, `"lastIndex"`, PropertyDescriptor { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+            1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%RegExp.prototype%"*, &laquo; [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] &raquo;).
+            1. Perform ! DefinePropertyOrThrow(_obj_, *"lastIndex"*, PropertyDescriptor { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Return _obj_.
           </emu-alg>
         </emu-clause>
@@ -31983,8 +31983,8 @@ THH:mm:ss.sss
             1. Else, let _P_ be ? ToString(_pattern_).
             1. If _flags_ is *undefined*, let _F_ be the empty String.
             1. Else, let _F_ be ? ToString(_flags_).
-            1. If _F_ contains any code unit other than `"g"`, `"i"`, `"m"`, `"s"`, `"u"`, or `"y"` or if it contains the same code unit more than once, throw a *SyntaxError* exception.
-            1. If _F_ contains `"u"`, let _BMP_ be *false*; else let _BMP_ be *true*.
+            1. If _F_ contains any code unit other than *"g"*, *"i"*, *"m"*, *"s"*, *"u"*, or *"y"* or if it contains the same code unit more than once, throw a *SyntaxError* exception.
+            1. If _F_ contains *"u"*, let _BMP_ be *false*; else let _BMP_ be *true*.
             1. If _BMP_ is *true*, then
               1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref> and interpreting each of its 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]| and use this result instead. Throw a *SyntaxError* exception if _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist.
               1. Let _patternCharacters_ be a List whose elements are the code unit elements of _P_.
@@ -31994,7 +31994,7 @@ THH:mm:ss.sss
             1. Set _obj_.[[OriginalSource]] to _P_.
             1. Set _obj_.[[OriginalFlags]] to _F_.
             1. Set _obj_.[[RegExpMatcher]] to the internal procedure that evaluates the above parse of _P_ by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
-            1. Perform ? Set(_obj_, `"lastIndex"`, 0, *true*).
+            1. Perform ? Set(_obj_, *"lastIndex"*, 0, *true*).
             1. Return _obj_.
           </emu-alg>
         </emu-clause>
@@ -32012,8 +32012,8 @@ THH:mm:ss.sss
           <h1>Runtime Semantics: EscapeRegExpPattern ( _P_, _F_ )</h1>
           <p>When the abstract operation EscapeRegExpPattern with arguments _P_ and _F_ is called, the following occurs:</p>
           <emu-alg>
-            1. Let _S_ be a String in the form of a |Pattern[~U]| (|Pattern[+U]| if _F_ contains `"u"`) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the internal procedure that would result from evaluating _S_ as a |Pattern[~U]| (|Pattern[+U]| if _F_ contains `"u"`) must behave identically to the internal procedure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
-            1. The code points `/` or any |LineTerminator| occurring in the pattern shall be escaped in _S_ as necessary to ensure that the string-concatenation of `"/"`, _S_, `"/"`, and _F_ can be parsed (in an appropriate lexical context) as a |RegularExpressionLiteral| that behaves identically to the constructed regular expression. For example, if _P_ is `"/"`, then _S_ could be `"\\/"` or `"\\u002F"`, among other possibilities, but not `"/"`, because `///` followed by _F_ would be parsed as a |SingleLineComment| rather than a |RegularExpressionLiteral|. If _P_ is the empty String, this specification can be met by letting _S_ be `"(?:)"`.
+            1. Let _S_ be a String in the form of a |Pattern[~U]| (|Pattern[+U]| if _F_ contains *"u"*) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the internal procedure that would result from evaluating _S_ as a |Pattern[~U]| (|Pattern[+U]| if _F_ contains *"u"*) must behave identically to the internal procedure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
+            1. The code points `/` or any |LineTerminator| occurring in the pattern shall be escaped in _S_ as necessary to ensure that the string-concatenation of *"/"*, _S_, *"/"*, and _F_ can be parsed (in an appropriate lexical context) as a |RegularExpressionLiteral| that behaves identically to the constructed regular expression. For example, if _P_ is *"/"*, then _S_ could be *"\\/"* or *"\\u002F"*, among other possibilities, but not *"/"*, because `///` followed by _F_ would be parsed as a |SingleLineComment| rather than a |RegularExpressionLiteral|. If _P_ is the empty String, this specification can be met by letting _S_ be *"(?:)"*.
             1. Return _S_.
           </emu-alg>
         </emu-clause>
@@ -32040,7 +32040,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
+        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>RegExp prototype methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -32057,7 +32057,7 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <emu-note>
-        <p>The RegExp prototype object does not have a `"valueOf"` property of its own; however, it inherits the `"valueOf"` property from the Object prototype object.</p>
+        <p>The RegExp prototype object does not have a *"valueOf"* property of its own; however, it inherits the *"valueOf"* property from the Object prototype object.</p>
       </emu-note>
 
       <emu-clause id="sec-regexp.prototype.constructor">
@@ -32082,7 +32082,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: Type(_R_) is Object.
             1. Assert: Type(_S_) is String.
-            1. Let _exec_ be ? Get(_R_, `"exec"`).
+            1. Let _exec_ be ? Get(_R_, *"exec"*).
             1. If IsCallable(_exec_) is *true*, then
               1. Let _result_ be ? Call(_exec_, _R_, &laquo; _S_ &raquo;).
               1. If Type(_result_) is neither Object nor Null, throw a *TypeError* exception.
@@ -32091,7 +32091,7 @@ THH:mm:ss.sss
             1. Return ? RegExpBuiltinExec(_R_, _S_).
           </emu-alg>
           <emu-note>
-            <p>If a callable `"exec"` property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behaviour for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of `"exec"`.</p>
+            <p>If a callable *"exec"* property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behaviour for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of *"exec"*.</p>
           </emu-note>
         </emu-clause>
 
@@ -32102,23 +32102,23 @@ THH:mm:ss.sss
             1. Assert: _R_ is an initialized RegExp instance.
             1. Assert: Type(_S_) is String.
             1. Let _length_ be the number of code units in _S_.
-            1. Let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
+            1. Let _lastIndex_ be ? ToLength(? Get(_R_, *"lastIndex"*)).
             1. Let _flags_ be _R_.[[OriginalFlags]].
-            1. If _flags_ contains `"g"`, let _global_ be *true*; else let _global_ be *false*.
-            1. If _flags_ contains `"y"`, let _sticky_ be *true*; else let _sticky_ be *false*.
+            1. If _flags_ contains *"g"*, let _global_ be *true*; else let _global_ be *false*.
+            1. If _flags_ contains *"y"*, let _sticky_ be *true*; else let _sticky_ be *false*.
             1. If _global_ is *false* and _sticky_ is *false*, set _lastIndex_ to 0.
             1. Let _matcher_ be _R_.[[RegExpMatcher]].
-            1. If _flags_ contains `"u"`, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
+            1. If _flags_ contains *"u"*, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
             1. Let _matchSucceeded_ be *false*.
             1. Repeat, while _matchSucceeded_ is *false*
               1. If _lastIndex_ &gt; _length_, then
                 1. If _global_ is *true* or _sticky_ is *true*, then
-                  1. Perform ? Set(_R_, `"lastIndex"`, 0, *true*).
+                  1. Perform ? Set(_R_, *"lastIndex"*, 0, *true*).
                 1. Return *null*.
               1. Let _r_ be _matcher_(_S_, _lastIndex_).
               1. If _r_ is ~failure~, then
                 1. If _sticky_ is *true*, then
-                  1. Perform ? Set(_R_, `"lastIndex"`, 0, *true*).
+                  1. Perform ? Set(_R_, *"lastIndex"*, 0, *true*).
                   1. Return *null*.
                 1. Set _lastIndex_ to AdvanceStringIndex(_S_, _lastIndex_, _fullUnicode_).
               1. Else,
@@ -32129,20 +32129,20 @@ THH:mm:ss.sss
               1. _e_ is an index into the _Input_ character list, derived from _S_, matched by _matcher_. Let _eUTF_ be the smallest index into _S_ that corresponds to the character at element _e_ of _Input_. If _e_ is greater than or equal to the number of elements in _Input_, then _eUTF_ is the number of code units in _S_.
               1. Set _e_ to _eUTF_.
             1. If _global_ is *true* or _sticky_ is *true*, then
-              1. Perform ? Set(_R_, `"lastIndex"`, _e_, *true*).
+              1. Perform ? Set(_R_, *"lastIndex"*, _e_, *true*).
             1. Let _n_ be the number of elements in _r_'s _captures_ List. (This is the same value as <emu-xref href="#sec-notation"></emu-xref>'s _NcapturingParens_.)
             1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
             1. Let _A_ be ! ArrayCreate(_n_ + 1).
-            1. Assert: The value of _A_'s `"length"` property is _n_ + 1.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, `"index"`, _lastIndex_).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, `"input"`, _S_).
+            1. Assert: The value of _A_'s *"length"* property is _n_ + 1.
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"index"*, _lastIndex_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"input"*, _S_).
             1. Let _matchedSubstr_ be the matched substring (i.e. the portion of _S_ between offset _lastIndex_ inclusive and offset _e_ exclusive).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, `"0"`, _matchedSubstr_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _matchedSubstr_).
             1. If _R_ contains any |GroupName|, then
               1. Let _groups_ be ObjectCreate(*null*).
             1. Else,
               1. Let _groups_ be *undefined*.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, `"groups"`, _groups_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
             1. For each integer _i_ such that _i_ &gt; 0 and _i_ &le; _n_, do
               1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
@@ -32199,17 +32199,17 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. Let _result_ be the empty String.
-          1. Let _global_ be ! ToBoolean(? Get(_R_, `"global"`)).
+          1. Let _global_ be ! ToBoolean(? Get(_R_, *"global"*)).
           1. If _global_ is *true*, append the code unit 0x0067 (LATIN SMALL LETTER G) as the last code unit of _result_.
-          1. Let _ignoreCase_ be ! ToBoolean(? Get(_R_, `"ignoreCase"`)).
+          1. Let _ignoreCase_ be ! ToBoolean(? Get(_R_, *"ignoreCase"*)).
           1. If _ignoreCase_ is *true*, append the code unit 0x0069 (LATIN SMALL LETTER I) as the last code unit of _result_.
-          1. Let _multiline_ be ! ToBoolean(? Get(_R_, `"multiline"`)).
+          1. Let _multiline_ be ! ToBoolean(? Get(_R_, *"multiline"*)).
           1. If _multiline_ is *true*, append the code unit 0x006D (LATIN SMALL LETTER M) as the last code unit of _result_.
-          1. Let _dotAll_ be ! ToBoolean(? Get(_R_, `"dotAll"`)).
+          1. Let _dotAll_ be ! ToBoolean(? Get(_R_, *"dotAll"*)).
           1. If _dotAll_ is *true*, append the code unit 0x0073 (LATIN SMALL LETTER S) as the last code unit of _result_.
-          1. Let _unicode_ be ! ToBoolean(? Get(_R_, `"unicode"`)).
+          1. Let _unicode_ be ! ToBoolean(? Get(_R_, *"unicode"*)).
           1. If _unicode_ is *true*, append the code unit 0x0075 (LATIN SMALL LETTER U) as the last code unit of _result_.
-          1. Let _sticky_ be ! ToBoolean(? Get(_R_, `"sticky"`)).
+          1. Let _sticky_ be ! ToBoolean(? Get(_R_, *"sticky"*)).
           1. If _sticky_ is *true*, append the code unit 0x0079 (LATIN SMALL LETTER Y) as the last code unit of _result_.
           1. Return _result_.
         </emu-alg>
@@ -32252,13 +32252,13 @@ THH:mm:ss.sss
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
-          1. Let _global_ be ! ToBoolean(? Get(_rx_, `"global"`)).
+          1. Let _global_ be ! ToBoolean(? Get(_rx_, *"global"*)).
           1. If _global_ is *false*, then
             1. Return ? RegExpExec(_rx_, _S_).
           1. Else,
             1. Assert: _global_ is *true*.
-            1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, `"unicode"`)).
-            1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
+            1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, *"unicode"*)).
+            1. Perform ? Set(_rx_, *"lastIndex"*, 0, *true*).
             1. Let _A_ be ! ArrayCreate(0).
             1. Let _n_ be 0.
             1. Repeat,
@@ -32267,15 +32267,15 @@ THH:mm:ss.sss
                 1. If _n_ = 0, return *null*.
                 1. Return _A_.
               1. Else,
-                1. Let _matchStr_ be ? ToString(? Get(_result_, `"0"`)).
+                1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
                 1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _matchStr_).
                 1. If _matchStr_ is the empty String, then
-                  1. Let _thisIndex_ be ? ToLength(? Get(_rx_, `"lastIndex"`)).
+                  1. Let _thisIndex_ be ? ToLength(? Get(_rx_, *"lastIndex"*)).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Perform ? Set(_rx_, `"lastIndex"`, _nextIndex_, *true*).
+                  1. Perform ? Set(_rx_, *"lastIndex"*, _nextIndex_, *true*).
                 1. Set _n_ to _n_ + 1.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.match]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.match]"*.</p>
         <emu-note>
           <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behaviour of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
         </emu-note>
@@ -32290,17 +32290,17 @@ THH:mm:ss.sss
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
           1. Let _C_ be ? SpeciesConstructor(_R_, %RegExp%).
-          1. Let _flags_ be ? ToString(? Get(_R_, `"flags"`)).
+          1. Let _flags_ be ? ToString(? Get(_R_, *"flags"*)).
           1. Let _matcher_ be ? Construct(_C_, &laquo; _R_, _flags_ &raquo;).
-          1. Let _lastIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
-          1. Perform ? Set(_matcher_, `"lastIndex"`, _lastIndex_, *true*).
-          1. If _flags_ contains `"g"`, let _global_ be *true*.
+          1. Let _lastIndex_ be ? ToLength(? Get(_R_, *"lastIndex"*)).
+          1. Perform ? Set(_matcher_, *"lastIndex"*, _lastIndex_, *true*).
+          1. If _flags_ contains *"g"*, let _global_ be *true*.
           1. Else, let _global_ be *false*.
-          1. If _flags_ contains `"u"`, let _fullUnicode_ be *true*.
+          1. If _flags_ contains *"u"*, let _fullUnicode_ be *true*.
           1. Else, let _fullUnicode_ be *false*.
           1. Return ! CreateRegExpStringIterator(_matcher_, _S_, _global_, _fullUnicode_).
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.matchAll]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.matchAll]"*.</p>
 
         <emu-clause id="sec-createregexpstringiterator" aoid="CreateRegExpStringIterator">
           <h1>CreateRegExpStringIterator ( _R_, _S_, _global_, _fullUnicode_ )</h1>
@@ -32347,10 +32347,10 @@ THH:mm:ss.sss
           1. Let _functionalReplace_ be IsCallable(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
-          1. Let _global_ be ! ToBoolean(? Get(_rx_, `"global"`)).
+          1. Let _global_ be ! ToBoolean(? Get(_rx_, *"global"*)).
           1. If _global_ is *true*, then
-            1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, `"unicode"`)).
-            1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
+            1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, *"unicode"*)).
+            1. Perform ? Set(_rx_, *"lastIndex"*, 0, *true*).
           1. Let _results_ be a new empty List.
           1. Let _done_ be *false*.
           1. Repeat, while _done_ is *false*
@@ -32360,19 +32360,19 @@ THH:mm:ss.sss
               1. Append _result_ to the end of _results_.
               1. If _global_ is *false*, set _done_ to *true*.
               1. Else,
-                1. Let _matchStr_ be ? ToString(? Get(_result_, `"0"`)).
+                1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
                 1. If _matchStr_ is the empty String, then
-                  1. Let _thisIndex_ be ? ToLength(? Get(_rx_, `"lastIndex"`)).
+                  1. Let _thisIndex_ be ? ToLength(? Get(_rx_, *"lastIndex"*)).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Perform ? Set(_rx_, `"lastIndex"`, _nextIndex_, *true*).
+                  1. Perform ? Set(_rx_, *"lastIndex"*, _nextIndex_, *true*).
           1. Let _accumulatedResult_ be the empty String value.
           1. Let _nextSourcePosition_ be 0.
           1. For each _result_ in _results_, do
             1. Let _nCaptures_ be ? LengthOfArrayLike(_result_).
             1. Set _nCaptures_ to max(_nCaptures_ - 1, 0).
-            1. Let _matched_ be ? ToString(? Get(_result_, `"0"`)).
+            1. Let _matched_ be ? ToString(? Get(_result_, *"0"*)).
             1. Let _matchLength_ be the number of code units in _matched_.
-            1. Let _position_ be ? ToInteger(? Get(_result_, `"index"`)).
+            1. Let _position_ be ? ToInteger(? Get(_result_, *"index"*)).
             1. Set _position_ to max(min(_position_, _lengthS_), 0).
             1. Let _n_ be 1.
             1. Let _captures_ be a new empty List.
@@ -32382,7 +32382,7 @@ THH:mm:ss.sss
                 1. Set _capN_ to ? ToString(_capN_).
               1. Append _capN_ as the last element of _captures_.
               1. Set _n_ to _n_ + 1.
-            1. Let _namedCaptures_ be ? Get(_result_, `"groups"`).
+            1. Let _namedCaptures_ be ? Get(_result_, *"groups"*).
             1. If _functionalReplace_ is *true*, then
               1. Let _replacerArgs_ be &laquo; _matched_ &raquo;.
               1. Append in list order the elements of _captures_ to the end of the List _replacerArgs_.
@@ -32400,7 +32400,7 @@ THH:mm:ss.sss
           1. If _nextSourcePosition_ &ge; _lengthS_, return _accumulatedResult_.
           1. Return the string-concatenation of _accumulatedResult_ and the substring of _S_ consisting of the code units from _nextSourcePosition_ (inclusive) up through the final code unit of _S_ (inclusive).
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.replace]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.replace]"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-regexp.prototype-@@search">
@@ -32410,19 +32410,19 @@ THH:mm:ss.sss
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
-          1. Let _previousLastIndex_ be ? Get(_rx_, `"lastIndex"`).
+          1. Let _previousLastIndex_ be ? Get(_rx_, *"lastIndex"*).
           1. If SameValue(_previousLastIndex_, 0) is *false*, then
-            1. Perform ? Set(_rx_, `"lastIndex"`, 0, *true*).
+            1. Perform ? Set(_rx_, *"lastIndex"*, 0, *true*).
           1. Let _result_ be ? RegExpExec(_rx_, _S_).
-          1. Let _currentLastIndex_ be ? Get(_rx_, `"lastIndex"`).
+          1. Let _currentLastIndex_ be ? Get(_rx_, *"lastIndex"*).
           1. If SameValue(_currentLastIndex_, _previousLastIndex_) is *false*, then
-            1. Perform ? Set(_rx_, `"lastIndex"`, _previousLastIndex_, *true*).
+            1. Perform ? Set(_rx_, *"lastIndex"*, _previousLastIndex_, *true*).
           1. If _result_ is *null*, return -1.
-          1. Return ? Get(_result_, `"index"`).
+          1. Return ? Get(_result_, *"index"*).
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.search]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.search]"*.</p>
         <emu-note>
-          <p>The `"lastIndex"` and `"global"` properties of this RegExp object are ignored when performing the search. The `"lastIndex"` property is left unchanged.</p>
+          <p>The *"lastIndex"* and *"global"* properties of this RegExp object are ignored when performing the search. The *"lastIndex"* property is left unchanged.</p>
         </emu-note>
       </emu-clause>
 
@@ -32433,7 +32433,7 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalSource]] internal slot, then
-            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return `"(?:)"`.
+            1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *"(?:)"*.
             1. Otherwise, throw a *TypeError* exception.
           1. Assert: _R_ has an [[OriginalFlags]] internal slot.
           1. Let _src_ be _R_.[[OriginalSource]].
@@ -32460,11 +32460,11 @@ THH:mm:ss.sss
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
           1. Let _C_ be ? SpeciesConstructor(_rx_, %RegExp%).
-          1. Let _flags_ be ? ToString(? Get(_rx_, `"flags"`)).
-          1. If _flags_ contains `"u"`, let _unicodeMatching_ be *true*.
+          1. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
+          1. If _flags_ contains *"u"*, let _unicodeMatching_ be *true*.
           1. Else, let _unicodeMatching_ be *false*.
-          1. If _flags_ contains `"y"`, let _newFlags_ be _flags_.
-          1. Else, let _newFlags_ be the string-concatenation of _flags_ and `"y"`.
+          1. If _flags_ contains *"y"*, let _newFlags_ be _flags_.
+          1. Else, let _newFlags_ be the string-concatenation of _flags_ and *"y"*.
           1. Let _splitter_ be ? Construct(_C_, &laquo; _rx_, _newFlags_ &raquo;).
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _lengthA_ be 0.
@@ -32475,15 +32475,15 @@ THH:mm:ss.sss
           1. If _size_ = 0, then
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is not *null*, return _A_.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, `"0"`, _S_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
             1. Return _A_.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &lt; _size_
-            1. Perform ? Set(_splitter_, `"lastIndex"`, _q_, *true*).
+            1. Perform ? Set(_splitter_, *"lastIndex"*, _q_, *true*).
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is *null*, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
             1. Else,
-              1. Let _e_ be ? ToLength(? Get(_splitter_, `"lastIndex"`)).
+              1. Let _e_ be ? ToLength(? Get(_splitter_, *"lastIndex"*)).
               1. Set _e_ to min(_e_, _size_).
               1. If _e_ = _p_, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
               1. Else,
@@ -32506,9 +32506,9 @@ THH:mm:ss.sss
           1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
           1. Return _A_.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.split]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.split]"*.</p>
         <emu-note>
-          <p>The `@@split` method ignores the value of the `"global"` and `"sticky"` properties of this RegExp object.</p>
+          <p>The `@@split` method ignores the value of the *"global"* and *"sticky"* properties of this RegExp object.</p>
         </emu-note>
       </emu-clause>
 
@@ -32544,9 +32544,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
-          1. Let _pattern_ be ? ToString(? Get(_R_, `"source"`)).
-          1. Let _flags_ be ? ToString(? Get(_R_, `"flags"`)).
-          1. Let _result_ be the string-concatenation of `"/"`, _pattern_, `"/"`, and _flags_.
+          1. Let _pattern_ be ? ToString(? Get(_R_, *"source"*)).
+          1. Let _flags_ be ? ToString(? Get(_R_, *"flags"*)).
+          1. Let _result_ be the string-concatenation of *"/"*, _pattern_, *"/"*, and _flags_.
           1. Return _result_.
         </emu-alg>
         <emu-note>
@@ -32574,13 +32574,13 @@ THH:mm:ss.sss
       <h1>Properties of RegExp Instances</h1>
       <p>RegExp instances are ordinary objects that inherit properties from the RegExp prototype object. RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and [[OriginalFlags]]. The value of the [[RegExpMatcher]] internal slot is an implementation-dependent representation of the |Pattern| of the RegExp object.</p>
       <emu-note>
-        <p>Prior to ECMAScript 2015, `RegExp` instances were specified as having the own data properties `"source"`, `"global"`, `"ignoreCase"`, and `"multiline"`. Those properties are now specified as accessor properties of `RegExp.prototype`.</p>
+        <p>Prior to ECMAScript 2015, `RegExp` instances were specified as having the own data properties *"source"*, *"global"*, *"ignoreCase"*, and *"multiline"*. Those properties are now specified as accessor properties of `RegExp.prototype`.</p>
       </emu-note>
       <p>RegExp instances also have the following property:</p>
 
       <emu-clause id="sec-lastindex">
         <h1>lastIndex</h1>
-        <p>The value of the `"lastIndex"` property specifies the String index at which to start the next match. It is coerced to an integer when used (see <emu-xref href="#sec-regexpbuiltinexec"></emu-xref>). This property shall have the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <p>The value of the *"lastIndex"* property specifies the String index at which to start the next match. It is coerced to an integer when used (see <emu-xref href="#sec-regexpbuiltinexec"></emu-xref>). This property shall have the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
@@ -32616,11 +32616,11 @@ THH:mm:ss.sss
               1. Return ! CreateIterResultObject(*undefined*, *true*).
             1. Else,
               1. If _global_ is *true*, then
-                1. Let _matchStr_ be ? ToString(? Get(_match_, `"0"`)).
+                1. Let _matchStr_ be ? ToString(? Get(_match_, *"0"*)).
                 1. If _matchStr_ is the empty string, then
-                  1. Let _thisIndex_ be ? ToLength(? Get(_R_, `"lastIndex"`)).
+                  1. Let _thisIndex_ be ? ToLength(? Get(_R_, *"lastIndex"*)).
                   1. Let _nextIndex_ be ! AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Perform ? Set(_R_, `"lastIndex"`, _nextIndex_, *true*).
+                  1. Perform ? Set(_R_, *"lastIndex"*, _nextIndex_, *true*).
                 1. Return ! CreateIterResultObject(_match_, *false*).
               1. Else,
                 1. Set _O_.[[Done]] to *true*.
@@ -32685,12 +32685,12 @@ THH:mm:ss.sss
       <p>The Array constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Array%</dfn>.</li>
-        <li>is the initial value of the `"Array"` property of the global object.</li>
+        <li>is the initial value of the *"Array"* property of the global object.</li>
         <li>creates and initializes a new Array exotic object when called as a constructor.</li>
         <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
         <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behaviour must include a `super` call to the `Array` constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
-        <li>has a `"length"` property whose value is 1.</li>
+        <li>has a *"length"* property whose value is 1.</li>
       </ul>
 
       <emu-clause id="sec-array-constructor-array">
@@ -32700,7 +32700,7 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ = 0.
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%Array.prototype%"`).
+          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
           1. Return ! ArrayCreate(0, _proto_).
         </emu-alg>
       </emu-clause>
@@ -32712,15 +32712,15 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ = 1.
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%Array.prototype%"`).
+          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
           1. Let _array_ be ! ArrayCreate(0, _proto_).
           1. If Type(_len_) is not Number, then
-            1. Perform ! CreateDataPropertyOrThrow(_array_, `"0"`, _len_).
+            1. Perform ! CreateDataPropertyOrThrow(_array_, *"0"*, _len_).
             1. Let _intLen_ be 1.
           1. Else,
             1. Let _intLen_ be ToUint32(_len_).
             1. If _intLen_ &ne; _len_, throw a *RangeError* exception.
-          1. Perform ! Set(_array_, `"length"`, _intLen_, *true*).
+          1. Perform ! Set(_array_, *"length"*, _intLen_, *true*).
           1. Return _array_.
         </emu-alg>
       </emu-clause>
@@ -32733,7 +32733,7 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ &ge; 2.
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, `"%Array.prototype%"`).
+          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
           1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
           1. Let _k_ be 0.
           1. Let _items_ be a zero-origined List containing the argument items in order.
@@ -32742,7 +32742,7 @@ THH:mm:ss.sss
             1. Let _itemK_ be _items_[_k_].
             1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
             1. Set _k_ to _k_ + 1.
-          1. Assert: The value of _array_'s `"length"` property is _numberOfArgs_.
+          1. Assert: The value of _array_'s *"length"* property is _numberOfArgs_.
           1. Return _array_.
         </emu-alg>
       </emu-clause>
@@ -32781,7 +32781,7 @@ THH:mm:ss.sss
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _next_ be ? IteratorStep(_iteratorRecord_).
               1. If _next_ is *false*, then
-                1. Perform ? Set(_A_, `"length"`, _k_, *true*).
+                1. Perform ? Set(_A_, *"length"*, _k_, *true*).
                 1. Return _A_.
               1. Let _nextValue_ be ? IteratorValue(_next_).
               1. If _mapping_ is *true*, then
@@ -32808,7 +32808,7 @@ THH:mm:ss.sss
             1. Else, let _mappedValue_ be _kValue_.
             1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_A_, `"length"`, _len_, *true*).
+          1. Perform ? Set(_A_, *"length"*, _len_, *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -32841,7 +32841,7 @@ THH:mm:ss.sss
             1. Let _Pk_ be ! ToString(_k_).
             1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _kValue_).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_A_, `"length"`, _len_, *true*).
+          1. Perform ? Set(_A_, *"length"*, _len_, *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -32864,7 +32864,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
+        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>Array prototype methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -32877,7 +32877,7 @@ THH:mm:ss.sss
       <ul>
         <li>is the intrinsic object <dfn>%ArrayPrototype%</dfn>.</li>
         <li>is an Array exotic object and has the internal methods specified for such objects.</li>
-        <li>has a `"length"` property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
+        <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <emu-note>
@@ -32913,12 +32913,12 @@ THH:mm:ss.sss
               1. If _n_ &ge; 2<sup>53</sup> - 1, throw a *TypeError* exception.
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _E_).
               1. Set _n_ to _n_ + 1.
-          1. Perform ? Set(_A_, `"length"`, _n_, *true*).
+          1. Perform ? Set(_A_, *"length"*, _n_, *true*).
           1. Return _A_.
         </emu-alg>
-        <p>The `"length"` property of the `concat` method is 1.</p>
+        <p>The *"length"* property of the `concat` method is 1.</p>
         <emu-note>
-          <p>The explicit setting of the `"length"` property in step 6 is necessary to ensure that its value is correct in situations where the trailing elements of the result Array are not present.</p>
+          <p>The explicit setting of the *"length"* property in step 6 is necessary to ensure that its value is correct in situations where the trailing elements of the result Array are not present.</p>
         </emu-note>
         <emu-note>
           <p>The `concat` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -33316,7 +33316,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _separator_ is *undefined*, let _sep_ be the single-element String `","`.
+          1. If _separator_ is *undefined*, let _sep_ be the single-element String *","*.
           1. Else, let _sep_ be ? ToString(_separator_).
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
@@ -33415,7 +33415,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If _len_ is zero, then
-            1. Perform ? Set(_O_, `"length"`, 0, *true*).
+            1. Perform ? Set(_O_, *"length"*, 0, *true*).
             1. Return *undefined*.
           1. Else,
             1. Assert: _len_ &gt; 0.
@@ -33423,7 +33423,7 @@ THH:mm:ss.sss
             1. Let _index_ be ! ToString(_newLen_).
             1. Let _element_ be ? Get(_O_, _index_).
             1. Perform ? DeletePropertyOrThrow(_O_, _index_).
-            1. Perform ? Set(_O_, `"length"`, _newLen_, *true*).
+            1. Perform ? Set(_O_, *"length"*, _newLen_, *true*).
             1. Return _element_.
         </emu-alg>
         <emu-note>
@@ -33447,10 +33447,10 @@ THH:mm:ss.sss
             1. Remove the first element from _items_ and let _E_ be the value of the element.
             1. Perform ? Set(_O_, ! ToString(_len_), _E_, *true*).
             1. Set _len_ to _len_ + 1.
-          1. Perform ? Set(_O_, `"length"`, _len_, *true*).
+          1. Perform ? Set(_O_, *"length"*, _len_, *true*).
           1. Return _len_.
         </emu-alg>
-        <p>The `"length"` property of the `push` method is 1.</p>
+        <p>The *"length"* property of the `push` method is 1.</p>
         <emu-note>
           <p>The `push` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -33589,9 +33589,9 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If _len_ is zero, then
-            1. Perform ? Set(_O_, `"length"`, 0, *true*).
+            1. Perform ? Set(_O_, *"length"*, 0, *true*).
             1. Return *undefined*.
-          1. Let _first_ be ? Get(_O_, `"0"`).
+          1. Let _first_ be ? Get(_O_, *"0"*).
           1. Let _k_ be 1.
           1. Repeat, while _k_ &lt; _len_
             1. Let _from_ be ! ToString(_k_).
@@ -33605,7 +33605,7 @@ THH:mm:ss.sss
               1. Perform ? DeletePropertyOrThrow(_O_, _to_).
             1. Set _k_ to _k_ + 1.
           1. Perform ? DeletePropertyOrThrow(_O_, ! ToString(_len_ - 1)).
-          1. Perform ? Set(_O_, `"length"`, _len_ - 1, *true*).
+          1. Perform ? Set(_O_, *"length"*, _len_ - 1, *true*).
           1. Return _first_.
         </emu-alg>
         <emu-note>
@@ -33637,11 +33637,11 @@ THH:mm:ss.sss
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _kValue_).
             1. Set _k_ to _k_ + 1.
             1. Set _n_ to _n_ + 1.
-          1. Perform ? Set(_A_, `"length"`, _n_, *true*).
+          1. Perform ? Set(_A_, *"length"*, _n_, *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The explicit setting of the `"length"` property of the result Array in step 11 was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting `"length"` became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
+          <p>The explicit setting of the *"length"* property of the result Array in step 11 was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
         <emu-note>
           <p>The `slice` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -33843,7 +33843,7 @@ THH:mm:ss.sss
               1. Let _fromValue_ be ? Get(_O_, _from_).
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_k_), _fromValue_).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_A_, `"length"`, _actualDeleteCount_, *true*).
+          1. Perform ? Set(_A_, *"length"*, _actualDeleteCount_, *true*).
           1. Let _items_ be a List whose elements are, in left to right order, the portion of the actual argument list starting with the third argument. The list is empty if fewer than three arguments were passed.
           1. Let _itemCount_ be the number of elements in _items_.
           1. If _itemCount_ &lt; _actualDeleteCount_, then
@@ -33881,11 +33881,11 @@ THH:mm:ss.sss
             1. Remove the first element from _items_ and let _E_ be the value of that element.
             1. Perform ? Set(_O_, ! ToString(_k_), _E_, *true*).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_O_, `"length"`, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
+          1. Perform ? Set(_O_, *"length"*, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The explicit setting of the `"length"` property of the result Array in step 19 was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting `"length"` became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
+          <p>The explicit setting of the *"length"* property of the result Array in step 19 was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
         <emu-note>
           <p>The `splice` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -33911,7 +33911,7 @@ THH:mm:ss.sss
               1. Set _R_ to the string-concatenation of _R_ and _separator_.
             1. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
             1. If _nextElement_ is not *undefined* or *null*, then
-              1. Let _S_ be ? ToString(? Invoke(_nextElement_, `"toLocaleString"`)).
+              1. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*)).
               1. Set _R_ to the string-concatenation of _R_ and _S_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.
@@ -33929,7 +33929,7 @@ THH:mm:ss.sss
         <p>When the `toString` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
-          1. Let _func_ be ? Get(_array_, `"join"`).
+          1. Let _func_ be ? Get(_array_, *"join"*).
           1. If IsCallable(_func_) is *false*, set _func_ to the intrinsic function %Object.prototype.toString%.
           1. Return ? Call(_func_, _array_).
         </emu-alg>
@@ -33968,10 +33968,10 @@ THH:mm:ss.sss
               1. Remove the first element from _items_ and let _E_ be the value of that element.
               1. Perform ? Set(_O_, ! ToString(_j_), _E_, *true*).
               1. Set _j_ to _j_ + 1.
-          1. Perform ? Set(_O_, `"length"`, _len_ + _argCount_, *true*).
+          1. Perform ? Set(_O_, *"length"*, _len_ + _argCount_, *true*).
           1. Return _len_ + _argCount_.
         </emu-alg>
-        <p>The `"length"` property of the `unshift` method is 1.</p>
+        <p>The *"length"* property of the `unshift` method is 1.</p>
         <emu-note>
           <p>The `unshift` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -33997,16 +33997,16 @@ THH:mm:ss.sss
         <p>The initial value of the @@unscopables data property is an object created by the following steps:</p>
         <emu-alg>
           1. Let _unscopableList_ be ObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"copyWithin"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"entries"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"fill"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"find"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"findIndex"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"flat"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"flatMap"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"includes"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"keys"`, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, `"values"`, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"copyWithin"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"entries"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"fill"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"find"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"findIndex"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"flat"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"flatMap"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"includes"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"keys"*, *true*).
+          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"values"*, *true*).
           1. Return _unscopableList_.
         </emu-alg>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -34019,14 +34019,14 @@ THH:mm:ss.sss
     <emu-clause id="sec-properties-of-array-instances">
       <h1>Properties of Array Instances</h1>
       <p>Array instances are Array exotic objects and have the internal methods specified for such objects. Array instances inherit properties from the Array prototype object.</p>
-      <p>Array instances have a `"length"` property, and a set of enumerable properties with array index names.</p>
+      <p>Array instances have a *"length"* property, and a set of enumerable properties with array index names.</p>
 
       <emu-clause id="sec-properties-of-array-instances-length">
         <h1>length</h1>
-        <p>The `"length"` property of an Array instance is a data property whose value is always numerically greater than the name of every configurable own property whose name is an array index.</p>
-        <p>The `"length"` property initially has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <p>The *"length"* property of an Array instance is a data property whose value is always numerically greater than the name of every configurable own property whose name is an array index.</p>
+        <p>The *"length"* property initially has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Reducing the value of the `"length"` property has the side-effect of deleting own array elements whose array index is between the old and new length values. However, non-configurable properties can not be deleted. Attempting to set the `"length"` property of an Array object to a value that is numerically less than or equal to the largest numeric own property name of an existing non-configurable <emu-xref href="#array-index">array-indexed</emu-xref> property of the array will result in the length being set to a numeric value that is one greater than that non-configurable numeric own property name. See <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.</p>
+          <p>Reducing the value of the *"length"* property has the side-effect of deleting own array elements whose array index is between the old and new length values. However, non-configurable properties can not be deleted. Attempting to set the *"length"* property of an Array object to a value that is numerically less than or equal to the largest numeric own property name of an existing non-configurable <emu-xref href="#array-index">array-indexed</emu-xref> property of the array will result in the length being set to a numeric value that is one greater than that non-configurable numeric own property name. See <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -34392,7 +34392,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Throw a *TypeError* exception.
         </emu-alg>
-        <p>The `"length"` property of the %TypedArray% constructor function is 0.</p>
+        <p>The *"length"* property of the %TypedArray% constructor function is 0.</p>
       </emu-clause>
     </emu-clause>
 
@@ -34402,7 +34402,7 @@ THH:mm:ss.sss
       <p>The %TypedArray% intrinsic object:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>has a `"name"` property whose value is *"TypedArray"*.</li>
+        <li>has a *"name"* property whose value is *"TypedArray"*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -34500,7 +34500,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
+        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>%TypedArray.prototype% methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -34626,7 +34626,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.every">
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -34686,37 +34686,37 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.find">
         <h1>%TypedArray%.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.findindex">
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.foreach">
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.includes">
         <h1>%TypedArray%.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.includes` is a distinct function that implements the same algorithm as `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.includes` is a distinct function that implements the same algorithm as `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.indexof">
         <h1>%TypedArray%.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.join">
         <h1>%TypedArray%.prototype.join ( _separator_ )</h1>
-        <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -34732,7 +34732,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.lastindexof">
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -34776,19 +34776,19 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.reduce">
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reduceright">
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reverse">
         <h1>%TypedArray%.prototype.reverse ( )</h1>
-        <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -34935,7 +34935,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.some">
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
@@ -35000,7 +35000,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.tolocalestring">
         <h1>%TypedArray%.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of `"length"`. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
         <emu-note>
           <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this function is based upon the algorithm for `Array.prototype.toLocaleString` that is in the ECMA-402 specification.</p>
@@ -35039,7 +35039,7 @@ THH:mm:ss.sss
           1. Return _name_.
         </emu-alg>
         <p>This property has the attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-        <p>The initial value of the `"name"` property of this function is *"get [Symbol.toStringTag]"*.</p>
+        <p>The initial value of the *"name"* property of this function is *"get [Symbol.toStringTag]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -35051,7 +35051,7 @@ THH:mm:ss.sss
         <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray%`.prototype` built-in methods.</li>
-        <li>has a `"length"` property whose value is 3.</li>
+        <li>has a *"length"* property whose value is 3.</li>
       </ul>
 
       <emu-clause id="sec-typedarray">
@@ -35084,7 +35084,7 @@ THH:mm:ss.sss
             1. Let _obj_ be IntegerIndexedObjectCreate(_proto_, &laquo; [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;).
             1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
             1. Set _obj_.[[TypedArrayName]] to _constructorName_.
-            1. If _constructorName_ is `"BigInt64Array"` or `"BigUint64Array"`, set _obj_.[[ContentType]] to ~BigInt~.
+            1. If _constructorName_ is *"BigInt64Array"* or *"BigUint64Array"*, set _obj_.[[ContentType]] to ~BigInt~.
             1. Otherwise, set _obj_.[[ContentType]] to ~Number~.
             1. If _length_ is not present, then
               1. Set _obj_.[[ByteLength]] to 0.
@@ -35262,7 +35262,7 @@ THH:mm:ss.sss
       <p>Each _TypedArray_ constructor:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %TypedArray%.</li>
-        <li>has a `"name"` property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.</li>
+        <li>has a *"name"* property whose value is the String value of the constructor name specified for it in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -35320,7 +35320,7 @@ THH:mm:ss.sss
       <p>The Map constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Map%</dfn>.</li>
-        <li>is the initial value of the `"Map"` property of the global object.</li>
+        <li>is the initial value of the *"Map"* property of the global object.</li>
         <li>creates and initializes a new Map object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behaviour must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
@@ -35331,10 +35331,10 @@ THH:mm:ss.sss
         <p>When the `Map` function is called with optional argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Map.prototype%"`, &laquo; [[MapData]] &raquo;).
+          1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Map.prototype%"*, &laquo; [[MapData]] &raquo;).
           1. Set _map_.[[MapData]] to a new empty List.
           1. If _iterable_ is not present, or is either *undefined* or *null*, return _map_.
-          1. Let _adder_ be ? Get(_map_, `"set"`).
+          1. Let _adder_ be ? Get(_map_, *"set"*).
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -35356,9 +35356,9 @@ THH:mm:ss.sss
             1. If Type(_nextItem_) is not Object, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iteratorRecord_, _error_).
-            1. Let _k_ be Get(_nextItem_, `"0"`).
+            1. Let _k_ be Get(_nextItem_, *"0"*).
             1. If _k_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _k_).
-            1. Let _v_ be Get(_nextItem_, `"1"`).
+            1. Let _v_ be Get(_nextItem_, *"1"*).
             1. If _v_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _v_).
             1. Let _status_ be Call(_adder_, _target_, &laquo; _k_.[[Value]], _v_.[[Value]] &raquo;).
             1. If _status_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _status_).
@@ -35389,7 +35389,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
+        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>Methods that create derived collection objects should call @@species to determine the constructor to use to create the derived objects. Subclass constructor may over-ride @@species to change the default constructor assignment.</p>
         </emu-note>
@@ -35556,7 +35556,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype-@@iterator">
         <h1>Map.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is the same function object as the initial value of the `"entries"` property.</p>
+        <p>The initial value of the @@iterator property is the same function object as the initial value of the *"entries"* property.</p>
       </emu-clause>
 
       <emu-clause id="sec-map.prototype-@@tostringtag">
@@ -35690,7 +35690,7 @@ THH:mm:ss.sss
       <p>The Set constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Set%</dfn>.</li>
-        <li>is the initial value of the `"Set"` property of the global object.</li>
+        <li>is the initial value of the *"Set"* property of the global object.</li>
         <li>creates and initializes a new Set object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behaviour must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
@@ -35701,11 +35701,11 @@ THH:mm:ss.sss
         <p>When the `Set` function is called with optional argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Set.prototype%"`, &laquo; [[SetData]] &raquo;).
+          1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Set.prototype%"*, &laquo; [[SetData]] &raquo;).
           1. Set _set_.[[SetData]] to a new empty List.
           1. If _iterable_ is not present, set _iterable_ to *undefined*.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
-          1. Let _adder_ be ? Get(_set_, `"add"`).
+          1. Let _adder_ be ? Get(_set_, *"add"*).
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
           1. Repeat,
@@ -35738,7 +35738,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
+        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>Methods that create derived collection objects should call @@species to determine the constructor to use to create the derived objects. Subclass constructor may over-ride @@species to change the default constructor assignment.</p>
         </emu-note>
@@ -35861,7 +35861,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.keys">
         <h1>Set.prototype.keys ( )</h1>
-        <p>The initial value of the `"keys"` property is the same function object as the initial value of the `"values"` property.</p>
+        <p>The initial value of the *"keys"* property is the same function object as the initial value of the *"values"* property.</p>
         <emu-note>
           <p>For iteration purposes, a Set appears similar to a Map where each entry has the same value for its key and value.</p>
         </emu-note>
@@ -35892,7 +35892,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype-@@iterator">
         <h1>Set.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is the same function object as the initial value of the `"values"` property.</p>
+        <p>The initial value of the @@iterator property is the same function object as the initial value of the *"values"* property.</p>
       </emu-clause>
 
       <emu-clause id="sec-set.prototype-@@tostringtag">
@@ -36029,7 +36029,7 @@ THH:mm:ss.sss
       <p>The WeakMap constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%WeakMap%</dfn>.</li>
-        <li>is the initial value of the `"WeakMap"` property of the global object.</li>
+        <li>is the initial value of the *"WeakMap"* property of the global object.</li>
         <li>creates and initializes a new WeakMap object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behaviour must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
@@ -36040,10 +36040,10 @@ THH:mm:ss.sss
         <p>When the `WeakMap` function is called with optional argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakMap.prototype%"`, &laquo; [[WeakMapData]] &raquo;).
+          1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakMap.prototype%"*, &laquo; [[WeakMapData]] &raquo;).
           1. Set _map_.[[WeakMapData]] to a new empty List.
           1. If _iterable_ is not present, or is either *undefined* or *null*, return _map_.
-          1. Let _adder_ be ? Get(_map_, `"set"`).
+          1. Let _adder_ be ? Get(_map_, *"set"*).
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -36175,7 +36175,7 @@ THH:mm:ss.sss
       <p>The WeakSet constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%WeakSet%</dfn>.</li>
-        <li>is the initial value of the `"WeakSet"` property of the global object.</li>
+        <li>is the initial value of the *"WeakSet"* property of the global object.</li>
         <li>creates and initializes a new WeakSet object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behaviour must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
@@ -36186,11 +36186,11 @@ THH:mm:ss.sss
         <p>When the `WeakSet` function is called with optional argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%WeakSet.prototype%"`, &laquo; [[WeakSetData]] &raquo;).
+          1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakSet.prototype%"*, &laquo; [[WeakSetData]] &raquo;).
           1. Set _set_.[[WeakSetData]] to a new empty List.
           1. If _iterable_ is not present, set _iterable_ to *undefined*.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
-          1. Let _adder_ be ? Get(_set_, `"add"`).
+          1. Let _adder_ be ? Get(_set_, *"add"*).
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
           1. Repeat,
@@ -36309,7 +36309,7 @@ THH:mm:ss.sss
         <h1>AllocateArrayBuffer ( _constructor_, _byteLength_ )</h1>
         <p>The abstract operation AllocateArrayBuffer with arguments _constructor_ and _byteLength_ is used to create an ArrayBuffer object. It performs the following steps:</p>
         <emu-alg>
-          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, `"%ArrayBuffer.prototype%"`, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] &raquo;).
+          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%ArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] &raquo;).
           1. Assert: _byteLength_ is an integer value &ge; 0.
           1. Let _block_ be ? CreateByteDataBlock(_byteLength_).
           1. Set _obj_.[[ArrayBufferData]] to _block_.
@@ -36515,7 +36515,7 @@ THH:mm:ss.sss
       <p>The ArrayBuffer constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%ArrayBuffer%</dfn>.</li>
-        <li>is the initial value of the `"ArrayBuffer"` property of the global object.</li>
+        <li>is the initial value of the *"ArrayBuffer"* property of the global object.</li>
         <li>creates and initializes a new ArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behaviour must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
@@ -36562,7 +36562,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
+        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>ArrayBuffer prototype methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -36652,7 +36652,7 @@ THH:mm:ss.sss
         <h1>AllocateSharedArrayBuffer ( _constructor_, _byteLength_ )</h1>
         <p>The abstract operation AllocateSharedArrayBuffer with arguments _constructor_ and _byteLength_ is used to create a SharedArrayBuffer object. It performs the following steps:</p>
         <emu-alg>
-          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, `"%SharedArrayBuffer.prototype%"`, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
+          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%SharedArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
           1. Assert: _byteLength_ is a nonnegative integer.
           1. Let _block_ be ? CreateSharedByteDataBlock(_byteLength_).
           1. Set _obj_.[[ArrayBufferData]] to _block_.
@@ -36680,7 +36680,7 @@ THH:mm:ss.sss
       <p>The SharedArrayBuffer constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%SharedArrayBuffer%</dfn>.</li>
-        <li>is the initial value of the `"SharedArrayBuffer"` property of the global object.</li>
+        <li>is the initial value of the *"SharedArrayBuffer"* property of the global object.</li>
         <li>creates and initializes a new SharedArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `SharedArrayBuffer` behaviour must include a `super` call to the `SharedArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
@@ -36721,7 +36721,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
+        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -36847,7 +36847,7 @@ THH:mm:ss.sss
       <p>The DataView constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%DataView%</dfn>.</li>
-        <li>is the initial value of the `"DataView"` property of the global object.</li>
+        <li>is the initial value of the *"DataView"* property of the global object.</li>
         <li>creates and initializes a new DataView object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behaviour must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
@@ -36868,7 +36868,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _viewByteLength_ be ? ToIndex(_byteLength_).
             1. If _offset_ + _viewByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%DataView.prototype%"`, &laquo; [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%DataView.prototype%"*, &laquo; [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] &raquo;).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
           1. Set _O_.[[ByteLength]] to _viewByteLength_.
@@ -37165,7 +37165,7 @@ THH:mm:ss.sss
     <p>The Atomics object:</p>
     <ul>
       <li>is the intrinsic object <dfn>%Atomics%</dfn>.</li>
-      <li>is the initial value of the `"Atomics"` property of the global object.</li>
+      <li>is the initial value of the *"Atomics"* property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
@@ -37188,7 +37188,7 @@ THH:mm:ss.sss
           1. Let _typeName_ be _typedArray_.[[TypedArrayName]].
           1. Let _type_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _typeName_.
           1. If _waitable_ is *true*, then
-            1. If _typeName_ is not `"Int32Array"` or `"BigInt64Array"`, throw a *TypeError* exception.
+            1. If _typeName_ is not *"Int32Array"* or *"BigInt64Array"*, throw a *TypeError* exception.
           1. Else,
             1. If ! IsUnclampedIntegerElementType(_type_) is *false* and ! IsBigIntElementType(_type_) is *false*, throw a *TypeError* exception.
           1. Assert: _typedArray_ has a [[ViewedArrayBuffer]] internal slot.
@@ -37449,7 +37449,7 @@ THH:mm:ss.sss
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. If _arrayTypeName_ is `"BigUint64Array"` or `"BigInt64Array"`, let _v_ be ? ToBigInt(_value_).
+        1. If _arrayTypeName_ is *"BigUint64Array"* or *"BigInt64Array"*, let _v_ be ? ToBigInt(_value_).
         1. Otherwise, let _v_ be ? ToInteger(_value_).
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
@@ -37476,7 +37476,7 @@ THH:mm:ss.sss
         1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_, *true*).
         1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. If _arrayTypeName_ is `"BigInt64Array"`, let _v_ be ? ToBigInt64(_value_).
+        1. If _arrayTypeName_ is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
         1. Otherwise, let _v_ be ? ToInt32(_value_).
         1. Let _q_ be ? ToNumber(_timeout_).
         1. If _q_ is *NaN*, let _t_ be *+&infin;*; else let _t_ be max(_q_, 0).
@@ -37491,7 +37491,7 @@ THH:mm:ss.sss
         1. Let _w_ be ! AtomicLoad(_typedArray_, _i_).
         1. If _v_ is not equal to _w_, then
           1. Perform LeaveCriticalSection(_WL_).
-          1. Return the String `"not-equal"`.
+          1. Return the String *"not-equal"*.
         1. Let _W_ be AgentSignifier().
         1. Perform AddWaiter(_WL_, _W_).
         1. Let _notified_ be Suspend(_WL_, _W_, _t_).
@@ -37500,8 +37500,8 @@ THH:mm:ss.sss
         1. Else,
           1. Perform RemoveWaiter(_WL_, _W_).
         1. Perform LeaveCriticalSection(_WL_).
-        1. If _notified_ is *true*, return the String `"ok"`.
-        1. Return the String `"timed-out"`.
+        1. If _notified_ is *true*, return the String *"ok"*.
+        1. Return the String *"timed-out"*.
       </emu-alg>
     </emu-clause>
 
@@ -37555,7 +37555,7 @@ THH:mm:ss.sss
     <p>The JSON object:</p>
     <ul>
       <li>is the intrinsic object <dfn>%JSON%</dfn>.</li>
-      <li>is the initial value of the `"JSON"` property of the global object.</li>
+      <li>is the initial value of the *"JSON"* property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>contains two functions, `parse` and `stringify`, that are used to parse and construct JSON texts.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -37571,7 +37571,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _JText_ be ? ToString(_text_).
         1. Parse _JText_ interpreted as UTF-16 encoded Unicode points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if _JText_ is not a valid JSON text as defined in that specification.
-        1. Let _scriptText_ be the string-concatenation of `"("`, _JText_, and `");"`.
+        1. Let _scriptText_ be the string-concatenation of *"("*, _JText_, and *");"*.
         1. Let _completion_ be the result of parsing and evaluating _scriptText_ as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
@@ -37584,7 +37584,7 @@ THH:mm:ss.sss
           1. Return _unfiltered_.
       </emu-alg>
       <p>This function is the <dfn>%JSONParse%</dfn> intrinsic object.</p>
-      <p>The `"length"` property of the `parse` function is 2.</p>
+      <p>The *"length"* property of the `parse` function is 2.</p>
       <emu-note>
         <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by Step 4 above. Step 2 verifies that _JText_ conforms to that subset, and step 6 verifies that that parsing and evaluation returns a value of an appropriate type.</p>
       </emu-note>
@@ -37671,7 +37671,7 @@ THH:mm:ss.sss
         1. Return ? SerializeJSONProperty(the empty String, _wrapper_).
       </emu-alg>
       <p>This function is the <dfn>%JSONStringify%</dfn> intrinsic object.</p>
-      <p>The `"length"` property of the `stringify` function is 3.</p>
+      <p>The *"length"* property of the `stringify` function is 3.</p>
       <emu-note>
         <p>JSON structures are allowed to be nested to any depth, but they must be acyclic. If _value_ is or contains a cyclic structure, then the stringify function must throw a *TypeError* exception. This is an example of a value that cannot be stringified:</p>
         <pre><code class="javascript">
@@ -37684,16 +37684,16 @@ THH:mm:ss.sss
         <p>Symbolic primitive values are rendered as follows:</p>
         <ul>
           <li>
-            The *null* value is rendered in JSON text as the String `"null"`.
+            The *null* value is rendered in JSON text as the String *"null"*.
           </li>
           <li>
             The *undefined* value is not rendered.
           </li>
           <li>
-            The *true* value is rendered in JSON text as the String `"true"`.
+            The *true* value is rendered in JSON text as the String *"true"*.
           </li>
           <li>
-            The *false* value is rendered in JSON text as the String `"false"`.
+            The *false* value is rendered in JSON text as the String *"false"*.
           </li>
         </ul>
       </emu-note>
@@ -37701,10 +37701,10 @@ THH:mm:ss.sss
         <p>String values are wrapped in QUOTATION MARK (`"`) code units. The code units `"` and `\\` are escaped with `\\` prefixes. Control characters code units are replaced with escape sequences `\\u`HHHH, or with the shorter forms, `\\b` (BACKSPACE), `\\f` (FORM FEED), `\\n` (LINE FEED), `\\r` (CARRIAGE RETURN), `\\t` (CHARACTER TABULATION).</p>
       </emu-note>
       <emu-note>
-        <p>Finite numbers are stringified as if by calling ToString(_number_). *NaN* and *Infinity* regardless of sign are represented as the String `"null"`.</p>
+        <p>Finite numbers are stringified as if by calling ToString(_number_). *NaN* and *Infinity* regardless of sign are represented as the String *"null"*.</p>
       </emu-note>
       <emu-note>
-        <p>Values that do not have a JSON representation (such as *undefined* and functions) do not produce a String. Instead they produce the *undefined* value. In arrays these values are represented as the String `"null"`. In objects an unrepresentable value causes the property to be excluded from stringification.</p>
+        <p>Values that do not have a JSON representation (such as *undefined* and functions) do not produce a String. Instead they produce the *undefined* value. In arrays these values are represented as the String *"null"*. In objects an unrepresentable value causes the property to be excluded from stringification.</p>
       </emu-note>
       <emu-note>
         <p>An object is rendered as U+007B (LEFT CURLY BRACKET) followed by zero or more properties, separated with a U+002C (COMMA), closed with a U+007D (RIGHT CURLY BRACKET). A property is a quoted String representing the key or property name, a U+003A (COLON), and then the stringified property value. An array is rendered as an opening U+005B (LEFT SQUARE BRACKET followed by zero or more values, separated with a U+002C (COMMA), closed with a U+005D (RIGHT SQUARE BRACKET).</p>
@@ -37716,7 +37716,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _value_ be ? Get(_holder_, _key_).
           1. If Type(_value_) is Object, then
-            1. Let _toJSON_ be ? Get(_value_, `"toJSON"`).
+            1. Let _toJSON_ be ? Get(_value_, *"toJSON"*).
             1. If IsCallable(_toJSON_) is *true*, then
               1. Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).
           1. If _ReplacerFunction_ is not *undefined*, then
@@ -37730,13 +37730,13 @@ THH:mm:ss.sss
               1. Set _value_ to _value_.[[BooleanData]].
             1. Else if _value_ has a [[BigIntData]] internal slot, then
               1. Set _value_ to _value_.[[BigIntData]].
-          1. If _value_ is *null*, return `"null"`.
-          1. If _value_ is *true*, return `"true"`.
-          1. If _value_ is *false*, return `"false"`.
+          1. If _value_ is *null*, return *"null"*.
+          1. If _value_ is *true*, return *"true"*.
+          1. If _value_ is *false*, return *"false"*.
           1. If Type(_value_) is String, return QuoteJSONString(_value_).
           1. If Type(_value_) is Number, then
             1. If _value_ is finite, return ! ToString(_value_).
-            1. Return `"null"`.
+            1. Return *"null"*.
           1. If Type(_value_) is BigInt, throw a *TypeError* exception.
           1. If Type(_value_) is Object and IsCallable(_value_) is *false*, then
             1. Let _isArray_ be ? IsArray(_value_).
@@ -37868,7 +37868,7 @@ THH:mm:ss.sss
           1. Assert: _n_ &le; 0xFFFF.
           1. Return the string-concatenation of:
             * the code unit 0x005C (REVERSE SOLIDUS)
-            * `"u"`
+            * *"u"*
             * the String representation of _n_, formatted as a four-digit lowercase hexadecimal number, padded to the left with zeroes if necessary
         </emu-alg>
       </emu-clause>
@@ -37890,21 +37890,21 @@ THH:mm:ss.sss
             1. Let _strP_ be ? SerializeJSONProperty(_P_, _value_).
             1. If _strP_ is not *undefined*, then
               1. Let _member_ be QuoteJSONString(_P_).
-              1. Set _member_ to the string-concatenation of _member_ and `":"`.
+              1. Set _member_ to the string-concatenation of _member_ and *":"*.
               1. If _gap_ is not the empty String, then
                 1. Set _member_ to the string-concatenation of _member_ and the code unit 0x0020 (SPACE).
               1. Set _member_ to the string-concatenation of _member_ and _strP_.
               1. Append _member_ to _partial_.
           1. If _partial_ is empty, then
-            1. Let _final_ be `"{}"`.
+            1. Let _final_ be *"{}"*.
           1. Else,
             1. If _gap_ is the empty String, then
               1. Let _properties_ be the String value formed by concatenating all the element Strings of _partial_ with each adjacent pair of Strings separated with the code unit 0x002C (COMMA). A comma is not inserted either before the first String or after the last String.
-              1. Let _final_ be the string-concatenation of `"{"`, _properties_, and `"}"`.
+              1. Let _final_ be the string-concatenation of *"{"*, _properties_, and *"}"*.
             1. Else,
               1. Let _separator_ be the string-concatenation of the code unit 0x002C (COMMA), the code unit 0x000A (LINE FEED), and _indent_.
               1. Let _properties_ be the String value formed by concatenating all the element Strings of _partial_ with each adjacent pair of Strings separated with _separator_. The _separator_ String is not inserted either before the first String or after the last String.
-              1. Let _final_ be the string-concatenation of `"{"`, the code unit 0x000A (LINE FEED), _indent_, _properties_, the code unit 0x000A (LINE FEED), _stepback_, and `"}"`.
+              1. Let _final_ be the string-concatenation of *"{"*, the code unit 0x000A (LINE FEED), _indent_, _properties_, the code unit 0x000A (LINE FEED), _stepback_, and *"}"*.
           1. Remove the last element of _stack_.
           1. Set _indent_ to _stepback_.
           1. Return _final_.
@@ -37925,20 +37925,20 @@ THH:mm:ss.sss
           1. Repeat, while _index_ &lt; _len_
             1. Let _strP_ be ? SerializeJSONProperty(! ToString(_index_), _value_).
             1. If _strP_ is *undefined*, then
-              1. Append `"null"` to _partial_.
+              1. Append *"null"* to _partial_.
             1. Else,
               1. Append _strP_ to _partial_.
             1. Set _index_ to _index_ + 1.
           1. If _partial_ is empty, then
-            1. Let _final_ be `"[]"`.
+            1. Let _final_ be *"[]"*.
           1. Else,
             1. If _gap_ is the empty String, then
               1. Let _properties_ be the String value formed by concatenating all the element Strings of _partial_ with each adjacent pair of Strings separated with the code unit 0x002C (COMMA). A comma is not inserted either before the first String or after the last String.
-              1. Let _final_ be the string-concatenation of `"["`, _properties_, and `"]"`.
+              1. Let _final_ be the string-concatenation of *"["*, _properties_, and *"]"*.
             1. Else,
               1. Let _separator_ be the string-concatenation of the code unit 0x002C (COMMA), the code unit 0x000A (LINE FEED), and _indent_.
               1. Let _properties_ be the String value formed by concatenating all the element Strings of _partial_ with each adjacent pair of Strings separated with _separator_. The _separator_ String is not inserted either before the first String or after the last String.
-              1. Let _final_ be the string-concatenation of `"["`, the code unit 0x000A (LINE FEED), _indent_, _properties_, the code unit 0x000A (LINE FEED), _stepback_, and `"]"`.
+              1. Let _final_ be the string-concatenation of *"["*, the code unit 0x000A (LINE FEED), _indent_, _properties_, the code unit 0x000A (LINE FEED), _stepback_, and *"]"*.
           1. Remove the last element of _stack_.
           1. Set _indent_ to _stepback_.
           1. Return _final_.
@@ -38019,13 +38019,13 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `"next"`
+                *"next"*
               </td>
               <td>
                 A function that returns an <i>IteratorResult</i> object.
               </td>
               <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>Iterator</i> has returned an <i>IteratorResult</i> object whose `"done"` property is *true*, then all subsequent calls to the `next` method of that object should also return an <i>IteratorResult</i> object whose `"done"` property is *true*. However, this requirement is not enforced.
+                The returned object must conform to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>Iterator</i> has returned an <i>IteratorResult</i> object whose *"done"* property is *true*, then all subsequent calls to the `next` method of that object should also return an <i>IteratorResult</i> object whose *"done"* property is *true*. However, this requirement is not enforced.
               </td>
             </tr>
             </tbody>
@@ -38050,24 +38050,24 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `"return"`
+                *"return"*
               </td>
               <td>
                 A function that returns an <i>IteratorResult</i> object.
               </td>
               <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller does not intend to make any more `next` method calls to the <i>Iterator</i>. The returned <i>IteratorResult</i> object will typically have a `"done"` property whose value is *true*, and a `"value"` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.
+                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller does not intend to make any more `next` method calls to the <i>Iterator</i>. The returned <i>IteratorResult</i> object will typically have a *"done"* property whose value is *true*, and a *"value"* property with the value passed as the argument of the `return` method. However, this requirement is not enforced.
               </td>
             </tr>
             <tr>
               <td>
-                `"throw"`
+                *"throw"*
               </td>
               <td>
                 A function that returns an <i>IteratorResult</i> object.
               </td>
               <td>
-                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to `throw` the value passed as the argument. If the method does not `throw`, the returned <i>IteratorResult</i> object will typically have a `"done"` property whose value is *true*.
+                The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to `throw` the value passed as the argument. If the method does not `throw`, the returned <i>IteratorResult</i> object will typically have a *"done"* property whose value is *true*.
               </td>
             </tr>
             </tbody>
@@ -38111,12 +38111,12 @@ THH:mm:ss.sss
               <th>Requirements</th>
             </tr>
             <tr>
-              <td>`"next"`</td>
+              <td>*"next"*</td>
               <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
               <td>
-                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose `"done"` property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose `"done"` property is *true*. However, this requirement is not enforced.</p>
+                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose *"done"* property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose *"done"* property is *true*. However, this requirement is not enforced.</p>
 
-                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `"value"` property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
+                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a *"value"* property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
               </td>
             </tr>
             </tbody>
@@ -38134,21 +38134,21 @@ THH:mm:ss.sss
               <th>Requirements</th>
             </tr>
             <tr>
-              <td>`"return"`</td>
+              <td>*"return"*</td>
               <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
               <td>
-                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a `"done"` property whose value is *true*, and a `"value"` property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
+                <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a *"done"* property whose value is *true*, and a *"value"* property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
 
-                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a `"value"` property whose value is not a promise (or "thenable"). If the argument value is used in the typical manner, then if it is a rejected promise, a promise rejected with the same reason should be returned; if it is a fulfilled promise, then its fulfillment value should be used as the `"value"` property of the returned promise's <i>IteratorResult</i> object fulfillment value. However, these requirements are also not enforced.</p>
+                <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a *"value"* property whose value is not a promise (or "thenable"). If the argument value is used in the typical manner, then if it is a rejected promise, a promise rejected with the same reason should be returned; if it is a fulfilled promise, then its fulfillment value should be used as the *"value"* property of the returned promise's <i>IteratorResult</i> object fulfillment value. However, these requirements are also not enforced.</p>
               </td>
             </tr>
             <tr>
-              <td>`"throw"`</td>
+              <td>*"throw"*</td>
               <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
               <td>
                 <p>The returned promise, when fulfilled, must fulfill with an object which conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to return a rejected promise which rejects with the value passed as the argument.</p>
 
-                <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a `"done"` property whose value is *true*. Additionally, it should have a `"value"` property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
+                <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a *"done"* property whose value is *true*. Additionally, it should have a *"value"* property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
               </td>
             </tr>
             </tbody>
@@ -38178,24 +38178,24 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>
-                `"done"`
+                *"done"*
               </td>
               <td>
                 Either *true* or *false*.
               </td>
               <td>
-                This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached `"done"` is *true*. If the end was not reached `"done"` is *false* and a value is available. If a `"done"` property (either own or inherited) does not exist, it is consider to have the value *false*.
+                This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached *"done"* is *true*. If the end was not reached *"done"* is *false* and a value is available. If a *"done"* property (either own or inherited) does not exist, it is consider to have the value *false*.
               </td>
             </tr>
             <tr>
               <td>
-                `"value"`
+                *"value"*
               </td>
               <td>
                 Any ECMAScript language value.
               </td>
               <td>
-                If done is *false*, this is the current iteration element value. If done is *true*, this is the return value of the iterator, if it supplied one. If the iterator does not have a return value, `"value"` is *undefined*. In that case, the `"value"` property may be absent from the conforming object if it does not inherit an explicit `"value"` property.
+                If done is *false*, this is the current iteration element value. If done is *true*, this is the return value of the iterator, if it supplied one. If the iterator does not have a return value, *"value"* is *undefined*. In that case, the *"value"* property may be absent from the conforming object if it does not inherit an explicit *"value"* property.
               </td>
             </tr>
             </tbody>
@@ -38223,7 +38223,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.iterator]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.iterator]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -38244,7 +38244,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"[Symbol.asyncIterator]"*.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.asyncIterator]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -38258,7 +38258,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _asyncIterator_ be ! ObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
           1. Set _asyncIterator_.[[SyncIteratorRecord]] to _syncIteratorRecord_.
-          1. Let _nextMethod_ be ! Get(_asyncIterator_, `"next"`).
+          1. Let _nextMethod_ be ! Get(_asyncIterator_, *"next"*).
           1. Let _iteratorRecord_ be the Record { [[Iterator]]: _asyncIterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
           1. Return _iteratorRecord_.
         </emu-alg>
@@ -38295,7 +38295,7 @@ THH:mm:ss.sss
             1. Assert: Type(_O_) is Object and _O_ has a [[SyncIteratorRecord]] internal slot.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
-            1. Let _return_ be GetMethod(_syncIterator_, `"return"`).
+            1. Let _return_ be GetMethod(_syncIterator_, *"return"*).
             1. IfAbruptRejectPromise(_return_, _promiseCapability_).
             1. If _return_ is *undefined*, then
               1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
@@ -38318,7 +38318,7 @@ THH:mm:ss.sss
             1. Assert: Type(_O_) is Object and _O_ has a [[SyncIteratorRecord]] internal slot.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
-            1. Let _throw_ be GetMethod(_syncIterator_, `"throw"`).
+            1. Let _throw_ be GetMethod(_syncIterator_, *"throw"*).
             1. IfAbruptRejectPromise(_throw_, _promiseCapability_).
             1. If _throw_ is *undefined*, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
@@ -38335,7 +38335,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-async-from-sync-iterator-value-unwrap-functions">
           <h1>Async-from-Sync Iterator Value Unwrap Functions</h1>
 
-          <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by AsyncFromSyncIteratorContinuation when processing the `"value"` property of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async-from-sync iterator value unwrap function has a [[Done]] internal slot.</p>
+          <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by AsyncFromSyncIteratorContinuation when processing the *"value"* property of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async-from-sync iterator value unwrap function has a [[Done]] internal slot.</p>
 
           <p>When an async-from-sync iterator value unwrap function is called with argument _value_, the following steps are taken:</p>
 
@@ -38432,7 +38432,7 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
-        <li>has a `"name"` property whose value is *"GeneratorFunction"*.</li>
+        <li>has a *"name"* property whose value is *"GeneratorFunction"*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -38454,7 +38454,7 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-56"></emu-xref>.</li>
-        <li>is the value of the `"prototype"` property of %GeneratorFunction%.</li>
+        <li>is the value of the *"prototype"* property of %GeneratorFunction%.</li>
         <li>is the intrinsic object <dfn>%Generator%</dfn> (see Figure 2).</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
@@ -38485,20 +38485,20 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction-instances-length">
         <h1>length</h1>
-        <p>The specification for the `"length"` property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to GeneratorFunction instances.</p>
+        <p>The specification for the *"length"* property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to GeneratorFunction instances.</p>
       </emu-clause>
 
       <emu-clause id="sec-generatorfunction-instances-name">
         <h1>name</h1>
-        <p>The specification for the `"name"` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to GeneratorFunction instances.</p>
+        <p>The specification for the *"name"* property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to GeneratorFunction instances.</p>
       </emu-clause>
 
       <emu-clause id="sec-generatorfunction-instances-prototype">
         <h1>prototype</h1>
-        <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's `"prototype"` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
+        <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's `"prototype"` property does not have a `"constructor"` property whose value is the GeneratorFunction instance.</p>
+          <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's *"prototype"* property does not have a *"constructor"* property whose value is the GeneratorFunction instance.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -38538,7 +38538,7 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
-        <li>has a `"name"` property whose value is *"AsyncGeneratorFunction"*.</li>
+        <li>has a *"name"* property whose value is *"AsyncGeneratorFunction"*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -38560,7 +38560,7 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
-        <li>is the value of the `"prototype"` property of %AsyncGeneratorFunction%.</li>
+        <li>is the value of the *"prototype"* property of %AsyncGeneratorFunction%.</li>
         <li>is %AsyncGenerator%.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
@@ -38591,21 +38591,21 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-length">
         <h1>length</h1>
-        <p>The value of the `"length"` property is an integer that indicates the typical number of arguments expected by the AsyncGeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of an AsyncGeneratorFunction when invoked on a number of arguments other than the number specified by its `"length"` property depends on the function.</p>
+        <p>The value of the *"length"* property is an integer that indicates the typical number of arguments expected by the AsyncGeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of an AsyncGeneratorFunction when invoked on a number of arguments other than the number specified by its *"length"* property depends on the function.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-name">
         <h1>name</h1>
-        <p>The specification for the `"name"` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncGeneratorFunction instances.</p>
+        <p>The specification for the *"name"* property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncGeneratorFunction instances.</p>
       </emu-clause>
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-prototype">
         <h1>prototype</h1>
-        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's `"prototype"` property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator object when the generator function object is invoked using [[Call]].</p>
+        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator object when the generator function object is invoked using [[Call]].</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Unlike function instances, the object that is the value of the an AsyncGeneratorFunction's `"prototype"` property does not have a `"constructor"` property whose value is the AsyncGeneratorFunction instance.</p>
+          <p>Unlike function instances, the object that is the value of the an AsyncGeneratorFunction's *"prototype"* property does not have a *"constructor"* property whose value is the AsyncGeneratorFunction instance.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -38614,14 +38614,14 @@ THH:mm:ss.sss
   <emu-clause id="sec-generator-objects">
     <h1>Generator Objects</h1>
     <p>A Generator object is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
-    <p>Generator instances directly inherit properties from the object that is the value of the `"prototype"` property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %Generator.prototype%.</p>
+    <p>Generator instances directly inherit properties from the object that is the value of the *"prototype"* property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %Generator.prototype%.</p>
 
     <emu-clause id="sec-properties-of-generator-prototype">
       <h1>Properties of the Generator Prototype Object</h1>
       <p>The Generator prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%GeneratorPrototype%</dfn>.</li>
-        <li>is the initial value of the `"prototype"` property of %Generator% (the `GeneratorFunction.prototype`).</li>
+        <li>is the initial value of the *"prototype"* property of %Generator% (the `GeneratorFunction.prototype`).</li>
         <li>is an ordinary object.</li>
         <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
@@ -38824,14 +38824,14 @@ THH:mm:ss.sss
     <h1>AsyncGenerator Objects</h1>
     <p>An AsyncGenerator object is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
 
-    <p>AsyncGenerator instances directly inherit properties from the object that is the value of the `"prototype"` property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGenerator.prototype%.</p>
+    <p>AsyncGenerator instances directly inherit properties from the object that is the value of the *"prototype"* property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGenerator.prototype%.</p>
 
     <emu-clause id="sec-properties-of-asyncgenerator-prototype">
       <h1>Properties of the AsyncGenerator Prototype Object</h1>
       <p>The AsyncGenerator prototype object:</p>
       <ul>
         <li>is the intrinsic object <dfn>%AsyncGeneratorPrototype%</dfn>.</li>
-        <li>is the initial value of the `"prototype"` property of %AsyncGenerator% (the `AsyncGeneratorFunction.prototype`).</li>
+        <li>is the initial value of the *"prototype"* property of %AsyncGenerator% (the `AsyncGeneratorFunction.prototype`).</li>
         <li>is an ordinary object.</li>
         <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %AsyncIteratorPrototype%.</li>
@@ -39047,7 +39047,7 @@ THH:mm:ss.sss
             1. Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
           </emu-alg>
 
-          <p>The `"length"` property of an AsyncGeneratorResumeNext return processor fulfilled function is 1.</p>
+          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor fulfilled function is 1.</p>
         </emu-clause>
 
         <emu-clause id="async-generator-resume-next-return-processor-rejected">
@@ -39063,7 +39063,7 @@ THH:mm:ss.sss
             1. Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
           </emu-alg>
 
-          <p>The `"length"` property of an AsyncGeneratorResumeNext return processor rejected function is 1.</p>
+          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor rejected function is 1.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39288,7 +39288,7 @@ THH:mm:ss.sss
             1. Set _alreadyResolved_.[[Value]] to *true*.
             1. Return RejectPromise(_promise_, _reason_).
           </emu-alg>
-          <p>The `"length"` property of a promise reject function is 1.</p>
+          <p>The *"length"* property of a promise reject function is 1.</p>
         </emu-clause>
 
         <emu-clause id="sec-promise-resolve-functions">
@@ -39307,16 +39307,16 @@ THH:mm:ss.sss
               1. Return RejectPromise(_promise_, _selfResolutionError_).
             1. If Type(_resolution_) is not Object, then
               1. Return FulfillPromise(_promise_, _resolution_).
-            1. Let _then_ be Get(_resolution_, `"then"`).
+            1. Let _then_ be Get(_resolution_, *"then"*).
             1. If _then_ is an abrupt completion, then
               1. Return RejectPromise(_promise_, _then_.[[Value]]).
             1. Let _thenAction_ be _then_.[[Value]].
             1. If IsCallable(_thenAction_) is *false*, then
               1. Return FulfillPromise(_promise_, _resolution_).
-            1. Perform EnqueueJob(`"PromiseJobs"`, PromiseResolveThenableJob, &laquo; _promise_, _resolution_, _thenAction_ &raquo;).
+            1. Perform EnqueueJob(*"PromiseJobs"*, PromiseResolveThenableJob, &laquo; _promise_, _resolution_, _thenAction_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The `"length"` property of a promise resolve function is 1.</p>
+          <p>The *"length"* property of a promise resolve function is 1.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39368,7 +39368,7 @@ THH:mm:ss.sss
             1. Set _promiseCapability_.[[Reject]] to _reject_.
             1. Return *undefined*.
           </emu-alg>
-          <p>The `"length"` property of a GetCapabilitiesExecutor function is 2.</p>
+          <p>The *"length"* property of a GetCapabilitiesExecutor function is 2.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39392,7 +39392,7 @@ THH:mm:ss.sss
           1. Set _promise_.[[PromiseFulfillReactions]] to *undefined*.
           1. Set _promise_.[[PromiseRejectReactions]] to *undefined*.
           1. Set _promise_.[[PromiseState]] to ~rejected~.
-          1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"reject"`).
+          1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, *"reject"*).
           1. Return TriggerPromiseReactions(_reactions_, _reason_).
         </emu-alg>
       </emu-clause>
@@ -39402,7 +39402,7 @@ THH:mm:ss.sss
         <p>The abstract operation TriggerPromiseReactions takes a collection of PromiseReactionRecords and enqueues a new Job for each record. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReactionRecord, and if the [[Handler]] is a function, calls it passing the given argument. If the [[Handler]] is *undefined*, the behaviour is determined by the [[Type]].</p>
         <emu-alg>
           1. For each _reaction_ in _reactions_, in original insertion order, do
-            1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _reaction_, _argument_ &raquo;).
+            1. Perform EnqueueJob(*"PromiseJobs"*, PromiseReactionJob, &laquo; _reaction_, _argument_ &raquo;).
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>
@@ -39418,15 +39418,15 @@ THH:mm:ss.sss
           <p>HostPromiseRejectionTracker is called in two scenarios:</p>
 
           <ul>
-            <li>When a promise is rejected without any handlers, it is called with its _operation_ argument set to `"reject"`.</li>
-            <li>When a handler is added to a rejected promise for the first time, it is called with its _operation_ argument set to `"handle"`.</li>
+            <li>When a promise is rejected without any handlers, it is called with its _operation_ argument set to *"reject"*.</li>
+            <li>When a handler is added to a rejected promise for the first time, it is called with its _operation_ argument set to *"handle"*.</li>
           </ul>
 
           <p>A typical implementation of HostPromiseRejectionTracker might try to notify developers of unhandled rejections, while also being careful to notify them if such previous notifications are later invalidated by new handlers being attached.</p>
         </emu-note>
 
         <emu-note>
-          <p>If _operation_ is `"handle"`, an implementation should not hold a reference to _promise_ in a way that would interfere with garbage collection. An implementation may hold a reference to _promise_ if _operation_ is `"reject"`, since it is expected that rejections will be rare and not on hot code paths.</p>
+          <p>If _operation_ is *"handle"*, an implementation should not hold a reference to _promise_ in a way that would interfere with garbage collection. An implementation may hold a reference to _promise_ if _operation_ is *"reject"*, since it is expected that rejections will be rare and not on hot code paths.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -39481,7 +39481,7 @@ THH:mm:ss.sss
       <p>The Promise constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Promise%</dfn>.</li>
-        <li>is the initial value of the `"Promise"` property of the global object.</li>
+        <li>is the initial value of the *"Promise"* property of the global object.</li>
         <li>creates and initializes a new Promise object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behaviour must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
@@ -39493,7 +39493,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
-          1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%Promise.prototype%"`, &laquo; [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] &raquo;).
+          1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Promise.prototype%"*, &laquo; [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] &raquo;).
           1. Set _promise_.[[PromiseState]] to ~pending~.
           1. Set _promise_.[[PromiseFulfillReactions]] to a new empty List.
           1. Set _promise_.[[PromiseRejectReactions]] to a new empty List.
@@ -39548,7 +39548,7 @@ THH:mm:ss.sss
             1. Assert: _resultCapability_ is a PromiseCapability Record.
             1. Let _values_ be a new empty List.
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
-            1. Let _promiseResolve_ be ? Get(_constructor_, `"resolve"`).
+            1. Let _promiseResolve_ be ? Get(_constructor_, *"resolve"*).
             1. If ! IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
             1. Let _index_ be 0.
             1. Repeat,
@@ -39575,7 +39575,7 @@ THH:mm:ss.sss
               1. Set _resolveElement_.[[Capability]] to _resultCapability_.
               1. Set _resolveElement_.[[RemainingElements]] to _remainingElementsCount_.
               1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] + 1.
-              1. Perform ? Invoke(_nextPromise_, `"then"`, &laquo; _resolveElement_, _resultCapability_.[[Reject]] &raquo;).
+              1. Perform ? Invoke(_nextPromise_, *"then"*, &laquo; _resolveElement_, _resultCapability_.[[Reject]] &raquo;).
               1. Set _index_ to _index_ + 1.
           </emu-alg>
         </emu-clause>
@@ -39600,7 +39600,7 @@ THH:mm:ss.sss
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The `"length"` property of a `Promise.all` resolve element function is 1.</p>
+          <p>The *"length"* property of a `Promise.all` resolve element function is 1.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39631,7 +39631,7 @@ THH:mm:ss.sss
             1. Let _values_ be a new empty List.
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
-            1. Let _promiseResolve_ be ? Get(_constructor_, `"resolve"`).
+            1. Let _promiseResolve_ be ? Get(_constructor_, *"resolve"*).
             1. If IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
             1. Repeat,
               1. Let _next_ be IteratorStep(_iteratorRecord_).
@@ -39665,7 +39665,7 @@ THH:mm:ss.sss
               1. Set _rejectElement_.[[Capability]] to _resultCapability_.
               1. Set _rejectElement_.[[RemainingElements]] to _remainingElementsCount_.
               1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] + 1.
-              1. Perform ? Invoke(_nextPromise_, `"then"`, &laquo; _resolveElement_, _rejectElement_ &raquo;).
+              1. Perform ? Invoke(_nextPromise_, *"then"*, &laquo; _resolveElement_, _rejectElement_ &raquo;).
               1. Set _index_ to _index_ + 1.
           </emu-alg>
         </emu-clause>
@@ -39684,8 +39684,8 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be _F_.[[Capability]].
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Let _obj_ be ! ObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"status"`, `"fulfilled"`).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"value"`, _x_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"fulfilled"*).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
@@ -39693,7 +39693,7 @@ THH:mm:ss.sss
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The `"length"` property of a `Promise.allSettled` resolve element function is 1.</p>
+          <p>The *"length"* property of a `Promise.allSettled` resolve element function is 1.</p>
         </emu-clause>
 
         <emu-clause id="sec-promise.allsettled-reject-element-functions">
@@ -39710,8 +39710,8 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be _F_.[[Capability]].
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Let _obj_ be ! ObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"status"`, `"rejected"`).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, `"reason"`, _x_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"rejected"*).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"reason"*, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
@@ -39719,7 +39719,7 @@ THH:mm:ss.sss
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The `"length"` property of a `Promise.allSettled` reject element function is 1.</p>
+          <p>The *"length"* property of a `Promise.allSettled` reject element function is 1.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39756,7 +39756,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
             1. Assert: _resultCapability_ is a PromiseCapability Record.
-            1. Let _promiseResolve_ be ? Get(_constructor_, `"resolve"`).
+            1. Let _promiseResolve_ be ? Get(_constructor_, *"resolve"*).
             1. If ! IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
             1. Repeat,
               1. Let _next_ be IteratorStep(_iteratorRecord_).
@@ -39769,7 +39769,7 @@ THH:mm:ss.sss
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
-              1. Perform ? Invoke(_nextPromise_, `"then"`, &laquo; _resultCapability_.[[Resolve]], _resultCapability_.[[Reject]] &raquo;).
+              1. Perform ? Invoke(_nextPromise_, *"then"*, &laquo; _resultCapability_.[[Resolve]], _resultCapability_.[[Reject]] &raquo;).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -39808,7 +39808,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: Type(_C_) is Object.
             1. If IsPromise(_x_) is *true*, then
-              1. Let _xConstructor_ be ? Get(_x_, `"constructor"`).
+              1. Let _xConstructor_ be ? Get(_x_, *"constructor"*).
               1. If SameValue(_xConstructor_, _C_) is *true*, return _x_.
             1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
             1. Perform ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _x_ &raquo;).
@@ -39823,7 +39823,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
-        <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
+        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
           <p>Promise prototype methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
@@ -39845,7 +39845,7 @@ THH:mm:ss.sss
         <p>When the `catch` method is called with argument _onRejected_, the following steps are taken:</p>
         <emu-alg>
           1. Let _promise_ be the *this* value.
-          1. Return ? Invoke(_promise_, `"then"`, &laquo; *undefined*, _onRejected_ &raquo;).
+          1. Return ? Invoke(_promise_, *"then"*, &laquo; *undefined*, _onRejected_ &raquo;).
         </emu-alg>
       </emu-clause>
 
@@ -39874,7 +39874,7 @@ THH:mm:ss.sss
             1. Let _catchFinally_ be ! CreateBuiltinFunction(_stepsCatchFinally_, &laquo; [[Constructor]], [[OnFinally]] &raquo;).
             1. Set _catchFinally_.[[Constructor]] to _C_.
             1. Set _catchFinally_.[[OnFinally]] to _onFinally_.
-          1. Return ? Invoke(_promise_, `"then"`, &laquo; _thenFinally_, _catchFinally_ &raquo;).
+          1. Return ? Invoke(_promise_, *"then"*, &laquo; _thenFinally_, _catchFinally_ &raquo;).
         </emu-alg>
 
         <emu-clause id="sec-thenfinallyfunctions">
@@ -39890,9 +39890,9 @@ THH:mm:ss.sss
             1. Assert: IsConstructor(_C_) is *true*.
             1. Let _promise_ be ? PromiseResolve(_C_, _result_).
             1. Let _valueThunk_ be equivalent to a function that returns _value_.
-            1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_ &raquo;).
+            1. Return ? Invoke(_promise_, *"then"*, &laquo; _valueThunk_ &raquo;).
           </emu-alg>
-          <p>The `"length"` property of a Then Finally function is *1*.</p>
+          <p>The *"length"* property of a Then Finally function is *1*.</p>
         </emu-clause>
 
         <emu-clause id="sec-catchfinallyfunctions">
@@ -39908,9 +39908,9 @@ THH:mm:ss.sss
             1. Assert: IsConstructor(_C_) is *true*.
             1. Let _promise_ be ? PromiseResolve(_C_, _result_).
             1. Let _thrower_ be equivalent to a function that throws _reason_.
-            1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_ &raquo;).
+            1. Return ? Invoke(_promise_, *"then"*, &laquo; _thrower_ &raquo;).
           </emu-alg>
-          <p>The `"length"` property of a Catch Finally function is *1*.</p>
+          <p>The *"length"* property of a Catch Finally function is *1*.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39946,12 +39946,12 @@ THH:mm:ss.sss
               1. Append _rejectReaction_ as the last element of the List that is _promise_.[[PromiseRejectReactions]].
             1. Else if _promise_.[[PromiseState]] is ~fulfilled~, then
               1. Let _value_ be _promise_.[[PromiseResult]].
-              1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _fulfillReaction_, _value_ &raquo;).
+              1. Perform EnqueueJob(*"PromiseJobs"*, PromiseReactionJob, &laquo; _fulfillReaction_, _value_ &raquo;).
             1. Else,
               1. Assert: The value of _promise_.[[PromiseState]] is ~rejected~.
               1. Let _reason_ be _promise_.[[PromiseResult]].
-              1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
-              1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _rejectReaction_, _reason_ &raquo;).
+              1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, *"handle"*).
+              1. Perform EnqueueJob(*"PromiseJobs"*, PromiseReactionJob, &laquo; _rejectReaction_, _reason_ &raquo;).
             1. Set _promise_.[[PromiseIsHandled]] to *true*.
             1. If _resultCapability_ is *undefined*, then
               1. Return *undefined*.
@@ -40066,7 +40066,7 @@ THH:mm:ss.sss
       <ul>
         <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
-        <li>has a `"name"` property whose value is *"AsyncFunction"*.</li>
+        <li>has a *"name"* property whose value is *"AsyncFunction"*.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -40088,7 +40088,7 @@ THH:mm:ss.sss
       <ul>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</li>
-        <li>is the value of the `"prototype"` property of %AsyncFunction%.</li>
+        <li>is the value of the *"prototype"* property of %AsyncFunction%.</li>
         <li>is the intrinsic object <dfn>%AsyncFunctionPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
@@ -40117,12 +40117,12 @@ THH:mm:ss.sss
       <p>Each AsyncFunction instance has the following own properties:</p>
       <emu-clause id="sec-async-function-instances-length">
         <h1>length</h1>
-        <p>The specification for the `"length"` property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to AsyncFunction instances.</p>
+        <p>The specification for the *"length"* property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to AsyncFunction instances.</p>
       </emu-clause>
 
       <emu-clause id="sec-async-function-instances-name">
         <h1>name</h1>
-        <p>The specification for the `"name"` property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncFunction instances.</p>
+        <p>The specification for the *"name"* property of Function instances given in <emu-xref href="#sec-function-instances-name"></emu-xref> also applies to AsyncFunction instances.</p>
       </emu-clause>
     </emu-clause>
 
@@ -40166,7 +40166,7 @@ THH:mm:ss.sss
     <p>The Reflect object:</p>
     <ul>
       <li>is the intrinsic object <dfn>%Reflect%</dfn>.</li>
-      <li>is the initial value of the `"Reflect"` property of the global object.</li>
+      <li>is the initial value of the *"Reflect"* property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       <li>is not a function object.</li>
@@ -40319,7 +40319,7 @@ THH:mm:ss.sss
       <p>The Proxy constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%Proxy%</dfn>.</li>
-        <li>is the initial value of the `"Proxy"` property of the global object.</li>
+        <li>is the initial value of the *"Proxy"* property of the global object.</li>
         <li>creates and initializes a new proxy exotic object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
       </ul>
@@ -40339,7 +40339,7 @@ THH:mm:ss.sss
       <p>The Proxy constructor:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>does not have a `"prototype"` property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
+        <li>does not have a *"prototype"* property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -40352,8 +40352,8 @@ THH:mm:ss.sss
           1. Let _revoker_ be ! CreateBuiltinFunction(_steps_, &laquo; [[RevocableProxy]] &raquo;).
           1. Set _revoker_.[[RevocableProxy]] to _p_.
           1. Let _result_ be ObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, `"proxy"`, _p_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, `"revoke"`, _revoker_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _p_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, *"revoke"*, _revoker_).
           1. Return _result_.
         </emu-alg>
 
@@ -40372,7 +40372,7 @@ THH:mm:ss.sss
             1. Set _p_.[[ProxyHandler]] to *null*.
             1. Return *undefined*.
           </emu-alg>
-          <p>The `"length"` property of a Proxy revocation function is 0.</p>
+          <p>The *"length"* property of a Proxy revocation function is 0.</p>
         </emu-clause>
       </emu-clause>
     </emu-clause>
@@ -41913,18 +41913,18 @@ THH:mm:ss.sss
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _char_ be the code unit (represented as a 16-bit unsigned integer) at index _k_ within _string_.
-            1. If _char_ is one of the code units in `"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@*_+-./"`, then
+            1. If _char_ is one of the code units in *"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@\*_+-./"*, then
               1. Let _S_ be the String value containing the single code unit _char_.
             1. Else if _char_ &ge; 256, then
               1. Let _n_ be the numeric value of _char_.
               1. Let _S_ be the string-concatenation of:
-                * `"%u"`
+                * *"%u"*
                 * the String representation of _n_, formatted as a four-digit uppercase hexadecimal number, padded to the left with zeroes if necessary
             1. Else,
               1. Assert: _char_ &lt; 256.
               1. Let _n_ be the numeric value of _char_.
               1. Let _S_ be the string-concatenation of:
-                * `"%"`
+                * *"%"*
                 * the String representation of _n_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
             1. Set _R_ to the string-concatenation of the previous value of _R_ and _S_.
             1. Set _k_ to _k_ + 1.
@@ -42063,7 +42063,7 @@ THH:mm:ss.sss
           1. Let _size_ be the number of code units in _S_.
           1. If _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
           1. Let _resultLength_ be min(max(_end_, 0), _size_ - _intStart_).
-          1. If _resultLength_ &le; 0, return the empty String `""`.
+          1. If _resultLength_ &le; 0, return the empty String *""*.
           1. Return the String value containing _resultLength_ consecutive code units from _S_ beginning with the code unit at index _intStart_.
         </emu-alg>
         <emu-note>
@@ -42076,7 +42076,7 @@ THH:mm:ss.sss
         <p>When the `anchor` method is called with argument _name_, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"a"`, `"name"`, _name_).
+          1. Return ? CreateHTML(_S_, *"a"*, *"name"*, _name_).
         </emu-alg>
 
         <emu-annex id="sec-createhtml" aoid="CreateHTML">
@@ -42085,10 +42085,10 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _str_ be ? RequireObjectCoercible(_string_).
             1. Let _S_ be ? ToString(_str_).
-            1. Let _p1_ be the string-concatenation of `"&lt;"` and _tag_.
+            1. Let _p1_ be the string-concatenation of *"&lt;"* and _tag_.
             1. If _attribute_ is not the empty String, then
               1. Let _V_ be ? ToString(_value_).
-              1. Let _escapedV_ be the String value that is the same as _V_ except that each occurrence of the code unit 0x0022 (QUOTATION MARK) in _V_ has been replaced with the six code unit sequence `"&amp;quot;"`.
+              1. Let _escapedV_ be the String value that is the same as _V_ except that each occurrence of the code unit 0x0022 (QUOTATION MARK) in _V_ has been replaced with the six code unit sequence *"&amp;quot;"*.
               1. Set _p1_ to the string-concatenation of:
                 * _p1_
                 * the code unit 0x0020 (SPACE)
@@ -42097,9 +42097,9 @@ THH:mm:ss.sss
                 * the code unit 0x0022 (QUOTATION MARK)
                 * _escapedV_
                 * the code unit 0x0022 (QUOTATION MARK)
-            1. Let _p2_ be the string-concatenation of _p1_ and `"&gt;"`.
+            1. Let _p2_ be the string-concatenation of _p1_ and *"&gt;"*.
             1. Let _p3_ be the string-concatenation of _p2_ and _S_.
-            1. Let _p4_ be the string-concatenation of _p3_, `"&lt;/"`, _tag_, and `"&gt;"`.
+            1. Let _p4_ be the string-concatenation of _p3_, *"&lt;/"*, _tag_, and *"&gt;"*.
             1. Return _p4_.
           </emu-alg>
         </emu-annex>
@@ -42110,7 +42110,7 @@ THH:mm:ss.sss
         <p>When the `big` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"big"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"big"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
@@ -42119,7 +42119,7 @@ THH:mm:ss.sss
         <p>When the `blink` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"blink"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"blink"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
@@ -42128,7 +42128,7 @@ THH:mm:ss.sss
         <p>When the `bold` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"b"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"b"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
@@ -42137,7 +42137,7 @@ THH:mm:ss.sss
         <p>When the `fixed` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"tt"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"tt"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
@@ -42146,7 +42146,7 @@ THH:mm:ss.sss
         <p>When the `fontcolor` method is called with argument _color_, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"font"`, `"color"`, _color_).
+          1. Return ? CreateHTML(_S_, *"font"*, *"color"*, _color_).
         </emu-alg>
       </emu-annex>
 
@@ -42155,7 +42155,7 @@ THH:mm:ss.sss
         <p>When the `fontsize` method is called with argument _size_, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"font"`, `"size"`, _size_).
+          1. Return ? CreateHTML(_S_, *"font"*, *"size"*, _size_).
         </emu-alg>
       </emu-annex>
 
@@ -42164,7 +42164,7 @@ THH:mm:ss.sss
         <p>When the `italics` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"i"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"i"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
@@ -42173,7 +42173,7 @@ THH:mm:ss.sss
         <p>When the `link` method is called with argument _url_, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"a"`, `"href"`, _url_).
+          1. Return ? CreateHTML(_S_, *"a"*, *"href"*, _url_).
         </emu-alg>
       </emu-annex>
 
@@ -42182,7 +42182,7 @@ THH:mm:ss.sss
         <p>When the `small` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"small"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"small"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
@@ -42191,7 +42191,7 @@ THH:mm:ss.sss
         <p>When the `strike` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"strike"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"strike"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
@@ -42200,7 +42200,7 @@ THH:mm:ss.sss
         <p>When the `sub` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"sub"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"sub"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
@@ -42209,24 +42209,24 @@ THH:mm:ss.sss
         <p>When the `sup` method is called with no arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, `"sup"`, `""`, `""`).
+          1. Return ? CreateHTML(_S_, *"sup"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 
       <emu-annex id="String.prototype.trimleft">
         <h1>String.prototype.trimLeft ( )</h1>
         <emu-note>
-          <p>The property `"trimStart"` is preferred. The `"trimLeft"` property is provided principally for compatibility with old code. It is recommended that the `"trimStart"` property be used in new ECMAScript code.</p>
+          <p>The property *"trimStart"* is preferred. The *"trimLeft"* property is provided principally for compatibility with old code. It is recommended that the *"trimStart"* property be used in new ECMAScript code.</p>
         </emu-note>
-        <p>The initial value of the `"trimLeft"` property is the same function object as the initial value of the `String.prototype.trimStart` property.</p>
+        <p>The initial value of the *"trimLeft"* property is the same function object as the initial value of the `String.prototype.trimStart` property.</p>
       </emu-annex>
 
       <emu-annex id="String.prototype.trimright">
         <h1>String.prototype.trimRight ( )</h1>
         <emu-note>
-          <p>The property `"trimEnd"` is preferred. The `"trimRight"` property is provided principally for compatibility with old code. It is recommended that the `"trimEnd"` property be used in new ECMAScript code.</p>
+          <p>The property *"trimEnd"* is preferred. The *"trimRight"* property is provided principally for compatibility with old code. It is recommended that the *"trimEnd"* property be used in new ECMAScript code.</p>
         </emu-note>
-        <p>The initial value of the `"trimRight"` property is the same function object as the initial value of the `String.prototype.trimEnd` property.</p>
+        <p>The initial value of the *"trimRight"* property is the same function object as the initial value of the `String.prototype.trimEnd` property.</p>
       </emu-annex>
     </emu-annex>
 
@@ -42272,7 +42272,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-date.prototype.togmtstring">
         <h1>Date.prototype.toGMTString ( )</h1>
         <emu-note>
-          <p>The property `"toUTCString"` is preferred. The `"toGMTString"` property is provided principally for compatibility with old code. It is recommended that the `"toUTCString"` property be used in new ECMAScript code.</p>
+          <p>The property *"toUTCString"* is preferred. The *"toGMTString"* property is provided principally for compatibility with old code. It is recommended that the *"toUTCString"* property be used in new ECMAScript code.</p>
         </emu-note>
         <p>The function object that is the initial value of `Date.prototype.toGMTString` is the same function object that is the initial value of `Date.prototype.toUTCString`.</p>
       </emu-annex>
@@ -42317,7 +42317,7 @@ THH:mm:ss.sss
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for `"__proto__"` and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
+          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
         </li>
       </ul>
       <emu-note>
@@ -42433,7 +42433,7 @@ THH:mm:ss.sss
               1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of _parameterNames_, then
                 1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
-                1. If _initializedBindings_ does not contain _F_ and _F_ is not `"arguments"`, then
+                1. If _initializedBindings_ does not contain _F_ and _F_ is not *"arguments"*, then
                   1. Perform ! _varEnvRec_.CreateMutableBinding(_F_, *false*).
                   1. Perform _varEnvRec_.InitializeBinding(_F_, *undefined*).
                   1. Append _F_ to _instantiatedVarNames_.
@@ -42713,7 +42713,7 @@ THH:mm:ss.sss
                   Object (has an [[IsHTMLDDA]] internal slot)
                 </td>
                 <td>
-                  `"undefined"`
+                  *"undefined"*
                 </td>
               </tr>
             </tbody>
@@ -42741,10 +42741,10 @@ THH:mm:ss.sss
       Assignment to an undeclared identifier or otherwise unresolvable reference does not create a property in the global object. When a simple assignment occurs within strict mode code, its |LeftHandSideExpression| must not evaluate to an unresolvable Reference. If it does a *ReferenceError* exception is thrown (<emu-xref href="#sec-putvalue"></emu-xref>). The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, nor to a non-existent property of an object whose [[Extensible]] internal slot has the value *false*. In these cases a `TypeError` exception is thrown (<emu-xref href="#sec-assignment-operators"></emu-xref>).
     </li>
     <li>
-      An |IdentifierReference| with the StringValue `"eval"` or `"arguments"` may not appear as the |LeftHandSideExpression| of an Assignment operator (<emu-xref href="#sec-assignment-operators"></emu-xref>) or of an |UpdateExpression| (<emu-xref href="#sec-update-expressions"></emu-xref>) or as the |UnaryExpression| operated upon by a Prefix Increment (<emu-xref href="#sec-prefix-increment-operator"></emu-xref>) or a Prefix Decrement (<emu-xref href="#sec-prefix-decrement-operator"></emu-xref>) operator.
+      An |IdentifierReference| with the StringValue *"eval"* or *"arguments"* may not appear as the |LeftHandSideExpression| of an Assignment operator (<emu-xref href="#sec-assignment-operators"></emu-xref>) or of an |UpdateExpression| (<emu-xref href="#sec-update-expressions"></emu-xref>) or as the |UnaryExpression| operated upon by a Prefix Increment (<emu-xref href="#sec-prefix-increment-operator"></emu-xref>) or a Prefix Decrement (<emu-xref href="#sec-prefix-decrement-operator"></emu-xref>) operator.
     </li>
     <li>
-      Arguments objects for strict functions define a non-configurable accessor property `"callee"` which throws a *TypeError* exception on access (<emu-xref href="#sec-createunmappedargumentsobject"></emu-xref>).
+      Arguments objects for strict functions define a non-configurable accessor property *"callee"* which throws a *TypeError* exception on access (<emu-xref href="#sec-createunmappedargumentsobject"></emu-xref>).
     </li>
     <li>
       Arguments objects for strict functions do not dynamically share their <emu-xref href="#array-index">array-indexed</emu-xref> property values with the corresponding formal parameter bindings of their functions. (<emu-xref href="#sec-arguments-exotic-objects"></emu-xref>).
@@ -42753,7 +42753,7 @@ THH:mm:ss.sss
       For strict functions, if an arguments object is created the binding of the local identifier `arguments` to the arguments object is immutable and hence may not be the target of an assignment expression. (<emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>).
     </li>
     <li>
-      It is a *SyntaxError* if the StringValue of a |BindingIdentifier| is `"eval"` or `"arguments"` within strict mode code (<emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>).
+      It is a *SyntaxError* if the StringValue of a |BindingIdentifier| is *"eval"* or *"arguments"* within strict mode code (<emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
       Strict mode eval code cannot instantiate variables or functions in the variable environment of the caller to eval. Instead, a new variable environment is created and that environment is used for declaration binding instantiation for the eval code (<emu-xref href="#sec-eval-x"></emu-xref>).
@@ -42777,7 +42777,7 @@ THH:mm:ss.sss
       It is a *SyntaxError* if the same |BindingIdentifier| appears more than once in the |FormalParameters| of a strict function. An attempt to create such a function using a `Function`, `Generator`, or `AsyncFunction` constructor is a *SyntaxError* (<emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-createdynamicfunction"></emu-xref>).
     </li>
     <li>
-      An implementation may not extend, beyond that defined in this specification, the meanings within strict functions of properties named `"caller"` or `"arguments"` of function instances.
+      An implementation may not extend, beyond that defined in this specification, the meanings within strict functions of properties named *"caller"* or *"arguments"* of function instances.
     </li>
   </ul>
 </emu-annex>
@@ -42787,10 +42787,10 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-candeclareglobalvar"></emu-xref>-<emu-xref href="#sec-createglobalfunctionbinding"></emu-xref> Edition 5 and 5.1 used a property existence test to determine whether a global object property corresponding to a new global declaration already existed. ECMAScript 2015 uses an own property existence test. This corresponds to what has been most commonly implemented by web browsers.</p>
   <p><emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>: The 5<sup>th</sup> Edition moved the capture of the current array length prior to the integer conversion of the array index or new length value. However, the captured length value could become invalid if the conversion process has the side-effect of changing the array length. ECMAScript 2015 specifies that the current array length must be captured after the possible occurrence of such side-effects.</p>
   <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0* or *-0* as the representation of a 0 time value. ECMAScript 2015 specifies that *+0* always returned. This means that for ECMAScript 2015 the time value of a Date object is never observably *-0* and methods that return time values never return *-0*.</p>
-  <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a UTC offset representation is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as `"z"`.</p>
+  <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a UTC offset representation is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as *"z"*.</p>
   <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>
-  <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the `"source"` property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `/`.</p>
+  <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the *"source"* property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `/`.</p>
   <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by one only if the pattern matched the empty string.</p>
   <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>, <emu-xref href="#sec-sortcompare"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0* was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-dependent. In practice, implementations call ToNumber.</p>
 </emu-annex>
@@ -42817,7 +42817,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-try-statement"></emu-xref>: In ECMAScript 2015, it is an early error for a |Catch| clause to contain a `var` declaration for the same |Identifier| that appears as the |Catch| clause parameter. In previous editions, such a variable declaration would be instantiated in the enclosing variable environment but the declaration's |Initializer| value would be assigned to the |Catch| parameter.</p>
   <p><emu-xref href="#sec-try-statement"></emu-xref>, <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref>: In ECMAScript 2015, a runtime *SyntaxError* is thrown if a |Catch| clause evaluates a non-strict direct `eval` whose eval code includes a `var` or `FunctionDeclaration` declaration that binds the same |Identifier| that appears as the |Catch| clause parameter.</p>
   <p><emu-xref href="#sec-try-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the completion value of a |TryStatement| is never the value ~empty~. If the |Block| part of a |TryStatement| evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined*. If the |Block| part of a |TryStatement| evaluates to a throw completion and it has a |Catch| part that evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined* if there is no |Finally| clause or if its |Finally| clause evaluates to an ~empty~ normal completion.</p>
-  <p><emu-xref href="#sec-method-definitions-runtime-semantics-propertydefinitionevaluation"></emu-xref> In ECMAScript 2015, the function objects that are created as the values of the [[Get]] or [[Set]] attribute of accessor properties in an |ObjectLiteral| are not constructor functions and they do not have a `"prototype"` own property. In the previous edition, they were constructors and had a `"prototype"` property.</p>
+  <p><emu-xref href="#sec-method-definitions-runtime-semantics-propertydefinitionevaluation"></emu-xref> In ECMAScript 2015, the function objects that are created as the values of the [[Get]] or [[Set]] attribute of accessor properties in an |ObjectLiteral| are not constructor functions and they do not have a *"prototype"* own property. In the previous edition, they were constructors and had a *"prototype"* property.</p>
   <p><emu-xref href="#sec-object.freeze"></emu-xref>: In ECMAScript 2015, if the argument to `Object.freeze` is not an object it is treated as if it was a non-extensible ordinary object with no own properties. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.getownpropertydescriptor"></emu-xref>: In ECMAScript 2015, if the argument to `Object.getOwnPropertyDescriptor` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.getownpropertynames"></emu-xref>: In ECMAScript 2015, if the argument to `Object.getOwnPropertyNames` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
@@ -42829,7 +42829,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-object.preventextensions"></emu-xref>: In ECMAScript 2015, if the argument to `Object.preventExtensions` is not an object it is treated as if it was a non-extensible ordinary object with no own properties. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.seal"></emu-xref>: In ECMAScript 2015, if the argument to `Object.seal` is not an object it is treated as if it was a non-extensible ordinary object with no own properties. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-function.prototype.bind"></emu-xref>: In ECMAScript 2015, the [[Prototype]] internal slot of a bound function is set to the [[GetPrototypeOf]] value of its target function. In the previous edition, [[Prototype]] was always set to %Function.prototype%.</p>
-  <p><emu-xref href="#sec-function-instances-length"></emu-xref>: In ECMAScript 2015, the `"length"` property of function instances is configurable. In previous editions it was non-configurable.</p>
+  <p><emu-xref href="#sec-function-instances-length"></emu-xref>: In ECMAScript 2015, the *"length"* property of function instances is configurable. In previous editions it was non-configurable.</p>
   <p><emu-xref href="#sec-properties-of-the-nativeerror-constructors"></emu-xref>: In ECMAScript 2015, the [[Prototype]] internal slot of a _NativeError_ constructor is the Error constructor. In previous editions it was the Function prototype object.</p>
   <p><emu-xref href="#sec-properties-of-the-date-prototype-object"></emu-xref> In ECMAScript 2015, the Date prototype object is not a Date instance. In previous editions it was a Date instance whose TimeValue was *NaN*.</p>
   <p><emu-xref href="#sec-string.prototype.localecompare"></emu-xref> In ECMAScript 2015, the `String.prototype.localeCompare` function must treat Strings that are canonically equivalent according to the Unicode standard as being identical. In previous editions implementations were permitted to ignore canonical equivalence and could instead use a bit-wise comparison.</p>
@@ -42837,7 +42837,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-string.prototype.trim"></emu-xref> In ECMAScript 2015, the `String.prototype.trim` method is defined to recognize white space code points that may exists outside of the Unicode BMP. However, as of Unicode 7 no such code points are defined. In previous editions such code points would not have been recognized as white space.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref> In ECMAScript 2015, If the _pattern_ argument is a RegExp instance and the _flags_ argument is not *undefined*, a new RegExp instance is created just like _pattern_ except that _pattern_'s flags are replaced by the argument _flags_. In previous editions a *TypeError* exception was thrown when _pattern_ was a RegExp instance and _flags_ was not *undefined*.</p>
   <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, the RegExp prototype object is not a RegExp instance. In previous editions it was a RegExp instance whose pattern is the empty string.</p>
-  <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, `"source"`, `"global"`, `"ignoreCase"`, and `"multiline"` are accessor properties defined on the RegExp prototype object. In previous editions they were data properties defined on RegExp instances.</p>
+  <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, *"source"*, *"global"*, *"ignoreCase"*, and *"multiline"* are accessor properties defined on the RegExp prototype object. In previous editions they were data properties defined on RegExp instances.</p>
   <p><emu-xref href="#sec-atomics.notify"></emu-xref>: In ECMAScript 2019, `Atomics.wake` has been renamed to `Atomics.notify` to prevent confusion with `Atomics.wait`.</p>
   <p><emu-xref="#sec-asyncfromsynciteratorcontinuation"></emu-xref>, <emu-xref href="#sec-asyncgeneratorresumenext"></emu-xref>: In ECMAScript 2019, the number of Jobs enqueued by `await` was reduced, which could create an observable difference in resolution order between a `then()` call and an `await` expression.</p>
 </emu-annex>


### PR DESCRIPTION
#1725 included a new section on Value Notation; this PR enacts it by updating <code>\`"foo"\`</code> → <code>\*"foo"\*</code> throughout the spec. This means that all ECMAScript language values shall now be stylized as such.
