### PR TITLE
reword only use of "_x_'s Y component"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7422,7 +7422,7 @@
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
         1. Let _ec_ be the topmost execution context on the execution context stack whose ScriptOrModule component is not *null*.
-        1. If no such execution context exists, return *null*. Otherwise, return _ec_'s ScriptOrModule component.
+        1. If no such execution context exists, return *null*. Otherwise, return _ec_'s ScriptOrModule.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Partially addresses #1742, changing the singular use of "_x_'s Y component" to the closest common form, "_x_'s Y".