### PR TITLE
Editorial: Improve consistency of backtick use for built-ins.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -308,9 +308,9 @@
 
     <emu-clause id="sec-boolean-object">
       <h1>Boolean object</h1>
-      <p>member of the Object type that is an instance of the standard built-in `Boolean` constructor</p>
+      <p>member of the Object type that is an instance of the standard built-in Boolean constructor</p>
       <emu-note>
-        <p>A Boolean object is created by using the `Boolean` constructor in a `new` expression, supplying a Boolean value as an argument. The resulting object has an internal slot whose value is the Boolean value. A Boolean object can be coerced to a Boolean value.</p>
+        <p>A Boolean object is created by using the Boolean constructor in a `new` expression, supplying a Boolean value as an argument. The resulting object has an internal slot whose value is the Boolean value. A Boolean object can be coerced to a Boolean value.</p>
       </emu-note>
     </emu-clause>
 
@@ -329,9 +329,9 @@
 
     <emu-clause id="sec-string-object">
       <h1>String object</h1>
-      <p>member of the Object type that is an instance of the standard built-in `String` constructor</p>
+      <p>member of the Object type that is an instance of the standard built-in String constructor</p>
       <emu-note>
-        <p>A String object is created by using the `String` constructor in a `new` expression, supplying a String value as an argument. The resulting object has an internal slot whose value is the String value. A String object can be coerced to a String value by calling the `String` constructor as a function (<emu-xref href="#sec-string-constructor-string-value"></emu-xref>).</p>
+        <p>A String object is created by using the String constructor in a `new` expression, supplying a String value as an argument. The resulting object has an internal slot whose value is the String value. A String object can be coerced to a String value by calling the String constructor as a function (<emu-xref href="#sec-string-constructor-string-value"></emu-xref>).</p>
       </emu-note>
     </emu-clause>
 
@@ -350,9 +350,9 @@
 
     <emu-clause id="sec-number-object">
       <h1>Number object</h1>
-      <p>member of the Object type that is an instance of the standard built-in `Number` constructor</p>
+      <p>member of the Object type that is an instance of the standard built-in Number constructor</p>
       <emu-note>
-        <p>A Number object is created by using the `Number` constructor in a `new` expression, supplying a Number value as an argument. The resulting object has an internal slot whose value is the Number value. A Number object can be coerced to a Number value by calling the `Number` constructor as a function (<emu-xref href="#sec-number-constructor-number-value"></emu-xref>).</p>
+        <p>A Number object is created by using the Number constructor in a `new` expression, supplying a Number value as an argument. The resulting object has an internal slot whose value is the Number value. A Number object can be coerced to a Number value by calling the Number constructor as a function (<emu-xref href="#sec-number-constructor-number-value"></emu-xref>).</p>
       </emu-note>
     </emu-clause>
 
@@ -378,7 +378,7 @@
 
     <emu-clause id="sec-bigint-object">
       <h1>BigInt object</h1>
-      <p>member of the Object type that is an instance of the standard built-in `BigInt` constructor</p>
+      <p>member of the Object type that is an instance of the standard built-in BigInt constructor</p>
     </emu-clause>
 
     <emu-clause id="sec-symbol-value">
@@ -393,7 +393,7 @@
 
     <emu-clause id="sec-symbol-object">
       <h1>Symbol object</h1>
-      <p>member of the Object type that is an instance of the standard built-in `Symbol` constructor</p>
+      <p>member of the Object type that is an instance of the standard built-in Symbol constructor</p>
     </emu-clause>
 
     <emu-clause id="sec-terms-and-definitions-function">
@@ -2681,7 +2681,7 @@
                 `Array`
               </td>
               <td>
-                The `Array` constructor (<emu-xref href="#sec-array-constructor"></emu-xref>)
+                The Array constructor (<emu-xref href="#sec-array-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -2692,7 +2692,7 @@
                 `ArrayBuffer`
               </td>
               <td>
-                The `ArrayBuffer` constructor (<emu-xref href="#sec-arraybuffer-constructor"></emu-xref>)
+                The ArrayBuffer constructor (<emu-xref href="#sec-arraybuffer-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -2860,7 +2860,7 @@
                 `BigInt`
               </td>
               <td>
-                The `BigInt` constructor (<emu-xref href="#sec-bigint-constructor"></emu-xref>)
+                The BigInt constructor (<emu-xref href="#sec-bigint-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -2871,7 +2871,7 @@
                 `BigInt64Array`
               </td>
               <td>
-                The `BigInt64Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The BigInt64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -2882,7 +2882,7 @@
                 `BigUint64Array`
               </td>
               <td>
-                The `BigUint64Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The BigUint64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -2893,7 +2893,7 @@
                 `Boolean`
               </td>
               <td>
-                The `Boolean` constructor (<emu-xref href="#sec-boolean-constructor"></emu-xref>)
+                The Boolean constructor (<emu-xref href="#sec-boolean-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -2915,7 +2915,7 @@
                 `DataView`
               </td>
               <td>
-                The `DataView` constructor (<emu-xref href="#sec-dataview-constructor"></emu-xref>)
+                The DataView constructor (<emu-xref href="#sec-dataview-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -2937,7 +2937,7 @@
                 `Date`
               </td>
               <td>
-                The `Date` constructor (<emu-xref href="#sec-date-constructor"></emu-xref>)
+                The Date constructor (<emu-xref href="#sec-date-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3003,7 +3003,7 @@
                 `Error`
               </td>
               <td>
-                The `Error` constructor (<emu-xref href="#sec-error-constructor"></emu-xref>)
+                The Error constructor (<emu-xref href="#sec-error-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3036,7 +3036,7 @@
                 `EvalError`
               </td>
               <td>
-                The `EvalError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
+                The EvalError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3058,7 +3058,7 @@
                 `Float32Array`
               </td>
               <td>
-                The `Float32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Float32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3080,7 +3080,7 @@
                 `Float64Array`
               </td>
               <td>
-                The `Float64Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Float64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3112,7 +3112,7 @@
                 `Function`
               </td>
               <td>
-                The `Function` constructor (<emu-xref href="#sec-function-constructor"></emu-xref>)
+                The Function constructor (<emu-xref href="#sec-function-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3164,7 +3164,7 @@
                 `Int8Array`
               </td>
               <td>
-                The `Int8Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Int8Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3186,7 +3186,7 @@
                 `Int16Array`
               </td>
               <td>
-                The `Int16Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Int16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3208,7 +3208,7 @@
                 `Int32Array`
               </td>
               <td>
-                The `Int32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Int32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3295,7 +3295,7 @@
                 `Map`
               </td>
               <td>
-                The `Map` constructor (<emu-xref href="#sec-map-constructor"></emu-xref>)
+                The Map constructor (<emu-xref href="#sec-map-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3338,7 +3338,7 @@
                 `Number`
               </td>
               <td>
-                The `Number` constructor (<emu-xref href="#sec-number-constructor"></emu-xref>)
+                The Number constructor (<emu-xref href="#sec-number-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3360,7 +3360,7 @@
                 `Object`
               </td>
               <td>
-                The `Object` constructor (<emu-xref href="#sec-object-constructor"></emu-xref>)
+                The Object constructor (<emu-xref href="#sec-object-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3426,7 +3426,7 @@
                 `Promise`
               </td>
               <td>
-                The `Promise` constructor (<emu-xref href="#sec-promise-constructor"></emu-xref>)
+                The Promise constructor (<emu-xref href="#sec-promise-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3492,7 +3492,7 @@
                 `Proxy`
               </td>
               <td>
-                The `Proxy` constructor (<emu-xref href="#sec-proxy-constructor"></emu-xref>)
+                The Proxy constructor (<emu-xref href="#sec-proxy-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3503,7 +3503,7 @@
                 `RangeError`
               </td>
               <td>
-                The `RangeError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>)
+                The RangeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3525,7 +3525,7 @@
                 `ReferenceError`
               </td>
               <td>
-                The `ReferenceError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
+                The ReferenceError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3558,7 +3558,7 @@
                 `RegExp`
               </td>
               <td>
-                The `RegExp` constructor (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
+                The RegExp constructor (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3590,7 +3590,7 @@
                 `Set`
               </td>
               <td>
-                The `Set` constructor (<emu-xref href="#sec-set-constructor"></emu-xref>)
+                The Set constructor (<emu-xref href="#sec-set-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3622,7 +3622,7 @@
                 `SharedArrayBuffer`
               </td>
               <td>
-                The `SharedArrayBuffer` constructor (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
+                The SharedArrayBuffer constructor (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3644,7 +3644,7 @@
                 `String`
               </td>
               <td>
-                The `String` constructor (<emu-xref href="#sec-string-constructor"></emu-xref>)
+                The String constructor (<emu-xref href="#sec-string-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3676,7 +3676,7 @@
                 `Symbol`
               </td>
               <td>
-                The `Symbol` constructor (<emu-xref href="#sec-symbol-constructor"></emu-xref>)
+                The Symbol constructor (<emu-xref href="#sec-symbol-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3698,7 +3698,7 @@
                 `SyntaxError`
               </td>
               <td>
-                The `SyntaxError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
+                The SyntaxError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3750,7 +3750,7 @@
                 `TypeError`
               </td>
               <td>
-                The `TypeError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
+                The TypeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3772,7 +3772,7 @@
                 `Uint8Array`
               </td>
               <td>
-                The `Uint8Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Uint8Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3794,7 +3794,7 @@
                 `Uint8ClampedArray`
               </td>
               <td>
-                The `Uint8ClampedArray` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Uint8ClampedArray constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3816,7 +3816,7 @@
                 `Uint16Array`
               </td>
               <td>
-                The `Uint16Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Uint16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3838,7 +3838,7 @@
                 `Uint32Array`
               </td>
               <td>
-                The `Uint32Array` constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Uint32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3860,7 +3860,7 @@
                 `URIError`
               </td>
               <td>
-                The `URIError` constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>)
+                The URIError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3882,7 +3882,7 @@
                 `WeakMap`
               </td>
               <td>
-                The `WeakMap` constructor (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
+                The WeakMap constructor (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3904,7 +3904,7 @@
                 `WeakSet`
               </td>
               <td>
-                The `WeakSet` constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
+                The WeakSet constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -10471,7 +10471,7 @@
       </li>
     </ul>
     <emu-note>
-      <p>Function code is generally provided as the bodies of Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>), Arrow Function Definitions (<emu-xref href="#sec-arrow-function-definitions"></emu-xref>), Method Definitions (<emu-xref href="#sec-method-definitions"></emu-xref>), Generator Function Definitions (<emu-xref href="#sec-generator-function-definitions"></emu-xref>), Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>), Async Generator Function Definitions (<emu-xref href="#sec-async-generator-function-definitions"></emu-xref>), and Async Arrow Functions (<emu-xref href="#sec-async-arrow-function-definitions"></emu-xref>). Function code is also derived from the arguments to the `Function` constructor (<emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>), the `GeneratorFunction` constructor (<emu-xref href="#sec-generatorfunction"></emu-xref>), and the `AsyncFunction` constructor (<emu-xref href="#sec-async-function-constructor-arguments"></emu-xref>).</p>
+      <p>Function code is generally provided as the bodies of Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>), Arrow Function Definitions (<emu-xref href="#sec-arrow-function-definitions"></emu-xref>), Method Definitions (<emu-xref href="#sec-method-definitions"></emu-xref>), Generator Function Definitions (<emu-xref href="#sec-generator-function-definitions"></emu-xref>), Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>), Async Generator Function Definitions (<emu-xref href="#sec-async-generator-function-definitions"></emu-xref>), and Async Arrow Functions (<emu-xref href="#sec-async-arrow-function-definitions"></emu-xref>). Function code is also derived from the arguments to the Function constructor (<emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>), the GeneratorFunction constructor (<emu-xref href="#sec-generatorfunction"></emu-xref>), and the AsyncFunction constructor (<emu-xref href="#sec-async-function-constructor-arguments"></emu-xref>).</p>
     </emu-note>
     <emu-note>
       <p>The practical effect of including the |BindingIdentifier| in function code is that the Early Errors for strict mode code are applied to a |BindingIdentifier| that is the name of a function whose body contains a "use strict" directive, even if the surrounding code is not strict mode code.</p>
@@ -10497,7 +10497,7 @@
           Function code is strict mode code if the associated |FunctionDeclaration|, |FunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |MethodDefinition|, |ArrowFunction|, or |AsyncArrowFunction| is contained in strict mode code or if the code that produces the value of the function's [[ECMAScriptCode]] internal slot begins with a Directive Prologue that contains a Use Strict Directive.
         </li>
         <li>
-          Function code that is supplied as the arguments to the built-in `Function`, `Generator`, `AsyncFunction`, and `AsyncGenerator` constructors is strict mode code if the last argument is a String that when processed is a |FunctionBody| that begins with a Directive Prologue that contains a Use Strict Directive.
+          Function code that is supplied as the arguments to the built-in Function, Generator, AsyncFunction, and AsyncGenerator constructors is strict mode code if the last argument is a String that when processed is a |FunctionBody| that begins with a Directive Prologue that contains a Use Strict Directive.
         </li>
       </ul>
       <p>ECMAScript code that is not strict mode code is called <dfn id="non-strict-code">non-strict code</dfn>.</p>
@@ -11696,7 +11696,7 @@
     <emu-clause id="sec-literals-regular-expression-literals">
       <h1>Regular Expression Literals</h1>
       <emu-note>
-        <p>A regular expression literal is an input element that is converted to a RegExp object (see <emu-xref href="#sec-regexp-regular-expression-objects"></emu-xref>) each time the literal is evaluated. Two regular expression literals in a program evaluate to regular expression objects that never compare as `===` to each other even if the two literals' contents are identical. A RegExp object may also be created at runtime by `new RegExp` or calling the `RegExp` constructor as a function (see <emu-xref href="#sec-regexp-constructor"></emu-xref>).</p>
+        <p>A regular expression literal is an input element that is converted to a RegExp object (see <emu-xref href="#sec-regexp-regular-expression-objects"></emu-xref>) each time the literal is evaluated. Two regular expression literals in a program evaluate to regular expression objects that never compare as `===` to each other even if the two literals' contents are identical. A RegExp object may also be created at runtime by `new RegExp` or calling the RegExp constructor as a function (see <emu-xref href="#sec-regexp-constructor"></emu-xref>).</p>
       </emu-note>
       <p>The productions below describe the syntax for a regular expression literal and are used by the input element scanner to find the end of the regular expression literal. The source text comprising the |RegularExpressionBody| and the |RegularExpressionFlags| are subsequently parsed again using the more stringent ECMAScript Regular Expression grammar (<emu-xref href="#sec-patterns"></emu-xref>).</p>
       <p>An implementation may extend the ECMAScript Regular Expression grammar defined in <emu-xref href="#sec-patterns"></emu-xref>, but it must not extend the |RegularExpressionBody| and |RegularExpressionFlags| productions defined below or the productions used by these productions.</p>
@@ -24824,7 +24824,7 @@
   <p>An implementation shall report all errors as specified, except for the following:</p>
   <ul>
     <li>
-      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may extend |Script| syntax, |Module| syntax, and regular expression pattern or flag syntax. To permit this, all operations (such as calling `eval`, using a regular expression literal, or using the `Function` or `RegExp` constructor) that are allowed to throw *SyntaxError* are permitted to exhibit implementation-defined behaviour instead of throwing *SyntaxError* when they encounter an implementation-defined extension to the script syntax or regular expression pattern or flag syntax.
+      Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may extend |Script| syntax, |Module| syntax, and regular expression pattern or flag syntax. To permit this, all operations (such as calling `eval`, using a regular expression literal, or using the Function or RegExp constructor) that are allowed to throw *SyntaxError* are permitted to exhibit implementation-defined behaviour instead of throwing *SyntaxError* when they encounter an implementation-defined extension to the script syntax or regular expression pattern or flag syntax.
     </li>
     <li>
       Except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>, an implementation may provide additional types, values, objects, properties, and functions beyond those described in this specification. This may cause constructs (such as looking up a variable in the global scope) to have implementation-defined behaviour instead of throwing an error (such as *ReferenceError*).
@@ -24836,7 +24836,7 @@
     <p>An implementation must not extend this specification in the following ways:</p>
     <ul>
       <li>
-        ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named *"caller"* or *"arguments"*. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the `Function` constructor, generator functions created using the `Generator` constructor, async functions created using the `AsyncFunction` constructor, and functions created using the `bind` method also must not be created with such own properties.
+        ECMAScript function objects defined using syntactic constructors in strict mode code must not be created with own properties named *"caller"* or *"arguments"*. Such own properties also must not be created for function objects defined using an |ArrowFunction|, |MethodDefinition|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, |ClassDeclaration|, |ClassExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, or |AsyncArrowFunction| regardless of whether the definition is contained in strict mode code. Built-in functions, strict functions created using the Function constructor, generator functions created using the Generator constructor, async functions created using the AsyncFunction constructor, and functions created using the `bind` method also must not be created with such own properties.
       </li>
       <li>
         If an implementation extends any function object with an own property named *"caller"* the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
@@ -25779,7 +25779,7 @@
           1. If _value_ is *undefined* or *null*, return OrdinaryObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
-        <p>The *"length"* property of the `Object` constructor function is 1.</p>
+        <p>The *"length"* property of the `Object` function is 1.</p>
       </emu-clause>
     </emu-clause>
 
@@ -26211,7 +26211,7 @@
         <li>is the intrinsic object <dfn>%Function%</dfn>.</li>
         <li>is the initial value of the *"Function"* property of the global object.</li>
         <li>creates and initializes a new function object when called as a function rather than as a constructor. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Function` behaviour must include a `super` call to the `Function` constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of `Function`. There is no syntactic means to create instances of `Function` subclasses except for the built-in `GeneratorFunction`, `AsyncFunction`, and `AsyncGeneratorFunction` subclasses.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Function behaviour must include a `super` call to the Function constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of Function. There is no syntactic means to create instances of Function subclasses except for the built-in GeneratorFunction, AsyncFunction, and AsyncGeneratorFunction subclasses.</li>
       </ul>
 
       <emu-clause id="sec-function-p1-p2-pn-body">
@@ -26528,7 +26528,7 @@
         <li>is the initial value of the *"Boolean"* property of the global object.</li>
         <li>creates and initializes a new Boolean object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Boolean` behaviour must include a `super` call to the `Boolean` constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Boolean behaviour must include a `super` call to the Boolean constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-boolean-constructor-boolean-value">
@@ -26891,7 +26891,7 @@
         <li>is the intrinsic object <dfn>%Error%</dfn>.</li>
         <li>is the initial value of the *"Error"* property of the global object.</li>
         <li>creates and initializes a new Error object when called as a function rather than as a constructor. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Error` behaviour must include a `super` call to the `Error` constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Error behaviour must include a `super` call to the Error constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-error-message">
@@ -27098,7 +27098,7 @@
         <li>is the initial value of the *"Number"* property of the global object.</li>
         <li>creates and initializes a new Number object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Number` behaviour must include a `super` call to the `Number` constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Number behaviour must include a `super` call to the Number constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-number-constructor-number-value">
@@ -27444,7 +27444,7 @@
         <li>is the intrinsic object <dfn>%BigInt%</dfn>.</li>
         <li>is the initial value of the *"BigInt"* property of the global object.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
-        <li>is not intended to be used with the `new` operator or to be subclassed. It may be used as the value of an `extends` clause of a class definition but a `super` call to the `BigInt` constructor will cause an exception.</li>
+        <li>is not intended to be used with the `new` operator or to be subclassed. It may be used as the value of an `extends` clause of a class definition but a `super` call to the BigInt constructor will cause an exception.</li>
       </ul>
 
       <emu-clause id="sec-bigint-constructor-number-value">
@@ -28832,7 +28832,7 @@ THH:mm:ss.sss
         <li>creates and initializes a new Date object when called as a constructor.</li>
         <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
         <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Date` behaviour must include a `super` call to the `Date` constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Date behaviour must include a `super` call to the Date constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
         <li>has a *"length"* property whose value is 7.</li>
       </ul>
 
@@ -28965,7 +28965,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The *"length"* property of the `UTC` function is 7.</p>
         <emu-note>
-          <p>The `UTC` function differs from the `Date` constructor in two ways: it returns a time value as a Number, rather than creating a Date object, and it interprets the arguments in UTC rather than as local time.</p>
+          <p>The `UTC` function differs from the Date constructor in two ways: it returns a time value as a Number, rather than creating a Date object, and it interprets the arguments in UTC rather than as local time.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -29818,7 +29818,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"String"* property of the global object.</li>
         <li>creates and initializes a new String object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `String` behaviour must include a `super` call to the `String` constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified String behaviour must include a `super` call to the String constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-string-constructor-string-value">
@@ -29912,7 +29912,7 @@ THH:mm:ss.sss
             1. Set _nextIndex_ to _nextIndex_ + 1.
         </emu-alg>
         <emu-note>
-          <p>String.raw is intended for use as a tag function of a Tagged Template (<emu-xref href="#sec-tagged-templates"></emu-xref>). When called as such, the first argument will be a well formed template object and the rest parameter will contain the substitution values.</p>
+          <p>The `raw` function is intended for use as a tag function of a Tagged Template (<emu-xref href="#sec-tagged-templates"></emu-xref>). When called as such, the first argument will be a well formed template object and the rest parameter will contain the substitution values.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -30853,7 +30853,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-patterns">
       <h1>Patterns</h1>
-      <p>The `RegExp` constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
+      <p>The RegExp constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
         Pattern[U, N] ::
@@ -32509,7 +32509,7 @@ THH:mm:ss.sss
         <li>is the intrinsic object <dfn>%RegExp%</dfn>.</li>
         <li>is the initial value of the *"RegExp"* property of the global object.</li>
         <li>creates and initializes a new RegExp object when called as a function rather than as a constructor. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `RegExp` behaviour must include a `super` call to the `RegExp` constructor to create and initialize subclass instances with the necessary internal slots.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified RegExp behaviour must include a `super` call to the RegExp constructor to create and initialize subclass instances with the necessary internal slots.</li>
       </ul>
 
       <emu-clause id="sec-regexp-pattern-flags">
@@ -33157,7 +33157,7 @@ THH:mm:ss.sss
       <h1>Properties of RegExp Instances</h1>
       <p>RegExp instances are ordinary objects that inherit properties from the RegExp prototype object. RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and [[OriginalFlags]]. The value of the [[RegExpMatcher]] internal slot is an abstract closure representation of the |Pattern| of the RegExp object.</p>
       <emu-note>
-        <p>Prior to ECMAScript 2015, `RegExp` instances were specified as having the own data properties *"source"*, *"global"*, *"ignoreCase"*, and *"multiline"*. Those properties are now specified as accessor properties of `RegExp.prototype`.</p>
+        <p>Prior to ECMAScript 2015, RegExp instances were specified as having the own data properties *"source"*, *"global"*, *"ignoreCase"*, and *"multiline"*. Those properties are now specified as accessor properties of `RegExp.prototype`.</p>
       </emu-note>
       <p>RegExp instances also have the following property:</p>
 
@@ -33272,7 +33272,7 @@ THH:mm:ss.sss
         <li>creates and initializes a new Array exotic object when called as a constructor.</li>
         <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
         <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic `Array` behaviour must include a `super` call to the `Array` constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic Array behaviour must include a `super` call to the Array constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
         <li>has a *"length"* property whose value is 1.</li>
       </ul>
 
@@ -35896,7 +35896,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Map"* property of the global object.</li>
         <li>creates and initializes a new Map object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Map` behaviour must include a `super` call to the `Map` constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Map behaviour must include a `super` call to the Map constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-map-iterable">
@@ -36265,7 +36265,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Set"* property of the global object.</li>
         <li>creates and initializes a new Set object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Set` behaviour must include a `super` call to the `Set` constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Set behaviour must include a `super` call to the Set constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-set-iterable">
@@ -36603,7 +36603,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"WeakMap"* property of the global object.</li>
         <li>creates and initializes a new WeakMap object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakMap` behaviour must include a `super` call to the `WeakMap` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakMap behaviour must include a `super` call to the WeakMap constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-weakmap-iterable">
@@ -36749,7 +36749,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"WeakSet"* property of the global object.</li>
         <li>creates and initializes a new WeakSet object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakSet` behaviour must include a `super` call to the `WeakSet` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakSet behaviour must include a `super` call to the WeakSet constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-weakset-iterable">
@@ -37088,7 +37088,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"ArrayBuffer"* property of the global object.</li>
         <li>creates and initializes a new ArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ArrayBuffer` behaviour must include a `super` call to the `ArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified ArrayBuffer behaviour must include a `super` call to the ArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-arraybuffer-length">
@@ -37253,7 +37253,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"SharedArrayBuffer"* property of the global object.</li>
         <li>creates and initializes a new SharedArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `SharedArrayBuffer` behaviour must include a `super` call to the `SharedArrayBuffer` constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified SharedArrayBuffer behaviour must include a `super` call to the SharedArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
       </ul>
 
       <emu-note>
@@ -37420,7 +37420,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"DataView"* property of the global object.</li>
         <li>creates and initializes a new DataView object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `DataView` behaviour must include a `super` call to the `DataView` constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified DataView behaviour must include a `super` call to the DataView constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
@@ -37725,7 +37725,7 @@ THH:mm:ss.sss
       <h1>Properties of DataView Instances</h1>
       <p>DataView instances are ordinary objects that inherit properties from the DataView prototype object. DataView instances each have [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], and [[ByteOffset]] internal slots.</p>
       <emu-note>
-        <p>The value of the [[DataView]] internal slot is not used within this specification. The simple presence of that internal slot is used within the specification to identify objects created using the `DataView` constructor.</p>
+        <p>The value of the [[DataView]] internal slot is not used within this specification. The simple presence of that internal slot is used within the specification to identify objects created using the DataView constructor.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -38600,7 +38600,7 @@ THH:mm:ss.sss
           </table>
         </emu-table>
         <emu-note>
-          <p>Arguments may be passed to the next function but their interpretation and validity is dependent upon the target <i>Iterator</i>. The for-of statement and other common users of <em>Iterators</em> do not pass any arguments, so <i>Iterator</i> objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
+          <p>Arguments may be passed to the `next` function but their interpretation and validity is dependent upon the target <i>Iterator</i>. The for-of statement and other common users of <em>Iterators</em> do not pass any arguments, so <i>Iterator</i> objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
         </emu-note>
         <emu-table id="table-54" caption="<i>Iterator</i> Interface Optional Properties">
           <table>
@@ -38691,7 +38691,7 @@ THH:mm:ss.sss
           </table>
         </emu-table>
         <emu-note>
-          <p>Arguments may be passed to the next function but their interpretation and validity is dependent upon the target <i>AsyncIterator</i>. The `for`-`await`-`of` statement and other common users of <em>AsyncIterators</em> do not pass any arguments, so <i>AsyncIterator</i> objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
+          <p>Arguments may be passed to the `next` function but their interpretation and validity is dependent upon the target <i>AsyncIterator</i>. The `for`-`await`-`of` statement and other common users of <em>AsyncIterators</em> do not pass any arguments, so <i>AsyncIterator</i> objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
         </emu-note>
         <emu-table id="table-async-iterator-optional" caption="<i>AsyncIterator</i> Interface Optional Properties">
           <table>
@@ -38976,7 +38976,7 @@ THH:mm:ss.sss
       <ul>
         <li>is the intrinsic object <dfn>%GeneratorFunction%</dfn>.</li>
         <li>creates and initializes a new GeneratorFunction object when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `GeneratorFunction` behaviour must include a `super` call to the `GeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of `GeneratorFunction`. There is no syntactic means to create instances of `GeneratorFunction` subclasses.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.</li>
       </ul>
 
       <emu-clause id="sec-generatorfunction">
@@ -38998,7 +38998,7 @@ THH:mm:ss.sss
       <h1>Properties of the GeneratorFunction Constructor</h1>
       <p>The GeneratorFunction constructor:</p>
       <ul>
-        <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
+        <li>is a standard built-in function object that inherits from the Function constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
         <li>has a *"name"* property whose value is *"GeneratorFunction"*.</li>
         <li>has the following properties:</li>
@@ -39082,7 +39082,7 @@ THH:mm:ss.sss
       <ul>
         <li>is the intrinsic object <dfn>%AsyncGeneratorFunction%</dfn>.</li>
         <li>creates and initializes a new AsyncGeneratorFunction object when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `AsyncGeneratorFunction` behaviour must include a `super` call to the `AsyncGeneratorFunction` constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of `AsyncGeneratorFunction`. There is no syntactic means to create instances of `AsyncGeneratorFunction` subclasses.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncGeneratorFunction behaviour must include a `super` call to the AsyncGeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of AsyncGeneratorFunction. There is no syntactic means to create instances of AsyncGeneratorFunction subclasses.</li>
       </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction">
@@ -39104,7 +39104,7 @@ THH:mm:ss.sss
       <h1>Properties of the AsyncGeneratorFunction Constructor</h1>
       <p>The AsyncGeneratorFunction constructor:</p>
       <ul>
-        <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
+        <li>is a standard built-in function object that inherits from the Function constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
         <li>has a *"name"* property whose value is *"AsyncGeneratorFunction"*.</li>
         <li>has the following properties:</li>
@@ -39909,10 +39909,10 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-newpromisecapability" aoid="NewPromiseCapability">
         <h1>NewPromiseCapability ( _C_ )</h1>
-        <p>The abstract operation NewPromiseCapability takes argument _C_. It attempts to use _C_ as a constructor in the fashion of the built-in `Promise` constructor to create a Promise object and extract its `resolve` and `reject` functions. The Promise object plus the `resolve` and `reject` functions are used to initialize a new PromiseCapability Record. It performs the following steps when called:</p>
+        <p>The abstract operation NewPromiseCapability takes argument _C_. It attempts to use _C_ as a constructor in the fashion of the built-in Promise constructor to create a Promise object and extract its `resolve` and `reject` functions. The Promise object plus the `resolve` and `reject` functions are used to initialize a new PromiseCapability Record. It performs the following steps when called:</p>
         <emu-alg>
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
-          1. NOTE: _C_ is assumed to be a constructor function that supports the parameter conventions of the `Promise` constructor (see <emu-xref href="#sec-promise-executor"></emu-xref>).
+          1. NOTE: _C_ is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see <emu-xref href="#sec-promise-executor"></emu-xref>).
           1. Let _promiseCapability_ be the PromiseCapability { [[Promise]]: *undefined*, [[Resolve]]: *undefined*, [[Reject]]: *undefined* }.
           1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-getcapabilitiesexecutor-functions" title></emu-xref>.
           1. Let _executor_ be ! CreateBuiltinFunction(_steps_, &laquo; [[Capability]] &raquo;).
@@ -40069,7 +40069,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Promise"* property of the global object.</li>
         <li>creates and initializes a new Promise object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Promise` behaviour must include a `super` call to the `Promise` constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
+        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Promise behaviour must include a `super` call to the Promise constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-promise-executor">
@@ -40092,7 +40092,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The _executor_ argument must be a function object. It is called for initiating and reporting completion of the possibly deferred action represented by this Promise object. The executor is called with two arguments: _resolve_ and _reject_. These are functions that may be used by the _executor_ function to report eventual completion or failure of the deferred computation. Returning from the executor function does not mean that the deferred action has been completed but only that the request to eventually perform the deferred action has been accepted.</p>
           <p>The _resolve_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _resolve_ function to indicate that it wishes to resolve the associated Promise object. The argument passed to the _resolve_ function represents the eventual value of the deferred action and can be either the actual fulfillment value or another Promise object which will provide the value if it is fulfilled.</p>
-          <p>The _reject_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _reject_ function to indicate that the associated Promise is rejected and will never be fulfilled. The argument passed to the _reject_ function is used as the rejection value of the promise. Typically it will be an `Error` object.</p>
+          <p>The _reject_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _reject_ function to indicate that the associated Promise is rejected and will never be fulfilled. The argument passed to the _reject_ function is used as the rejection value of the promise. Typically it will be an Error object.</p>
           <p>The resolve and reject functions passed to an _executor_ function by the Promise constructor have the capability to actually resolve and reject the associated promise. Subclasses may have different constructor behaviour that passes in customized values for resolve and reject.</p>
         </emu-note>
       </emu-clause>
@@ -40122,7 +40122,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>This function is the <dfn>%Promise_all%</dfn> intrinsic object.</p>
         <emu-note>
-          <p>The `all` function requires its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
+          <p>The `all` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
         <emu-clause id="sec-performpromiseall" aoid="PerformPromiseAll">
@@ -40204,7 +40204,7 @@ THH:mm:ss.sss
           1. Return Completion(_result_).
         </emu-alg>
         <emu-note>
-          <p>The `allSettled` function requires its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
+          <p>The `allSettled` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
         <emu-clause id="sec-performpromiseallsettled" aoid="PerformPromiseAllSettled">
@@ -40332,7 +40332,7 @@ THH:mm:ss.sss
           <p>If the _iterable_ argument is empty or if none of the promises in _iterable_ ever settle then the pending promise returned by this method will never be settled.</p>
         </emu-note>
         <emu-note>
-          <p>The `race` function expects its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor. It also expects that its *this* value provides a `resolve` method.</p>
+          <p>The `race` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor. It also expects that its *this* value provides a `resolve` method.</p>
         </emu-note>
 
         <emu-clause id="sec-performpromiserace" aoid="PerformPromiseRace">
@@ -40370,7 +40370,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>This function is the <dfn>%Promise_reject%</dfn> intrinsic object.</p>
         <emu-note>
-          <p>The `reject` function expects its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
+          <p>The `reject` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
       </emu-clause>
 
@@ -40384,7 +40384,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>This function is the <dfn>%Promise_resolve%</dfn> intrinsic object.</p>
         <emu-note>
-          <p>The `resolve` function expects its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
+          <p>The `resolve` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
         <emu-clause id="sec-promise-resolve" aoid="PromiseResolve">
@@ -40627,7 +40627,7 @@ THH:mm:ss.sss
         <li>is the intrinsic object <dfn>%AsyncFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new AsyncFunction object when called as a function rather than as a constructor. Thus the function call `AsyncFunction(&hellip;)` is equivalent to the object creation expression `new AsyncFunction(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the `AsyncFunction` constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the AsyncFunction constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour.</li>
       </ul>
 
       <emu-clause id="sec-async-function-constructor-arguments">
@@ -40650,7 +40650,7 @@ THH:mm:ss.sss
 
       <p>The AsyncFunction constructor:</p>
       <ul>
-        <li>is a standard built-in function object that inherits from the `Function` constructor.</li>
+        <li>is a standard built-in function object that inherits from the Function constructor.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function%.</li>
         <li>has a *"name"* property whose value is *"AsyncFunction"*.</li>
         <li>has the following properties:</li>
@@ -43364,7 +43364,7 @@ THH:mm:ss.sss
       It is a *SyntaxError* if a |CatchParameter| occurs within strict mode code and BoundNames of |CatchParameter| contains either `eval` or `arguments` (<emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
-      It is a *SyntaxError* if the same |BindingIdentifier| appears more than once in the |FormalParameters| of a strict function. An attempt to create such a function using a `Function`, `Generator`, or `AsyncFunction` constructor is a *SyntaxError* (<emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-createdynamicfunction"></emu-xref>).
+      It is a *SyntaxError* if the same |BindingIdentifier| appears more than once in the |FormalParameters| of a strict function. An attempt to create such a function using a Function, Generator, or AsyncFunction constructor is a *SyntaxError* (<emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-createdynamicfunction"></emu-xref>).
     </li>
     <li>
       An implementation may not extend, beyond that defined in this specification, the meanings within strict functions of properties named *"caller"* or *"arguments"* of function instances.


### PR DESCRIPTION
### Problem

All cases of `<built-in> {object, type, value, instance, prototype}` throughout the spec have the built-in name consistently unstylized. `<built-in> constructor`, however, varies: usually the name is unstylized, but sometimes it's written with backticks.

I originally thought to do away with _all_ of these backticks, but I ended up feeling like perhaps the backticks are meant to distinguish "the concrete <code>\`&lt;built-in&gt;\`</code> constructor function" from "the conceptual `<built-in>` constructor", in which case some of them could be legitimate.

For instance:
- <code>The AsyncGeneratorFunction constructor ... is a standard built-in function object that inherits from the \`Function\` constructor</code> certainly feels broken, but...
- <code>A Number object is created by using the \`Number\` constructor in a \`new\` expression</code> might be concrete enough to warrant backticks.

### Solution

- Remove backticks around cases of `<built-in> constructor` ~that aren't clearly referring to a concrete function~
- Remove backticks for all cases of `<built-in> behaviour`

(Also, as a drive-by fix: add missing backticks for a few function names.)