### PR TITLE
Editorial: Set [[SourceText]] inside OrdinaryFunctionCreate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8465,13 +8465,14 @@
     </emu-clause>
 
     <emu-clause id="sec-ordinaryfunctioncreate" aoid="OrdinaryFunctionCreate" oldids="sec-functionallocate,sec-functioninitialize,sec-functioncreate,sec-generatorfunctioncreate,sec-asyncgeneratorfunctioncreate,sec-async-functions-abstract-operations-async-function-create">
-      <h1>OrdinaryFunctionCreate ( _functionPrototype_, _ParameterList_, _Body_, _thisMode_, _Scope_ )</h1>
-      <p>The abstract operation OrdinaryFunctionCreate takes arguments _functionPrototype_ (an Object), _ParameterList_ (a Parse Node), _Body_ (a Parse Node), _thisMode_ (either ~lexical-this~ or ~non-lexical-this~), and _Scope_ (an Environment Record). It performs the following steps when called:</p>
+      <h1>OrdinaryFunctionCreate ( _functionPrototype_, _sourceText_, _ParameterList_, _Body_, _thisMode_, _Scope_ )</h1>
+      <p>The abstract operation OrdinaryFunctionCreate takes arguments _functionPrototype_ (an Object), _sourceText_ (a sequence of Unicode code points), _ParameterList_ (a Parse Node), _Body_ (a Parse Node), _thisMode_ (either ~lexical-this~ or ~non-lexical-this~), and _Scope_ (an Environment Record). _sourceText_ is the source text of the syntactic definition of the function to be created. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_functionPrototype_) is Object.
         1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-27"></emu-xref>.
         1. Let _F_ be ! OrdinaryObjectCreate(_functionPrototype_, _internalSlotsList_).
         1. Set _F_.[[Call]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
+        1. Set _F_.[[SourceText]] to _sourceText_.
         1. Set _F_.[[FormalParameters]] to _ParameterList_.
         1. Set _F_.[[ECMAScriptCode]] to _Body_.
         1. If the source text matching _Body_ is strict mode code, let _Strict_ be *true*; else let _Strict_ be *false*.
@@ -19783,18 +19784,18 @@
       <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
-        1. Let _F_ be OrdinaryFunctionCreate(%Function.prototype%, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |FunctionDeclaration|.
+        1. Let _F_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_F_, _name_).
         1. Perform MakeConstructor(_F_).
-        1. Set _F_.[[SourceText]] to the source text matched by |FunctionDeclaration|.
         1. Return _F_.
       </emu-alg>
       <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _F_ be OrdinaryFunctionCreate(%Function.prototype%, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |FunctionDeclaration|.
+        1. Let _F_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_F_, *"default"*).
         1. Perform MakeConstructor(_F_).
-        1. Set _F_.[[SourceText]] to the source text matched by |FunctionDeclaration|.
         1. Return _F_.
       </emu-alg>
       <emu-note>
@@ -19808,10 +19809,10 @@
       <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |FunctionExpression|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Perform MakeConstructor(_closure_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |FunctionExpression|.
         1. Return _closure_.
       </emu-alg>
     </emu-clause>
@@ -19839,10 +19840,10 @@
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _funcEnv_).
+        1. Let _sourceText_ be the source text matched by |FunctionExpression|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _funcEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Perform MakeConstructor(_closure_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |FunctionExpression|.
         1. Perform _funcEnv_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
       </emu-alg>
@@ -20108,10 +20109,10 @@
       <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _sourceText_ be the source text matched by |ArrowFunction|.
         1. Let _parameters_ be CoveredFormalsList of |ArrowParameters|.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _parameters_, |ConciseBody|, ~lexical-this~, _scope_).
+        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _parameters_, |ConciseBody|, ~lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |ArrowFunction|.
         1. Return _closure_.
       </emu-alg>
     </emu-clause>
@@ -20264,9 +20265,9 @@
           1. Let _prototype_ be _functionPrototype_.
         1. Else,
           1. Let _prototype_ be %Function.prototype%.
-        1. Let _closure_ be OrdinaryFunctionCreate(_prototype_, |UniqueFormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |MethodDefinition|.
+        1. Let _closure_ be OrdinaryFunctionCreate(_prototype_, _sourceText_, |UniqueFormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |MethodDefinition|.
         1. Return the Record { [[Key]]: _propKey_, [[Closure]]: _closure_ }.
       </emu-alg>
     </emu-clause>
@@ -20287,11 +20288,11 @@
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_, *"get"*).
-        1. Set _closure_.[[SourceText]] to the source text matched by |MethodDefinition|.
         1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
@@ -20300,10 +20301,10 @@
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |MethodDefinition|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
-        1. Set _closure_.[[SourceText]] to the source text matched by |MethodDefinition|.
         1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
@@ -20516,20 +20517,20 @@
       <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
-        1. Let _F_ be OrdinaryFunctionCreate(%Generator%, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
+        1. Let _F_ be OrdinaryFunctionCreate(%Generator%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_F_, _name_).
         1. Let _prototype_ be OrdinaryObjectCreate(%Generator.prototype%).
         1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Set _F_.[[SourceText]] to the source text matched by |GeneratorDeclaration|.
         1. Return _F_.
       </emu-alg>
       <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _F_ be OrdinaryFunctionCreate(%Generator%, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
+        1. Let _F_ be OrdinaryFunctionCreate(%Generator%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_F_, *"default"*).
         1. Let _prototype_ be OrdinaryObjectCreate(%Generator.prototype%).
         1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Set _F_.[[SourceText]] to the source text matched by |GeneratorDeclaration|.
         1. Return _F_.
       </emu-alg>
       <emu-note>
@@ -20546,12 +20547,12 @@
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Generator%, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Generator%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_).
         1. Let _prototype_ be OrdinaryObjectCreate(%Generator.prototype%).
         1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Set _closure_.[[SourceText]] to the source text matched by |GeneratorMethod|.
         1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
@@ -20563,11 +20564,11 @@
       <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Generator%, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Generator%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Let _prototype_ be OrdinaryObjectCreate(%Generator.prototype%).
         1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Set _closure_.[[SourceText]] to the source text matched by |GeneratorExpression|.
         1. Return _closure_.
       </emu-alg>
     </emu-clause>
@@ -20584,12 +20585,12 @@
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _closure_ be OrdinaryFunctionCreate(%Generator%, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_).
+        1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Generator%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Let _prototype_ be OrdinaryObjectCreate(%Generator.prototype%).
         1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform _funcEnv_.InitializeBinding(_name_, _closure_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |GeneratorExpression|.
         1. Return _closure_.
       </emu-alg>
       <emu-note>
@@ -20841,11 +20842,11 @@
       </emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
-        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |AsyncGeneratorDeclaration|.
+        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform ! SetFunctionName(_F_, _name_).
         1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGenerator.prototype%).
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Set _F_.[[SourceText]] to the source text matched by |AsyncGeneratorDeclaration|.
         1. Return _F_.
       </emu-alg>
 
@@ -20853,11 +20854,11 @@
         AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _F_ be OrdinaryFunctionCreate(%AsyncGenerator%, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |AsyncGeneratorDeclaration|.
+        1. Let _F_ be OrdinaryFunctionCreate(%AsyncGenerator%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_F_, *"default"*).
         1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGenerator.prototype%).
         1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Set _F_.[[SourceText]] to the source text matched by |AsyncGeneratorDeclaration|.
         1. Return _F_.
       </emu-alg>
       <emu-note>
@@ -20875,12 +20876,12 @@
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform ! MakeMethod(_closure_, _object_).
         1. Perform ! SetFunctionName(_closure_, _propKey_).
         1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGenerator.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncGeneratorMethod|.
         1. Let _desc_ be PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
@@ -20894,11 +20895,11 @@
       </emu-grammar>
       <emu-alg>
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGenerator.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncGeneratorExpression|.
         1. Return _closure_.
       </emu-alg>
     </emu-clause>
@@ -20921,12 +20922,12 @@
         1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_).
+        1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_).
         1. Perform ! SetFunctionName(_closure_, _name_).
         1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGenerator.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncGeneratorExpression|.
         1. Return _closure_.
       </emu-alg>
       <emu-note>
@@ -21493,18 +21494,18 @@
       </emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
-        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |AsyncFunctionDeclaration|.
+        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform ! SetFunctionName(_F_, _name_).
-        1. Set _F_.[[SourceText]] to the source text matched by |AsyncFunctionDeclaration|.
         1. Return _F_.
       </emu-alg>
       <emu-grammar>
         AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |AsyncFunctionDeclaration|.
+        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform ! SetFunctionName(_F_, *"default"*).
-        1. Set _F_.[[SourceText]] to the source text matched by |AsyncFunctionDeclaration|.
         1. Return _F_.
       </emu-alg>
     </emu-clause>
@@ -21536,10 +21537,10 @@
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |AsyncMethod|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform ! MakeMethod(_closure_, _object_).
         1. Perform ! SetFunctionName(_closure_, _propKey_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncMethod|.
         1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
@@ -21553,9 +21554,9 @@
       </emu-grammar>
       <emu-alg>
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
+        1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncFunctionExpression|.
         1. Return _closure_.
       </emu-alg>
     </emu-clause>
@@ -21591,10 +21592,10 @@
         1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_).
+        1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_).
         1. Perform ! SetFunctionName(_closure_, _name_).
         1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncFunctionExpression|.
         1. Return _closure_.
       </emu-alg>
 
@@ -21843,10 +21844,10 @@
       </emu-grammar>
       <emu-alg>
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _parameters_ be |AsyncArrowBindingIdentifier|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _parameters_, |AsyncConciseBody|, ~lexical-this~, _scope_).
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncArrowFunction|.
         1. Return _closure_.
       </emu-alg>
       <emu-grammar>
@@ -21854,11 +21855,11 @@
       </emu-grammar>
       <emu-alg>
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
         1. Let _parameters_ be the |ArrowFormalParameters| of _head_.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _parameters_, |AsyncConciseBody|, ~lexical-this~, _scope_).
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Set _closure_.[[SourceText]] to the source text matched by |AsyncArrowFunction|.
         1. Return _closure_.
       </emu-alg>
     </emu-clause>
@@ -26170,6 +26171,9 @@
                 1. Set _k_ to _k_ + 1.
               1. Let _bodyArg_ be _args_[_k_].
             1. Let _bodyString_ be the string-concatenation of 0x000A (LINE FEED), ? ToString(_bodyArg_), and 0x000A (LINE FEED).
+            1. Let _prefix_ be the prefix associated with _kind_ in <emu-xref href="#table-dynamic-function-sourcetext-prefixes"></emu-xref>.
+            1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
+            1. Let _sourceText_ be ! UTF16DecodeString(_sourceString_).
             1. Perform the following substeps in an implementation-dependent order, possibly interleaving parsing and error detection:
               1. Let _parameters_ be the result of parsing ! UTF16DecodeString(_P_), using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
               1. Let _body_ be the result of parsing ! UTF16DecodeString(_bodyString_), using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
@@ -26190,7 +26194,7 @@
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _fallbackProto_).
             1. Let _realmF_ be the current Realm Record.
             1. Let _scope_ be _realmF_.[[GlobalEnv]].
-            1. Let _F_ be ! OrdinaryFunctionCreate(_proto_, _parameters_, _body_, ~non-lexical-this~, _scope_).
+            1. Let _F_ be ! OrdinaryFunctionCreate(_proto_, _sourceText_, _parameters_, _body_, ~non-lexical-this~, _scope_).
             1. Perform SetFunctionName(_F_, *"anonymous"*).
             1. If _kind_ is ~generator~, then
               1. Let _prototype_ be OrdinaryObjectCreate(%Generator.prototype%).
@@ -26200,9 +26204,6 @@
               1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~normal~, perform MakeConstructor(_F_).
             1. NOTE: Functions whose _kind_ is ~async~ are not constructible and do not have a [[Construct]] internal method or a *"prototype"* property.
-            1. Let _prefix_ be the prefix associated with _kind_ in <emu-xref href="#table-dynamic-function-sourcetext-prefixes"></emu-xref>.
-            1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
-            1. Set _F_.[[SourceText]] to ! UTF16DecodeString(_sourceString_).
             1. Return _F_.
           </emu-alg>
           <emu-note>


### PR DESCRIPTION
Every call to OrdinaryFunctionCreate is closely followed by a step that sets the `[[SourceText]]` of the resulting function object. Replace all but one of the latter steps by passing another argument
to `OrdinaryFunctionCreate`.

---
Re "all but one": the exception is in `CreateDynamicFunction`, where there isn't a Parse Node that represents the whole function, so we just pass `~empty~` to `OrdinaryFunctionCreate` and set the function's `[[SourceText]]` explicitly later. If you'd like this case to be handled inside `OrdinaryFunctionCreate` as well, I can think of a few ways:

- Say that the new parameter is either a Parse Node (handled as in this PR) **or** it's a sequence of Unicode code points (which gets assigned directly to `_F_.[[SourceText]]`). In `CreateDynamicFunction`, we'd move up the definitions of `_prefix_` and `_sourceString_`, and then pass `UTF16DecodeString(_sourceString_)` to the new parameter.

- Say that the new parameter is *always* a sequence of Unicode code points. `CreateDynamicFunction` would be handled as above, but all the other invocations would be preceded by a step `Let _sourceText_ be the source text matched by |Foo|.` and then pass `_sourceText_` rather than `|Foo|` to the new parameter. This would undo most of the savings of this PR, although we could regain most of it if we defined an abstract operation that returned the source text matched by a Parse Node; then we could avoid the extra step and pass (say) `SourceText(|Foo|)` to the new parameter.

- Say that the new parameter is *always* a Parse Node. In `CreateDynamicFunction`, you'd have to actually parse `UTF16DecodeString(_sourceString_)` and then pass the result to the new parameter. Note that we're already parsing most of it, to get the values of `_parameters_` and `_body_`, so parsing the whole thing isn't that big a stretch (and you could extract `_parameters_` and `_body_` from it, instead of parsing them separately). The goal symbol for the parse would depend on `_kind_`, so we could specify that in a new column in the following table.

---
Downstream uses:
* Web IDL: none
* HTML: [One invocation](https://html.spec.whatwg.org/#event-handler-attributes:js-ordinaryfunctioncreate). With the PR as given, it could just pass `~empty~`. With any of the bulleted alternatives, it would have to do something else (possibly similar to what `CreateDynamicFunction` does). But it raises the question of what is web reality for the toString of a function created in this way.