### PR TITLE
Normative: Fully specify legal escape sequences in RegExp capture group names

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30885,7 +30885,7 @@ THH:mm:ss.sss
           `.`
           `\` AtomEscape[?U, ?N]
           CharacterClass[?U]
-          `(` GroupSpecifier[?U] Disjunction[?U, ?N] `)`
+          `(` GroupSpecifier Disjunction[?U, ?N] `)`
           `(` `?` `:` Disjunction[?U, ?N] `)`
 
         SyntaxCharacter :: one of
@@ -30898,7 +30898,7 @@ THH:mm:ss.sss
           DecimalEscape
           CharacterClassEscape[?U]
           CharacterEscape[?U]
-          [+N] `k` GroupName[?U]
+          [+N] `k` GroupName
 
         CharacterEscape[U] ::
           ControlEscape
@@ -30915,27 +30915,27 @@ THH:mm:ss.sss
           `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
           `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
 
-        GroupSpecifier[U] ::
+        GroupSpecifier ::
           [empty]
-          `?` GroupName[?U]
+          `?` GroupName
 
-        GroupName[U] ::
-          `&lt;` RegExpIdentifierName[?U] `&gt;`
+        GroupName ::
+          `&lt;` RegExpIdentifierName `&gt;`
 
-        RegExpIdentifierName[U] ::
-          RegExpIdentifierStart[?U]
-          RegExpIdentifierName[?U] RegExpIdentifierPart[?U]
+        RegExpIdentifierName ::
+          RegExpIdentifierStart
+          RegExpIdentifierName RegExpIdentifierPart
 
-        RegExpIdentifierStart[U] ::
+        RegExpIdentifierStart ::
           UnicodeIDStart
           `$`
           `_`
-          `\` RegExpUnicodeEscapeSequence[?U]
+          `\` RegExpUnicodeEscapeSequence[+U]
 
-        RegExpIdentifierPart[U] ::
+        RegExpIdentifierPart ::
           UnicodeIDContinue
           `$`
-          `\` RegExpUnicodeEscapeSequence[?U]
+          `\` RegExpUnicodeEscapeSequence[+U]
           &lt;ZWNJ&gt;
           &lt;ZWJ&gt;
 
@@ -31086,13 +31086,13 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierStart[U] :: `\` RegExpUnicodeEscapeSequence[?U]</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the SV of |RegExpUnicodeEscapeSequence| is none of *"$"*, or *"_"*, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is none of *"$"*, or *"_"*, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierPart[U] :: `\` RegExpUnicodeEscapeSequence[?U]</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the SV of |RegExpUnicodeEscapeSequence| is none of *"$"*, or *"_"*, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is none of *"$"*, or *"_"*, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar>


### PR DESCRIPTION
Fixes #1861. See that issue for context. Marked as normative despite fixing a spec bug because there are two sensible behaviors possible here, either of which is compatible with the current (incomplete) specification.

This PR takes the approach of making `/(?<\ud835\udc9c>.)/u` legal (in addition to making `/(?<\u{1d49c}>.)/u` legal, which is more obviously the intent of the current incomplete spec text).