### PR TITLE
Normative: make SharedArrayBuffer optional

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37458,11 +37458,13 @@ THH:mm:ss.sss
       <p>The SharedArrayBuffer constructor:</p>
       <ul>
         <li>is <dfn>%SharedArrayBuffer%</dfn>.</li>
-        <li>is the initial value of the *"SharedArrayBuffer"* property of the global object.</li>
+        <li>is the initial value of the *"SharedArrayBuffer"* property of the global object, if that property is present (see below).</li>
         <li>creates and initializes a new SharedArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified SharedArrayBuffer behaviour must include a `super` call to the SharedArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
       </ul>
+
+      <p>Whenever a host does not provide concurrent access to SharedArrayBuffer objects it may omit the *"SharedArrayBuffer"* property of the global object.</p>
 
       <emu-note>
         <p>Unlike an `ArrayBuffer`, a `SharedArrayBuffer` cannot become detached, and its internal [[ArrayBufferData]] slot is never *null*.</p>


### PR DESCRIPTION
See https://github.com/tc39/ecma262/issues/1435.

We could do the whole host hook song and dance, but that seems like overkill.

This PR takes the approach of making the `SharedArrayBuffer` property of the global object optional for hosts which do not provide concurrent access to SAB objects. There's no other way of getting a `SharedArrayBuffer` object (in this spec, certainly), so I think that's sufficient.

cc @erights @annevk @syg

Closes #1435.