### PR TITLE
Editorial: Improve readability in 11.10.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12260,7 +12260,7 @@
 
     <p>As new syntactic features are added to ECMAScript, additional grammar productions could be added that cause lines relying on automatic semicolon insertion preceding them to change grammar productions when parsed.</p>
 
-    <p>The interesting cases of automatic semicolon insertion are places where a semicolon may or may not be inserted depending on preceding source text according to the rules above. These places are considered interesting if changes outside of an existing source text grammar production could change the grammar production of the existing source text depending on automatic semicolon insertion. The rest of this section describes a number of interesting cases of automatic semicolon insertion in this version of ECMAScript.</p>
+    <p>For the purposes of this section, a case of automatic semicolon insertion is considered interesting if it is a place where a semicolon may or may not be inserted, depending on the source text which precedes it. The rest of this section describes a number of interesting cases of automatic semicolon insertion in this version of ECMAScript.</p>
     <emu-clause id="sec-asi-interesting-cases-in-statement-lists">
       <h1>Interesting Cases of Automatic Semicolon Insertion in Statement Lists</h1>
       <p>In a |StatementList|, many |StatementListItem|s end in semicolons, which may be omitted using automatic semicolon insertion. As a consequence of the rules above, at the end of a line ending an expression, a semicolon is required if the following line begins with any of the following:</p>


### PR DESCRIPTION
Just a small wordsmithing follow-up to #1062:

We have two sentences in a row saying effectively the same thing in different words, namely, the definition of "interesting". In fact, the previous paragraph already sets up the same concept (surprising reparses) for a different purpose (_new_ productions instead of existing ones) so in addition to eliminating a sentence here, we can also make a cleaner transition into the new paragraph.