### PR TITLE
Editorial: Rename predicate function parameter of Array methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33623,26 +33623,26 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.some">
-        <h1>Array.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Array.prototype.some ( _predicate_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `some` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *true*. If such an element is found, `some` immediately returns *true*. Otherwise, `some` returns *false*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
-          <p>`some` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `some` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `some` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time that `some` visits them; elements that are deleted after the call to `some` begins and before being visited are not visited. `some` acts like the "exists" quantifier in mathematics. In particular, for an empty array, it returns *false*.</p>
+          <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `some` calls _predicate_ once for each element present in the array, in ascending order, until it finds one where _predicate_ returns *true*. If such an element is found, `some` immediately returns *true*. Otherwise, `some` returns *false*. _predicate_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_.</p>
+          <p>_predicate_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
+          <p>`some` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
+          <p>The range of elements processed by `some` is set before the first call to _predicate_. Elements that are appended to the array after the call to `some` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `some` visits them; elements that are deleted after the call to `some` begins and before being visited are not visited. `some` acts like the "exists" quantifier in mathematics. In particular, for an empty array, it returns *false*.</p>
         </emu-note>
         <p>When the `some` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _testResult_ is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.

--- a/spec.html
+++ b/spec.html
@@ -32987,7 +32987,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+          1. If ! IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
@@ -33042,7 +33042,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+          1. If ! IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
@@ -33635,7 +33635,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+          1. If ! IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
@@ -34633,7 +34633,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+          1. If ! IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _kept_ be a new empty List.
           1. Let _k_ be 0.
           1. Let _captured_ be 0.

--- a/spec.html
+++ b/spec.html
@@ -34626,21 +34626,21 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.filter">
-        <h1>%TypedArray%.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>%TypedArray%.prototype.filter ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.filter` are the same as for `Array.prototype.filter` as defined in <emu-xref href="#sec-array.prototype.filter"></emu-xref>.</p>
         <p>When the `filter` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _kept_ be a new empty List.
           1. Let _k_ be 0.
           1. Let _captured_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _selected_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
             1. If _selected_ is *true*, then
               1. Append _kValue_ to the end of _kept_.
               1. Set _captured_ to _captured_ + 1.

--- a/spec.html
+++ b/spec.html
@@ -33030,19 +33030,19 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.filter">
-        <h1>Array.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Array.prototype.filter ( _predicate_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `filter` calls _callbackfn_ once for each element in the array, in ascending order, and constructs a new array of all the values for which _callbackfn_ returns *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
-          <p>`filter` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `filter` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `filter` begins will not be visited by _callbackfn_. If existing elements of the array are changed their value as passed to _callbackfn_ will be the value at the time `filter` visits them; elements that are deleted after the call to `filter` begins and before being visited are not visited.</p>
+          <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `filter` calls _predicate_ once for each element in the array, in ascending order, and constructs a new array of all the values for which _predicate_ returns *true*. _predicate_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_.</p>
+          <p>_predicate_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
+          <p>`filter` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
+          <p>The range of elements processed by `filter` is set before the first call to _predicate_. Elements which are appended to the array after the call to `filter` begins will not be visited by _predicate_. If existing elements of the array are changed their value as passed to _predicate_ will be the value at the time `filter` visits them; elements that are deleted after the call to `filter` begins and before being visited are not visited.</p>
         </emu-note>
         <p>When the `filter` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
@@ -33051,7 +33051,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _selected_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _selected_ is *true*, then
                 1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_to_), _kValue_).
                 1. Set _to_ to _to_ + 1.

--- a/spec.html
+++ b/spec.html
@@ -34904,8 +34904,8 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.some">
-        <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <h1>%TypedArray%.prototype.some ( _predicate_ [ , _thisArg_ ] )</h1>
+        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -32978,7 +32978,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `every` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *false*. If such an element is found, `every` immediately returns *false*. Otherwise, if _callbackfn_ returned *true* for all elements, `every` will return *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
           <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`every` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `every` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `every` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `every` visits them; elements that are deleted after the call to `every` begins and before being visited are not visited. `every` acts like the "for all" quantifier in mathematics. In particular, for an empty array, it returns *true*.</p>
@@ -33033,7 +33033,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `filter` calls _callbackfn_ once for each element in the array, in ascending order, and constructs a new array of all the values for which _callbackfn_ returns *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
           <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`filter` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `filter` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `filter` begins will not be visited by _callbackfn_. If existing elements of the array are changed their value as passed to _callbackfn_ will be the value at the time `filter` visits them; elements that are deleted after the call to `filter` begins and before being visited are not visited.</p>
@@ -33068,7 +33068,7 @@ THH:mm:ss.sss
         <p>The `find` method is called with one or two arguments, _predicate_ and _thisArg_.</p>
         <emu-note>
           <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `find` calls _predicate_ once for each element of the array, in ascending order, until it finds one where _predicate_ returns *true*. If such an element is found, `find` immediately returns that element value. Otherwise, `find` returns *undefined*.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_.</p>
           <p>_predicate_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`find` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
           <p>The range of elements processed by `find` is set before the first call to _predicate_. Elements that are appended to the array after the call to `find` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `find` visits them.</p>
@@ -33096,7 +33096,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
         <emu-note>
           <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `findIndex` calls _predicate_ once for each element of the array, in ascending order, until it finds one where _predicate_ returns *true*. If such an element is found, `findIndex` immediately returns the index of that element value. Otherwise, `findIndex` returns -1.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_.</p>
           <p>_predicate_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`findIndex` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
           <p>The range of elements processed by `findIndex` is set before the first call to _predicate_. Elements that are appended to the array after the call to `findIndex` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `findIndex` visits them.</p>
@@ -33186,7 +33186,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each element present in the array, in ascending order. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
           <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
         </emu-note>
@@ -33352,7 +33352,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.map ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments. `map` calls _callbackfn_ once for each element in the array, in ascending order, and constructs a new Array from the results. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
           <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`map` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `map` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `map` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `map` visits them; elements that are deleted after the call to `map` begins and before being visited are not visited.</p>
@@ -33626,7 +33626,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `some` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *true*. If such an element is found, `some` immediately returns *true*. Otherwise, `some` returns *false*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
           <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`some` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `some` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `some` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time that `some` visits them; elements that are deleted after the call to `some` begins and before being visited are not visited. `some` acts like the "exists" quantifier in mathematics. In particular, for an empty array, it returns *false*.</p>
@@ -35441,7 +35441,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each key/value pair present in the map object, in key insertion order. _callbackfn_ is called only for keys of the map which actually exist; it is not called for keys that have been deleted from the map.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
           <p>_callbackfn_ is called with three arguments: the value of the item, the key of the item, and the Map object being traversed.</p>
           <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_. Each entry of a map's [[MapData]] is only visited once. New keys added after the call to `forEach` begins are visited. A key will be revisited if it is deleted after it has been visited and then re-added before the `forEach` call completes. Keys that are deleted after the call to `forEach` begins and before being visited are not visited unless the key is added again before the `forEach` call completes.</p>
         </emu-note>
@@ -35805,7 +35805,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-note>
           <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each value present in the set object, in value insertion order. _callbackfn_ is called only for values of the Set which actually exist; it is not called for keys that have been deleted from the set.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
           <p>_callbackfn_ is called with three arguments: the first two arguments are a value contained in the Set. The same value is passed for both arguments. The Set object being traversed is passed as the third argument.</p>
           <p>The _callbackfn_ is called with three arguments to be consistent with the call back functions used by `forEach` methods for Map and Array. For Sets, each item value is considered to be both the key and the value.</p>
           <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>

--- a/spec.html
+++ b/spec.html
@@ -34597,8 +34597,8 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.every">
-        <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
+        <h1>%TypedArray%.prototype.every ( _predicate_ [ , _thisArg_ ] )</h1>
+        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* object's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -32975,26 +32975,26 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.every">
-        <h1>Array.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Array.prototype.every ( _predicate_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `every` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *false*. If such an element is found, `every` immediately returns *false*. Otherwise, if _callbackfn_ returned *true* for all elements, `every` will return *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
-          <p>`every` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `every` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `every` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `every` visits them; elements that are deleted after the call to `every` begins and before being visited are not visited. `every` acts like the "for all" quantifier in mathematics. In particular, for an empty array, it returns *true*.</p>
+          <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `every` calls _predicate_ once for each element present in the array, in ascending order, until it finds one where _predicate_ returns *false*. If such an element is found, `every` immediately returns *false*. Otherwise, if _predicate_ returned *true* for all elements, `every` will return *true*. _predicate_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_.</p>
+          <p>_predicate_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
+          <p>`every` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
+          <p>The range of elements processed by `every` is set before the first call to _predicate_. Elements which are appended to the array after the call to `every` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time `every` visits them; elements that are deleted after the call to `every` begins and before being visited are not visited. `every` acts like the "for all" quantifier in mathematics. In particular, for an empty array, it returns *true*.</p>
         </emu-note>
         <p>When the `every` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
               1. If _testResult_ is *false*, return *false*.
             1. Set _k_ to _k_ + 1.
           1. Return *true*.


### PR DESCRIPTION
This change makes naming more descriptive and consistent with `Array.prototype.find` and `Array.prototype.findIndex`.

b662dff is a follow-up of #1411.
See also #1786.