### PR TITLE
Editorial: `CreateArrayIterator`: add missing `kind` assertion

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34427,6 +34427,7 @@ THH:mm:ss.sss
         <p>Several methods of Array objects return Iterator objects. The abstract operation CreateArrayIterator with arguments _array_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
         <emu-alg>
           1. Assert: Type(_array_) is Object.
+          1. Assert: _kind_ is ~key+value~, ~key~, or ~value~.
           1. Let _iterator_ be ObjectCreate(%ArrayIteratorPrototype%, &laquo; [[IteratedArrayLike]], [[ArrayLikeNextIndex]], [[ArrayLikeIterationKind]] &raquo;).
           1. Set _iterator_.[[IteratedArrayLike]] to _array_.
           1. Set _iterator_.[[ArrayLikeNextIndex]] to 0.


### PR DESCRIPTION
`CreateArrayIterator` is only ever called with one of three values; but there is no assertion that this is the case except inside the `next` method.