### PR TITLE
Editorial: Fix dangling "Otherwise" step

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12938,8 +12938,7 @@
           1. If FlagText of _literal_ contains any code points other than `g`, `i`, `m`, `s`, `u`, or `y`, or if it contains the same code point more than once, return *false*.
           1. Let _P_ be BodyText of _literal_.
           1. If FlagText of _literal_ contains `u`, then
-            1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[+U, +N]|. If _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist, return *false*.
-            1. Otherwise, return *true*.
+            1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[+U, +N]|. If _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist, return *false*. Otherwise, return *true*.
           1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]|. If _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist, return *false*. Otherwise, return *true*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
This one's my fault: during review of PR #1464, I suggested a change to (what is now) the "Parse" line, without noticing that it stranded the "Otherwise" line.
