### PR TITLE
Editorial: Fix outdated Step # references.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15387,7 +15387,7 @@
         1. Return _r_.
       </emu-alg>
       <emu-note>
-        <p>When an assignment occurs within strict mode code, it is a runtime error if _lref_ in step 1.f of the first algorithm or step 7 of the second algorithm it is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, nor to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
+        <p>When an assignment occurs within strict mode code, it is a runtime error if _lref_ in step 1.e of the first algorithm or step 7 of the second algorithm is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, nor to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
       </emu-note>
     </emu-clause>
 
@@ -16547,7 +16547,7 @@
           1. Return ? PutValue(_lhs_, _value_).
         </emu-alg>
         <emu-note>
-          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's object Environment Record, then step 6 will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
+          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's object Environment Record, then step 5 will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
         </emu-note>
         <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
@@ -20061,7 +20061,7 @@
         1. Return _closure_.
       </emu-alg>
       <emu-note>
-        <p>An |ArrowFunction| does not define local bindings for `arguments`, `super`, `this`, or `new.target`. Any reference to `arguments`, `super`, `this`, or `new.target` within an |ArrowFunction| must resolve to a binding in a lexically enclosing environment. Typically this will be the Function Environment of an immediately enclosing function. Even though an |ArrowFunction| may contain references to `super`, the function object created in step 4 is not made into a method by performing MakeMethod. An |ArrowFunction| that references `super` is always contained within a non-|ArrowFunction| and the necessary state to implement `super` is accessible via the _scope_ that is captured by the function object of the |ArrowFunction|.</p>
+        <p>An |ArrowFunction| does not define local bindings for `arguments`, `super`, `this`, or `new.target`. Any reference to `arguments`, `super`, `this`, or `new.target` within an |ArrowFunction| must resolve to a binding in a lexically enclosing environment. Typically this will be the Function Environment of an immediately enclosing function. Even though an |ArrowFunction| may contain references to `super`, the function object created in step 3 is not made into a method by performing MakeMethod. An |ArrowFunction| that references `super` is always contained within a non-|ArrowFunction| and the necessary state to implement `super` is accessible via the _scope_ that is captured by the function object of the |ArrowFunction|.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -26255,7 +26255,7 @@
           <p>The _thisArg_ value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* _thisArg_ is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the _thisArg_ is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
         </emu-note>
         <emu-note>
-          <p>If _func_ is an arrow function or a bound function then the _thisArg_ will be ignored by the function [[Call]] in step 5.</p>
+          <p>If _func_ is an arrow function or a bound function then the _thisArg_ will be ignored by the function [[Call]] in step 6.</p>
         </emu-note>
       </emu-clause>
 
@@ -26304,7 +26304,7 @@
           <p>The _thisArg_ value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* _thisArg_ is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the _thisArg_ is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
         </emu-note>
         <emu-note>
-          <p>If _func_ is an arrow function or a bound function then the _thisArg_ will be ignored by the function [[Call]] in step 5.</p>
+          <p>If _func_ is an arrow function or a bound function then the _thisArg_ will be ignored by the function [[Call]] in step 6.</p>
         </emu-note>
       </emu-clause>
 
@@ -31484,7 +31484,7 @@ THH:mm:ss.sss
             <p>because each iteration of the outermost `*` clears all captured Strings contained in the quantified |Atom|, which in this case includes capture Strings numbered 2, 3, 4, and 5.</p>
           </emu-note>
           <emu-note>
-            <p>Step 1 of the RepeatMatcher's _d_ closure states that, once the minimum number of repetitions has been satisfied, any more expansions of |Atom| that match the empty character sequence are not considered for further repetitions. This prevents the regular expression engine from falling into an infinite loop on patterns such as:</p>
+            <p>Step 2.a of the RepeatMatcher states that once the minimum number of repetitions has been satisfied, any more expansions of |Atom| that match the empty character sequence are not considered for further repetitions. This prevents the regular expression engine from falling into an infinite loop on patterns such as:</p>
             <pre><code class="javascript">/(a*)*/.exec("b")</code></pre>
             <p>or the slightly more complicated:</p>
             <pre><code class="javascript">/(a*)b\1+/.exec("baaaac")</code></pre>
@@ -40531,7 +40531,7 @@ THH:mm:ss.sss
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
-          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, the step 3.g above.
+          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, the step 4.g above.
           1. Return.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Noticed by @bathos in https://github.com/tc39/ecma262/issues/1834#issuecomment-571075603.

I'm shocked by how many of these there are, but it makes sense because there's nothing to enforce their correctness. We really could use a safer approach here, but in the mean time, this should fix what's no longer accurate.