### PR TITLE
Normative: make EnumerableOwnPropertyNames ordered

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5897,7 +5897,6 @@
                   1. Assert: _kind_ is ~key+value~.
                   1. Let _entry_ be ! CreateArrayFromList(&laquo; _key_, _value_ &raquo;).
                   1. Append _entry_ to _properties_.
-        1. Order the elements of _properties_ so they are in the same relative order as would be produced by the Iterator that would be returned if the EnumerateObjectProperties internal method were invoked with _O_.
         1. Return _properties_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Related to [proposal-for-in-order](https://github.com/tc39/proposal-for-in-order). Added as a separate PR because this change wasn't technically in scope during the process for that proposal. Thanks to @domenic for [bringing this to my attention](https://github.com/tc39/proposal-for-in-order/issues/19#issue-509659089).

`EnumerableOwnPropertyNames` is used by `Object.keys`, `Object.values`, `Object.entries`, `JSON.parse`, and `JSON.stringify`.

Removing this line has the effect of requiring those to be ordered the same way as `Reflect.ownKeys`, which is fully specified, rather than `for-in`, which is only partially specified.

I have not been able to find cases where implementations order any of the APIs which use `EnumerableOwnPropertyNames` differently than they would `Reflect.ownKeys`, even in the presence of exotic objects and accessors which modify the object being iterated. So removing this line should not have any effects on the implementations I have on hand.

I want to make this change for two reasons:

1. It removes a case where implementations are permitted to differ, and
2. This line is incredibly confusing anyway, since it is impossible for an implementation to know how the "the Iterator that would be returned if the EnumerateObjectProperties internal method were invoked with _O_" would behave without actually invoking it, which can have arbitrary other side effects.