### PR TITLE
Normative: Promise.{all,allSettled,race} should check resolve is a function before opening their iterable

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40100,9 +40100,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
+          1. Let _promiseResolve_ be GetPromiseResolve(_C_).
+          1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
           1. Let _iteratorRecord_ be GetIterator(_iterable_).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
-          1. Let _result_ be PerformPromiseAll(_iteratorRecord_, _C_, _promiseCapability_).
+          1. Let _result_ be PerformPromiseAll(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
           1. If _result_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to IteratorClose(_iteratorRecord_, _result_).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
@@ -40113,16 +40115,26 @@ THH:mm:ss.sss
           <p>The `all` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
+        <emu-clause id="sec-getpromiseresolve" aoid="GetPromiseResolve">
+          <h1>Runtime Semantics: GetPromiseResolve ( _promiseConstructor_ )</h1>
+          <p>The abstract operation GetPromiseResolve takes argument _promiseConstructor_. It performs the following steps when called:</p>
+          <emu-alg>
+            1. Assert: IsConstructor(_promiseConstructor_) is *true*.
+            1. Let _promiseResolve_ be ? Get(_promiseConstructor_, *"resolve"*).
+            1. If IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
+            1. Return _promiseResolve_.
+          </emu-alg>
+        </emu-clause>
+
         <emu-clause id="sec-performpromiseall" aoid="PerformPromiseAll">
-          <h1>Runtime Semantics: PerformPromiseAll ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
-          <p>The abstract operation PerformPromiseAll takes arguments _iteratorRecord_, _constructor_, and _resultCapability_. It performs the following steps when called:</p>
+          <h1>Runtime Semantics: PerformPromiseAll ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
+          <p>The abstract operation PerformPromiseAll takes arguments _iteratorRecord_, _constructor_, _resultCapability_, and _promiseResolve_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
             1. Assert: _resultCapability_ is a PromiseCapability Record.
+            1. Assert: IsCallable(_promiseResolve_) is *true*.
             1. Let _values_ be a new empty List.
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
-            1. Let _promiseResolve_ be ? Get(_constructor_, *"resolve"*).
-            1. If ! IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
             1. Let _index_ be 0.
             1. Repeat,
               1. Let _next_ be IteratorStep(_iteratorRecord_).
@@ -40183,9 +40195,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
+          1. Let _promiseResolve_ be GetPromiseResolve(_C_).
+          1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
           1. Let _iteratorRecord_ be GetIterator(_iterable_).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
-          1. Let _result_ be PerformPromiseAllSettled(_iteratorRecord_, _C_, _promiseCapability_).
+          1. Let _result_ be PerformPromiseAllSettled(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
           1. If _result_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to IteratorClose(_iteratorRecord_, _result_).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
@@ -40196,16 +40210,15 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-performpromiseallsettled" aoid="PerformPromiseAllSettled">
-          <h1>Runtime Semantics: PerformPromiseAllSettled ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
-          <p>The abstract operation PerformPromiseAllSettled takes arguments _iteratorRecord_, _constructor_, and _resultCapability_. It performs the following steps when called:</p>
+          <h1>Runtime Semantics: PerformPromiseAllSettled ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
+          <p>The abstract operation PerformPromiseAllSettled takes arguments _iteratorRecord_, _constructor_, _resultCapability_, and _promiseResolve_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: ! IsConstructor(_constructor_) is *true*.
             1. Assert: _resultCapability_ is a PromiseCapability Record.
+            1. Assert: IsCallable(_promiseResolve_) is *true*.
             1. Let _values_ be a new empty List.
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
-            1. Let _promiseResolve_ be ? Get(_constructor_, *"resolve"*).
-            1. If IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
             1. Repeat,
               1. Let _next_ be IteratorStep(_iteratorRecord_).
               1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -40308,9 +40321,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
+          1. Let _promiseResolve_ be GetPromiseResolve(_C_).
+          1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
           1. Let _iteratorRecord_ be GetIterator(_iterable_).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
-          1. Let _result_ be PerformPromiseRace(_iteratorRecord_, _C_, _promiseCapability_).
+          1. Let _result_ be PerformPromiseRace(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
           1. If _result_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to IteratorClose(_iteratorRecord_, _result_).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
@@ -40324,13 +40339,12 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-performpromiserace" aoid="PerformPromiseRace">
-          <h1>Runtime Semantics: PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
-          <p>The abstract operation PerformPromiseRace takes arguments _iteratorRecord_, _constructor_, and _resultCapability_. It performs the following steps when called:</p>
+          <h1>Runtime Semantics: PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
+          <p>The abstract operation PerformPromiseRace takes arguments _iteratorRecord_, _constructor_, _resultCapability_, and _promiseResolve_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
             1. Assert: _resultCapability_ is a PromiseCapability Record.
-            1. Let _promiseResolve_ be ? Get(_constructor_, *"resolve"*).
-            1. If ! IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
+            1. Assert: IsCallable(_promiseResolve_) is *true*.
             1. Repeat,
               1. Let _next_ be IteratorStep(_iteratorRecord_).
               1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.


### PR DESCRIPTION
This change makes promise.{all,allSettled,race} behave more like a canonical JS implementation.  In particular, the resolve property is now checked to be callable before beginning iteration on the first argument.

Closes #1902.
