### PR TITLE
find Directive Prologue in appropriate node in IsStrict/ContainsUsestrict

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19147,7 +19147,7 @@
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
-        1. If the Directive Prologue of |FunctionStatementList| contains a Use Strict Directive, return *true*; otherwise, return *false*.
+        1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -21818,9 +21818,9 @@
 
     <emu-clause id="sec-static-semantics-isstrict">
       <h1>Static Semantics: IsStrict</h1>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-grammar>Script : ScriptBody?</emu-grammar>
       <emu-alg>
-        1. If the Directive Prologue of |StatementList| contains a Use Strict Directive, return *true*; otherwise, return *false*.
+        1. If |ScriptBody| is present and the Directive Prologue of |ScriptBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Two things:

1. Define `IsStrict` for `Script`, since that's how it's applied.
1. Refer to the directive prologue of a `ScriptBody`/`FunctionBody` since that's how it's defined.