### PR TITLE
Editorial: Add BigInt to the list of reference base value types and the language types intro text

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -921,7 +921,7 @@
 
   <emu-clause id="sec-ecmascript-language-types">
     <h1>ECMAScript Language Types</h1>
-    <p>An <dfn>ECMAScript language type</dfn> corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, and Object. An <dfn>ECMAScript language value</dfn> is a value that is characterized by an ECMAScript language type.</p>
+    <p>An <dfn>ECMAScript language type</dfn> corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, BigInt, and Object. An <dfn>ECMAScript language value</dfn> is a value that is characterized by an ECMAScript language type.</p>
 
     <emu-clause id="sec-ecmascript-language-types-undefined-type">
       <h1>The Undefined Type</h1>
@@ -4101,7 +4101,7 @@
       <emu-note>
         <p>The Reference type is used to explain the behaviour of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a reference.</p>
       </emu-note>
-      <p>A <dfn>Reference</dfn> is a resolved name or property binding. A Reference consists of three components, the base value component, the referenced name component, and the Boolean-valued strict reference flag. The base value component is either *undefined*, an Object, a Boolean, a String, a Symbol, a Number, or an Environment Record. A base value component of *undefined* indicates that the Reference could not be resolved to a binding. The referenced name component is a String or Symbol value.</p>
+      <p>A <dfn>Reference</dfn> is a resolved name or property binding. A Reference consists of three components, the base value component, the referenced name component, and the Boolean-valued strict reference flag. The base value component is either *undefined*, an Object, a Boolean, a String, a Symbol, a Number, a BigInt, or an Environment Record. A base value component of *undefined* indicates that the Reference could not be resolved to a binding. The referenced name component is a String or Symbol value.</p>
       <p>A <dfn id="super-reference">Super Reference</dfn> is a Reference that is used to represent a name binding that was expressed using the super keyword. A Super Reference has an additional thisValue component, and its base value component will never be an Environment Record.</p>
       <p>The following abstract operations are used in this specification to operate on references:</p>
 
@@ -5809,7 +5809,7 @@
       <h1>CreateListFromArrayLike ( _obj_ [ , _elementTypes_ ] )</h1>
       <p>The abstract operation CreateListFromArrayLike is used to create a List value whose elements are provided by the indexed properties of an array-like object, _obj_. The optional argument _elementTypes_ is a List containing the names of ECMAScript Language Types that are allowed for element values of the List that is created. This abstract operation performs the following steps:</p>
       <emu-alg>
-        1. If _elementTypes_ is not present, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, Object &raquo;.
+        1. If _elementTypes_ is not present, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, BigInt, Object &raquo;.
         1. If Type(_obj_) is not Object, throw a *TypeError* exception.
         1. Let _len_ be ? LengthOfArrayLike(_obj_).
         1. Let _list_ be a new empty List.


### PR DESCRIPTION
Similar to https://github.com/tc39/ecma262/pull/1769 — BigInt was absent from the list of types that the base value component of a Reference could be.

Note that it is already included and handled as a possible base value in the [HasPrimitiveBase abstract op](https://tc39.es/ecma262/#sec-hasprimitivebase).

I was unsure if there was any particular logic to the ordering of types, so I just slotted it in the ‘most alphabetic’ seeming part of the list. Alternatively, the sentence could be reworded to avoid listing them all if it’s felt that this is becoming an update hazard, e.g.

> The base value component is either an Environment Record or a language type other than Null.

Or, if it’s desired to draw additional attention to undefined’s distinct significance here:

> The base value component is either an Environment Record or a language type other than Null (but including *undefined*).

(ref #1515)