### PR TITLE
Normative: Restore BigInt.prototype.toJSON

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37708,8 +37708,8 @@ THH:mm:ss.sss
         <p>The abstract operation SerializeJSONProperty with arguments _key_, and _holder_ has access to _ReplacerFunction_ from the invocation of the `stringify` method. Its algorithm is as follows:</p>
         <emu-alg>
           1. Let _value_ be ? Get(_holder_, _key_).
-          1. If Type(_value_) is Object, then
-            1. Let _toJSON_ be ? Get(_value_, *"toJSON"*).
+          1. If Type(_value_) is Object or BigInt, then
+            1. Let _toJSON_ be ? GetV(_value_, *"toJSON"*).
             1. If IsCallable(_toJSON_) is *true*, then
               1. Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).
           1. If _ReplacerFunction_ is not *undefined*, then


### PR DESCRIPTION
Adds the explicit `SerializeJSONProperty` carve-out for `BigInt`
and change to `GetV` that were part of the proposal spec text.

Fixes #1755
