### PR TITLE
Editorial: Remove erroneous emu-grammar attribute.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15128,7 +15128,7 @@
 
     <emu-clause id="sec-binary-bitwise-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <p>The production <emu-grammar type="example">A : A @ B</emu-grammar>, where @ is one of the bitwise operators in the productions above, is evaluated as follows:</p>
+      <p>The production <emu-grammar>A : A @ B</emu-grammar>, where @ is one of the bitwise operators in the productions above, is evaluated as follows:</p>
       <emu-alg>
         1. Let _lref_ be the result of evaluating _A_.
         1. Let _lval_ be ? GetValue(_lref_).


### PR DESCRIPTION
See https://github.com/bterlson/ecmarkup/issues/126#issuecomment-570834393.

A certain `emu-grammar` element is currently marked `type="example"` in spite of clearly being no such thing. This has no visible effect at the moment but it will soon.