### PR TITLE
Normative: make async iterators next/return/throw not pass `undefined` when value is absent

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38899,20 +38899,23 @@ THH:mm:ss.sss
         </ul>
 
         <emu-clause id="sec-%asyncfromsynciteratorprototype%.next">
-          <h1>%AsyncFromSyncIteratorPrototype%.next ( _value_ )</h1>
+          <h1>%AsyncFromSyncIteratorPrototype%.next ( [ _value_ ] )</h1>
           <emu-alg>
             1. Let _O_ be the *this* value.
             1. Assert: Type(_O_) is Object and _O_ has a [[SyncIteratorRecord]] internal slot.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
-            1. Let _result_ be IteratorNext(_syncIteratorRecord_, _value_).
+            1. If _value_ is present, then
+              1. Let _result_ be IteratorNext(_syncIteratorRecord_, _value_).
+            1. Else,
+              1. Let _result_ be IteratorNext(_syncIteratorRecord_).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
             1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
           </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-%asyncfromsynciteratorprototype%.return">
-          <h1>%AsyncFromSyncIteratorPrototype%.return ( _value_ )</h1>
+          <h1>%AsyncFromSyncIteratorPrototype%.return ( [ _value_ ] )</h1>
 
           <emu-alg>
             1. Let _O_ be the *this* value.
@@ -38925,7 +38928,10 @@ THH:mm:ss.sss
               1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
-            1. Let _result_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
+            1. If _value_ is present, then
+              1. Let _result_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
+            1. Else,
+              1. Let _result_ be Call(_return_, _syncIterator_).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
             1. If Type(_result_) is not Object, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
@@ -38935,7 +38941,8 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-%asyncfromsynciteratorprototype%.throw">
-          <h1>%AsyncFromSyncIteratorPrototype%.throw ( _value_ )</h1>
+          <h1>%AsyncFromSyncIteratorPrototype%.throw ( [ _value_ ] )</h1>
+          <emu-note>In this specification, _value_ is always provided, but is left optional for consistency with <emu-xref title href="#sec-%asyncfromsynciteratorprototype%.return"></emu-xref>.</emu-note>
 
           <emu-alg>
             1. Let _O_ be the *this* value.
@@ -38947,7 +38954,10 @@ THH:mm:ss.sss
             1. If _throw_ is *undefined*, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
-            1. Let _result_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
+            1. If _value_ is present, then
+              1. Let _result_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
+            1. Else,
+              1. Let _result_ be Call(_throw_, _syncIterator_).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
             1. If Type(_result_) is not Object, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).


### PR DESCRIPTION
This is admittedly a very minor change.
```js
const o = {
  next(...args) { console.log('args', args); return { done: true }; },
  [Symbol.iterator]() { return this }
};
for (const item of o) {}
```
logs `'args', []`

```js
(async () => {
  const o = {
    next(...args) { console.log('args', args); return { done: true }; },
    [Symbol.iterator]() { return this }
  };
  for await (const item of o) {}
})();
```
logs `'args', [undefined]`. The intention of this change is to make async iteration match sync iteration from the perspective of a userland iterator `next` method.

This was an intentional decision made by the feature champion in https://github.com/tc39/proposal-async-iteration/issues/113, but I don't recall it being discussed in committee. I find this inconsistency mildly troubling, and would like to correct it.

It has relevance as well for the ["iterator helpers" proposal](https://github.com/tc39/proposal-iterator-helpers/issues/63).