### PR TITLE
rename cxt/ctx variables to context

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21962,21 +21962,21 @@
 
       <emu-alg>
         1. Let _globalEnv_ be _scriptRecord_.[[Realm]].[[GlobalEnv]].
-        1. Let _scriptCxt_ be a new ECMAScript code execution context.
-        1. Set the Function of _scriptCxt_ to *null*.
-        1. Set the Realm of _scriptCxt_ to _scriptRecord_.[[Realm]].
-        1. Set the ScriptOrModule of _scriptCxt_ to _scriptRecord_.
-        1. Set the VariableEnvironment of _scriptCxt_ to _globalEnv_.
-        1. Set the LexicalEnvironment of _scriptCxt_ to _globalEnv_.
+        1. Let _scriptContext_ be a new ECMAScript code execution context.
+        1. Set the Function of _scriptContext_ to *null*.
+        1. Set the Realm of _scriptContext_ to _scriptRecord_.[[Realm]].
+        1. Set the ScriptOrModule of _scriptContext_ to _scriptRecord_.
+        1. Set the VariableEnvironment of _scriptContext_ to _globalEnv_.
+        1. Set the LexicalEnvironment of _scriptContext_ to _globalEnv_.
         1. Suspend the currently running execution context.
-        1. Push _scriptCxt_ onto the execution context stack; _scriptCxt_ is now the running execution context.
+        1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _scriptBody_ be _scriptRecord_.[[ECMAScriptCode]].
         1. Let _result_ be GlobalDeclarationInstantiation(_scriptBody_, _globalEnv_).
         1. If _result_.[[Type]] is ~normal~, then
           1. Set _result_ to the result of evaluating _scriptBody_.
         1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
           1. Set _result_ to NormalCompletion(*undefined*).
-        1. Suspend _scriptCxt_ and remove it from the execution context stack.
+        1. Suspend _scriptContext_ and remove it from the execution context stack.
         1. Assert: The execution context stack is not empty.
         1. Resume the context that is now on the top of the execution context stack as the running execution context.
         1. Return Completion(_result_).
@@ -23471,15 +23471,15 @@
                   1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
                   1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
-            1. Let _moduleCxt_ be a new ECMAScript code execution context.
-            1. Set the Function of _moduleCxt_ to *null*.
+            1. Let _moduleContext_ be a new ECMAScript code execution context.
+            1. Set the Function of _moduleContext_ to *null*.
             1. Assert: _module_.[[Realm]] is not *undefined*.
-            1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
-            1. Set the ScriptOrModule of _moduleCxt_ to _module_.
-            1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
-            1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
-            1. Set _module_.[[Context]] to _moduleCxt_.
-            1. Push _moduleCxt_ onto the execution context stack; _moduleCxt_ is now the running execution context.
+            1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
+            1. Set the ScriptOrModule of _moduleContext_ to _module_.
+            1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
+            1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
+            1. Set _module_.[[Context]] to _moduleContext_.
+            1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
             1. Let _code_ be _module_.[[ECMAScriptCode]].
             1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
             1. Let _declaredVarNames_ be a new empty List.
@@ -23499,7 +23499,7 @@
                 1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
                   1. Let _fo_ be InstantiateFunctionObject of _d_ with argument _env_.
                   1. Call _envRec_.InitializeBinding(_dn_, _fo_).
-            1. Remove _moduleCxt_ from the execution context stack.
+            1. Remove _moduleContext_ from the execution context stack.
             1. Return NormalCompletion(~empty~).
           </emu-alg>
         </emu-clause>
@@ -23514,10 +23514,10 @@
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
             1. Suspend the currently running execution context.
-            1. Let _moduleCxt_ be _module_.[[Context]].
-            1. Push _moduleCxt_ onto the execution context stack; _moduleCxt_ is now the running execution context.
+            1. Let _moduleContext_ be _module_.[[Context]].
+            1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
             1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
-            1. Suspend _moduleCxt_ and remove it from the execution context stack.
+            1. Suspend _moduleContext_ and remove it from the execution context stack.
             1. Resume the context that is now on the top of the execution context stack as the running execution context.
             1. Return Completion(_result_).
           </emu-alg>
@@ -24460,29 +24460,29 @@
             1. If _inDerivedConstructor_ is *false*, and _body_ Contains |SuperCall|, throw a *SyntaxError* exception.
           1. If _strictCaller_ is *true*, let _strictEval_ be *true*.
           1. Else, let _strictEval_ be IsStrict of _script_.
-          1. Let _ctx_ be the running execution context.
-          1. NOTE: If _direct_ is *true*, _ctx_ will be the execution context that performed the direct eval. If _direct_ is *false*, _ctx_ will be the execution context for the invocation of the `eval` function.
+          1. Let _runningContext_ be the running execution context.
+          1. NOTE: If _direct_ is *true*, _runningContext_ will be the execution context that performed the direct eval. If _direct_ is *false*, _runningContext_ will be the execution context for the invocation of the `eval` function.
           1. If _direct_ is *true*, then
-            1. Let _lexEnv_ be NewDeclarativeEnvironment(_ctx_'s LexicalEnvironment).
-            1. Let _varEnv_ be _ctx_'s VariableEnvironment.
+            1. Let _lexEnv_ be NewDeclarativeEnvironment(_runningContext_'s LexicalEnvironment).
+            1. Let _varEnv_ be _runningContext_'s VariableEnvironment.
           1. Else,
             1. Let _lexEnv_ be NewDeclarativeEnvironment(_evalRealm_.[[GlobalEnv]]).
             1. Let _varEnv_ be _evalRealm_.[[GlobalEnv]].
           1. If _strictEval_ is *true*, set _varEnv_ to _lexEnv_.
-          1. If _ctx_ is not already suspended, suspend _ctx_.
-          1. Let _evalCxt_ be a new ECMAScript code execution context.
-          1. Set the _evalCxt_'s Function to *null*.
-          1. Set the _evalCxt_'s Realm to _evalRealm_.
-          1. Set the _evalCxt_'s ScriptOrModule to _ctx_'s ScriptOrModule.
-          1. Set the _evalCxt_'s VariableEnvironment to _varEnv_.
-          1. Set the _evalCxt_'s LexicalEnvironment to _lexEnv_.
-          1. Push _evalCxt_ onto the execution context stack; _evalCxt_ is now the running execution context.
+          1. If _runningContext_ is not already suspended, suspend _runningContext_.
+          1. Let _evalContext_ be a new ECMAScript code execution context.
+          1. Set _evalContext_'s Function to *null*.
+          1. Set _evalContext_'s Realm to _evalRealm_.
+          1. Set _evalContext_'s ScriptOrModule to _runningContext_'s ScriptOrModule.
+          1. Set _evalContext_'s VariableEnvironment to _varEnv_.
+          1. Set _evalContext_'s LexicalEnvironment to _lexEnv_.
+          1. Push _evalContext_ onto the execution context stack; _evalContext_ is now the running execution context.
           1. Let _result_ be EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _strictEval_).
           1. If _result_.[[Type]] is ~normal~, then
             1. Set _result_ to the result of evaluating _body_.
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
-          1. Suspend _evalCxt_ and remove it from the execution context stack.
+          1. Suspend _evalContext_ and remove it from the execution context stack.
           1. Resume the context that is now on the top of the execution context stack as the running execution context.
           1. Return Completion(_result_).
         </emu-alg>


### PR DESCRIPTION
We were using both `cxt` and `ctx` as a shortening of "context" in variable names. To avoid this inconsistency, I just replaced them with `context`.