### PR TITLE
Editorial: Add subscripts to BindingIdentifier static semantics.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12252,7 +12252,7 @@
         </li>
       </ul>
       <emu-grammar>
-        BindingIdentifier : `yield`
+        BindingIdentifier[Yield, Await] : `yield`
       </emu-grammar>
       <ul>
         <li>
@@ -12260,7 +12260,7 @@
         </li>
       </ul>
       <emu-grammar>
-        BindingIdentifier : `await`
+        BindingIdentifier[Yield, Await] : `await`
       </emu-grammar>
       <ul>
         <li>


### PR DESCRIPTION
Adding subscripts here makes sense, because the semantics specifically talk
about the presence of a parameter.

Also, the productions below, where the semantics also talk about the presence
of a parameter, already have the subscripts. So it's inconsistent to not have
them here.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
