### PR TITLE
Editorial: Clean up some inline notes.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1990,7 +1990,8 @@
               1. Assert: _op_ is *"^"*.
               1. Let _tmp_ be BinaryXor(_x_ modulo 2, _y_ modulo 2).
             1. If _tmp_ &ne; 0, then
-              1. Set _result_ to _result_ - 2<sup>_shift_</sup>. NOTE: This extends the sign.
+              1. Set _result_ to _result_ - 2<sup>_shift_</sup>.
+              1. NOTE: This extends the sign.
             1. Return _result_.
           </emu-alg>
         </emu-clause>
@@ -5451,8 +5452,10 @@
         1. Assert: Type(_p_) is String.
         1. Assert: Type(_q_) is String.
         1. If _q_ can be the string-concatenation of _p_ and some other String _r_, return *true*. Otherwise, return *false*.
-        1. NOTE: Any String is a prefix of itself, because _r_ may be the empty String.
       </emu-alg>
+      <emu-note>
+        <p>Any String is a prefix of itself, because _r_ may be the empty String.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-samevalue" aoid="SameValue">
@@ -5528,7 +5531,8 @@
             1. Let _nx_ be ! StringToBigInt(_px_).
             1. If _nx_ is *NaN*, return *undefined*.
             1. Return BigInt::lessThan(_nx_, _py_).
-          1. Let _nx_ be ? ToNumeric(_px_). NOTE: Because _px_ and _py_ are primitive values evaluation order is not important.
+          1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
+          1. Let _nx_ be ? ToNumeric(_px_).
           1. Let _ny_ be ? ToNumeric(_py_).
           1. If Type(_nx_) is the same as Type(_ny_), return Type(_nx_)::lessThan(_nx_, _ny_).
           1. Assert: Type(_nx_) is BigInt and Type(_ny_) is Number, or Type(_nx_) is Number and Type(_ny_) is BigInt.
@@ -8681,7 +8685,7 @@
           1. If _strict_ is *true* or if _simpleParameterList_ is *false*, then
             1. Let _ao_ be CreateUnmappedArgumentsObject(_argumentsList_).
           1. Else,
-            1. NOTE: mapped argument object is only provided for non-strict functions that don't have a rest parameter, any parameter default value initializers, or any destructured parameters.
+            1. NOTE: A mapped argument object is only provided for non-strict functions that don't have a rest parameter, any parameter default value initializers, or any destructured parameters.
             1. Let _ao_ be CreateMappedArgumentsObject(_func_, _formals_, _argumentsList_, _envRec_).
           1. If _strict_ is *true*, then
             1. Perform ! _envRec_.CreateImmutableBinding(*"arguments"*, *false*).
@@ -8720,7 +8724,7 @@
               1. Else,
                 1. Let _initialValue_ be ! _envRec_.GetBindingValue(_n_, *false*).
               1. Call _varEnvRec_.InitializeBinding(_n_, _initialValue_).
-              1. NOTE: vars whose names are the same as a formal parameter, initially have the same value as the corresponding initialized parameter.
+              1. NOTE: A var with the same name as a formal parameter initially has the same value as the corresponding initialized parameter.
         1. NOTE: Annex <emu-xref href="#sec-web-compat-functiondeclarationinstantiation"></emu-xref> adds additional steps at this point.
         1. If _strict_ is *false*, then
           1. Let _lexEnv_ be NewDeclarativeEnvironment(_varEnv_).
@@ -18737,7 +18741,8 @@
         1. Let _R_ be the result of evaluating |DefaultClause|.
         1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
         1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
-        1. For each |CaseClause| _C_ in _B_ (NOTE: this is another complete iteration of the second |CaseClauses|), do
+        1. NOTE: The following is another complete iteration of the second |CaseClauses|.
+        1. For each |CaseClause| _C_ in _B_, do
           1. Let _R_ be the result of evaluating |CaseClause| _C_.
           1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
           1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).


### PR DESCRIPTION
This PR cleans up a couple of notes which are inlined into algorithms:
- Move notes that share a line with a normal algorithm step to their own line. (x3)
- Un-inline a final note which refers to the algorithm as a whole. (x1)
- Fix grammar. (x2)