### PR TITLE
spec: corrects the TypeError description as its name represent

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26471,7 +26471,7 @@
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-typeerror">
         <h1>TypeError</h1>
-        <p>TypeError is used to indicate an unsuccessful operation when none of the other _NativeError_ objects are an appropriate indication of the failure cause.</p>
+        <p>TypeError is used to indicate that a value is not of the expected type.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-urierror">


### PR DESCRIPTION
The `TypeError` should own itself purpose just like the title described, and as for default
case, the `Error` is better choice.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
