### PR TITLE
Editorial: fix misleading uses of 'operator'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2444,7 +2444,7 @@
                 (a List of <em>any</em>, Object) <b>&rarr;</b> Object
               </td>
               <td>
-                Creates an object. Invoked via the `new` or `super` operators. The first argument to the internal method is a list containing the arguments of the operator. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
+                Creates an object. Invoked via the `new` operator or a `super` call. The first argument to the internal method is a list containing the arguments of the constructor invocation or the `super` call. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
               </td>
             </tr>
             </tbody>
@@ -13465,7 +13465,7 @@
             a?.b
             `c`
           </code></pre>
-          <p>so that it would be interpreted as two valid statements. The purpose is to maintain consistency with similar code without optional chaining operator:</p>
+          <p>so that it would be interpreted as two valid statements. The purpose is to maintain consistency with similar code without optional chaining:</p>
           <pre><code class="javascript">
             a.b
             `c`


### PR DESCRIPTION
Hello, there are two uses of the word 'operator' that refer to those not defined to be operators. This PR proposes to replace them with other appropriate words.

- “`new` or `super` operators”
  - While `new` is actually an operator ([12.3.5 The new Operator](https://tc39.es/ecma262/#sec-new-operator)), `super` is not ([12.3.7 The super Keyword](https://tc39.es/ecma262/#sec-super-keyword)). Following @ljharb's suggestion, this PR rephrases it to “`new` operator or a `super` call`”.
- “optional chaining operator”
  - The production that starts from `?.` token is simply called optional chains ([12.3.9 Optional Chains](https://tc39.es/ecma262/#sec-optional-chains)). Since the paragraph in question discusses syntactic analysis, I chose the word 'syntax'.