### PR TITLE
Editorial: Update InternalizeJSONProperty to accept reviver explicitly

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38133,7 +38133,7 @@ THH:mm:ss.sss
           1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Let _rootName_ be the empty String.
           1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
-          1. Return ? InternalizeJSONProperty(_root_, _rootName_).
+          1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_).
         1. Else,
           1. Return _unfiltered_.
       </emu-alg>
@@ -38144,8 +38144,8 @@ THH:mm:ss.sss
       </emu-note>
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">
-        <h1>Runtime Semantics: InternalizeJSONProperty ( _holder_, _name_ )</h1>
-        <p>The abstract operation InternalizeJSONProperty is a recursive abstract operation that takes two parameters: a _holder_ object and the String _name_ of a property in that object. InternalizeJSONProperty uses the value of _reviver_ that was originally passed to the above parse function.</p>
+        <h1>Runtime Semantics: InternalizeJSONProperty ( _holder_, _name_, _reviver_ )</h1>
+        <p>The abstract operation InternalizeJSONProperty is a recursive abstract operation that takes three parameters: a _holder_ object, the String _name_ of a property in that object, and a _reviver_ function.</p>
         <emu-note>
           <p>This algorithm intentionally does not throw an exception if either [[Delete]] or CreateDataProperty return *false*.</p>
         </emu-note>
@@ -38157,7 +38157,7 @@ THH:mm:ss.sss
               1. Let _I_ be 0.
               1. Let _len_ be ? LengthOfArrayLike(_val_).
               1. Repeat, while _I_ &lt; _len_,
-                1. Let _newElement_ be ? InternalizeJSONProperty(_val_, ! ToString(_I_)).
+                1. Let _newElement_ be ? InternalizeJSONProperty(_val_, ! ToString(_I_), _reviver_).
                 1. If _newElement_ is *undefined*, then
                   1. Perform ? _val_.[[Delete]](! ToString(_I_)).
                 1. Else,
@@ -38166,7 +38166,7 @@ THH:mm:ss.sss
             1. Else,
               1. Let _keys_ be ? EnumerableOwnPropertyNames(_val_, ~key~).
               1. For each String _P_ in _keys_, do
-                1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_).
+                1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_, _reviver_).
                 1. If _newElement_ is *undefined*, then
                   1. Perform ? _val_.[[Delete]](_P_).
                 1. Else,


### PR DESCRIPTION
Fixes #1878

(copied from [JSON.parse source text access
 proposal](https://tc39.es/proposal-json-parse-with-source/#sec-internalizejsonproperty))

No effects on downstream dependencies:
* [Web IDL](https://heycam.github.io/webidl/)
* [HTML Standard](https://html.spec.whatwg.org/)