### PR TITLE
Editorial: Let code wrap in tables-in-notes.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41,6 +41,9 @@
     padding-left: 0;
     list-style: none;
   }
+  emu-note emu-table td code {
+    white-space: normal;
+  } 
 </style>
 <pre class=metadata>
   title: ECMAScript&reg; 2020 Language&nbsp;Specification


### PR DESCRIPTION
Resolves #1843.