### PR TITLE
Editorial: Stylize "this object" consistently.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29504,7 +29504,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.concat">
         <h1>String.prototype.concat ( ..._args_ )</h1>
         <emu-note>
-          <p>When the `concat` method is called it returns the String value consisting of the code units of the `this` object (converted to a String) followed by the code units of each of the arguments converted to a String. The result is a String value, not a String object.</p>
+          <p>When the `concat` method is called it returns the String value consisting of the code units of the *this* object (converted to a String) followed by the code units of each of the arguments converted to a String. The result is a String value, not a String object.</p>
         </emu-note>
         <p>When the `concat` method is called with zero or more arguments, the following steps are taken:</p>
         <emu-alg>
@@ -29770,7 +29770,7 @@ THH:mm:ss.sss
           1. Return the String value that is made from _n_ copies of _S_ appended together.
         </emu-alg>
         <emu-note>
-          <p>This method creates the String value consisting of the code units of the `this` object (converted to String) repeated _count_ times.</p>
+          <p>This method creates the String value consisting of the code units of the *this* object (converted to String) repeated _count_ times.</p>
         </emu-note>
         <emu-note>
           <p>The `repeat` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -32066,7 +32066,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>RegExp prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>RegExp prototype methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -32890,7 +32890,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>Array prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>Array prototype methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -34526,7 +34526,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>%TypedArray.prototype% methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>%TypedArray.prototype% methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -36588,7 +36588,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>ArrayBuffer prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>ArrayBuffer prototype methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -39849,7 +39849,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The value of the `"name"` property of this function is *"get [Symbol.species]"*.</p>
         <emu-note>
-          <p>Promise prototype methods normally use their `this` object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
+          <p>Promise prototype methods normally use their *this* object's constructor to create a derived object. However, a subclass constructor may over-ride that default behaviour by redefining its @@species property.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
Currently we have 7 cases of '`this` object' and 19 cases of '**this** object' in the spec.

This appears to be short for '**this** value (which is an object)', so let's unify them accordingly.