### PR TITLE
Bugfix: Fix the LexicalEnvironment of the execution context during function parameter eval

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8668,6 +8668,8 @@
           1. Let _calleeEnv_ be the LexicalEnvironment of _calleeContext_.
           1. Let _env_ be NewDeclarativeEnvironment(_calleeEnv_).
           1. Let _envRec_ be _env_'s EnvironmentRecord.
+          1. Assert: The VariableEnvironment of _calleeContext_ is _calleeEnv_.
+          1. Set the LexicalEnvironment of _calleeContext_ to _env_.
         1. For each String _paramName_ in _parameterNames_, do
           1. Let _alreadyDeclared_ be _envRec_.HasBinding(_paramName_).
           1. NOTE: Early errors ensure that duplicate parameter names can only occur in non-strict functions that do not have parameter default values or rest parameters.


### PR DESCRIPTION
Fallout from #1046. When creating a new environment so that
sloppy direct eval-introduced vars are in a different environment, the
LexicalEnvironment of the execution context was not updated.

Thanks to @devsnek for the catch.