### PR TITLE
Editorial: fix two [[FooIteratorNextIndex]] descriptions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30296,7 +30296,7 @@ THH:mm:ss.sss
                 [[StringIteratorNextIndex]]
               </td>
               <td>
-                The integer index of the next string index to be examined by this iteration.
+                The integer index of the next string element (code unit) to be examined by this iteration.
               </td>
             </tr>
             </tbody>
@@ -34096,7 +34096,7 @@ THH:mm:ss.sss
                 [[ArrayIteratorNextIndex]]
               </td>
               <td>
-                The integer index of the next integer index to be examined by this iteration.
+                The integer index of the next array element to be examined by this iteration.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
... that refer to the index of an index rather than the index of an element.

[Cherry-picked from PR #1623.]