### PR TITLE
Editorial: Tweak casing of "empty String" and "Number value"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -328,18 +328,18 @@
       <h1>Number object</h1>
       <p>member of the Object type that is an instance of the standard built-in `Number` constructor</p>
       <emu-note>
-        <p>A Number object is created by using the `Number` constructor in a `new` expression, supplying a number value as an argument. The resulting object has an internal slot whose value is the number value. A Number object can be coerced to a number value by calling the `Number` constructor as a function (<emu-xref href="#sec-number-constructor-number-value"></emu-xref>).</p>
+        <p>A Number object is created by using the `Number` constructor in a `new` expression, supplying a Number value as an argument. The resulting object has an internal slot whose value is the Number value. A Number object can be coerced to a Number value by calling the `Number` constructor as a function (<emu-xref href="#sec-number-constructor-number-value"></emu-xref>).</p>
       </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-terms-and-definitions-infinity">
       <h1>Infinity</h1>
-      <p>number value that is the positive infinite number value</p>
+      <p>Number value that is the positive infinite Number value</p>
     </emu-clause>
 
     <emu-clause id="sec-terms-and-definitions-nan">
       <h1>NaN</h1>
-      <p>number value that is an IEEE 754-2008 &ldquo;Not-a-Number&rdquo; value</p>
+      <p>Number value that is an IEEE 754-2008 &ldquo;Not-a-Number&rdquo; value</p>
     </emu-clause>
 
     <emu-clause id="sec-terms-and-definitions-bigint-value">
@@ -2038,7 +2038,7 @@
           An <dfn>accessor property</dfn> associates a key value with one or two accessor functions, and a set of Boolean attributes. The accessor functions are used to store or retrieve an ECMAScript language value that is associated with the property.
         </li>
       </ul>
-      <p>Properties are identified using key values. A property key value is either an ECMAScript String value or a Symbol value. All String and Symbol values, including the empty string, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String value.</p>
+      <p>Properties are identified using key values. A property key value is either an ECMAScript String value or a Symbol value. All String and Symbol values, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String value.</p>
       <p>An <dfn id="integer-index">integer index</dfn> is a String-valued property key that is a canonical numeric String (see <emu-xref href="#sec-canonicalnumericindexstring"></emu-xref>) and whose numeric value is either *+0* or a positive integer &le; 2<sup>53</sup> - 1. An <dfn id="array-index">array index</dfn> is an integer index whose numeric value _i_ is in the range <emu-eqn>+0 &le; _i_ &lt; 2<sup>32</sup> - 1</emu-eqn>.</p>
       <p>Property keys are used to access properties and their values. There are two kinds of access for properties: <em>get</em> and <em>set</em>, corresponding to value retrieval and assignment, respectively. The properties accessible via get and set access includes both <em>own properties</em> that are a direct part of an object and <em>inherited properties</em> which are provided by another associated object via a property inheritance relationship. Inherited properties may be either own or inherited properties of the associated object. Each own property of an object must each have a key value that is distinct from the key values of the other own properties of that object.</p>
       <p>All objects are logically collections of properties, but there are multiple forms of objects that differ in their semantics for accessing and manipulating their properties. <dfn id="ordinary-objects">Ordinary objects</dfn> are the most common form of objects and have the default object semantics. An <dfn id="exotic-object">exotic object</dfn> is any form of object whose property semantics differ in any way from the default semantics.</p>
@@ -26277,7 +26277,7 @@
           1. Else, let _L_ be 0.
           1. Perform ! SetFunctionLength(_F_, _L_).
           1. Let _targetName_ be ? Get(_Target_, *"name"*).
-          1. If Type(_targetName_) is not String, set _targetName_ to the empty string.
+          1. If Type(_targetName_) is not String, set _targetName_ to the empty String.
           1. Perform SetFunctionName(_F_, _targetName_, *"bound"*).
           1. Return _F_.
         </emu-alg>
@@ -26713,7 +26713,7 @@
           <emu-alg>
             1. Assert: Type(_sym_) is Symbol.
             1. Let _desc_ be _sym_'s [[Description]] value.
-            1. If _desc_ is *undefined*, set _desc_ to the empty string.
+            1. If _desc_ is *undefined*, set _desc_ to the empty String.
             1. Assert: Type(_desc_) is String.
             1. Return the string-concatenation of *"Symbol("*, _desc_, and *")"*.
           </emu-alg>
@@ -29400,7 +29400,7 @@ THH:mm:ss.sss
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
             1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _yv_ be YearFromTime(_tv_).
-            1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be *"-"*.
+            1. If _yv_ &ge; 0, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
             1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
             1. Let _paddedYear_ be ! StringPad(_year_, 4, *"0"*, ~start~).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
@@ -29597,7 +29597,7 @@ THH:mm:ss.sss
             1. If _offset_ &ge; 0, let _offsetSign_ be *"+"*; otherwise, let _offsetSign_ be *"-"*.
             1. Let _offsetMin_ be the String representation of MinFromTime(abs(_offset_)), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
             1. Let _offsetHour_ be the String representation of HourFromTime(abs(_offset_)), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-            1. Let _tzName_ be an implementation-defined string that is either the empty string or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-dependent timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
+            1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-dependent timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>
         </emu-clause>
@@ -29637,7 +29637,7 @@ THH:mm:ss.sss
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
           1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
           1. Let _yv_ be YearFromTime(_tv_).
-          1. If _yv_ &ge; 0, let _yearSign_ be the empty string; otherwise, let _yearSign_ be *"-"*.
+          1. If _yv_ &ge; 0, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
           1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
           1. Let _paddedYear_ be ! StringPad(_year_, 4, *"0"*, ~start~).
           1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
@@ -29730,7 +29730,7 @@ THH:mm:ss.sss
             1. Let _nextCU_ be ? ToUint16(_next_).
             1. Append _nextCU_ to the end of _elements_.
             1. Set _nextIndex_ to _nextIndex_ + 1.
-          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty string is returned.
+          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty String is returned.
         </emu-alg>
         <p>The *"length"* property of the `fromCharCode` function is 1.</p>
       </emu-clause>
@@ -29750,7 +29750,7 @@ THH:mm:ss.sss
             1. If _nextCP_ &lt; 0 or _nextCP_ &gt; 0x10FFFF, throw a *RangeError* exception.
             1. Append the elements of the UTF16Encoding of _nextCP_ to the end of _elements_.
             1. Set _nextIndex_ to _nextIndex_ + 1.
-          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty string is returned.
+          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty String is returned.
         </emu-alg>
         <p>The *"length"* property of the `fromCodePoint` function is 1.</p>
       </emu-clause>
@@ -29770,7 +29770,7 @@ THH:mm:ss.sss
           1. Let _cooked_ be ? ToObject(_template_).
           1. Let _raw_ be ? ToObject(? Get(_cooked_, *"raw"*)).
           1. Let _literalSegments_ be ? LengthOfArrayLike(_raw_).
-          1. If _literalSegments_ &le; 0, return the empty string.
+          1. If _literalSegments_ &le; 0, return the empty String.
           1. Let _stringElements_ be a new empty List.
           1. Let _nextIndex_ be 0.
           1. Repeat,
@@ -29778,7 +29778,7 @@ THH:mm:ss.sss
             1. Let _nextSeg_ be ? ToString(? Get(_raw_, _nextKey_)).
             1. Append in order the code unit elements of _nextSeg_ to the end of _stringElements_.
             1. If _nextIndex_ + 1 = _literalSegments_, then
-              1. Return the String value whose code units are, in order, the elements in the List _stringElements_. If _stringElements_ has no elements, the empty string is returned.
+              1. Return the String value whose code units are, in order, the elements in the List _stringElements_. If _stringElements_ has no elements, the empty String is returned.
             1. If _nextIndex_ &lt; _numberOfSubstitutions_, let _next_ be _substitutions_[_nextIndex_].
             1. Else, let _next_ be the empty String.
             1. Let _nextSub_ be ? ToString(_next_).
@@ -30302,7 +30302,7 @@ THH:mm:ss.sss
                       1. Else,
                         1. Let _groupName_ be the enclosed substring.
                         1. Let _capture_ be ? Get(_namedCaptures_, _groupName_).
-                        1. If _capture_ is *undefined*, replace the text through `>` with the empty string.
+                        1. If _capture_ is *undefined*, replace the text through `>` with the empty String.
                         1. Otherwise, replace the text through `>` with ? ToString(_capture_).
                   </emu-alg>
                 </td>
@@ -33012,7 +33012,7 @@ THH:mm:ss.sss
             1. Else,
               1. If _global_ is *true*, then
                 1. Let _matchStr_ be ? ToString(? Get(_match_, *"0"*)).
-                1. If _matchStr_ is the empty string, then
+                1. If _matchStr_ is the empty String, then
                   1. Let _thisIndex_ be ? ToLength(? Get(_R_, *"lastIndex"*)).
                   1. Let _nextIndex_ be ! AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
                   1. Perform ? Set(_R_, *"lastIndex"*, _nextIndex_, *true*).
@@ -40484,7 +40484,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-async-function-prototype-properties-toStringTag">
         <h1>AsyncFunction.prototype [ @@toStringTag ]</h1>
 
-        <p>The initial value of the @@toStringTag property is the string value *"AsyncFunction"*.</p>
+        <p>The initial value of the @@toStringTag property is the String value *"AsyncFunction"*.</p>
 
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
@@ -42292,7 +42292,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Set _string_ to ? ToString(_string_).
           1. Let _length_ be the number of code units in _string_.
-          1. Let _R_ be the empty string.
+          1. Let _R_ be the empty String.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _char_ be the code unit (represented as a 16-bit unsigned integer) at index _k_ within _string_.
@@ -42446,7 +42446,7 @@ THH:mm:ss.sss
           1. Let _size_ be the number of code units in _S_.
           1. If _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
           1. Let _resultLength_ be min(max(_end_, 0), _size_ - _intStart_).
-          1. If _resultLength_ &le; 0, return the empty String *""*.
+          1. If _resultLength_ &le; 0, return the empty String.
           1. Return the String value containing _resultLength_ consecutive code units from _S_ beginning with the code unit at index _intStart_.
         </emu-alg>
         <emu-note>
@@ -43174,7 +43174,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the *"source"* property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `/`.</p>
-  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by one only if the pattern matched the empty string.</p>
+  <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by one only if the pattern matched the empty String.</p>
   <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>, <emu-xref href="#sec-sortcompare"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0* was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-dependent. In practice, implementations call ToNumber.</p>
 </emu-annex>
 
@@ -43219,7 +43219,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-string.prototype.tolowercase"></emu-xref> and <emu-xref href="#sec-string.prototype.touppercase"></emu-xref> In ECMAScript 2015, lowercase/upper conversion processing operates on code points. In previous editions such the conversion processing was only applied to individual code units. The only affected code points are those in the Deseret block of Unicode.</p>
   <p><emu-xref href="#sec-string.prototype.trim"></emu-xref> In ECMAScript 2015, the `String.prototype.trim` method is defined to recognize white space code points that may exists outside of the Unicode BMP. However, as of Unicode 7 no such code points are defined. In previous editions such code points would not have been recognized as white space.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref> In ECMAScript 2015, If the _pattern_ argument is a RegExp instance and the _flags_ argument is not *undefined*, a new RegExp instance is created just like _pattern_ except that _pattern_'s flags are replaced by the argument _flags_. In previous editions a *TypeError* exception was thrown when _pattern_ was a RegExp instance and _flags_ was not *undefined*.</p>
-  <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, the RegExp prototype object is not a RegExp instance. In previous editions it was a RegExp instance whose pattern is the empty string.</p>
+  <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, the RegExp prototype object is not a RegExp instance. In previous editions it was a RegExp instance whose pattern is the empty String.</p>
   <p><emu-xref href="#sec-properties-of-the-regexp-prototype-object"></emu-xref> In ECMAScript 2015, *"source"*, *"global"*, *"ignoreCase"*, and *"multiline"* are accessor properties defined on the RegExp prototype object. In previous editions they were data properties defined on RegExp instances.</p>
   <p><emu-xref href="#sec-atomics.notify"></emu-xref>: In ECMAScript 2019, `Atomics.wake` has been renamed to `Atomics.notify` to prevent confusion with `Atomics.wait`.</p>
   <p><emu-xref href="#sec-asyncfromsynciteratorcontinuation"></emu-xref>, <emu-xref href="#sec-asyncgeneratorresumenext"></emu-xref>: In ECMAScript 2019, the number of Jobs enqueued by `await` was reduced, which could create an observable difference in resolution order between a `then()` call and an `await` expression.</p>


### PR DESCRIPTION
There is minor inconsistency with casing: 63 occurrences of "empty **S**tring", 15 of "empty **s**tring". Should we uppercase all the "string"s in this PR to avoid any possible doubt on primitive vs object wrapper?