### PR TITLE
Editorial: quick fixes for recent merges

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4830,7 +4830,7 @@
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, or *-0*, return *+0*.
-        1. If _number_ is *+&infin;*, or *-&infin;*, return _number_.
+        1. If _number_ is *+&infin;* or *-&infin;*, return _number_.
         1. Let _integer_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. If _integer_ is *-0*, return *+0*.
         1. Return _integer_.

--- a/spec.html
+++ b/spec.html
@@ -11100,9 +11100,12 @@
     <h1>Punctuators</h1>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
+      Punctuator ::
+        OptionalChainingPunctuator
+        OtherPunctuator
+
       OptionalChainingPunctuator ::
         `?.` [lookahead &lt;! DecimalDigit]
-        OtherPunctuator
 
       OtherPunctuator :: one of
         `{` `(` `)` `[` `]`
@@ -11118,10 +11121,6 @@
         `?` `:`
         `=` `+=` `-=` `*=` `%=` `**=` `&lt;&lt;=` `&gt;&gt;=` `&gt;&gt;&gt;=` `&amp;=` `|=` `^=`
         `=&gt;`
-
-      Punctuator ::
-        OptionalChainingPunctuator
-        OtherPunctuator
 
       DivPunctuator ::
         `/`
@@ -13555,9 +13554,9 @@
       <emu-clause id="sec-left-hand-side-expressions-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>
-          OptionalChain[Yield, Await] :
-            `?.` TemplateLiteral[?Yield, ?Await, +Tagged]
-            OptionalChain[?Yield, ?Await] TemplateLiteral[?Yield, ?Await, +Tagged]
+          OptionalChain :
+            `?.` TemplateLiteral
+            OptionalChain TemplateLiteral
         </emu-grammar>
         <ul>
           <li>
@@ -13803,21 +13802,21 @@
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the code matched by this |CallExpression| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the code matched by this |CallExpression| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-evaluate-property-access-with-expression-key" aoid="EvaluatePropertyAccessWithExpressionKey">
-      <h1>Runtime Semantics: EvaluatePropertyAccessWithExpressionKey( _baseValue_, _expression_, _strict_ )</h1>
+      <h1>Runtime Semantics: EvaluatePropertyAccessWithExpressionKey ( _baseValue_, _expression_, _strict_ )</h1>
       <p>The abstract operation EvaluatePropertyAccessWithExpressionKey takes as arguments a value _baseValue_, a Parse Node _expression_, and a Boolean argument _strict_. It performs the following steps:</p>
       <emu-alg>
         1. Let _propertyNameReference_ be the result of evaluating _expression_.
@@ -13828,10 +13827,10 @@
       </emu-alg>
     </emu-clause>
     <emu-clause id="sec-evaluate-property-access-with-identifier-key" aoid="EvaluatePropertyAccessWithIdentifierKey">
-      <h1>Runtime Semantics: EvaluatePropertyAccessWithIdentifierKey( _baseValue_, _identifierName_, _strict_ )</h1>
+      <h1>Runtime Semantics: EvaluatePropertyAccessWithIdentifierKey ( _baseValue_, _identifierName_, _strict_ )</h1>
       <p>The abstract operation EvaluatePropertyAccessWithIdentifierKey takes as arguments a value _baseValue_, a Parse Node _identifierName_, and a Boolean argument _strict_. It performs the following steps:</p>
       <emu-alg>
-        1. Assert: _identifierName_ is an |IdentifierName|
+        1. Assert: _identifierName_ is an |IdentifierName|.
         1. Let _bv_ be ? RequireObjectCoercible(_baseValue_).
         1. Let _propertyNameString_ be StringValue of _identifierName_.
         1. Return a value of type Reference whose base value component is _bv_, whose referenced name component is _propertyNameString_, and whose strict reference flag is _strict_.
@@ -14095,12 +14094,12 @@
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain Arguments</emu-grammar>
@@ -14117,7 +14116,7 @@
           1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? ChainEvaluation of _optionalChain_ with arguments _baseValue_ and _baseReference_.
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_newValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain `.` IdentifierName</emu-grammar>
@@ -14125,7 +14124,7 @@
           1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? ChainEvaluation of _optionalChain_ with arguments _baseValue_ and _baseReference_.
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithIdentifierKey(_newValue_, |IdentifierName|, _strict_).
         </emu-alg>
       </emu-clause>
@@ -15322,7 +15321,7 @@
       <emu-alg>
         1. Let _lref_ be the result of evaluating |CoalesceExpressionHead|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. If _lval_ is *undefined* or *null*,
+        1. If _lval_ is *undefined* or *null*, then
           1. Let _rref_ be the result of evaluating |BitwiseORExpression|.
           1. Return ? GetValue(_rref_).
         1. Otherwise, return _lval_.
@@ -21737,7 +21736,7 @@
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-containsusestrict">
       <h1>Static Semantics: ContainsUseStrict</h1>
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
-      <emu-grammar>AsyncConciseBody : AssignmentExpression</emu-grammar>
+      <emu-grammar>AsyncConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
@@ -41541,6 +41540,8 @@ THH:mm:ss.sss
     <emu-prodref name=UnicodeIDContinue></emu-prodref>
     <emu-prodref name=ReservedWord></emu-prodref>
     <emu-prodref name=Punctuator></emu-prodref>
+    <emu-prodref name=OptionalChainingPunctuator></emu-prodref>
+    <emu-prodref name=OtherPunctuator></emu-prodref>
     <emu-prodref name=DivPunctuator></emu-prodref>
     <emu-prodref name=RightBracePunctuator></emu-prodref>
     <emu-prodref name=NullLiteral></emu-prodref>
@@ -41648,6 +41649,8 @@ THH:mm:ss.sss
     <emu-prodref name=ImportCall></emu-prodref>
     <emu-prodref name=Arguments></emu-prodref>
     <emu-prodref name=ArgumentList></emu-prodref>
+    <emu-prodref name=OptionalExpression></emu-prodref>
+    <emu-prodref name=OptionalChain></emu-prodref>
     <emu-prodref name=LeftHandSideExpression></emu-prodref>
     <emu-prodref name=UpdateExpression></emu-prodref>
     <emu-prodref name=UnaryExpression></emu-prodref>
@@ -41752,6 +41755,7 @@ THH:mm:ss.sss
     <emu-prodref name=ArrowFunction></emu-prodref>
     <emu-prodref name=ArrowParameters></emu-prodref>
     <emu-prodref name=ConciseBody></emu-prodref>
+    <emu-prodref name=ExpressionBody></emu-prodref>
     <p>When the production <emu-prodref name=ArrowParameters a="parencover"></emu-prodref> is recognized the following grammar is used to refine the interpretation of |CoverParenthesizedExpressionAndArrowParameterList|:</p>
     <emu-prodref name=ArrowFormalParameters></emu-prodref>
     <p>&nbsp;</p>

--- a/spec.html
+++ b/spec.html
@@ -27073,7 +27073,7 @@
         <emu-alg>
           1. If _value_ is present, then
             1. Let _prim_ be ? ToNumeric(_value_).
-            1. If Type(_prim_) is BigInt, let _n_ be the Number value for _prim_.
+            1. If Type(_prim_) is BigInt, let _n_ be the Number value for the mathematical value of _prim_.
             1. Otherwise, let _n_ be _prim_.
           1. Else,
             1. Let _n_ be *+0*.

--- a/spec.html
+++ b/spec.html
@@ -10903,7 +10903,7 @@
 
       LineTerminatorSequence ::
         &lt;LF&gt;
-        &lt;CR&gt; [lookahead != &lt;LF&gt; ]
+        &lt;CR&gt; [lookahead != &lt;LF&gt;]
         &lt;LS&gt;
         &lt;PS&gt;
         &lt;CR&gt; &lt;LF&gt;
@@ -11878,7 +11878,7 @@
           TemplateCharacter TemplateCharacters?
 
         TemplateCharacter ::
-          `$` [lookahead != `{` ]
+          `$` [lookahead != `{`]
           `\` EscapeSequence
           `\` NotEscapeSequence
           LineContinuation
@@ -11899,10 +11899,10 @@
           `u` `{` CodePoint [lookahead &lt;! HexDigit] [lookahead != `}`]
 
         NotCodePoint ::
-          HexDigits [> but only if MV of |HexDigits| &gt; 0x10FFFF ]
+          HexDigits [> but only if MV of |HexDigits| &gt; 0x10FFFF]
 
         CodePoint ::
-          HexDigits [> but only if MV of |HexDigits| &le; 0x10FFFF ]
+          HexDigits [> but only if MV of |HexDigits| &le; 0x10FFFF]
       </emu-grammar>
       <p>A conforming implementation must not use the extended definition of |EscapeSequence| described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref> when parsing a |TemplateCharacter|.</p>
       <emu-note>
@@ -12091,7 +12091,7 @@
             The TRV of <emu-grammar>LineTerminatorSequence :: &lt;PS&gt;</emu-grammar> is the code unit 0x2029 (PARAGRAPH SEPARATOR).
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt;&lt;LF&gt;</emu-grammar> is the sequence consisting of the code unit 0x000A (LINE FEED).
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt; &lt;LF&gt;</emu-grammar> is the sequence consisting of the code unit 0x000A (LINE FEED).
           </li>
         </ul>
         <emu-note>
@@ -13532,7 +13532,7 @@
         `?.` IdentifierName
         `?.` TemplateLiteral[?Yield, ?Await, +Tagged]
         OptionalChain[?Yield, ?Await] Arguments[?Yield, ?Await]
-        OptionalChain[?Yield, ?Await]  `[` Expression[+In, ?Yield, ?Await] `]`
+        OptionalChain[?Yield, ?Await] `[` Expression[+In, ?Yield, ?Await] `]`
         OptionalChain[?Yield, ?Await] `.` IdentifierName
         OptionalChain[?Yield, ?Await] TemplateLiteral[?Yield, ?Await, +Tagged]
 
@@ -17312,10 +17312,10 @@
         `for` `(` [lookahead != `let` `[`] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` [lookahead != `let` ] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+        `for` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         `for` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        [+Await] `for` `await` `(` [lookahead != `let` ] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+        [+Await] `for` `await` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         [+Await] `for` `await` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
         [+Await] `for` `await` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
 
@@ -17766,7 +17766,6 @@
             `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-
         </emu-grammar>
         <emu-alg>
           1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
@@ -19919,7 +19918,7 @@
         CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parencover
 
       ConciseBody[In] :
-        [lookahead != `{` ] ExpressionBody[?In, ~Await]
+        [lookahead != `{`] ExpressionBody[?In, ~Await]
         `{` FunctionBody[~Yield, ~Await] `}`
 
       ExpressionBody[In, Await] :
@@ -24483,7 +24482,7 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportFromClause : `*` `as` IdentifierName </emu-grammar>
+        <emu-grammar>ExportFromClause : `*` `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Return a List containing the StringValue of |IdentifierName|.
         </emu-alg>


### PR DESCRIPTION
The phrase "the Number value for X" is only defined on mathematical values,
but `_prim_` is a BigInt value here.
So we have to take the mathematical value of `_prim_`
before applying "the Number value for ..."

(Quick fix for PR #1766.)