### PR TITLE
Normative: Properly handle Number(BigInt)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26571,8 +26571,12 @@
         <h1>Number ( _value_ )</h1>
         <p>When `Number` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
-          1. If _value_ is present, let _n_ be ? ToNumber(_value_).
-          1. Else, let _n_ be *+0*.
+          1. If _value_ is present, then
+            1. Let _prim_ be ? ToNumeric(_value_).
+            1. If Type(_prim_) is BigInt, let _n_ be the Number value for _prim_.
+            1. Otherwise, let _n_ be _prim_.
+          1. Else,
+            1. Let _n_ be *+0*.
           1. If NewTarget is *undefined*, return _n_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Number.prototype%"*, &laquo; [[NumberData]] &raquo;).
           1. Set _O_.[[NumberData]] to _n_.


### PR DESCRIPTION
It closes #1754. This change is missing from original BigInt additions (#1515), but it was specified in the BigInt [spec text](https://tc39.es/proposal-bigint/#sec-number-constructor-number-value).

CC @littledan @devsnek @ljharb 