### PR TITLE
Editorial: adding ids to individual algorithms of equality semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14748,7 +14748,7 @@
     <emu-clause id="sec-equality-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
-      <emu-alg>
+      <emu-alg id="alg-equality-operators-eqeq-runtime-semantics-evaluation">
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
@@ -14756,7 +14756,7 @@
         1. Return the result of performing Abstract Equality Comparison _rval_ == _lval_.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
-      <emu-alg>
+      <emu-alg id="alg-equality-operators-neqeq-runtime-semantics-evaluation">
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
@@ -14766,7 +14766,7 @@
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
-      <emu-alg>
+      <emu-alg id="alg-equality-operators-eqeqeq-runtime-semantics-evaluation">
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
@@ -14774,7 +14774,7 @@
         1. Return the result of performing Strict Equality Comparison _rval_ === _lval_.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
-      <emu-alg>
+      <emu-alg id="alg-equality-operators-neqeqeq-runtime-semantics-evaluation">
         1. Let _lref_ be the result of evaluating |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.


### PR DESCRIPTION
This PR adds ids to the different `emu-alg` of the [equality semantics](https://tc39.es/ecma262/#sec-equality-operators-runtime-semantics-evaluation). This does not change the way the specification is rendered.

I have two questions about this PR:
- Is it a good approach to have links to algorithms when there are several in a section?
- What should be the naming convention for these links?