### PR TITLE
Editorial: Lookahead single-element shorthand permits terminal sequences

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -671,7 +671,7 @@
           `9`
       </emu-grammar>
       <p>If the phrase &ldquo;[empty]&rdquo; appears as the right-hand side of a production, it indicates that the production's right-hand side contains no terminals or nonterminals.</p>
-      <p>If the phrase &ldquo;[lookahead &notin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may not be used if the immediately following input token sequence is a member of the given _set_. The _set_ can be written as a comma separated list of one or two element terminal sequences enclosed in curly brackets. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all terminals to which that nonterminal could expand. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead &ne; _terminal_]&rdquo; may be used.</p>
+      <p>If the phrase &ldquo;[lookahead &notin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may not be used if the immediately following input token sequence is a member of the given _set_. The _set_ can be written as a comma separated list of one or two element terminal sequences enclosed in curly brackets. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all terminals to which that nonterminal could expand. If the _set_ consists of a single terminal sequence the phrase &ldquo;[lookahead &ne; _terminal_ _sequence_]&rdquo; may be used.</p>
       <p>For example, given the definitions:</p>
       <emu-grammar type="example">
         DecimalDigit :: one of
@@ -688,7 +688,7 @@
           DecimalDigit [lookahead &lt;! DecimalDigit]
       </emu-grammar>
       <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
-      <p>Similarly, if the phrase &ldquo;[lookahead &isin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the immediately following input token sequence is a member of the given _set_. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead = _terminal_]&rdquo; may be used.</p>
+      <p>Similarly, if the phrase &ldquo;[lookahead &isin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the immediately following input token sequence is a member of the given _set_. If the _set_ consists of a single terminal sequence the phrase &ldquo;[lookahead = _terminal_ _sequence_]&rdquo; may be used.</p>
       <p>If the phrase &ldquo;[no |LineTerminator| here]&rdquo; appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a |LineTerminator| occurs in the input stream at the indicated position. For example, the production:</p>
       <emu-grammar type="example">
         ThrowStatement :


### PR DESCRIPTION
Currently, the [Grammar Notation](https://tc39.es/ecma262/#sec-grammar-notation) section describes when the `≠` shorthand is permitted for `∉` as follows:

![image](https://user-images.githubusercontent.com/6257356/71751854-ef91f880-2e4a-11ea-8077-036ba43085f4.png)

(With similar text following for `=` / `∈`.)

The shorthand for single members is used with terminal sequences, though:

![image](https://user-images.githubusercontent.com/6257356/71752040-96769480-2e4b-11ea-80a3-994b1a680af6.png)

That makes sense, given the set notation permits sequences, but it means the description in Grammar Notation is incorrect. It may just be a typo in origin.

This change would align the descriptions with how this notation is used in practice later in the spec. It preserves the existing constraint that the sequences in question be composed of terminals only.

---

(Regarding markup: I found I needed to write `_terminal_ _sequence_` instead of `_terminal sequence_`, and it’s maybe a bit odd that these italicized terms should be the ‘click to highlight’ sort since this isn’t algorithmic text. Should they be marked up using `<em>` or `<i>` instead maybe?)