### PR TITLE
Editorial: Annex A tweaks

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41601,9 +41601,8 @@ THH:mm:ss.sss
     <h1>Expressions</h1>
     <emu-prodref name="IdentifierReference"></emu-prodref>
     <emu-prodref name="BindingIdentifier"></emu-prodref>
-    <emu-prodref name="Identifier"></emu-prodref>
-    <emu-prodref name="AsyncArrowBindingIdentifier"></emu-prodref>
     <emu-prodref name="LabelIdentifier"></emu-prodref>
+    <emu-prodref name="Identifier"></emu-prodref>
     <emu-prodref name="PrimaryExpression"></emu-prodref>
     <emu-prodref name="CoverParenthesizedExpressionAndArrowParameterList"></emu-prodref>
     <p>When processing an instance of the production <emu-prodref name="PrimaryExpression" a="parencover"></emu-prodref> the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
@@ -41632,11 +41631,9 @@ THH:mm:ss.sss
     <emu-prodref name="NewTarget"></emu-prodref>
     <emu-prodref name="NewExpression"></emu-prodref>
     <emu-prodref name="CallExpression"></emu-prodref>
-    <emu-prodref name="CoverCallExpressionAndAsyncArrowHead"></emu-prodref>
     <p>When processing an instance of the production <emu-prodref name="CallExpression" a="callcover"></emu-prodref> the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
     <emu-prodref name="CallMemberExpression"></emu-prodref>
     <p>&nbsp;</p>
-
     <emu-prodref name="SuperCall"></emu-prodref>
     <emu-prodref name="ImportCall"></emu-prodref>
     <emu-prodref name="Arguments"></emu-prodref>
@@ -41663,6 +41660,7 @@ THH:mm:ss.sss
     <emu-prodref name="ShortCircuitExpression"></emu-prodref>
     <emu-prodref name="ConditionalExpression"></emu-prodref>
     <emu-prodref name="AssignmentExpression"></emu-prodref>
+    <emu-prodref name="AssignmentOperator"></emu-prodref>
     <p>In certain circumstances when processing an instance of the production <emu-prodref name="AssignmentExpression" a="assignment"></emu-prodref> the following grammar is used to refine the interpretation of |LeftHandSideExpression|:</p>
     <emu-prodref name="AssignmentPattern"></emu-prodref>
     <emu-prodref name="ObjectAssignmentPattern"></emu-prodref>
@@ -41676,7 +41674,6 @@ THH:mm:ss.sss
     <emu-prodref name="AssignmentRestElement"></emu-prodref>
     <emu-prodref name="DestructuringAssignmentTarget"></emu-prodref>
     <p>&nbsp;</p>
-    <emu-prodref name="AssignmentOperator"></emu-prodref>
     <emu-prodref name="Expression"></emu-prodref>
   </emu-annex>
 
@@ -41753,6 +41750,8 @@ THH:mm:ss.sss
     <p>&nbsp;</p>
     <emu-prodref name="AsyncArrowFunction"></emu-prodref>
     <emu-prodref name="AsyncConciseBody"></emu-prodref>
+    <emu-prodref name="AsyncArrowBindingIdentifier"></emu-prodref>
+    <emu-prodref name="CoverCallExpressionAndAsyncArrowHead"></emu-prodref>
     <p>When the production <emu-prodref name="AsyncArrowFunction" a="callcover"></emu-prodref> is recognized the following grammar is used to refine the interpretation of |CoverParenthesizedExpressionAndArrowParameterList|:</p>
     <emu-prodref name="AsyncArrowHead"></emu-prodref>
     <p>&nbsp;</p>
@@ -41767,9 +41766,9 @@ THH:mm:ss.sss
     <emu-prodref name="AsyncGeneratorDeclaration"></emu-prodref>
     <emu-prodref name="AsyncGeneratorExpression"></emu-prodref>
     <emu-prodref name="AsyncGeneratorBody"></emu-prodref>
-    <emu-prodref name="AsyncMethod"></emu-prodref>
     <emu-prodref name="AsyncFunctionDeclaration"></emu-prodref>
     <emu-prodref name="AsyncFunctionExpression"></emu-prodref>
+    <emu-prodref name="AsyncMethod"></emu-prodref>
     <emu-prodref name="AsyncFunctionBody"></emu-prodref>
     <emu-prodref name="AwaitExpression"></emu-prodref>
     <emu-prodref name="ClassDeclaration"></emu-prodref>

--- a/spec.html
+++ b/spec.html
@@ -41752,7 +41752,7 @@ THH:mm:ss.sss
     <emu-prodref name="AsyncConciseBody"></emu-prodref>
     <emu-prodref name="AsyncArrowBindingIdentifier"></emu-prodref>
     <emu-prodref name="CoverCallExpressionAndAsyncArrowHead"></emu-prodref>
-    <p>When the production <emu-prodref name="AsyncArrowFunction" a="callcover"></emu-prodref> is recognized the following grammar is used to refine the interpretation of |CoverParenthesizedExpressionAndArrowParameterList|:</p>
+    <p>When the production <emu-prodref name="AsyncArrowFunction" a="callcover"></emu-prodref> is recognized the following grammar is used to refine the interpretation of |CoverCallExpressionAndAsyncArrowHead|:</p>
     <emu-prodref name="AsyncArrowHead"></emu-prodref>
     <p>&nbsp;</p>
     <emu-prodref name="MethodDefinition"></emu-prodref>

--- a/spec.html
+++ b/spec.html
@@ -41814,13 +41814,6 @@ THH:mm:ss.sss
     <emu-prodref name="StrNumericLiteral"></emu-prodref>
     <emu-prodref name="StrDecimalLiteral"></emu-prodref>
     <emu-prodref name="StrUnsignedDecimalLiteral"></emu-prodref>
-    <emu-prodref name="DecimalDigits"></emu-prodref>
-    <emu-prodref name="DecimalDigit"></emu-prodref>
-    <emu-prodref name="ExponentPart"></emu-prodref>
-    <emu-prodref name="ExponentIndicator"></emu-prodref>
-    <emu-prodref name="SignedInteger"></emu-prodref>
-    <emu-prodref name="HexIntegerLiteral"></emu-prodref>
-    <emu-prodref name="HexDigit"></emu-prodref>
     <p>All grammar symbols not explicitly defined by the |StringNumericLiteral| grammar have the definitions used in the <emu-xref href="#sec-literals-numeric-literals">Lexical Grammar for numeric literals</emu-xref>.</p>
   </emu-annex>
 


### PR DESCRIPTION
This PR cherry-picks commits 4 - 7 of PR #1651. Their purpose is to reduce inconsistencies between the main body and Annex A (Grammar Summary), making it easier to keep them in synch going forward.