### PR TITLE
Editorial: Fix Elymiac row markup in scripts table

### DIFF
--- a/table-unicode-script-values.html
+++ b/table-unicode-script-values.html
@@ -317,7 +317,7 @@
     <tr>
       <td>
         <ul>
-          <td>`Elymaic`</td>
+          <li>`Elymaic`</li>
           <li>`Elym`</li>
         </ul>
       </td>


### PR DESCRIPTION
Accidental `<td>` where `<li>` was expected in the row for Elymaic / Elym in the Unicode script values table is bustin out weird:

![image](https://user-images.githubusercontent.com/6257356/69370638-52994880-0c6c-11ea-9c24-2c778c20c513.png)
![image](https://user-images.githubusercontent.com/6257356/69370654-5e850a80-0c6c-11ea-8555-a5a7f05d70ed.png)
