### PR TITLE
Normative: `ToInteger`: fix spec bug from #1827 that allows (-1,0) to produce `-0`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4831,7 +4831,9 @@
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, or *-0*, return *+0*.
         1. If _number_ is *+&infin;*, or *-&infin;*, return _number_.
-        1. Return the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Let _integer_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. If _integer_ is *-0*, return *+0*.
+        1. Return _integer_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Per https://github.com/tc39/ecma262/pull/1827#issuecomment-586545198