### PR TITLE
Editorial: correct 'import * circularity' to 'export * circularity'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23802,7 +23802,7 @@
             1. Assert: _exportStarSet_ is a List of Source Text Module Records.
             1. Let _module_ be this Source Text Module Record.
             1. If _exportStarSet_ contains _module_, then
-              1. Assert: We've reached the starting point of an `import *` circularity.
+              1. Assert: We've reached the starting point of an `export *` circularity.
               1. Return a new empty List.
             1. Append _module_ to _exportStarSet_.
             1. Let _exportedNames_ be a new empty List.


### PR DESCRIPTION
Hello, Step 4.a of [GetExportedNames](https://tc39.es/ecma262/#sec-getexportednames) refers to an '`import *` circularity', but it should be corrected to `export *` circularity'.

The GetExportedNames concrete method recurses for each entry in [[StarExportEntries]] of this Module Record. The role of _exportStarSet_ in GetExportedNames is to prevent an infinite loop due to the recursion.
Contents of [[StarExportEntries]] of Source Text Module Records correspond to _starExportEntries_ in [ParseModule](https://tc39.es/ecma262/#sec-parsemodule), which is a list of [ExportEntry Records](https://tc39.es/ecma262/#exportentry-record) whose [[ImportName]] is "*" and [[ExportName]] is null.
According to [Static Semantics of ExportEntries](https://tc39.es/ecma262/#sec-exports-static-semantics-exportentries) and  [Table 48](https://tc39.es/ecma262/#table-42), such an ExportEntry comes from the `export * from "specifier"` syntax.

Therefore, the circularity comes from the `export *` syntax rather than `import *`, so proposing this fix.