### PR TITLE
Normative: Remove steps 2 and 4 from ProxyCreate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10326,9 +10326,7 @@
       <p>The abstract operation ProxyCreate takes arguments _target_ and _handler_. It is used to specify the creation of new Proxy exotic objects. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
-        1. If _target_ is a Proxy exotic object and _target_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
         1. If Type(_handler_) is not Object, throw a *TypeError* exception.
-        1. If _handler_ is a Proxy exotic object and _handler_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
         1. Let _P_ be ! MakeBasicObject(&laquo; [[ProxyHandler]], [[ProxyTarget]] &raquo;).
         1. Set _P_'s essential internal methods, except for [[Call]] and [[Construct]], to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
         1. If IsCallable(_target_) is *true*, then


### PR DESCRIPTION
Currently, [ProxyCreate][0] is sensitive to whether its arguments are revoked proxies. If either is, it throws a TypeError. This PR alters the algorithm to remove that sensitivity. Its consequence is that a Proxy could be created successfully where _target_ or _handlers_ are revoked Proxy exotic objects. (It was already possible for such Proxies to exist — just not for them to be _created_ while already in that state.)

The motivation for this change is discussed in issue #1798. Quoting @erights:

> It is a mistake because it makes the revocable-ness state of a proxy observable. When we first introduced revocable proxies, we intended observational equivalence to a handler that only throws. We were not trying to introduce behavior that could not otherwise be expressed. We were trying to enable gc. [...] Step 2 breaks that illusion and makes detectable a state change that should have been encapsulated in the proxy.

Per @caridy the intention for this PR is to

> gather feedback from now until the next meeting (early next year).

Note that while part of the motivation for this change is to reduce the observability of an object’s status as a (revoked) Proxy exotic object, it would not in itself eliminate it. It will remain possible to detect if any object is a revoked Proxy because of step 3.a. of [IsArray][1] and, for a subset of objects, through more complex maneuvers, [GetFunctionRealm][2]. It’s possible that both of these algorithms could be altered to cease revealing this information web-safely, but I’m hardly certain of that.

[0]: https://tc39.es/ecma262/#sec-proxycreate
[1]: https://tc39.es/ecma262/#sec-isarray
[2]: https://tc39.es/ecma262/#sec-getfunctionrealm

Fixes #1798.