### PR TITLE
Meta: Stop letting ecmarkup load 262's own outdated bibliography file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ipr-check": "node scripts/check-form tc39/ecma262 \"$TRAVIS_COMMIT\"",
     "build-es2019": "git remote remove origin && git remote add origin \"git@github.com:$TRAVIS_REPO_SLUG.git\" && git fetch --quiet origin && git checkout --quiet es2019 && mkdir \"out/2019\" && cp -R img \"out/2019\" && ecmarkup --verbose spec.html out/2019/index.html --css out/2019/ecmarkup.css --js out/2019/ecmarkup.js && git checkout --quiet test-travis",
     "prebuild-master": "npm run clean && mkdir out && cp -R img out",
-    "build-master": "ecmarkup --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
+    "build-master": "npm run wipe-es6biblio && ecmarkup --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
     "build": "npm run build-master",
     "build-for-pdf": "npm run build-master -- --old-toc",
     "build-travis": "npm run build-master && npm run build-es2019",
@@ -15,7 +15,8 @@
     "build-snapshot": "npm run build-master && node scripts/insert_snapshot_warning.js",
     "clean": "rm -rf out",
     "test": "exit 0",
-    "watch": "npm run build-master -- --watch"
+    "watch": "npm run build-master -- --watch",
+    "wipe-es6biblio": "echo \"{}\" > node_modules/ecmarkup/es6biblio.json"
   },
   "repository": "tc39/ecma262",
   "author": "ECMA TC39",


### PR DESCRIPTION
### Problem

Links to abstract operations `thisBooleanValue` and `thisTimeValue` are absolute and point to https://tc39.github.io/ecma262.

### Cause

- ecmarkup contains an [es6biblio.json](https://github.com/bterlson/ecmarkup/blob/master/es6biblio.json) file which enables other specs / proposals to reference ECMA-262.
- This file has not been updated in over three years.
- Unlike [consciously-linked](https://bterlson.github.io/ecmarkup/#emu-biblio) bibliographies, es6biblio.json is [loaded unconditionally](https://github.com/bterlson/ecmarkup/blob/master/src/Spec.ts#L190).

And so, ecmarkup thinks living ECMA-262 is just some spec that happens to reference ES2017.

### Solution

1. Ensure es6biblio.json is an empty object before building 262 (this PR).
2. Update es6biblio.json over in ecmarkup, since everybody else needs it (PR https://github.com/bterlson/ecmarkup/pull/167).
3. Have ecmarkup allow 262 to opt out of loading es6biblio.json (issue https://github.com/bterlson/ecmarkup/issues/168).