### PR TITLE
Editorial: Improve `Array.[[DefineOwnProperty]]` length variable names

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14080,18 +14080,18 @@
           1. If _P_ is *"length"*, then
             1. Return ? ArraySetLength(_A_, _Desc_).
           1. Else if _P_ is an array index, then
-            1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
-            1. Assert: IsDataDescriptor(_oldLenDesc_) is *true*.
-            1. Assert: _oldLenDesc_.[[Configurable]] is *false*.
-            1. Let _oldLen_ be _oldLenDesc_.[[Value]].
-            1. Assert: _oldLen_ is a non-negative integral Number.
+            1. Let _lengthDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
+            1. Assert: IsDataDescriptor(_lengthDesc_) is *true*.
+            1. Assert: _lengthDesc_.[[Configurable]] is *false*.
+            1. Let _length_ be _lengthDesc_.[[Value]].
+            1. Assert: _length_ is a non-negative integral Number.
             1. Let _index_ be ! ToUint32(_P_).
-            1. If _index_ &ge; _oldLen_ and _oldLenDesc_.[[Writable]] is *false*, return *false*.
+            1. If _index_ &ge; _length_ and _lengthDesc_.[[Writable]] is *false*, return *false*.
             1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
             1. If _succeeded_ is *false*, return *false*.
-            1. If _index_ &ge; _oldLen_, then
-              1. Set _oldLenDesc_.[[Value]] to _index_ + *1*<sub>𝔽</sub>.
-              1. Set _succeeded_ to ! OrdinaryDefineOwnProperty(_A_, *"length"*, _oldLenDesc_).
+            1. If _index_ &ge; _length_, then
+              1. Set _lengthDesc_.[[Value]] to _index_ + *1*<sub>𝔽</sub>.
+              1. Set _succeeded_ to ! OrdinaryDefineOwnProperty(_A_, *"length"*, _lengthDesc_).
               1. Assert: _succeeded_ is *true*.
             1. Return *true*.
           1. Return ? OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).


### PR DESCRIPTION
In&nbsp;[**Array&nbsp;Exotic&nbsp;Objects**<code>.</code>&#x2060;<code>[[DefineOwnProperty]]</code><code>(</code><code><var>P</var></code><code>,</code><code><var>Desc</var></code><code>)</code>](https://tc39.es/ecma262#sec-array-exotic-objects-defineownproperty-p-desc), only&nbsp;the&nbsp;<code><var>oldLenDesc</var></code> and&nbsp;<code><var>oldLen</var></code> variables are&nbsp;used, and&nbsp;there’s&nbsp;no&nbsp;<code><var>newLenDesc</var></code> or&nbsp;<code><var>newLen</var></code>&nbsp;variable referenced&nbsp;anywhere, so&nbsp;I’m&nbsp;renaming <code><var>oldLenDesc</var></code>&nbsp;and&nbsp;<code><var>oldLen</var></code> to&nbsp;<code><var>lengthDesc</var></code> and&nbsp;<code><var>length</var></code>&nbsp;respectively.