### PR TITLE
Editorial: Spec variables shouldn't use TDZ in their names.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17914,18 +17914,18 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
-        <h1>Runtime Semantics: ForIn/OfHeadEvaluation ( _TDZnames_, _expr_, _iterationKind_ )</h1>
-        <p>The abstract operation ForIn/OfHeadEvaluation is called with arguments _TDZnames_, _expr_, and _iterationKind_. The value of _iterationKind_ is either ~enumerate~, ~iterate~, or ~async-iterate~.</p>
+      <emu-clause id="sec-runtime-semantics-forinofheadevaluation" oldids="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
+        <h1>Runtime Semantics: ForIn/OfHeadEvaluation ( _uninitializedBoundNames_, _expr_, _iterationKind_ )</h1>
+        <p>The abstract operation ForIn/OfHeadEvaluation is called with arguments _uninitializedBoundNames_, _expr_, and _iterationKind_. The value of _iterationKind_ is either ~enumerate~, ~iterate~, or ~async-iterate~.</p>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
-          1. If _TDZnames_ is not an empty List, then
-            1. Assert: _TDZnames_ has no duplicate entries.
-            1. Let _TDZ_ be NewDeclarativeEnvironment(_oldEnv_).
-            1. Let _TDZEnvRec_ be _TDZ_'s EnvironmentRecord.
-            1. For each string _name_ in _TDZnames_, do
-              1. Perform ! _TDZEnvRec_.CreateMutableBinding(_name_, *false*).
-            1. Set the running execution context's LexicalEnvironment to _TDZ_.
+          1. If _uninitializedBoundNames_ is not an empty List, then
+            1. Assert: _uninitializedBoundNames_ has no duplicate entries.
+            1. Let _newEnv_ be NewDeclarativeEnvironment(_oldEnv_).
+            1. Let _newEnvRec_ be _newEnv_'s EnvironmentRecord.
+            1. For each string _name_ in _uninitializedBoundNames_, do
+              1. Perform ! _newEnvRec_.CreateMutableBinding(_name_, *false*).
+            1. Set the running execution context's LexicalEnvironment to _newEnv_.
           1. Let _exprRef_ be the result of evaluating _expr_.
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Let _exprValue_ be ? GetValue(_exprRef_).


### PR DESCRIPTION
Resolves #1905.