### PR TITLE
Normative: ToInteger normalizes `-0` to `+0`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4829,8 +4829,8 @@
       <p>The abstract operation ToInteger converts _argument_ to an integral Number value. This abstract operation functions as follows:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, return *+0*.
-        1. If _number_ is *+0*, *-0*, *+&infin;*, or *-&infin;*, return _number_.
+        1. If _number_ is *NaN*, *+0*, or *-0*, return *+0*.
+        1. If _number_ is *+&infin;*, or *-&infin;*, return _number_.
         1. Return the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
       </emu-alg>
     </emu-clause>
@@ -5295,7 +5295,7 @@
           1. Let _integerIndex_ be ? ToInteger(_value_).
           1. If _integerIndex_ &lt; 0, throw a *RangeError* exception.
           1. Let _index_ be ! ToLength(_integerIndex_).
-          1. If SameValueZero(_integerIndex_, _index_) is *false*, throw a *RangeError* exception.
+          1. If ! SameValue(_integerIndex_, _index_) is *false*, throw a *RangeError* exception.
         1. Return _index_.
       </emu-alg>
     </emu-clause>
@@ -28609,9 +28609,7 @@
         <emu-alg>
           1. If _time_ is not finite, return *NaN*.
           1. If abs(_time_) &gt; 8.64 &times; 10<sup>15</sup>, return *NaN*.
-          1. Let _clippedTime_ be ! ToInteger(_time_).
-          1. If _clippedTime_ is *-0*, set _clippedTime_ to *+0*.
-          1. Return _clippedTime_.
+          1. Return ! ToInteger(_time_).
         </emu-alg>
         <emu-note>
           <p>The point of step 4 is that an implementation is permitted a choice of internal representations of time values, for example as a 64-bit signed integer or as a 64-bit floating-point value. Depending on the implementation, this internal representation may or may not distinguish *-0* and *+0*.</p>
@@ -33773,7 +33771,7 @@ THH:mm:ss.sss
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
           1. If _n_ &ge; _len_, return -1.
           1. If _n_ &ge; 0, then
-            1. If _n_ is *-0*, let _k_ be *+0*; else let _k_ be _n_.
+            1. Let _k_ be _n_.
           1. Else,
             1. Let _k_ be _len_ + _n_.
             1. If _k_ &lt; 0, set _k_ to 0.
@@ -33840,7 +33838,7 @@ THH:mm:ss.sss
           1. If _len_ is 0, return -1.
           1. If _fromIndex_ is present, let _n_ be ? ToInteger(_fromIndex_); else let _n_ be _len_ - 1.
           1. If _n_ &ge; 0, then
-            1. If _n_ is *-0*, let _k_ be *+0*; else let _k_ be min(_n_, _len_ - 1).
+            1. Let _k_ be min(_n_, _len_ - 1).
           1. Else,
             1. Let _k_ be _len_ + _n_.
           1. Repeat, while _k_ &ge; 0


### PR DESCRIPTION
Fixes #1637.

This only has an observable impact on `Atomics.store`.