### PR TITLE
Revert "Editorial: remove context copy from AsyncFunctionStart (#1685)"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40125,6 +40125,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _runningContext_ be the running execution context.
           1. Let _asyncContext_ be a copy of _runningContext_.
+          1. NOTE: Copying the execution state is required for the step below to resume its execution. It is ill-defined to resume a currently executing context.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. Let _result_ be the result of evaluating _asyncFunctionBody_.
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.

--- a/spec.html
+++ b/spec.html
@@ -40123,7 +40123,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-async-functions-abstract-operations-async-function-start" aoid="AsyncFunctionStart">
         <h1>AsyncFunctionStart ( _promiseCapability_, _asyncFunctionBody_ )</h1>
         <emu-alg>
-          1. Let _asyncContext_ be the running execution context.
+          1. Let _runningContext_ be the running execution context.
+          1. Let _asyncContext_ be a copy of _runningContext_.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. Let _result_ be the result of evaluating _asyncFunctionBody_.
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
@@ -40138,9 +40139,7 @@ THH:mm:ss.sss
             1. Return.
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.
-          1. Assert: When we return here, _asyncContext_ has been removed from the execution context stack.
-          1. Push _asyncContext_ onto the execution context stack.
-          1. NOTE: Pushing _asyncContext_ onto the execution context stack is needed to fulfill invariants of <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist">Function [[Call]]</a>.
+          1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
           1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, the step 3.g above.
           1. Return.
         </emu-alg>


### PR DESCRIPTION
This reverts commit e9faaa18253f2d6dc063f4cb3c4cf481e8f4f849.

I now think my analysis in #1685 of removing the copy was incorrect. After discussion with @devsnek on IRC, the issue comes down to this step:

4. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.

That seems to assume that _asyncContext_ can be "executed" and its _result_ observed without overwriting the current "execution" of AsyncFunctionStart. If _asyncContext_ isn't a copied context but instead **is** the current context, I think that step is ill-formed, it'd be like a jump or tail call: there's no way to get the _result_ as required by that step.

All in all it seems clearer to me to revert.