### PR TITLE
add missing ContainsUseStrict definition for AsyncConciseBody

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21287,6 +21287,15 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-containsusestrict">
+      <h1>Static Semantics: ContainsUseStrict</h1>
+      <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
+      <emu-grammar>AsyncConciseBody : AssignmentExpression</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
       <emu-grammar>


### PR DESCRIPTION
At first, I noticed that there was a missing `ContainsUseStrict` definition for `AsyncConciseBody`, which was used in an early error, so I added the missing definition. ~But then I noticed that there was no way for the early error condition to be `true`, so I removed the early error and the `ContainsUseStrict` definitions became dead, so I removed those, too.~