### PR TITLE
Editorial: Give emu-notes some color.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41,6 +41,19 @@
     padding-left: 0;
     list-style: none;
   }
+  /* the following overrides need to be moved into ecmarkup itself */
+  emu-note {
+    color: inherit;
+    border-left: 5px solid #52E052;
+    background: #E9FBE9;
+    padding: 10px 10px 10px 0;
+  }
+  pre code.hljs {
+    background: transparent;
+  }
+  emu-table td {
+    background: #fff;
+  }
 </style>
 <pre class=metadata>
   title: ECMAScript&reg; 2020 Language&nbsp;Specification


### PR DESCRIPTION
Resolves #1825.
(_Well, sort of. This should eventually be done in ecmarkup itself, but ecmarkup is tricky to get changes into at the moment, and it's nice to have a concrete 262 snapshot to critique._)

This PR implements the "green notes without colored NOTE indicator" approach of https://github.com/tc39/ecma262/issues/1825#issuecomment-570971879.

Specifically:
- Borrow green border and background colors from Bikeshed
    (_easier than inventing something new, at least as a starting point_)
- Remove grey text color
- Add 10px padding to the three non-border sides
- Make `<code>` background transparent and `<td>` background white
    (_existing issues that only become visible when sitting on top of a non-white background_)
