### PR TITLE
Editorial: Define+use `ClassElementKind`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21130,23 +21130,36 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-static-semantics-classelementkind">
+      <h1>Static Semantics: ClassElementKind</h1>
+      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
+      <emu-alg>
+        1. If PropName of |MethodDefinition| is *"constructor"*, return ~ConstructorMethod~.
+        1. Return ~NonConstructorMethod~.
+      </emu-alg>
+      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-alg>
+        1. Return ~NonConstructorMethod~.
+      </emu-alg>
+      <emu-grammar>ClassElement : `;`</emu-grammar>
+      <emu-alg>
+        1. Return ~empty~.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-static-semantics-constructormethod">
       <h1>Static Semantics: ConstructorMethod</h1>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return ~empty~.
-        1. If IsStatic of |ClassElement| is *true*, return ~empty~.
-        1. If PropName of |ClassElement| is not *"constructor"*, return ~empty~.
-        1. Return |ClassElement|.
+        1. If ClassElementKind of |ClassElement| is ~ConstructorMethod~, return |ClassElement|.
+        1. Return ~empty~.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _head_ be ConstructorMethod of |ClassElementList|.
         1. If _head_ is not ~empty~, return _head_.
-        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return ~empty~.
-        1. If IsStatic of |ClassElement| is *true*, return ~empty~.
-        1. If PropName of |ClassElement| is not *"constructor"*, return ~empty~.
-        1. Return |ClassElement|.
+        1. If ClassElementKind of |ClassElement| is ~ConstructorMethod~, return |ClassElement|.
+        1. Return ~empty~.
       </emu-alg>
       <emu-note>
         <p>Early Error rules ensure that there is only one method definition named *"constructor"* and that it is not an accessor property or generator definition.</p>
@@ -21242,16 +21255,15 @@
       <h1>Static Semantics: NonConstructorMethodDefinitions</h1>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return a new empty List.
-        1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is *"constructor"*, return a new empty List.
-        1. Return a List containing |ClassElement|.
+        1. If ClassElementKind of |ClassElement| is ~NonConstructorMethod~, then
+          1. Return a List containing |ClassElement|.
+        1. Return a new empty List.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _list_ be NonConstructorMethodDefinitions of |ClassElementList|.
-        1. If |ClassElement| is <emu-grammar>ClassElement : `;`</emu-grammar> , return _list_.
-        1. If IsStatic of |ClassElement| is *false* and PropName of |ClassElement| is *"constructor"*, return _list_.
-        1. Append |ClassElement| to the end of _list_.
+        1. If ClassElementKind of |ClassElement| is ~NonConstructorMethod~, then
+          1. Append |ClassElement| to the end of _list_.
         1. Return _list_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
The syntax-directed operations `ConstructorMethod` and `NonConstructorMethodDefinitions` have some duplicated code. Factor out this code and define a new SDO `ClassElementKind`.