### PR TITLE
Editorial: quick fix re insertion of global BigInt

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25040,11 +25040,6 @@
       <p>See <emu-xref href="#sec-arraybuffer-constructor"></emu-xref>.</p>
     </emu-clause>
 
-    <emu-clause id="sec-constructor-properties-of-the-global-object-boolean">
-      <h1>Boolean ( . . . )</h1>
-      <p>See <emu-xref href="#sec-boolean-constructor"></emu-xref>.</p>
-    </emu-clause>
-
     <emu-clause id="sec-constructor-properties-of-the-global-object-bigint">
       <h1>BigInt ( . . . )</h1>
       <p>See <emu-xref href="#sec-bigint-constructor"></emu-xref>.</p>
@@ -25058,6 +25053,11 @@
     <emu-clause id="sec-constructor-properties-of-the-global-object-biguint64array">
       <h1>BigUint64Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-typedarray-constructors"></emu-xref>.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-constructor-properties-of-the-global-object-boolean">
+      <h1>Boolean ( . . . )</h1>
+      <p>See <emu-xref href="#sec-boolean-constructor"></emu-xref>.</p>
     </emu-clause>
 
     <emu-clause id="sec-constructor-properties-of-the-global-object-dataview">


### PR DESCRIPTION
PR #1753 inserted the BigInt* clauses after Boolean,
but they should be *before* Boolean.