### PR TITLE
Editorial: use consistent wording for abstract operation preambles

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1751,6 +1751,7 @@
 
         <emu-clause id="sec-numberbitwiseop" aoid="NumberBitwiseOp">
           <h1>NumberBitwiseOp ( _op_, _x_, _y_ )</h1>
+          <p>The abstract operation NumberBitwiseOp takes arguments _op_, _x_, and _y_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
@@ -1962,6 +1963,7 @@
 
         <emu-clause id="sec-binaryand" aoid="BinaryAnd">
           <h1>BinaryAnd ( _x_, _y_ )</h1>
+          <p>The abstract operation BinaryAnd takes arguments _x_ and _y_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _x_ is 0 or 1.
             1. Assert: _y_ is 0 or 1.
@@ -1972,6 +1974,7 @@
 
         <emu-clause id="sec-binaryor" aoid="BinaryOr">
           <h1>BinaryOr ( _x_, _y_ )</h1>
+          <p>The abstract operation BinaryOr takes arguments _x_ and _y_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _x_ is 0 or 1.
             1. Assert: _y_ is 0 or 1.
@@ -1982,6 +1985,7 @@
 
         <emu-clause id="sec-binaryxor" aoid="BinaryXor">
           <h1>BinaryXor ( _x_, _y_ )</h1>
+          <p>The abstract operation BinaryXor takes arguments _x_ and _y_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _x_ is 0 or 1.
             1. Assert: _y_ is 0 or 1.
@@ -1993,6 +1997,7 @@
 
         <emu-clause id="sec-bigintbitwiseop" aoid="BigIntBitwiseOp">
           <h1>BigIntBitwiseOp ( _op_, _x_, _y_ )</h1>
+          <p>The abstract operation BigIntBitwiseOp takes arguments _op_, _x_, and _y_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _op_ is *"&amp;"*, *"|"*, or *"^"*.
             1. Let _result_ be *0n*.
@@ -4069,10 +4074,9 @@
 
         <emu-clause id="await-fulfilled">
           <h1>Await Fulfilled Functions</h1>
-
           <p>An Await fulfilled function is an anonymous built-in function that is used as part of the Await specification device to deliver the promise fulfillment value to the caller as a normal completion. Each Await fulfilled function has an [[AsyncContext]] internal slot.</p>
-
           <p>When an Await fulfilled function is called with argument _value_, the following steps are taken:</p>
+
 
           <emu-alg>
             1. Let _F_ be the active function object.
@@ -4090,10 +4094,9 @@
 
         <emu-clause id="await-rejected">
           <h1>Await Rejected Functions</h1>
-
           <p>An Await rejected function is an anonymous built-in function that is used as part of the Await specification device to deliver the promise rejection reason to the caller as an abrupt throw completion. Each Await rejected function has an [[AsyncContext]] internal slot.</p>
-
           <p>When an Await rejected function is called with argument _reason_, the following steps are taken:</p>
+
 
           <emu-alg>
             1. Let _F_ be the active function object.
@@ -4136,7 +4139,7 @@
 
       <emu-clause id="sec-updateempty" aoid="UpdateEmpty">
         <h1>UpdateEmpty ( _completionRecord_, _value_ )</h1>
-        <p>The abstract operation UpdateEmpty with arguments _completionRecord_ and _value_ performs the following steps:</p>
+        <p>The abstract operation UpdateEmpty takes arguments _completionRecord_ and _value_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: If _completionRecord_.[[Type]] is either ~return~ or ~throw~, then _completionRecord_.[[Value]] is not ~empty~.
           1. If _completionRecord_.[[Value]] is not ~empty~, return Completion(_completionRecord_).
@@ -4156,6 +4159,7 @@
 
       <emu-clause id="sec-getbase" aoid="GetBase" oldids="ao-getbase">
         <h1>GetBase ( _V_ )</h1>
+        <p>The abstract operation GetBase takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_V_) is Reference.
           1. Return the base value component of _V_.
@@ -4164,6 +4168,7 @@
 
       <emu-clause id="sec-getreferencedname" aoid="GetReferencedName" oldids="ao-getreferencedname">
         <h1>GetReferencedName ( _V_ )</h1>
+        <p>The abstract operation GetReferencedName takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_V_) is Reference.
           1. Return the referenced name component of _V_.
@@ -4172,6 +4177,7 @@
 
       <emu-clause id="sec-isstrictreference" aoid="IsStrictReference" oldids="ao-isstrictreference">
         <h1>IsStrictReference ( _V_ )</h1>
+        <p>The abstract operation IsStrictReference takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_V_) is Reference.
           1. Return the strict reference flag of _V_.
@@ -4180,6 +4186,7 @@
 
       <emu-clause id="sec-hasprimitivebase" aoid="HasPrimitiveBase" oldids="ao-hasprimitivebase">
         <h1>HasPrimitiveBase ( _V_ )</h1>
+        <p>The abstract operation HasPrimitiveBase takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_V_) is Reference.
           1. If Type(_V_'s base value component) is Boolean, String, Symbol, BigInt, or Number, return *true*; otherwise return *false*.
@@ -4188,6 +4195,7 @@
 
       <emu-clause id="sec-ispropertyreference" aoid="IsPropertyReference" oldids="ao-ispropertyreference">
         <h1>IsPropertyReference ( _V_ )</h1>
+        <p>The abstract operation IsPropertyReference takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_V_) is Reference.
           1. If either the base value component of _V_ is an Object or HasPrimitiveBase(_V_) is *true*, return *true*; otherwise return *false*.
@@ -4196,6 +4204,7 @@
 
       <emu-clause id="sec-isunresolvablereference" aoid="IsUnresolvableReference" oldids="ao-isunresolvablereference">
         <h1>IsUnresolvableReference ( _V_ )</h1>
+        <p>The abstract operation IsUnresolvableReference takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_V_) is Reference.
           1. If the base value component of _V_ is *undefined*, return *true*; otherwise return *false*.
@@ -4204,6 +4213,7 @@
 
       <emu-clause id="sec-issuperreference" aoid="IsSuperReference" oldids="ao-issuperreference">
         <h1>IsSuperReference ( _V_ )</h1>
+        <p>The abstract operation IsSuperReference takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_V_) is Reference.
           1. If _V_ has a thisValue component, return *true*; otherwise return *false*.
@@ -4212,6 +4222,7 @@
 
       <emu-clause id="sec-getvalue" aoid="GetValue">
         <h1>GetValue ( _V_ )</h1>
+        <p>The abstract operation GetValue takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. ReturnIfAbrupt(_V_).
           1. If Type(_V_) is not Reference, return _V_.
@@ -4233,6 +4244,7 @@
 
       <emu-clause id="sec-putvalue" aoid="PutValue">
         <h1>PutValue ( _V_, _W_ )</h1>
+        <p>The abstract operation PutValue takes arguments _V_ and _W_. It performs the following steps when called:</p>
         <emu-alg>
           1. ReturnIfAbrupt(_V_).
           1. ReturnIfAbrupt(_W_).
@@ -4261,6 +4273,7 @@
 
       <emu-clause id="sec-getthisvalue" aoid="GetThisValue">
         <h1>GetThisValue ( _V_ )</h1>
+        <p>The abstract operation GetThisValue takes argument _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyReference(_V_) is *true*.
           1. If IsSuperReference(_V_) is *true*, then
@@ -4271,6 +4284,7 @@
 
       <emu-clause id="sec-initializereferencedbinding" aoid="InitializeReferencedBinding">
         <h1>InitializeReferencedBinding ( _V_, _W_ )</h1>
+        <p>The abstract operation InitializeReferencedBinding takes arguments _V_ and _W_. It performs the following steps when called:</p>
         <emu-alg>
           1. ReturnIfAbrupt(_V_).
           1. ReturnIfAbrupt(_W_).
@@ -4291,7 +4305,7 @@
 
       <emu-clause id="sec-isaccessordescriptor" aoid="IsAccessorDescriptor">
         <h1>IsAccessorDescriptor ( _Desc_ )</h1>
-        <p>When the abstract operation IsAccessorDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The abstract operation IsAccessorDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
           1. If both _Desc_.[[Get]] and _Desc_.[[Set]] are absent, return *false*.
@@ -4301,7 +4315,7 @@
 
       <emu-clause id="sec-isdatadescriptor" aoid="IsDataDescriptor">
         <h1>IsDataDescriptor ( _Desc_ )</h1>
-        <p>When the abstract operation IsDataDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The abstract operation IsDataDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
           1. If both _Desc_.[[Value]] and _Desc_.[[Writable]] are absent, return *false*.
@@ -4311,7 +4325,7 @@
 
       <emu-clause id="sec-isgenericdescriptor" aoid="IsGenericDescriptor">
         <h1>IsGenericDescriptor ( _Desc_ )</h1>
-        <p>When the abstract operation IsGenericDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The abstract operation IsGenericDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
           1. If IsAccessorDescriptor(_Desc_) and IsDataDescriptor(_Desc_) are both *false*, return *true*.
@@ -4321,7 +4335,7 @@
 
       <emu-clause id="sec-frompropertydescriptor" aoid="FromPropertyDescriptor">
         <h1>FromPropertyDescriptor ( _Desc_ )</h1>
-        <p>When the abstract operation FromPropertyDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The abstract operation FromPropertyDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *undefined*.
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
@@ -4344,7 +4358,7 @@
 
       <emu-clause id="sec-topropertydescriptor" aoid="ToPropertyDescriptor">
         <h1>ToPropertyDescriptor ( _Obj_ )</h1>
-        <p>When the abstract operation ToPropertyDescriptor is called with object _Obj_, the following steps are taken:</p>
+        <p>The abstract operation ToPropertyDescriptor takes argument _Obj_. It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_Obj_) is not Object, throw a *TypeError* exception.
           1. Let _desc_ be a new Property Descriptor that initially has no fields.
@@ -4382,7 +4396,7 @@
 
       <emu-clause id="sec-completepropertydescriptor" aoid="CompletePropertyDescriptor">
         <h1>CompletePropertyDescriptor ( _Desc_ )</h1>
-        <p>When the abstract operation CompletePropertyDescriptor is called with Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The abstract operation CompletePropertyDescriptor takes argument _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _Desc_ is a Property Descriptor.
           1. Let _like_ be the Record { [[Value]]: *undefined*, [[Writable]]: *false*, [[Get]]: *undefined*, [[Set]]: *undefined*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -4430,7 +4444,7 @@
 
       <emu-clause id="sec-createbytedatablock" aoid="CreateByteDataBlock">
         <h1>CreateByteDataBlock ( _size_ )</h1>
-        <p>When the abstract operation CreateByteDataBlock is called with integer argument _size_, the following steps are taken:</p>
+        <p>The abstract operation CreateByteDataBlock takes argument _size_ (an integer). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _size_ &ge; 0.
           1. Let _db_ be a new Data Block value consisting of _size_ bytes. If it is impossible to create such a Data Block, throw a *RangeError* exception.
@@ -4441,7 +4455,7 @@
 
       <emu-clause id="sec-createsharedbytedatablock" aoid="CreateSharedByteDataBlock">
         <h1>CreateSharedByteDataBlock ( _size_ )</h1>
-        <p>When the abstract operation CreateSharedByteDataBlock is called with integer argument _size_, the following steps are taken:</p>
+        <p>The abstract operation CreateSharedByteDataBlock takes argument _size_ (an integer). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _size_ &ge; 0.
           1. Let _db_ be a new Shared Data Block value consisting of _size_ bytes. If it is impossible to create such a Shared Data Block, throw a *RangeError* exception.
@@ -4456,7 +4470,7 @@
 
       <emu-clause id="sec-copydatablockbytes" aoid="CopyDataBlockBytes">
         <h1>CopyDataBlockBytes ( _toBlock_, _toIndex_, _fromBlock_, _fromIndex_, _count_ )</h1>
-        <p>When the abstract operation CopyDataBlockBytes is called, the following steps are taken:</p>
+        <p>The abstract operation CopyDataBlockBytes takes arguments _toBlock_, _toIndex_, _fromBlock_, _fromIndex_, and _count_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _fromBlock_ and _toBlock_ are distinct Data Block or Shared Data Block values.
           1. Assert: _fromIndex_, _toIndex_, and _count_ are integer values &ge; 0.
@@ -4501,7 +4515,7 @@
 
     <emu-clause id="sec-toprimitive" aoid="ToPrimitive" oldids="table-9">
       <h1>ToPrimitive ( _input_ [ , _PreferredType_ ] )</h1>
-      <p>The abstract operation ToPrimitive takes an _input_ argument and an optional argument _PreferredType_. The abstract operation ToPrimitive converts its _input_ argument to a non-Object type. If an object is capable of converting to more than one primitive type, it may use the optional hint _PreferredType_ to favour that type. Conversion occurs according to the following algorithm:</p>
+      <p>The abstract operation ToPrimitive takes argument _input_ and optional argument _PreferredType_. It converts its _input_ argument to a non-Object type. If an object is capable of converting to more than one primitive type, it may use the optional hint _PreferredType_ to favour that type. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _input_ is an ECMAScript language value.
         1. If Type(_input_) is Object, then
@@ -4525,7 +4539,7 @@
 
       <emu-clause id="sec-ordinarytoprimitive" aoid="OrdinaryToPrimitive">
         <h1>OrdinaryToPrimitive ( _O_, _hint_ )</h1>
-        <p>When the abstract operation OrdinaryToPrimitive is called with arguments _O_ and _hint_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryToPrimitive takes arguments _O_ and _hint_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_O_) is Object.
           1. Assert: Type(_hint_) is String and its value is either *"string"* or *"number"*.
@@ -4545,7 +4559,7 @@
 
     <emu-clause id="sec-toboolean" aoid="ToBoolean">
       <h1>ToBoolean ( _argument_ )</h1>
-      <p>The abstract operation ToBoolean converts _argument_ to a value of type Boolean according to <emu-xref href="#table-10"></emu-xref>:</p>
+      <p>The abstract operation ToBoolean takes argument _argument_. It converts _argument_ to a value of type Boolean according to <emu-xref href="#table-10"></emu-xref>:</p>
       <emu-table id="table-10" caption="ToBoolean Conversions">
         <table>
           <tbody>
@@ -4628,7 +4642,7 @@
 
     <emu-clause id="sec-tonumeric" aoid="ToNumeric">
       <h1>ToNumeric ( _value_ )</h1>
-      <p>The abstract operation ToNumeric returns _value_ converted to a numeric value of type Number or BigInt. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToNumeric takes argument _value_. It returns _value_ converted to a numeric value of type Number or BigInt. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _primValue_ be ? ToPrimitive(_value_, hint Number).
         1. If Type(_primValue_) is BigInt, return _primValue_.
@@ -4638,7 +4652,7 @@
 
     <emu-clause id="sec-tonumber" aoid="ToNumber">
       <h1>ToNumber ( _argument_ )</h1>
-      <p>The abstract operation ToNumber converts _argument_ to a value of type Number according to <emu-xref href="#table-11"></emu-xref>:</p>
+      <p>The abstract operation ToNumber takes argument _argument_. It converts _argument_ to a value of type Number according to <emu-xref href="#table-11"></emu-xref>:</p>
       <emu-table id="table-11" caption="ToNumber Conversions">
         <table>
           <tbody>
@@ -4852,7 +4866,7 @@
 
     <emu-clause id="sec-tointeger" aoid="ToInteger">
       <h1>ToInteger ( _argument_ )</h1>
-      <p>The abstract operation ToInteger converts _argument_ to an integral Number value. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToInteger takes argument _argument_. It converts _argument_ to an integral Number value. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, or *-0*, return *+0*.
@@ -4865,7 +4879,7 @@
 
     <emu-clause id="sec-toint32" aoid="ToInt32">
       <h1>ToInt32 ( _argument_ )</h1>
-      <p>The abstract operation ToInt32 converts _argument_ to one of 2<sup>32</sup> integer values in the range <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToInt32 takes argument _argument_. It converts _argument_ to one of 2<sup>32</sup> integer values in the range <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
@@ -4891,7 +4905,7 @@
 
     <emu-clause id="sec-touint32" aoid="ToUint32">
       <h1>ToUint32 ( _argument_ )</h1>
-      <p>The abstract operation ToUint32 converts _argument_ to one of 2<sup>32</sup> integer values in the range 0 through <emu-eqn>2<sup>32</sup> - 1</emu-eqn>, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToUint32 takes argument _argument_. It converts _argument_ to one of 2<sup>32</sup> integer values in the range 0 through <emu-eqn>2<sup>32</sup> - 1</emu-eqn>, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
@@ -4920,7 +4934,7 @@
 
     <emu-clause id="sec-toint16" aoid="ToInt16">
       <h1>ToInt16 ( _argument_ )</h1>
-      <p>The abstract operation ToInt16 converts _argument_ to one of 2<sup>16</sup> integer values in the range -32768 through 32767, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToInt16 takes argument _argument_. It converts _argument_ to one of 2<sup>16</sup> integer values in the range -32768 through 32767, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
@@ -4932,7 +4946,7 @@
 
     <emu-clause id="sec-touint16" aoid="ToUint16">
       <h1>ToUint16 ( _argument_ )</h1>
-      <p>The abstract operation ToUint16 converts _argument_ to one of 2<sup>16</sup> integer values in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToUint16 takes argument _argument_. It converts _argument_ to one of 2<sup>16</sup> integer values in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
@@ -4955,7 +4969,7 @@
 
     <emu-clause id="sec-toint8" aoid="ToInt8">
       <h1>ToInt8 ( _argument_ )</h1>
-      <p>The abstract operation ToInt8 converts _argument_ to one of 2<sup>8</sup> integer values in the range -128 through 127, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToInt8 takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integer values in the range -128 through 127, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
@@ -4967,7 +4981,7 @@
 
     <emu-clause id="sec-touint8" aoid="ToUint8">
       <h1>ToUint8 ( _argument_ )</h1>
-      <p>The abstract operation ToUint8 converts _argument_ to one of 2<sup>8</sup> integer values in the range 0 through 255, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToUint8 takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integer values in the range 0 through 255, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
@@ -4979,7 +4993,7 @@
 
     <emu-clause id="sec-touint8clamp" aoid="ToUint8Clamp">
       <h1>ToUint8Clamp ( _argument_ )</h1>
-      <p>The abstract operation ToUint8Clamp converts _argument_ to one of 2<sup>8</sup> integer values in the range 0 through 255, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToUint8Clamp takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integer values in the range 0 through 255, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, return *+0*.
@@ -4998,7 +5012,7 @@
 
     <emu-clause id="sec-tobigint" aoid="ToBigInt">
       <h1>ToBigInt ( _argument_ )</h1>
-      <p>The abstract operation ToBigInt converts its argument _argument_ to a BigInt value, or throws if an implicit conversion from Number would be required.</p>
+      <p>The abstract operation ToBigInt takes argument _argument_. It converts _argument_ to a BigInt value, or throws if an implicit conversion from Number would be required. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _prim_ be ? ToPrimitive(_argument_, hint Number).
         1. Return the value that _prim_ corresponds to in <emu-xref href="#table-tobigint"></emu-xref>.
@@ -5090,7 +5104,7 @@
 
     <emu-clause id="sec-tobigint64" aoid="ToBigInt64">
       <h1>ToBigInt64 ( _argument_ )</h1>
-      <p>The abstract operation ToBigInt64 converts _argument_ to one of 2<sup>64</sup> integer values in the range -2<sup>63</sup> through 2<sup>63</sup>-1, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToBigInt64 takes argument _argument_. It converts _argument_ to one of 2<sup>64</sup> integer values in the range -2<sup>63</sup> through 2<sup>63</sup>-1, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
         1. Let _int64bit_ be _n_ modulo 2<sup>64</sup>.
@@ -5100,7 +5114,7 @@
 
     <emu-clause id="sec-tobiguint64" aoid="ToBigUint64">
       <h1>ToBigUint64 ( _argument_ )</h1>
-      <p>The abstract operation ToBigUint64 converts _argument_ to one of 2<sup>64</sup> integer values in the range 0 through 2<sup>64</sup>-1, inclusive. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToBigUint64 takes argument _argument_. It converts _argument_ to one of 2<sup>64</sup> integer values in the range 0 through 2<sup>64</sup>-1, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
         1. Let _int64bit_ be _n_ modulo 2<sup>64</sup>.
@@ -5110,7 +5124,7 @@
 
     <emu-clause id="sec-tostring" aoid="ToString">
       <h1>ToString ( _argument_ )</h1>
-      <p>The abstract operation ToString converts _argument_ to a value of type String according to <emu-xref href="#table-12"></emu-xref>:</p>
+      <p>The abstract operation ToString takes argument _argument_. It converts _argument_ to a value of type String according to <emu-xref href="#table-12"></emu-xref>:</p>
       <emu-table id="table-12" caption="ToString Conversions">
         <table>
           <tbody>
@@ -5198,7 +5212,7 @@
 
     <emu-clause id="sec-toobject" aoid="ToObject">
       <h1>ToObject ( _argument_ )</h1>
-      <p>The abstract operation ToObject converts _argument_ to a value of type Object according to <emu-xref href="#table-13"></emu-xref>:</p>
+      <p>The abstract operation ToObject takes argument _argument_. It converts _argument_ to a value of type Object according to <emu-xref href="#table-13"></emu-xref>:</p>
       <emu-table id="table-13" caption="ToObject Conversions">
         <table>
           <tbody>
@@ -5281,7 +5295,7 @@
 
     <emu-clause id="sec-topropertykey" aoid="ToPropertyKey">
       <h1>ToPropertyKey ( _argument_ )</h1>
-      <p>The abstract operation ToPropertyKey converts _argument_ to a value that can be used as a property key by performing the following steps:</p>
+      <p>The abstract operation ToPropertyKey takes argument _argument_. It converts _argument_ to a value that can be used as a property key. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _key_ be ? ToPrimitive(_argument_, hint String).
         1. If Type(_key_) is Symbol, then
@@ -5292,7 +5306,7 @@
 
     <emu-clause id="sec-tolength" aoid="ToLength">
       <h1>ToLength ( _argument_ )</h1>
-      <p>The abstract operation ToLength converts _argument_ to an integer suitable for use as the length of an array-like object. It performs the following steps:</p>
+      <p>The abstract operation ToLength takes argument _argument_. It converts _argument_ to an integer suitable for use as the length of an array-like object. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _len_ be ? ToInteger(_argument_).
         1. If _len_ &le; *+0*, return *+0*.
@@ -5302,7 +5316,7 @@
 
     <emu-clause id="sec-canonicalnumericindexstring" aoid="CanonicalNumericIndexString">
       <h1>CanonicalNumericIndexString ( _argument_ )</h1>
-      <p>The abstract operation CanonicalNumericIndexString returns _argument_ converted to a Number value if it is a String representation of a Number that would be produced by ToString, or the string *"-0"*. Otherwise, it returns *undefined*. This abstract operation functions as follows:</p>
+      <p>The abstract operation CanonicalNumericIndexString takes argument _argument_. It returns _argument_ converted to a Number value if it is a String representation of a Number that would be produced by ToString, or the string *"-0"*. Otherwise, it returns *undefined*. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_argument_) is String.
         1. If _argument_ is *"-0"*, return *-0*.
@@ -5315,7 +5329,7 @@
 
     <emu-clause id="sec-toindex" aoid="ToIndex">
       <h1>ToIndex ( _value_ )</h1>
-      <p>The abstract operation ToIndex returns _value_ argument converted to a non-negative integer if it is a valid integer index value. This abstract operation functions as follows:</p>
+      <p>The abstract operation ToIndex takes argument _value_. It returns _value_ argument converted to a non-negative integer if it is a valid integer index value. It performs the following steps when called:</p>
       <emu-alg>
         1. If _value_ is *undefined*, then
           1. Let _index_ be 0.
@@ -5334,7 +5348,7 @@
 
     <emu-clause id="sec-requireobjectcoercible" aoid="RequireObjectCoercible">
       <h1>RequireObjectCoercible ( _argument_ )</h1>
-      <p>The abstract operation RequireObjectCoercible throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-14"></emu-xref>:</p>
+      <p>The abstract operation RequireObjectCoercible takes argument _argument_. It throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-14"></emu-xref>:</p>
       <emu-table id="table-14" caption="RequireObjectCoercible Results">
         <table>
           <tbody>
@@ -5417,7 +5431,7 @@
 
     <emu-clause id="sec-isarray" aoid="IsArray">
       <h1>IsArray ( _argument_ )</h1>
-      <p>The abstract operation IsArray takes one argument _argument_, and performs the following steps:</p>
+      <p>The abstract operation IsArray takes argument _argument_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ is an Array exotic object, return *true*.
@@ -5431,7 +5445,7 @@
 
     <emu-clause id="sec-iscallable" aoid="IsCallable">
       <h1>IsCallable ( _argument_ )</h1>
-      <p>The abstract operation IsCallable determines if _argument_, which must be an ECMAScript language value, is a callable function with a [[Call]] internal method.</p>
+      <p>The abstract operation IsCallable takes argument _argument_ (an ECMAScript language value). It determines if _argument_ is a callable function with a [[Call]] internal method. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ has a [[Call]] internal method, return *true*.
@@ -5441,7 +5455,7 @@
 
     <emu-clause id="sec-isconstructor" aoid="IsConstructor">
       <h1>IsConstructor ( _argument_ )</h1>
-      <p>The abstract operation IsConstructor determines if _argument_, which must be an ECMAScript language value, is a function object with a [[Construct]] internal method.</p>
+      <p>The abstract operation IsConstructor takes argument _argument_ (an ECMAScript language value). It determines if _argument_ is a function object with a [[Construct]] internal method. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. If _argument_ has a [[Construct]] internal method, return *true*.
@@ -5451,7 +5465,7 @@
 
     <emu-clause id="sec-isextensible-o" aoid="IsExtensible">
       <h1>IsExtensible ( _O_ )</h1>
-      <p>The abstract operation IsExtensible is used to determine whether additional properties can be added to the object that is _O_. A Boolean value is returned. This abstract operation performs the following steps:</p>
+      <p>The abstract operation IsExtensible takes argument _O_ (an Object) and returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether additional properties can be added to _O_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Return ? _O_.[[IsExtensible]]().
@@ -5460,7 +5474,7 @@
 
     <emu-clause id="sec-isinteger" aoid="IsInteger">
       <h1>IsInteger ( _argument_ )</h1>
-      <p>The abstract operation IsInteger determines if _argument_ is a finite integer Number value.</p>
+      <p>The abstract operation IsInteger takes argument _argument_. It determines if _argument_ is a finite integer Number value. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_argument_) is not Number, return *false*.
         1. If _argument_ is *NaN*, *+&infin;*, or *-&infin;*, return *false*.
@@ -5471,7 +5485,7 @@
 
     <emu-clause id="sec-isnonnegativeinteger" aoid="IsNonNegativeInteger">
       <h1>IsNonNegativeInteger ( _argument_ )</h1>
-      <p>The abstract operation IsNonNegativeInteger determines if _argument_ is non-negative integer Number value.</p>
+      <p>The abstract operation IsNonNegativeInteger takes argument _argument_. It determines if _argument_ is a non-negative integer Number value. It performs the following steps when called:</p>
       <emu-alg>
         1. If ! IsInteger(_argument_) is *true* and _argument_ &ge; 0, return *true*.
         1. Otherwise, return *false*.
@@ -5480,7 +5494,7 @@
 
     <emu-clause id="sec-ispropertykey" aoid="IsPropertyKey">
       <h1>IsPropertyKey ( _argument_ )</h1>
-      <p>The abstract operation IsPropertyKey determines if _argument_, which must be an ECMAScript language value, is a value that may be used as a property key.</p>
+      <p>The abstract operation IsPropertyKey takes argument _argument_ (an ECMAScript language value). It determines if _argument_ is a value that may be used as a property key. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_argument_) is String, return *true*.
         1. If Type(_argument_) is Symbol, return *true*.
@@ -5490,7 +5504,7 @@
 
     <emu-clause id="sec-isregexp" aoid="IsRegExp">
       <h1>IsRegExp ( _argument_ )</h1>
-      <p>The abstract operation IsRegExp with argument _argument_ performs the following steps:</p>
+      <p>The abstract operation IsRegExp takes argument _argument_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. Let _matcher_ be ? Get(_argument_, @@match).
@@ -5502,7 +5516,7 @@
 
     <emu-clause id="sec-isstringprefix" aoid="IsStringPrefix">
       <h1>IsStringPrefix ( _p_, _q_ )</h1>
-      <p>The abstract operation IsStringPrefix determines if String _p_ is a prefix of String _q_.</p>
+      <p>The abstract operation IsStringPrefix takes arguments _p_ (a String) and _q_ (a String). It determines if _p_ is a prefix of _q_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_p_) is String.
         1. Assert: Type(_q_) is String.
@@ -5515,7 +5529,7 @@
 
     <emu-clause id="sec-samevalue" aoid="SameValue">
       <h1>SameValue ( _x_, _y_ )</h1>
-      <p>The internal comparison abstract operation SameValue(_x_, _y_), where _x_ and _y_ are ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
+      <p>The abstract operation SameValue takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value) and returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number or BigInt, then
@@ -5529,7 +5543,7 @@
 
     <emu-clause id="sec-samevaluezero" aoid="SameValueZero">
       <h1>SameValueZero ( _x_, _y_ )</h1>
-      <p>The internal comparison abstract operation SameValueZero(_x_, _y_), where _x_ and _y_ are ECMAScript language values, produces *true* or *false*. Such a comparison is performed as follows:</p>
+      <p>The abstract operation SameValueZero takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value) and returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number or BigInt, then
@@ -5543,7 +5557,7 @@
 
     <emu-clause id="sec-samevaluenonnumeric" aoid="SameValueNonNumeric" oldids="sec-samevaluenonnumber">
       <h1>SameValueNonNumeric ( _x_, _y_ )</h1>
-      <p>The internal comparison abstract operation SameValueNonNumeric(_x_, _y_), where neither _x_ nor _y_ are numeric type values, produces *true* or *false*. Such a comparison is performed as follows:</p>
+      <p>The abstract operation SameValueNonNumeric takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value) and returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_x_) is not Number or BigInt.
         1. Assert: Type(_x_) is the same as Type(_y_).
@@ -5650,7 +5664,7 @@
 
     <emu-clause id="sec-makebasicobject" aoid="MakeBasicObject">
       <h1>MakeBasicObject ( _internalSlotsList_ )</h1>
-      <p>The abstract operation MakeBasicObject is the source of all ECMAScript objects that are created algorithmically, including both ordinary objects and exotic objects. It factors out common steps used in creating all objects, and centralizes object creation.</p>
+      <p>The abstract operation MakeBasicObject takes argument _internalSlotsList_. It is the source of all ECMAScript objects that are created algorithmically, including both ordinary objects and exotic objects. It factors out common steps used in creating all objects, and centralizes object creation. It performs the following steps when called:</p>
 
       <emu-alg>
         1. Assert: _internalSlotsList_ is a List of internal slot names.
@@ -5669,7 +5683,7 @@
 
     <emu-clause id="sec-get-o-p" aoid="Get">
       <h1>Get ( _O_, _P_ )</h1>
-      <p>The abstract operation Get is used to retrieve the value of a specific property of an object. The operation is called with arguments _O_ and _P_ where _O_ is the object and _P_ is the property key. This abstract operation performs the following steps:</p>
+      <p>The abstract operation Get takes arguments _O_ (an Object) and _P_ (a property key). It is used to retrieve the value of a specific property of an object. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5679,7 +5693,7 @@
 
     <emu-clause id="sec-getv" aoid="GetV">
       <h1>GetV ( _V_, _P_ )</h1>
-      <p>The abstract operation GetV is used to retrieve the value of a specific property of an ECMAScript language value. If the value is not an object, the property lookup is performed using a wrapper object appropriate for the type of the value. The operation is called with arguments _V_ and _P_ where _V_ is the value and _P_ is the property key. This abstract operation performs the following steps:</p>
+      <p>The abstract operation GetV takes arguments _V_ (an ECMAScript language value) and _P_ (a property key). It is used to retrieve the value of a specific property of an ECMAScript language value. If the value is not an object, the property lookup is performed using a wrapper object appropriate for the type of the value. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _O_ be ? ToObject(_V_).
@@ -5689,7 +5703,7 @@
 
     <emu-clause id="sec-set-o-p-v-throw" aoid="Set">
       <h1>Set ( _O_, _P_, _V_, _Throw_ )</h1>
-      <p>The abstract operation Set is used to set the value of a specific property of an object. The operation is called with arguments _O_, _P_, _V_, and _Throw_ where _O_ is the object, _P_ is the property key, _V_ is the new value for the property and _Throw_ is a Boolean flag. This abstract operation performs the following steps:</p>
+      <p>The abstract operation Set takes arguments _O_ (an Object), _P_ (a property key), _V_ (an ECMAScript language value), and _Throw_ (a Boolean). It is used to set the value of a specific property of an object. _V_ is the new value for the property. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5702,7 +5716,7 @@
 
     <emu-clause id="sec-createdataproperty" aoid="CreateDataProperty">
       <h1>CreateDataProperty ( _O_, _P_, _V_ )</h1>
-      <p>The abstract operation CreateDataProperty is used to create a new own property of an object. The operation is called with arguments _O_, _P_, and _V_ where _O_ is the object, _P_ is the property key, and _V_ is the value for the property. This abstract operation performs the following steps:</p>
+      <p>The abstract operation CreateDataProperty takes arguments _O_ (an Object), _P_ (a property key), and _V_ (an ECMAScript language value). It is used to create a new own property of an object. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5716,7 +5730,7 @@
 
     <emu-clause id="sec-createmethodproperty" aoid="CreateMethodProperty">
       <h1>CreateMethodProperty ( _O_, _P_, _V_ )</h1>
-      <p>The abstract operation CreateMethodProperty is used to create a new own property of an object. The operation is called with arguments _O_, _P_, and _V_ where _O_ is the object, _P_ is the property key, and _V_ is the value for the property. This abstract operation performs the following steps:</p>
+      <p>The abstract operation CreateMethodProperty takes arguments _O_ (an Object), _P_ (a property key), and _V_ (an ECMAScript language value). It is used to create a new own property of an object. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5730,7 +5744,7 @@
 
     <emu-clause id="sec-createdatapropertyorthrow" aoid="CreateDataPropertyOrThrow">
       <h1>CreateDataPropertyOrThrow ( _O_, _P_, _V_ )</h1>
-      <p>The abstract operation CreateDataPropertyOrThrow is used to create a new own property of an object. It throws a *TypeError* exception if the requested property update cannot be performed. The operation is called with arguments _O_, _P_, and _V_ where _O_ is the object, _P_ is the property key, and _V_ is the value for the property. This abstract operation performs the following steps:</p>
+      <p>The abstract operation CreateDataPropertyOrThrow takes arguments _O_ (an Object), _P_ (a property key), and _V_ (an ECMAScript language value). It is used to create a new own property of an object. It throws a *TypeError* exception if the requested property update cannot be performed. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5745,7 +5759,7 @@
 
     <emu-clause id="sec-definepropertyorthrow" aoid="DefinePropertyOrThrow">
       <h1>DefinePropertyOrThrow ( _O_, _P_, _desc_ )</h1>
-      <p>The abstract operation DefinePropertyOrThrow is used to call the [[DefineOwnProperty]] internal method of an object in a manner that will throw a *TypeError* exception if the requested property update cannot be performed. The operation is called with arguments _O_, _P_, and _desc_ where _O_ is the object, _P_ is the property key, and _desc_ is the Property Descriptor for the property. This abstract operation performs the following steps:</p>
+      <p>The abstract operation DefinePropertyOrThrow takes arguments _O_ (an Object), _P_ (a property key), and _desc_ (a Property Descriptor). It is used to call the [[DefineOwnProperty]] internal method of an object in a manner that will throw a *TypeError* exception if the requested property update cannot be performed. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5757,7 +5771,7 @@
 
     <emu-clause id="sec-deletepropertyorthrow" aoid="DeletePropertyOrThrow">
       <h1>DeletePropertyOrThrow ( _O_, _P_ )</h1>
-      <p>The abstract operation DeletePropertyOrThrow is used to remove a specific own property of an object. It throws an exception if the property is not configurable. The operation is called with arguments _O_ and _P_ where _O_ is the object and _P_ is the property key. This abstract operation performs the following steps:</p>
+      <p>The abstract operation DeletePropertyOrThrow takes arguments _O_ (an Object) and _P_ (a property key). It is used to remove a specific own property of an object. It throws an exception if the property is not configurable. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5769,7 +5783,7 @@
 
     <emu-clause id="sec-getmethod" aoid="GetMethod">
       <h1>GetMethod ( _V_, _P_ )</h1>
-      <p>The abstract operation GetMethod is used to get the value of a specific property of an ECMAScript language value when the value of the property is expected to be a function. The operation is called with arguments _V_ and _P_ where _V_ is the ECMAScript language value, _P_ is the property key. This abstract operation performs the following steps:</p>
+      <p>The abstract operation GetMethod takes arguments _V_ (an ECMAScript language value) and _P_ (a property key). It is used to get the value of a specific property of an ECMAScript language value when the value of the property is expected to be a function. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _func_ be ? GetV(_V_, _P_).
@@ -5781,7 +5795,7 @@
 
     <emu-clause id="sec-hasproperty" aoid="HasProperty">
       <h1>HasProperty ( _O_, _P_ )</h1>
-      <p>The abstract operation HasProperty is used to determine whether an object has a property with the specified property key. The property may be either an own or inherited. A Boolean value is returned. The operation is called with arguments _O_ and _P_ where _O_ is the object and _P_ is the property key. This abstract operation performs the following steps:</p>
+      <p>The abstract operation HasProperty takes arguments _O_ (an Object) and _P_ (a property key) and returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has a property with the specified property key. The property may be either an own or inherited. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5791,7 +5805,7 @@
 
     <emu-clause id="sec-hasownproperty" aoid="HasOwnProperty">
       <h1>HasOwnProperty ( _O_, _P_ )</h1>
-      <p>The abstract operation HasOwnProperty is used to determine whether an object has an own property with the specified property key. A Boolean value is returned. The operation is called with arguments _O_ and _P_ where _O_ is the object and _P_ is the property key. This abstract operation performs the following steps:</p>
+      <p>The abstract operation HasOwnProperty takes arguments _O_ (an Object) and _P_ (a property key) and returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has an own property with the specified property key. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5803,7 +5817,7 @@
 
     <emu-clause id="sec-call" aoid="Call">
       <h1>Call ( _F_, _V_ [ , _argumentsList_ ] )</h1>
-      <p>The abstract operation Call is used to call the [[Call]] internal method of a function object. The operation is called with arguments _F_, _V_, and optionally _argumentsList_ where _F_ is the function object, _V_ is an ECMAScript language value that is the *this* value of the [[Call]], and _argumentsList_ is the value passed to the corresponding argument of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. This abstract operation performs the following steps:</p>
+      <p>The abstract operation Call takes arguments _F_ (an ECMAScript language value) and _V_ (an ECMAScript language value) and optional argument _argumentsList_ (a List of ECMAScript language values). It is used to call the [[Call]] internal method of a function object. _F_ is the function object, _V_ is an ECMAScript language value that is the *this* value of the [[Call]], and _argumentsList_ is the value passed to the corresponding argument of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. It performs the following steps when called:</p>
       <emu-alg>
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
         1. If IsCallable(_F_) is *false*, throw a *TypeError* exception.
@@ -5813,7 +5827,7 @@
 
     <emu-clause id="sec-construct" aoid="Construct">
       <h1>Construct ( _F_ [ , _argumentsList_ [ , _newTarget_ ] ] )</h1>
-      <p>The abstract operation Construct is used to call the [[Construct]] internal method of a function object. The operation is called with arguments _F_, and optionally _argumentsList_, and _newTarget_ where _F_ is the function object. _argumentsList_ and _newTarget_ are the values to be passed as the corresponding arguments of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. If _newTarget_ is not present, _F_ is used as its value. This abstract operation performs the following steps:</p>
+      <p>The abstract operation Construct takes argument _F_ (a function object) and optional arguments _argumentsList_ and _newTarget_. It is used to call the [[Construct]] internal method of a function object. _argumentsList_ and _newTarget_ are the values to be passed as the corresponding arguments of the internal method. If _argumentsList_ is not present, a new empty List is used as its value. If _newTarget_ is not present, _F_ is used as its value. It performs the following steps when called:</p>
       <emu-alg>
         1. If _newTarget_ is not present, set _newTarget_ to _F_.
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
@@ -5828,7 +5842,7 @@
 
     <emu-clause id="sec-setintegritylevel" aoid="SetIntegrityLevel">
       <h1>SetIntegrityLevel ( _O_, _level_ )</h1>
-      <p>The abstract operation SetIntegrityLevel is used to fix the set of own properties of an object. This abstract operation performs the following steps:</p>
+      <p>The abstract operation SetIntegrityLevel takes arguments _O_ and _level_. It is used to fix the set of own properties of an object. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: _level_ is either ~sealed~ or ~frozen~.
@@ -5854,7 +5868,7 @@
 
     <emu-clause id="sec-testintegritylevel" aoid="TestIntegrityLevel">
       <h1>TestIntegrityLevel ( _O_, _level_ )</h1>
-      <p>The abstract operation TestIntegrityLevel is used to determine if the set of own properties of an object are fixed. This abstract operation performs the following steps:</p>
+      <p>The abstract operation TestIntegrityLevel takes arguments _O_ and _level_. It is used to determine if the set of own properties of an object are fixed. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Assert: _level_ is either ~sealed~ or ~frozen~.
@@ -5874,7 +5888,7 @@
 
     <emu-clause id="sec-createarrayfromlist" aoid="CreateArrayFromList">
       <h1>CreateArrayFromList ( _elements_ )</h1>
-      <p>The abstract operation CreateArrayFromList is used to create an Array object whose elements are provided by a List. This abstract operation performs the following steps:</p>
+      <p>The abstract operation CreateArrayFromList takes argument _elements_ (a List). It is used to create an Array object whose elements are provided by _elements_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _elements_ is a List whose elements are all ECMAScript language values.
         1. Let _array_ be ! ArrayCreate(0).
@@ -5888,7 +5902,7 @@
 
     <emu-clause id="sec-lengthofarraylike" aoid="LengthOfArrayLike">
       <h1>LengthOfArrayLike ( _obj_ )</h1>
-      <p>The abstract operation LengthOfArrayLike returns the value of the *"length"* property of an array-like object.</p>
+      <p>The abstract operation LengthOfArrayLike takes argument _obj_. It returns the value of the *"length"* property of an array-like object. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_obj_) is Object.
         1. Return ? ToLength(? Get(_obj_, *"length"*)).
@@ -5904,7 +5918,7 @@
 
     <emu-clause id="sec-createlistfromarraylike" aoid="CreateListFromArrayLike">
       <h1>CreateListFromArrayLike ( _obj_ [ , _elementTypes_ ] )</h1>
-      <p>The abstract operation CreateListFromArrayLike is used to create a List value whose elements are provided by the indexed properties of an array-like object, _obj_. The optional argument _elementTypes_ is a List containing the names of ECMAScript Language Types that are allowed for element values of the List that is created. This abstract operation performs the following steps:</p>
+      <p>The abstract operation CreateListFromArrayLike takes argument _obj_ and optional argument _elementTypes_ (a List of names of ECMAScript Language Types). It is used to create a List value whose elements are provided by the indexed properties of _obj_. _elementTypes_ contains the names of ECMAScript Language Types that are allowed for element values of the List that is created. It performs the following steps when called:</p>
       <emu-alg>
         1. If _elementTypes_ is not present, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, BigInt, Object &raquo;.
         1. If Type(_obj_) is not Object, throw a *TypeError* exception.
@@ -5923,7 +5937,7 @@
 
     <emu-clause id="sec-invoke" aoid="Invoke">
       <h1>Invoke ( _V_, _P_ [ , _argumentsList_ ] )</h1>
-      <p>The abstract operation Invoke is used to call a method property of an ECMAScript language value. The operation is called with arguments _V_, _P_, and optionally _argumentsList_ where _V_ serves as both the lookup point for the property and the *this* value of the call, _P_ is the property key, and _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, a new empty List is used as its value. This abstract operation performs the following steps:</p>
+      <p>The abstract operation Invoke takes arguments _V_ (an ECMAScript language value) and _P_ (a property key) and optional argument _argumentsList_ (a List of ECMAScript language values). It is used to call a method property of an ECMAScript language value. _V_ serves as both the lookup point for the property and the *this* value of the call. _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, a new empty List is used as its value. It performs the following steps when called:</p>
 
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
@@ -5935,7 +5949,7 @@
 
     <emu-clause id="sec-ordinaryhasinstance" aoid="OrdinaryHasInstance">
       <h1>OrdinaryHasInstance ( _C_, _O_ )</h1>
-      <p>The abstract operation OrdinaryHasInstance implements the default algorithm for determining if an object _O_ inherits from the instance object inheritance path provided by constructor _C_. This abstract operation performs the following steps:</p>
+      <p>The abstract operation OrdinaryHasInstance takes arguments _C_ (an ECMAScript language value) and _O_. It implements the default algorithm for determining if _O_ inherits from the instance object inheritance path provided by _C_. It performs the following steps when called:</p>
       <emu-alg>
         1. If IsCallable(_C_) is *false*, return *false*.
         1. If _C_ has a [[BoundTargetFunction]] internal slot, then
@@ -5953,7 +5967,7 @@
 
     <emu-clause id="sec-speciesconstructor" aoid="SpeciesConstructor">
       <h1>SpeciesConstructor ( _O_, _defaultConstructor_ )</h1>
-      <p>The abstract operation SpeciesConstructor is used to retrieve the constructor that should be used to create new objects that are derived from the argument object _O_. The _defaultConstructor_ argument is the constructor to use if a constructor @@species property cannot be found starting from _O_. This abstract operation performs the following steps:</p>
+      <p>The abstract operation SpeciesConstructor takes arguments _O_ (an Object) and _defaultConstructor_ (a constructor). It is used to retrieve the constructor that should be used to create new objects that are derived from _O_. _defaultConstructor_ is the constructor to use if a constructor @@species property cannot be found starting from _O_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Let _C_ be ? Get(_O_, *"constructor"*).
@@ -5968,7 +5982,7 @@
 
     <emu-clause id="sec-enumerableownpropertynames" aoid="EnumerableOwnPropertyNames" oldids="sec-enumerableownproperties">
       <h1>EnumerableOwnPropertyNames ( _O_, _kind_ )</h1>
-      <p>When the abstract operation EnumerableOwnPropertyNames is called with an Object _O_ and _kind_ which is one of (~key~, ~value~, ~key+value~), the following steps are taken:</p>
+      <p>The abstract operation EnumerableOwnPropertyNames takes arguments _O_ (an Object) and _kind_ (one of ~key~, ~value~, or ~key+value~). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_O_) is Object.
         1. Let _ownKeys_ be ? _O_.[[OwnPropertyKeys]]().
@@ -5991,7 +6005,7 @@
 
     <emu-clause id="sec-getfunctionrealm" aoid="GetFunctionRealm">
       <h1>GetFunctionRealm ( _obj_ )</h1>
-      <p>The abstract operation GetFunctionRealm with argument _obj_ performs the following steps:</p>
+      <p>The abstract operation GetFunctionRealm takes argument _obj_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: ! IsCallable(_obj_) is *true*.
         1. If _obj_ has a [[Realm]] internal slot, then
@@ -6012,7 +6026,7 @@
 
     <emu-clause id="sec-copydataproperties" aoid="CopyDataProperties">
       <h1>CopyDataProperties ( _target_, _source_, _excludedItems_ )</h1>
-      <p>When the abstract operation CopyDataProperties is called with arguments _target_, _source_, and _excludedItems_, the following steps are taken:</p>
+      <p>The abstract operation CopyDataProperties takes arguments _target_, _source_, and _excludedItems_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_target_) is Object.
         1. Assert: _excludedItems_ is a List of property keys.
@@ -6044,7 +6058,7 @@
 
     <emu-clause id="sec-getiterator" aoid="GetIterator">
       <h1>GetIterator ( _obj_ [ , _hint_ [ , _method_ ] ] )</h1>
-      <p>The abstract operation GetIterator with argument _obj_ and optional arguments _hint_ and _method_ performs the following steps:</p>
+      <p>The abstract operation GetIterator takes argument _obj_ and optional arguments _hint_ and _method_. It performs the following steps when called:</p>
       <emu-alg>
         1. If _hint_ is not present, set _hint_ to ~sync~.
         1. Assert: _hint_ is either ~sync~ or ~async~.
@@ -6066,7 +6080,7 @@
 
     <emu-clause id="sec-iteratornext" aoid="IteratorNext">
       <h1>IteratorNext ( _iteratorRecord_ [ , _value_ ] )</h1>
-      <p>The abstract operation IteratorNext with argument _iteratorRecord_ and optional argument _value_ performs the following steps:</p>
+      <p>The abstract operation IteratorNext takes argument _iteratorRecord_ and optional argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If _value_ is not present, then
           1. Let _result_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]]).
@@ -6079,7 +6093,7 @@
 
     <emu-clause id="sec-iteratorcomplete" aoid="IteratorComplete">
       <h1>IteratorComplete ( _iterResult_ )</h1>
-      <p>The abstract operation IteratorComplete with argument _iterResult_ performs the following steps:</p>
+      <p>The abstract operation IteratorComplete takes argument _iterResult_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_iterResult_) is Object.
         1. Return ! ToBoolean(? Get(_iterResult_, *"done"*)).
@@ -6088,7 +6102,7 @@
 
     <emu-clause id="sec-iteratorvalue" aoid="IteratorValue">
       <h1>IteratorValue ( _iterResult_ )</h1>
-      <p>The abstract operation IteratorValue with argument _iterResult_ performs the following steps:</p>
+      <p>The abstract operation IteratorValue takes argument _iterResult_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_iterResult_) is Object.
         1. Return ? Get(_iterResult_, *"value"*).
@@ -6097,7 +6111,7 @@
 
     <emu-clause id="sec-iteratorstep" aoid="IteratorStep">
       <h1>IteratorStep ( _iteratorRecord_ )</h1>
-      <p>The abstract operation IteratorStep with argument _iteratorRecord_ requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either *false* indicating that the iterator has reached its end or the IteratorResult object if a next value is available. IteratorStep performs the following steps:</p>
+      <p>The abstract operation IteratorStep takes argument _iteratorRecord_. It requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either *false* indicating that the iterator has reached its end or the IteratorResult object if a next value is available. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _result_ be ? IteratorNext(_iteratorRecord_).
         1. Let _done_ be ? IteratorComplete(_result_).
@@ -6108,7 +6122,7 @@
 
     <emu-clause id="sec-iteratorclose" aoid="IteratorClose">
       <h1>IteratorClose ( _iteratorRecord_, _completion_ )</h1>
-      <p>The abstract operation IteratorClose with arguments _iteratorRecord_ and _completion_ is used to notify an iterator that it should perform any actions it would normally perform when it has reached its completed state:</p>
+      <p>The abstract operation IteratorClose takes arguments _iteratorRecord_ and _completion_. It is used to notify an iterator that it should perform any actions it would normally perform when it has reached its completed state. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Assert: _completion_ is a Completion Record.
@@ -6125,7 +6139,7 @@
 
     <emu-clause id="sec-asynciteratorclose" aoid="AsyncIteratorClose">
       <h1>AsyncIteratorClose ( _iteratorRecord_, _completion_ )</h1>
-      <p>The abstract operation AsyncIteratorClose with arguments _iteratorRecord_ and _completion_ is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state:</p>
+      <p>The abstract operation AsyncIteratorClose takes arguments _iteratorRecord_ and _completion_. It is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Assert: _completion_ is a Completion Record.
@@ -6143,7 +6157,7 @@
 
     <emu-clause id="sec-createiterresultobject" aoid="CreateIterResultObject">
       <h1>CreateIterResultObject ( _value_, _done_ )</h1>
-      <p>The abstract operation CreateIterResultObject with arguments _value_ and _done_ creates an object that supports the IteratorResult interface by performing the following steps:</p>
+      <p>The abstract operation CreateIterResultObject takes arguments _value_ and _done_. It creates an object that supports the IteratorResult interface. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_done_) is Boolean.
         1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
@@ -6155,7 +6169,7 @@
 
     <emu-clause id="sec-createlistiteratorRecord" oldids="sec-createlistiterator" aoid="CreateListIteratorRecord">
       <h1>CreateListIteratorRecord ( _list_ )</h1>
-      <p>The abstract operation CreateListIteratorRecord with argument _list_ creates an Iterator (<emu-xref href="#sec-iterator-interface"></emu-xref>) object record whose next method returns the successive elements of _list_. It performs the following steps:</p>
+      <p>The abstract operation CreateListIteratorRecord takes argument _list_. It creates an Iterator (<emu-xref href="#sec-iterator-interface"></emu-xref>) object record whose next method returns the successive elements of _list_. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _iterator_ be OrdinaryObjectCreate(%IteratorPrototype%, &laquo; [[IteratedList]], [[ListNextIndex]] &raquo;).
         1. Set _iterator_.[[IteratedList]] to _list_.
@@ -7192,7 +7206,7 @@
 
       <emu-clause id="sec-getidentifierreference" aoid="GetIdentifierReference">
         <h1>GetIdentifierReference ( _lex_, _name_, _strict_ )</h1>
-        <p>The abstract operation GetIdentifierReference is called with a Lexical Environment _lex_, a String _name_, and a Boolean flag _strict_. The value of _lex_ may be *null*. When called, the following steps are performed:</p>
+        <p>The abstract operation GetIdentifierReference takes arguments _lex_ (a Lexical Environment or *null*), _name_ (a String), and _strict_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. If _lex_ is the value *null*, then
             1. Return a value of type Reference whose base value component is *undefined*, whose referenced name component is _name_, and whose strict reference flag is _strict_.
@@ -7208,7 +7222,7 @@
 
       <emu-clause id="sec-newdeclarativeenvironment" aoid="NewDeclarativeEnvironment">
         <h1>NewDeclarativeEnvironment ( _E_ )</h1>
-        <p>When the abstract operation NewDeclarativeEnvironment is called with a Lexical Environment as argument _E_ the following steps are performed:</p>
+        <p>The abstract operation NewDeclarativeEnvironment takes argument _E_ (a Lexical Environment). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _env_ be a new Lexical Environment.
           1. Let _envRec_ be a new declarative Environment Record containing no bindings.
@@ -7220,7 +7234,7 @@
 
       <emu-clause id="sec-newobjectenvironment" aoid="NewObjectEnvironment">
         <h1>NewObjectEnvironment ( _O_, _E_ )</h1>
-        <p>When the abstract operation NewObjectEnvironment is called with an Object _O_ and a Lexical Environment _E_ as arguments, the following steps are performed:</p>
+        <p>The abstract operation NewObjectEnvironment takes arguments _O_ (an Object) and _E_ (a Lexical Environment). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _env_ be a new Lexical Environment.
           1. Let _envRec_ be a new object Environment Record containing _O_ as the binding object.
@@ -7232,7 +7246,7 @@
 
       <emu-clause id="sec-newfunctionenvironment" aoid="NewFunctionEnvironment">
         <h1>NewFunctionEnvironment ( _F_, _newTarget_ )</h1>
-        <p>When the abstract operation NewFunctionEnvironment is called with arguments _F_ and _newTarget_ the following steps are performed:</p>
+        <p>The abstract operation NewFunctionEnvironment takes arguments _F_ and _newTarget_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _F_ is an ECMAScript function.
           1. Assert: Type(_newTarget_) is Undefined or Object.
@@ -7252,7 +7266,7 @@
 
       <emu-clause id="sec-newglobalenvironment" aoid="NewGlobalEnvironment">
         <h1>NewGlobalEnvironment ( _G_, _thisValue_ )</h1>
-        <p>When the abstract operation NewGlobalEnvironment is called with arguments _G_ and _thisValue_, the following steps are performed:</p>
+        <p>The abstract operation NewGlobalEnvironment takes arguments _G_ and _thisValue_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _env_ be a new Lexical Environment.
           1. Let _objRec_ be a new object Environment Record containing _G_ as the binding object.
@@ -7270,7 +7284,7 @@
 
       <emu-clause id="sec-newmoduleenvironment" aoid="NewModuleEnvironment">
         <h1>NewModuleEnvironment ( _E_ )</h1>
-        <p>When the abstract operation NewModuleEnvironment is called with a Lexical Environment argument _E_ the following steps are performed:</p>
+        <p>The abstract operation NewModuleEnvironment takes argument _E_ (a Lexical Environment). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _env_ be a new Lexical Environment.
           1. Let _envRec_ be a new module Environment Record containing no bindings.
@@ -7362,7 +7376,7 @@
 
     <emu-clause id="sec-createrealm" aoid="CreateRealm">
       <h1>CreateRealm ( )</h1>
-      <p>The abstract operation CreateRealm with no arguments performs the following steps:</p>
+      <p>The abstract operation CreateRealm takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _realmRec_ be a new Realm Record.
         1. Perform CreateIntrinsics(_realmRec_).
@@ -7375,7 +7389,7 @@
 
     <emu-clause id="sec-createintrinsics" aoid="CreateIntrinsics">
       <h1>CreateIntrinsics ( _realmRec_ )</h1>
-      <p>The abstract operation CreateIntrinsics with argument _realmRec_ performs the following steps:</p>
+      <p>The abstract operation CreateIntrinsics takes argument _realmRec_. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _intrinsics_ be a new Record.
         1. Set _realmRec_.[[Intrinsics]] to _intrinsics_.
@@ -7387,7 +7401,7 @@
 
     <emu-clause id="sec-setrealmglobalobject" aoid="SetRealmGlobalObject">
       <h1>SetRealmGlobalObject ( _realmRec_, _globalObj_, _thisValue_ )</h1>
-      <p>The abstract operation SetRealmGlobalObject with arguments _realmRec_, _globalObj_, and _thisValue_ performs the following steps:</p>
+      <p>The abstract operation SetRealmGlobalObject takes arguments _realmRec_, _globalObj_, and _thisValue_. It performs the following steps when called:</p>
       <emu-alg>
         1. If _globalObj_ is *undefined*, then
           1. Let _intrinsics_ be _realmRec_.[[Intrinsics]].
@@ -7403,7 +7417,7 @@
 
     <emu-clause id="sec-setdefaultglobalbindings" aoid="SetDefaultGlobalBindings">
       <h1>SetDefaultGlobalBindings ( _realmRec_ )</h1>
-      <p>The abstract operation SetDefaultGlobalBindings with argument _realmRec_ performs the following steps:</p>
+      <p>The abstract operation SetDefaultGlobalBindings takes argument _realmRec_. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _global_ be _realmRec_.[[GlobalObject]].
         1. For each property of the Global Object specified in clause <emu-xref href="#sec-global-object"></emu-xref>, do
@@ -7528,7 +7542,7 @@
 
     <emu-clause id="sec-getactivescriptormodule" aoid="GetActiveScriptOrModule">
       <h1>GetActiveScriptOrModule ( )</h1>
-      <p>The GetActiveScriptOrModule abstract operation is used to determine the running script or module, based on the running execution context. GetActiveScriptOrModule performs the following steps:</p>
+      <p>The abstract operation GetActiveScriptOrModule takes no arguments. It is used to determine the running script or module, based on the running execution context. It performs the following steps when called:</p>
 
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
@@ -7539,7 +7553,7 @@
 
     <emu-clause id="sec-resolvebinding" aoid="ResolveBinding">
       <h1>ResolveBinding ( _name_ [ , _env_ ] )</h1>
-      <p>The ResolveBinding abstract operation is used to determine the binding of _name_ passed as a String value. The optional argument _env_ can be used to explicitly provide the Lexical Environment that is to be searched for the binding. During execution of ECMAScript code, ResolveBinding is performed using the following algorithm:</p>
+      <p>The abstract operation ResolveBinding takes argument _name_ (a String) and optional argument _env_ (a Lexical Environment). It is used to determine the binding of _name_. _env_ can be used to explicitly provide the Lexical Environment that is to be searched for the binding. It performs the following steps when called:</p>
       <emu-alg>
         1. If _env_ is not present or if _env_ is *undefined*, then
           1. Set _env_ to the running execution context's LexicalEnvironment.
@@ -7554,7 +7568,7 @@
 
     <emu-clause id="sec-getthisenvironment" aoid="GetThisEnvironment">
       <h1>GetThisEnvironment ( )</h1>
-      <p>The abstract operation GetThisEnvironment finds the Environment Record that currently supplies the binding of the keyword `this`. GetThisEnvironment performs the following steps:</p>
+      <p>The abstract operation GetThisEnvironment takes no arguments. It finds the Environment Record that currently supplies the binding of the keyword `this`. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _lex_ be the running execution context's LexicalEnvironment.
         1. Repeat,
@@ -7572,7 +7586,7 @@
 
     <emu-clause id="sec-resolvethisbinding" aoid="ResolveThisBinding">
       <h1>ResolveThisBinding ( )</h1>
-      <p>The abstract operation ResolveThisBinding determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context. ResolveThisBinding performs the following steps:</p>
+      <p>The abstract operation ResolveThisBinding takes no arguments. It determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _envRec_ be GetThisEnvironment().
         1. Return ? _envRec_.GetThisBinding().
@@ -7581,7 +7595,7 @@
 
     <emu-clause id="sec-getnewtarget" aoid="GetNewTarget">
       <h1>GetNewTarget ( )</h1>
-      <p>The abstract operation GetNewTarget determines the NewTarget value using the LexicalEnvironment of the running execution context. GetNewTarget performs the following steps:</p>
+      <p>The abstract operation GetNewTarget takes no arguments. It determines the NewTarget value using the LexicalEnvironment of the running execution context. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _envRec_ be GetThisEnvironment().
         1. Assert: _envRec_ has a [[NewTarget]] field.
@@ -7591,7 +7605,7 @@
 
     <emu-clause id="sec-getglobalobject" aoid="GetGlobalObject">
       <h1>GetGlobalObject ( )</h1>
-      <p>The abstract operation GetGlobalObject returns the global object used by the currently running execution context. GetGlobalObject performs the following steps:</p>
+      <p>The abstract operation GetGlobalObject takes no arguments. It returns the global object used by the currently running execution context. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _currentRealm_ be the current Realm Record.
         1. Return _currentRealm_.[[GlobalObject]].
@@ -7625,7 +7639,6 @@
 
     <emu-clause id="sec-hostenqueuepromisejob" aoid="HostEnqueuePromiseJob">
       <h1>HostEnqueuePromiseJob ( _job_, _realm_ )</h1>
-
       <p>HostEnqueuePromiseJob is a host-defined abstract operation that schedules the Job abstract closure _job_ to be performed, at some future time. The abstract closures used with this algorithm are intended to be related to the handling of Promises, or otherwise, to be scheduled with equal priority to Promise handling operations.</p>
       <p>The _realm_ parameter is passed through to hosts with no normative requirements; it is either *null* or a Realm.</p>
 
@@ -7639,7 +7652,7 @@
 
   <emu-clause id="sec-initializehostdefinedrealm" aoid="InitializeHostDefinedRealm">
     <h1>InitializeHostDefinedRealm ( )</h1>
-    <p>The abstract operation InitializeHostDefinedRealm performs the following steps:</p>
+    <p>The abstract operation InitializeHostDefinedRealm takes no arguments. It performs the following steps when called:</p>
 
     <emu-alg>
       1. Let _realm_ be CreateRealm().
@@ -7731,7 +7744,7 @@
 
     <emu-clause id="sec-agentsignifier" aoid="AgentSignifier">
       <h1>AgentSignifier ( )</h1>
-      <p>The abstract operation AgentSignifier takes no arguments. It performs the following steps:</p>
+      <p>The abstract operation AgentSignifier takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _AR_ be the Agent Record of the surrounding agent.
         1. Return _AR_.[[Signifier]].
@@ -7740,7 +7753,7 @@
 
     <emu-clause id="sec-agentcansuspend" aoid="AgentCanSuspend">
       <h1>AgentCanSuspend ( )</h1>
-      <p>The abstract operation AgentCanSuspend takes no arguments. It performs the following steps:</p>
+      <p>The abstract operation AgentCanSuspend takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _AR_ be the Agent Record of the surrounding agent.
         1. Return _AR_.[[CanBlock]].
@@ -7841,7 +7854,7 @@
 
       <emu-clause id="sec-ordinarygetprototypeof" aoid="OrdinaryGetPrototypeOf">
         <h1>OrdinaryGetPrototypeOf ( _O_ )</h1>
-        <p>When the abstract operation OrdinaryGetPrototypeOf is called with Object _O_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryGetPrototypeOf takes argument _O_ (an Object). It performs the following steps when called:</p>
         <emu-alg>
           1. Return _O_.[[Prototype]].
         </emu-alg>
@@ -7857,7 +7870,7 @@
 
       <emu-clause id="sec-ordinarysetprototypeof" aoid="OrdinarySetPrototypeOf">
         <h1>OrdinarySetPrototypeOf ( _O_, _V_ )</h1>
-        <p>When the abstract operation OrdinarySetPrototypeOf is called with Object _O_ and value _V_, the following steps are taken:</p>
+        <p>The abstract operation OrdinarySetPrototypeOf takes arguments _O_ (an Object) and _V_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
           1. Let _current_ be _O_.[[Prototype]].
@@ -7890,7 +7903,7 @@
 
       <emu-clause id="sec-ordinaryisextensible" aoid="OrdinaryIsExtensible">
         <h1>OrdinaryIsExtensible ( _O_ )</h1>
-        <p>When the abstract operation OrdinaryIsExtensible is called with Object _O_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryIsExtensible takes argument _O_ (an Object). It performs the following steps when called:</p>
         <emu-alg>
           1. Return _O_.[[Extensible]].
         </emu-alg>
@@ -7906,7 +7919,7 @@
 
       <emu-clause id="sec-ordinarypreventextensions" aoid="OrdinaryPreventExtensions">
         <h1>OrdinaryPreventExtensions ( _O_ )</h1>
-        <p>When the abstract operation OrdinaryPreventExtensions is called with Object _O_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryPreventExtensions takes argument _O_ (an Object). It performs the following steps when called:</p>
         <emu-alg>
           1. Set _O_.[[Extensible]] to *false*.
           1. Return *true*.
@@ -7923,7 +7936,7 @@
 
       <emu-clause id="sec-ordinarygetownproperty" aoid="OrdinaryGetOwnProperty">
         <h1>OrdinaryGetOwnProperty ( _O_, _P_ )</h1>
-        <p>When the abstract operation OrdinaryGetOwnProperty is called with Object _O_ and with property key _P_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryGetOwnProperty takes arguments _O_ (an Object) and _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If _O_ does not have an own property with key _P_, return *undefined*.
@@ -7952,7 +7965,7 @@
 
       <emu-clause id="sec-ordinarydefineownproperty" aoid="OrdinaryDefineOwnProperty">
         <h1>OrdinaryDefineOwnProperty ( _O_, _P_, _Desc_ )</h1>
-        <p>When the abstract operation OrdinaryDefineOwnProperty is called with Object _O_, property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryDefineOwnProperty takes arguments _O_ (an Object), _P_ (a property key), and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
           1. Let _extensible_ be ? IsExtensible(_O_).
@@ -7962,7 +7975,7 @@
 
       <emu-clause id="sec-iscompatiblepropertydescriptor" aoid="IsCompatiblePropertyDescriptor">
         <h1>IsCompatiblePropertyDescriptor ( _Extensible_, _Desc_, _Current_ )</h1>
-        <p>When the abstract operation IsCompatiblePropertyDescriptor is called with Boolean value _Extensible_, and Property Descriptors _Desc_, and _Current_, the following steps are taken:</p>
+        <p>The abstract operation IsCompatiblePropertyDescriptor takes arguments _Extensible_ (a Boolean), _Desc_ (a Property Descriptor), and _Current_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
           1. Return ValidateAndApplyPropertyDescriptor(*undefined*, *undefined*, _Extensible_, _Desc_, _Current_).
         </emu-alg>
@@ -7970,7 +7983,7 @@
 
       <emu-clause id="sec-validateandapplypropertydescriptor" aoid="ValidateAndApplyPropertyDescriptor">
         <h1>ValidateAndApplyPropertyDescriptor ( _O_, _P_, _extensible_, _Desc_, _current_ )</h1>
-        <p>When the abstract operation ValidateAndApplyPropertyDescriptor is called with Object _O_, property key _P_, Boolean value _extensible_, and Property Descriptors _Desc_, and _current_, the following steps are taken:</p>
+        <p>The abstract operation ValidateAndApplyPropertyDescriptor takes arguments _O_ (an Object or *undefined*), _P_ (a property key), _extensible_ (a Boolean), _Desc_ (a Property Descriptor), and _current_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-note>
           <p>If *undefined* is passed as _O_, only validation is performed and no object updates are performed.</p>
         </emu-note>
@@ -8024,7 +8037,7 @@
 
       <emu-clause id="sec-ordinaryhasproperty" aoid="OrdinaryHasProperty">
         <h1>OrdinaryHasProperty ( _O_, _P_ )</h1>
-        <p>When the abstract operation OrdinaryHasProperty is called with Object _O_ and with property key _P_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryHasProperty takes arguments _O_ (an Object) and _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Let _hasOwn_ be ? _O_.[[GetOwnProperty]](_P_).
@@ -8047,7 +8060,7 @@
 
       <emu-clause id="sec-ordinaryget" aoid="OrdinaryGet">
         <h1>OrdinaryGet ( _O_, _P_, _Receiver_ )</h1>
-        <p>When the abstract operation OrdinaryGet is called with Object _O_, property key _P_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryGet takes arguments _O_ (an Object), _P_ (a property key), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
 
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
@@ -8074,7 +8087,7 @@
 
       <emu-clause id="sec-ordinaryset" aoid="OrdinarySet">
         <h1>OrdinarySet ( _O_, _P_, _V_, _Receiver_ )</h1>
-        <p>When the abstract operation OrdinarySet is called with Object _O_, property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
+        <p>The abstract operation OrdinarySet takes arguments _O_ (an Object), _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
 
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
@@ -8085,7 +8098,7 @@
 
       <emu-clause id="sec-ordinarysetwithowndescriptor" aoid="OrdinarySetWithOwnDescriptor">
         <h1>OrdinarySetWithOwnDescriptor ( _O_, _P_, _V_, _Receiver_, _ownDesc_ )</h1>
-        <p>When the abstract operation OrdinarySetWithOwnDescriptor is called with Object _O_, property key _P_, value _V_, ECMAScript language value _Receiver_, and Property Descriptor (or *undefined*) _ownDesc_, the following steps are taken:</p>
+        <p>The abstract operation OrdinarySetWithOwnDescriptor takes arguments _O_ (an Object), _P_ (a property key), _V_ (an ECMAScript language value), _Receiver_ (an ECMAScript language value), and _ownDesc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
 
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
@@ -8125,7 +8138,7 @@
 
       <emu-clause id="sec-ordinarydelete" aoid="OrdinaryDelete">
         <h1>OrdinaryDelete ( _O_, _P_ )</h1>
-        <p>When the abstract operation OrdinaryDelete is called with Object _O_ and property key _P_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryDelete takes arguments _O_ (an Object) and _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
@@ -8147,7 +8160,7 @@
 
       <emu-clause id="sec-ordinaryownpropertykeys" aoid="OrdinaryOwnPropertyKeys">
         <h1>OrdinaryOwnPropertyKeys ( _O_ )</h1>
-        <p>When the abstract operation OrdinaryOwnPropertyKeys is called with Object _O_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryOwnPropertyKeys takes argument _O_ (an Object). It performs the following steps when called:</p>
 
         <emu-alg>
           1. Let _keys_ be a new empty List.
@@ -8164,7 +8177,7 @@
 
     <emu-clause id="sec-ordinaryobjectcreate" aoid="OrdinaryObjectCreate" oldids="sec-objectcreate">
       <h1>OrdinaryObjectCreate ( _proto_ [ , _additionalInternalSlotsList_ ] )</h1>
-      <p>The abstract operation OrdinaryObjectCreate with argument _proto_ (an object or *null*) is used to specify the runtime creation of new ordinary objects. The optional argument _additionalInternalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object, beyond [[Prototype]] and [[Extensible]]. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
+      <p>The abstract operation OrdinaryObjectCreate takes argument _proto_ (an Object or *null*) and optional argument _additionalInternalSlotsList_ (a List of names of internal slots). It is used to specify the runtime creation of new ordinary objects. _additionalInternalSlotsList_ contains the names of additional internal slots that must be defined as part of the object, beyond [[Prototype]] and [[Extensible]]. If _additionalInternalSlotsList_ is not provided, a new empty List is used. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _internalSlotsList_ be &laquo; [[Prototype]], [[Extensible]] &raquo;.
         1. If _additionalInternalSlotsList_ is present, append each of its elements to _internalSlotsList_.
@@ -8180,7 +8193,7 @@
 
     <emu-clause id="sec-ordinarycreatefromconstructor" aoid="OrdinaryCreateFromConstructor">
       <h1>OrdinaryCreateFromConstructor ( _constructor_, _intrinsicDefaultProto_ [ , _internalSlotsList_ ] )</h1>
-      <p>The abstract operation OrdinaryCreateFromConstructor creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. The optional _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. If the list is not provided, a new empty List is used. This abstract operation performs the following steps:</p>
+      <p>The abstract operation OrdinaryCreateFromConstructor takes arguments _constructor_ and _intrinsicDefaultProto_ and optional argument _internalSlotsList_ (a List of names of internal slots). It creates an ordinary object whose [[Prototype]] value is retrieved from a constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. _internalSlotsList_ contains the names of additional internal slots that must be defined as part of the object. If _internalSlotsList_ is not provided, a new empty List is used. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Let _proto_ be ? GetPrototypeFromConstructor(_constructor_, _intrinsicDefaultProto_).
@@ -8190,7 +8203,7 @@
 
     <emu-clause id="sec-getprototypefromconstructor" aoid="GetPrototypeFromConstructor">
       <h1>GetPrototypeFromConstructor ( _constructor_, _intrinsicDefaultProto_ )</h1>
-      <p>The abstract operation GetPrototypeFromConstructor determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. This abstract operation performs the following steps:</p>
+      <p>The abstract operation GetPrototypeFromConstructor takes arguments _constructor_ and _intrinsicDefaultProto_. It determines the [[Prototype]] value that should be used to create an object corresponding to a specific constructor. The value is retrieved from the constructor's *"prototype"* property, if it exists. Otherwise the intrinsic named by _intrinsicDefaultProto_ is used for [[Prototype]]. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Assert: IsCallable(_constructor_) is *true*.
@@ -8207,7 +8220,7 @@
 
     <emu-clause id="sec-requireinternalslot" aoid="RequireInternalSlot">
       <h1>RequireInternalSlot ( _O_, _internalSlot_ )</h1>
-      <p>The abstract operation RequireInternalSlot throws an exception unless _O_ is an Object and has the given internal slot.</p>
+      <p>The abstract operation RequireInternalSlot takes arguments _O_ and _internalSlot_. It throws an exception unless _O_ is an Object and has the given internal slot. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_O_) is not Object, throw a *TypeError* exception.
         1. If _O_ does not have an _internalSlot_ internal slot, throw a *TypeError* exception.
@@ -8381,7 +8394,7 @@
 
       <emu-clause id="sec-prepareforordinarycall" aoid="PrepareForOrdinaryCall">
         <h1>PrepareForOrdinaryCall ( _F_, _newTarget_ )</h1>
-        <p>When the abstract operation PrepareForOrdinaryCall is called with function object _F_ and ECMAScript language value _newTarget_, the following steps are taken:</p>
+        <p>The abstract operation PrepareForOrdinaryCall takes arguments _F_ (a function object) and _newTarget_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_newTarget_) is Undefined or Object.
           1. Let _callerContext_ be the running execution context.
@@ -8402,7 +8415,7 @@
 
       <emu-clause id="sec-ordinarycallbindthis" aoid="OrdinaryCallBindThis">
         <h1>OrdinaryCallBindThis ( _F_, _calleeContext_, _thisArgument_ )</h1>
-        <p>When the abstract operation OrdinaryCallBindThis is called with function object _F_, execution context _calleeContext_, and ECMAScript value _thisArgument_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryCallBindThis takes arguments _F_ (a function object), _calleeContext_ (an execution context), and _thisArgument_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _thisMode_ be _F_.[[ThisMode]].
           1. If _thisMode_ is ~lexical~, return NormalCompletion(*undefined*).
@@ -8427,7 +8440,7 @@
 
       <emu-clause id="sec-ordinarycallevaluatebody" aoid="OrdinaryCallEvaluateBody">
         <h1>OrdinaryCallEvaluateBody ( _F_, _argumentsList_ )</h1>
-        <p>When the abstract operation OrdinaryCallEvaluateBody is called with function object _F_ and List _argumentsList_, the following steps are taken:</p>
+        <p>The abstract operation OrdinaryCallEvaluateBody takes arguments _F_ (a function object) and _argumentsList_ (a List). It performs the following steps when called:</p>
         <emu-alg>
           1. Return the result of EvaluateBody of the parsed code that is _F_.[[ECMAScriptCode]] passing _F_ and _argumentsList_ as the arguments.
         </emu-alg>
@@ -8462,7 +8475,7 @@
 
     <emu-clause id="sec-ordinaryfunctioncreate" aoid="OrdinaryFunctionCreate" oldids="sec-functionallocate,sec-functioninitialize,sec-functioncreate,sec-generatorfunctioncreate,sec-asyncgeneratorfunctioncreate,sec-async-functions-abstract-operations-async-function-create">
       <h1>OrdinaryFunctionCreate ( _functionPrototype_, _ParameterList_, _Body_, _thisMode_, _Scope_ )</h1>
-      <p>The abstract operation OrdinaryFunctionCreate requires the arguments: an object _functionPrototype_, a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, _thisMode_ which is either ~lexical-this~ or ~non-lexical-this~, and a Lexical Environment specified by _Scope_. OrdinaryFunctionCreate performs the following steps:</p>
+      <p>The abstract operation OrdinaryFunctionCreate takes arguments _functionPrototype_ (an Object), _ParameterList_ (a Parse Node), _Body_ (a Parse Node), _thisMode_ (either ~lexical-this~ or ~non-lexical-this~), and _Scope_ (a Lexical Environment). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_functionPrototype_) is Object.
         1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-27"></emu-xref>.
@@ -8488,7 +8501,7 @@
 
     <emu-clause id="sec-addrestrictedfunctionproperties" aoid="AddRestrictedFunctionProperties">
       <h1>AddRestrictedFunctionProperties ( _F_, _realm_ )</h1>
-      <p>The abstract operation AddRestrictedFunctionProperties is called with a function object _F_ and Realm Record _realm_ as its argument. It performs the following steps:</p>
+      <p>The abstract operation AddRestrictedFunctionProperties takes arguments _F_ (a function object) and _realm_ (a Realm Record). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _realm_.[[Intrinsics]].[[%ThrowTypeError%]] exists and has been initialized.
         1. Let _thrower_ be _realm_.[[Intrinsics]].[[%ThrowTypeError%]].
@@ -8509,7 +8522,7 @@
 
     <emu-clause id="sec-makeconstructor" aoid="MakeConstructor">
       <h1>MakeConstructor ( _F_ [ , _writablePrototype_ [ , _prototype_ ] ] )</h1>
-      <p>The abstract operation MakeConstructor requires a Function argument _F_ and optionally, a Boolean _writablePrototype_ and an object _prototype_. If _prototype_ is provided it is assumed to already contain, if needed, a *"constructor"* property whose value is _F_. This operation converts _F_ into a constructor by performing the following steps:</p>
+      <p>The abstract operation MakeConstructor takes argument _F_ (a function object) and optional arguments _writablePrototype_ (a Boolean) and _prototype_ (an Object). It converts _F_ into a constructor. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: IsConstructor(_F_) is *false*.
@@ -8527,7 +8540,7 @@
 
     <emu-clause id="sec-makeclassconstructor" aoid="MakeClassConstructor">
       <h1>MakeClassConstructor ( _F_ )</h1>
-      <p>The abstract operation MakeClassConstructor with argument _F_ performs the following steps:</p>
+      <p>The abstract operation MakeClassConstructor takes argument _F_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: _F_.[[IsClassConstructor]] is *false*.
@@ -8538,7 +8551,7 @@
 
     <emu-clause id="sec-makemethod" aoid="MakeMethod">
       <h1>MakeMethod ( _F_, _homeObject_ )</h1>
-      <p>The abstract operation MakeMethod with arguments _F_ and _homeObject_ configures _F_ as a method by performing the following steps:</p>
+      <p>The abstract operation MakeMethod takes arguments _F_ and _homeObject_. It configures _F_ as a method. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: Type(_homeObject_) is Object.
@@ -8549,7 +8562,7 @@
 
     <emu-clause id="sec-setfunctionname" aoid="SetFunctionName">
       <h1>SetFunctionName ( _F_, _name_ [ , _prefix_ ] )</h1>
-      <p>The abstract operation SetFunctionName requires a Function argument _F_, a String or Symbol argument _name_ and optionally a String argument _prefix_. This operation adds a *"name"* property to _F_ by performing the following steps:</p>
+      <p>The abstract operation SetFunctionName takes arguments _F_ (a function object) and _name_ (a property key) and optional argument _prefix_ (a String). It adds a *"name"* property to _F_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _F_ is an extensible object that does not have a *"name"* own property.
         1. Assert: Type(_name_) is either Symbol or String.
@@ -8566,7 +8579,7 @@
 
     <emu-clause id="sec-setfunctionlength" aoid="SetFunctionLength">
       <h1>SetFunctionLength ( _F_, _length_ )</h1>
-      <p>The abstract operation SetFunctionLength requires a Function argument _F_ and a Number argument _length_. This operation adds a *"length"* property to _F_ by performing the following steps:</p>
+      <p>The abstract operation SetFunctionLength takes arguments _F_ (a function object) and _length_ (a Number). It adds a *"length"* property to _F_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _F_ is an extensible object that does not have a *"length"* own property.
         1. Assert: Type(_length_) is Number.
@@ -8580,7 +8593,7 @@
       <emu-note>
         <p>When an execution context is established for evaluating an ECMAScript function a new function Environment Record is created and bindings for each formal parameter are instantiated in that Environment Record. Each declaration in the function body is also instantiated. If the function's formal parameters do not include any default value initializers then the body declarations are instantiated in the same Environment Record as the parameters. If default value parameter initializers exist, a second Environment Record is created for the body declarations. Formal parameters and functions are initialized as part of FunctionDeclarationInstantiation. All other bindings are initialized during evaluation of the function body.</p>
       </emu-note>
-      <p>FunctionDeclarationInstantiation is performed as follows using arguments _func_ and _argumentsList_. _func_ is the function object for which the execution context is being established.</p>
+      <p>The abstract operation FunctionDeclarationInstantiation takes arguments _func_ (a function object) and _argumentsList_. _func_ is the function object for which the execution context is being established. It performs the following steps when called:</p>
       <!--
         WARNING: If you add, remove, rename, or repurpose any variable names
                  within this algorithm, you may need to update
@@ -8751,7 +8764,7 @@
 
     <emu-clause id="sec-createbuiltinfunction" aoid="CreateBuiltinFunction">
       <h1>CreateBuiltinFunction ( _steps_, _internalSlotsList_ [ , _realm_ [ , _prototype_ ] ] )</h1>
-      <p>The abstract operation CreateBuiltinFunction takes arguments _steps_, _internalSlotsList_, _realm_, and _prototype_. The argument _internalSlotsList_ is a List of the names of additional internal slots that must be defined as part of the object. CreateBuiltinFunction returns a built-in function object created by the following steps:</p>
+      <p>The abstract operation CreateBuiltinFunction takes arguments _steps_ and _internalSlotsList_ (a List of names of internal slots) and optional arguments _realm_ and _prototype_. _internalSlotsList_ contains the names of additional internal slots that must be defined as part of the object. This operation creates a built-in function object. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _steps_ is either a set of algorithm steps or other definition of a function's behaviour provided in this specification.
         1. If _realm_ is not present, set _realm_ to the current Realm Record.
@@ -8857,7 +8870,7 @@
 
       <emu-clause id="sec-boundfunctioncreate" aoid="BoundFunctionCreate">
         <h1>BoundFunctionCreate ( _targetFunction_, _boundThis_, _boundArgs_ )</h1>
-        <p>The abstract operation BoundFunctionCreate with arguments _targetFunction_, _boundThis_, and _boundArgs_ is used to specify the creation of new bound function exotic objects. It performs the following steps:</p>
+        <p>The abstract operation BoundFunctionCreate takes arguments _targetFunction_, _boundThis_, and _boundArgs_. It is used to specify the creation of new bound function exotic objects. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_targetFunction_) is Object.
           1. Let _proto_ be ? _targetFunction_.[[GetPrototypeOf]]().
@@ -8912,7 +8925,7 @@
 
       <emu-clause id="sec-arraycreate" aoid="ArrayCreate">
         <h1>ArrayCreate ( _length_ [ , _proto_ ] )</h1>
-        <p>The abstract operation ArrayCreate with argument _length_ (either 0 or a positive integer) and optional argument _proto_ is used to specify the creation of new Array exotic objects. It performs the following steps:</p>
+        <p>The abstract operation ArrayCreate takes argument _length_ (a non-negative integer) and optional argument _proto_. It is used to specify the creation of new Array exotic objects. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: ! IsNonNegativeInteger(_length_) is *true*.
           1. If _length_ is *-0*, set _length_ to *+0*.
@@ -8928,7 +8941,7 @@
 
       <emu-clause id="sec-arrayspeciescreate" aoid="ArraySpeciesCreate">
         <h1>ArraySpeciesCreate ( _originalArray_, _length_ )</h1>
-        <p>The abstract operation ArraySpeciesCreate with arguments _originalArray_ and _length_ is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_. It performs the following steps:</p>
+        <p>The abstract operation ArraySpeciesCreate takes arguments _originalArray_ and _length_. It is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: ! IsNonNegativeInteger(_length_) is *true*.
           1. If _length_ is *-0*, set _length_ to *+0*.
@@ -8954,7 +8967,7 @@
 
       <emu-clause id="sec-arraysetlength" aoid="ArraySetLength">
         <h1>ArraySetLength ( _A_, _Desc_ )</h1>
-        <p>When the abstract operation ArraySetLength is called with an Array exotic object _A_, and Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The abstract operation ArraySetLength takes arguments _A_ (an Array object) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
           1. If _Desc_.[[Value]] is absent, then
             1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _Desc_).
@@ -9049,7 +9062,7 @@
 
       <emu-clause id="sec-stringcreate" aoid="StringCreate">
         <h1>StringCreate ( _value_, _prototype_ )</h1>
-        <p>The abstract operation StringCreate with arguments _value_ and _prototype_ is used to specify the creation of new String exotic objects. It performs the following steps:</p>
+        <p>The abstract operation StringCreate takes arguments _value_ and _prototype_. It is used to specify the creation of new String exotic objects. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_value_) is String.
           1. Let _S_ be ! MakeBasicObject(&laquo; [[Prototype]], [[Extensible]], [[StringData]] &raquo;).
@@ -9066,7 +9079,7 @@
 
       <emu-clause id="sec-stringgetownproperty" aoid="StringGetOwnProperty">
         <h1>StringGetOwnProperty ( _S_, _P_ )</h1>
-        <p>The abstract operation StringGetOwnProperty called with arguments _S_ and _P_ performs the following steps:</p>
+        <p>The abstract operation StringGetOwnProperty takes arguments _S_ and _P_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _S_ is an Object that has a [[StringData]] internal slot.
           1. Assert: IsPropertyKey(_P_) is *true*.
@@ -9201,7 +9214,7 @@
 
       <emu-clause id="sec-createunmappedargumentsobject" aoid="CreateUnmappedArgumentsObject">
         <h1>CreateUnmappedArgumentsObject ( _argumentsList_ )</h1>
-        <p>The abstract operation CreateUnmappedArgumentsObject called with an argument _argumentsList_ performs the following steps:</p>
+        <p>The abstract operation CreateUnmappedArgumentsObject takes argument _argumentsList_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _argumentsList_.
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
@@ -9220,7 +9233,7 @@
 
       <emu-clause id="sec-createmappedargumentsobject" aoid="CreateMappedArgumentsObject">
         <h1>CreateMappedArgumentsObject ( _func_, _formals_, _argumentsList_, _env_ )</h1>
-        <p>The abstract operation CreateMappedArgumentsObject is called with object _func_, Parse Node _formals_, List _argumentsList_, and Environment Record _env_. The following steps are performed:</p>
+        <p>The abstract operation CreateMappedArgumentsObject takes arguments _func_ (an Object), _formals_ (a Parse Node), _argumentsList_ (a List), and _env_ (an Environment Record). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _formals_ does not contain a rest parameter, any binding patterns, or any initializers. It may contain duplicate identifiers.
           1. Let _len_ be the number of elements in _argumentsList_.
@@ -9259,7 +9272,7 @@
 
         <emu-clause id="sec-makearggetter" aoid="MakeArgGetter">
           <h1>MakeArgGetter ( _name_, _env_ )</h1>
-          <p>The abstract operation MakeArgGetter called with String _name_ and Environment Record _env_ creates a built-in function object that when executed returns the value bound for _name_ in _env_. It performs the following steps:</p>
+          <p>The abstract operation MakeArgGetter takes arguments _name_ (a String) and _env_ (an Environment Record). It creates a built-in function object that when executed returns the value bound for _name_ in _env_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _steps_ be the steps of an ArgGetter function as specified below.
             1. Let _getter_ be ! CreateBuiltinFunction(_steps_, &laquo; [[Name]], [[Env]] &raquo;).
@@ -9281,7 +9294,7 @@
 
         <emu-clause id="sec-makeargsetter" aoid="MakeArgSetter">
           <h1>MakeArgSetter ( _name_, _env_ )</h1>
-          <p>The abstract operation MakeArgSetter called with String _name_ and Environment Record _env_ creates a built-in function object that when executed sets the value bound for _name_ in _env_. It performs the following steps:</p>
+          <p>The abstract operation MakeArgSetter takes arguments _name_ (a String) and _env_ (an Environment Record). It creates a built-in function object that when executed sets the value bound for _name_ in _env_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _steps_ be the steps of an ArgSetter function as specified below.
             1. Let _setter_ be ! CreateBuiltinFunction(_steps_, &laquo; [[Name]], [[Env]] &raquo;).
@@ -9409,7 +9422,7 @@
 
       <emu-clause id="sec-integerindexedobjectcreate" aoid="IntegerIndexedObjectCreate">
         <h1>IntegerIndexedObjectCreate ( _prototype_ )</h1>
-        <p>The abstract operation IntegerIndexedObjectCreate is used to specify the creation of new <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>. IntegerIndexedObjectCreate performs the following steps:</p>
+        <p>The abstract operation IntegerIndexedObjectCreate takes argument _prototype_. It is used to specify the creation of new <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _internalSlotsList_ be &laquo; [[Prototype]], [[Extensible]], [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;.
           1. Let _A_ be ! MakeBasicObject(_internalSlotsList_).
@@ -9426,7 +9439,7 @@
 
       <emu-clause id="sec-isvalidintegerindex" aoid="IsValidIntegerIndex">
         <h1>IsValidIntegerIndex ( _O_, _index_ )</h1>
-        <p>The abstract operation IsValidIntegerIndex with arguments _O_ and _index_ performs the following steps:</p>
+        <p>The abstract operation IsValidIntegerIndex takes arguments _O_ and _index_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
           1. Assert: Type(_index_) is Number.
@@ -9439,7 +9452,7 @@
 
       <emu-clause id="sec-integerindexedelementget" aoid="IntegerIndexedElementGet">
         <h1>IntegerIndexedElementGet ( _O_, _index_ )</h1>
-        <p>The abstract operation IntegerIndexedElementGet with arguments _O_ and _index_ performs the following steps:</p>
+        <p>The abstract operation IntegerIndexedElementGet takes arguments _O_ and _index_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
           1. Assert: Type(_index_) is Number.
@@ -9457,7 +9470,7 @@
 
       <emu-clause id="sec-integerindexedelementset" aoid="IntegerIndexedElementSet">
         <h1>IntegerIndexedElementSet ( _O_, _index_, _value_ )</h1>
-        <p>The abstract operation IntegerIndexedElementSet with arguments _O_, _index_, and _value_ performs the following steps:</p>
+        <p>The abstract operation IntegerIndexedElementSet takes arguments _O_, _index_, and _value_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
           1. Assert: Type(_index_) is Number.
@@ -9657,7 +9670,7 @@
 
       <emu-clause id="sec-modulenamespacecreate" aoid="ModuleNamespaceCreate">
         <h1>ModuleNamespaceCreate ( _module_, _exports_ )</h1>
-        <p>The abstract operation ModuleNamespaceCreate with arguments _module_, and _exports_ is used to specify the creation of new module namespace exotic objects. It performs the following steps:</p>
+        <p>The abstract operation ModuleNamespaceCreate takes arguments _module_ and _exports_. It is used to specify the creation of new module namespace exotic objects. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _module_ is a Module Record.
           1. Assert: _module_.[[Namespace]] is *undefined*.
@@ -9696,7 +9709,7 @@
 
       <emu-clause id="sec-set-immutable-prototype" aoid="SetImmutablePrototype">
         <h1>SetImmutablePrototype ( _O_, _V_ )</h1>
-        <p>When the SetImmutablePrototype abstract operation is called with arguments _O_ and _V_, the following steps are taken:</p>
+        <p>The abstract operation SetImmutablePrototype takes arguments _O_ and _V_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
           1. Let _current_ be ? _O_.[[GetPrototypeOf]]().
@@ -10328,7 +10341,7 @@
 
     <emu-clause id="sec-proxycreate" aoid="ProxyCreate">
       <h1>ProxyCreate ( _target_, _handler_ )</h1>
-      <p>The abstract operation ProxyCreate with arguments _target_ and _handler_ is used to specify the creation of new Proxy exotic objects. It performs the following steps:</p>
+      <p>The abstract operation ProxyCreate takes arguments _target_ and _handler_. It is used to specify the creation of new Proxy exotic objects. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. If _target_ is a Proxy exotic object and _target_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
@@ -10367,7 +10380,7 @@
 
     <emu-clause id="sec-utf16encoding" aoid="UTF16Encoding">
       <h1>Static Semantics: UTF16Encoding ( _cp_ )</h1>
-      <p>The UTF16Encoding of a numeric code point value, _cp_, is determined as follows:</p>
+      <p>The abstract operation UTF16Encoding takes argument _cp_ (a numeric code point value). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: 0 &le; _cp_ &le; 0x10FFFF.
         1. If _cp_ &le; 0xFFFF, return _cp_.
@@ -10379,7 +10392,7 @@
 
     <emu-clause id="sec-utf16encode" aoid="UTF16Encode">
       <h1>Static Semantics: UTF16Encode ( _text_ )</h1>
-      <p>This abstract operation converts _text_, a sequence of Unicode code points, into a String value, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+      <p>The abstract operation UTF16Encode takes argument _text_ (a sequence of Unicode code points). It converts _text_ into a String value, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
       <emu-alg>
         1. Return the string-concatenation of the code units that are the UTF16Encoding of each code point in _text_, in order.
       </emu-alg>
@@ -10387,7 +10400,7 @@
 
     <emu-clause id="sec-utf16decodesurrogatepair" aoid="UTF16DecodeSurrogatePair" oldids="sec-utf16decode">
       <h1>Static Semantics: UTF16DecodeSurrogatePair ( _lead_, _trail_ )</h1>
-      <p>Two code units, _lead_ and _trail_, that form a UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> are converted to a code point by performing the following steps:</p>
+      <p>The abstract operation UTF16DecodeSurrogatePair takes arguments _lead_ (a code unit) and _trail_ (a code unit). Two code units that form a UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> are converted to a code point. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _lead_ is a <emu-xref href="#leading-surrogate"></emu-xref> and _trail_ is a <emu-xref href="#trailing-surrogate"></emu-xref>.
         1. Let _cp_ be (_lead_ - 0xD800) &times; 0x400 + (_trail_ - 0xDC00) + 0x10000.
@@ -10397,7 +10410,7 @@
 
     <emu-clause id="sec-codepointat" aoid="CodePointAt">
       <h1>Static Semantics: CodePointAt ( _string_, _position_ )</h1>
-      <p>The abstract operation CodePointAt interprets a String _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and reads from it a single code point starting with the code unit at index _position_. When called, the following steps are performed:</p>
+      <p>The abstract operation CodePointAt takes arguments _string_ (a String) and _position_ (a non-negative integer). It interprets _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and reads from it a single code point starting with the code unit at index _position_. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _size_ be the length of _string_.
         1. Assert: _position_ &ge; 0 and _position_ &lt; _size_.
@@ -10417,7 +10430,7 @@
 
     <emu-clause id="sec-utf16decodestring" aoid="UTF16DecodeString">
       <h1>Static Semantics: UTF16DecodeString ( _string_ )</h1>
-      <p>This abstract operation accepts a String value _string_ and returns the sequence of Unicode code points that results from interpreting it as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+      <p>The abstract operation UTF16DecodeString takes argument _string_ (a String). It returns the sequence of Unicode code points that results from interpreting _string_ as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _codePoints_ be a new empty List.
         1. Let _size_ be the length of _string_.
@@ -12401,6 +12414,7 @@
 
       <emu-clause id="sec-initializeboundname" aoid="InitializeBoundName">
         <h1>Runtime Semantics: InitializeBoundName ( _name_, _value_, _environment_ )</h1>
+        <p>The abstract operation InitializeBoundName takes arguments _name_, _value_, and _environment_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_name_) is String.
           1. If _environment_ is not *undefined*, then
@@ -13023,7 +13037,7 @@
 
       <emu-clause id="sec-isvalidregularexpressionliteral" aoid="IsValidRegularExpressionLiteral">
         <h1>Static Semantics: IsValidRegularExpressionLiteral ( _literal_ )</h1>
-        <p>The abstract operation IsValidRegularExpressionLiteral determines if its argument is a valid regular expression literal. The following steps are taken:</p>
+        <p>The abstract operation IsValidRegularExpressionLiteral takes argument _literal_. It determines if its argument is a valid regular expression literal. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _literal_ is a |RegularExpressionLiteral|.
           1. If FlagText of _literal_ contains any code points other than `g`, `i`, `m`, `s`, `u`, or `y`, or if it contains the same code point more than once, return *false*.
@@ -13197,7 +13211,7 @@
 
       <emu-clause id="sec-gettemplateobject" aoid="GetTemplateObject">
         <h1>Runtime Semantics: GetTemplateObject ( _templateLiteral_ )</h1>
-        <p>The abstract operation GetTemplateObject is called with a Parse Node, _templateLiteral_, as an argument. It performs the following steps:</p>
+        <p>The abstract operation GetTemplateObject takes argument _templateLiteral_ (a Parse Node). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _rawStrings_ be TemplateStrings of _templateLiteral_ with argument *true*.
           1. Let _realm_ be the current Realm Record.
@@ -13752,7 +13766,7 @@
 
     <emu-clause id="sec-evaluate-property-access-with-expression-key" aoid="EvaluatePropertyAccessWithExpressionKey">
       <h1>Runtime Semantics: EvaluatePropertyAccessWithExpressionKey ( _baseValue_, _expression_, _strict_ )</h1>
-      <p>The abstract operation EvaluatePropertyAccessWithExpressionKey takes as arguments a value _baseValue_, a Parse Node _expression_, and a Boolean argument _strict_. It performs the following steps:</p>
+      <p>The abstract operation EvaluatePropertyAccessWithExpressionKey takes arguments _baseValue_ (an ECMAScript language value), _expression_ (a Parse Node), and _strict_ (a Boolean). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _propertyNameReference_ be the result of evaluating _expression_.
         1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
@@ -13763,7 +13777,7 @@
     </emu-clause>
     <emu-clause id="sec-evaluate-property-access-with-identifier-key" aoid="EvaluatePropertyAccessWithIdentifierKey">
       <h1>Runtime Semantics: EvaluatePropertyAccessWithIdentifierKey ( _baseValue_, _identifierName_, _strict_ )</h1>
-      <p>The abstract operation EvaluatePropertyAccessWithIdentifierKey takes as arguments a value _baseValue_, a Parse Node _identifierName_, and a Boolean argument _strict_. It performs the following steps:</p>
+      <p>The abstract operation EvaluatePropertyAccessWithIdentifierKey takes arguments _baseValue_ (an ECMAScript language value), _identifierName_ (a Parse Node), and _strict_ (a Boolean). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _identifierName_ is an |IdentifierName|.
         1. Let _bv_ be ? RequireObjectCoercible(_baseValue_).
@@ -13788,7 +13802,7 @@
 
         <emu-clause id="sec-evaluatenew" aoid="EvaluateNew">
           <h1>Runtime Semantics: EvaluateNew ( _constructExpr_, _arguments_ )</h1>
-          <p>The abstract operation EvaluateNew with arguments _constructExpr_, and _arguments_ performs the following steps:</p>
+          <p>The abstract operation EvaluateNew takes arguments _constructExpr_ and _arguments_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _constructExpr_ is either a |NewExpression| or a |MemberExpression|.
             1. Assert: _arguments_ is either ~empty~ or an |Arguments|.
@@ -13841,7 +13855,7 @@
 
       <emu-clause id="sec-evaluatecall" aoid="EvaluateCall" oldids="sec-evaluatedirectcall">
         <h1>Runtime Semantics: EvaluateCall ( _func_, _ref_, _arguments_, _tailPosition_ )</h1>
-        <p>The abstract operation EvaluateCall takes as arguments a value _func_, a value _ref_, a Parse Node _arguments_, and a Boolean argument _tailPosition_. It performs the following steps:</p>
+        <p>The abstract operation EvaluateCall takes arguments _func_ (an ECMAScript language value), _ref_ (an ECMAScript language value), _arguments_ (a Parse Node), and _tailPosition_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_ref_) is Reference, then
             1. If IsPropertyReference(_ref_) is *true*, then
@@ -13902,7 +13916,7 @@
 
       <emu-clause id="sec-getsuperconstructor" aoid="GetSuperConstructor">
         <h1>Runtime Semantics: GetSuperConstructor ( )</h1>
-        <p>The abstract operation GetSuperConstructor performs the following steps:</p>
+        <p>The abstract operation GetSuperConstructor takes no arguments. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _envRec_ be GetThisEnvironment().
           1. Assert: _envRec_ is a function Environment Record.
@@ -13915,7 +13929,7 @@
 
       <emu-clause id="sec-makesuperpropertyreference" aoid="MakeSuperPropertyReference">
         <h1>Runtime Semantics: MakeSuperPropertyReference ( _actualThis_, _propertyKey_, _strict_ )</h1>
-        <p>The abstract operation MakeSuperPropertyReference with arguments _actualThis_, _propertyKey_, and _strict_ performs the following steps:</p>
+        <p>The abstract operation MakeSuperPropertyReference takes arguments _actualThis_, _propertyKey_, and _strict_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
           1. Assert: _env_.HasSuperBinding() is *true*.
@@ -15014,7 +15028,7 @@
 
     <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
       <h1>Runtime Semantics: InstanceofOperator ( _V_, _target_ )</h1>
-      <p>The abstract operation InstanceofOperator(_V_, _target_) implements the generic algorithm for determining if  ECMAScript value _V_ is an instance of object _target_ either by consulting _target_'s @@hasinstance method or, if absent, determining whether the value of _target_'s *"prototype"* property is present in _V_'s prototype chain. This abstract operation performs the following steps:</p>
+      <p>The abstract operation InstanceofOperator takes arguments _V_ (an ECMAScript language value) and _target_ (an ECMAScript language value). It implements the generic algorithm for determining if _V_ is an instance of _target_ either by consulting _target_'s @@hasinstance method or, if absent, determining whether the value of _target_'s *"prototype"* property is present in _V_'s prototype chain. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _instOfHandler_ be ? GetMethod(_target_, @@hasInstance).
@@ -16392,7 +16406,7 @@
       <emu-note>
         <p>When a |Block| or |CaseBlock| is evaluated a new declarative Environment Record is created and bindings for each block scoped variable, constant, function, or class declared in the block are instantiated in the Environment Record.</p>
       </emu-note>
-      <p>BlockDeclarationInstantiation is performed as follows using arguments _code_ and _env_. _code_ is the Parse Node corresponding to the body of the block. _env_ is the Lexical Environment in which bindings are to be created.</p>
+      <p>The abstract operation BlockDeclarationInstantiation takes arguments _code_ (a Parse Node) and _env_ (a Lexical Environment). _code_ is the Parse Node corresponding to the body of the block. _env_ is the Lexical Environment in which bindings are to be created. It performs the following steps when called:</p>
       <!--
         WARNING: If you add, remove, rename, or repurpose any variable names
                  within this algorithm, you may need to update
@@ -17374,7 +17388,7 @@
 
       <emu-clause id="sec-loopcontinues" aoid="LoopContinues">
         <h1>Runtime Semantics: LoopContinues ( _completion_, _labelSet_ )</h1>
-        <p>The abstract operation LoopContinues with arguments _completion_ and _labelSet_ is defined by the following steps:</p>
+        <p>The abstract operation LoopContinues takes arguments _completion_ and _labelSet_. It performs the following steps when called:</p>
         <emu-alg>
           1. If _completion_.[[Type]] is ~normal~, return *true*.
           1. If _completion_.[[Type]] is not ~continue~, return *false*.
@@ -17665,7 +17679,7 @@
 
       <emu-clause id="sec-forbodyevaluation" aoid="ForBodyEvaluation">
         <h1>Runtime Semantics: ForBodyEvaluation ( _test_, _increment_, _stmt_, _perIterationBindings_, _labelSet_ )</h1>
-        <p>The abstract operation ForBodyEvaluation with arguments _test_, _increment_, _stmt_, _perIterationBindings_, and _labelSet_ is performed as follows:</p>
+        <p>The abstract operation ForBodyEvaluation takes arguments _test_, _increment_, _stmt_, _perIterationBindings_, and _labelSet_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
@@ -17686,7 +17700,7 @@
 
       <emu-clause id="sec-createperiterationenvironment" aoid="CreatePerIterationEnvironment">
         <h1>Runtime Semantics: CreatePerIterationEnvironment ( _perIterationBindings_ )</h1>
-        <p>The abstract operation CreatePerIterationEnvironment with argument _perIterationBindings_ is performed as follows:</p>
+        <p>The abstract operation CreatePerIterationEnvironment takes argument _perIterationBindings_. It performs the following steps when called:</p>
         <emu-alg>
           1. If _perIterationBindings_ has any elements, then
             1. Let _lastIterationEnv_ be the running execution context's LexicalEnvironment.
@@ -18003,7 +18017,7 @@
 
       <emu-clause id="sec-runtime-semantics-forinofheadevaluation" oldids="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
         <h1>Runtime Semantics: ForIn/OfHeadEvaluation ( _uninitializedBoundNames_, _expr_, _iterationKind_ )</h1>
-        <p>The abstract operation ForIn/OfHeadEvaluation is called with arguments _uninitializedBoundNames_, _expr_, and _iterationKind_. The value of _iterationKind_ is either ~enumerate~, ~iterate~, or ~async-iterate~.</p>
+        <p>The abstract operation ForIn/OfHeadEvaluation takes arguments _uninitializedBoundNames_, _expr_, and _iterationKind_ (either ~enumerate~, ~iterate~, or ~async-iterate~). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. If _uninitializedBoundNames_ is not an empty List, then
@@ -18031,7 +18045,7 @@
 
       <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" aoid="ForIn/OfBodyEvaluation">
         <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ] )</h1>
-        <p>The abstract operation ForIn/OfBodyEvaluation is called with arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_, and optional argument _iteratorKind_. The value of _lhsKind_ is either ~assignment~, ~varBinding~ or ~lexicalBinding~. The value of _iteratorKind_ is either ~sync~ or ~async~.</p>
+        <p>The abstract operation ForIn/OfBodyEvaluation takes arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_ (either ~assignment~, ~varBinding~ or ~lexicalBinding~), and _labelSet_ and optional argument _iteratorKind_ (either ~sync~ or ~async~). It performs the following steps when called:</p>
         <emu-alg>
           1. If _iteratorKind_ is not present, set _iteratorKind_ to ~sync~.
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
@@ -18110,7 +18124,7 @@
 
       <emu-clause id="sec-enumerate-object-properties" aoid="EnumerateObjectProperties">
         <h1>EnumerateObjectProperties ( _O_ )</h1>
-        <p>When the abstract operation EnumerateObjectProperties is called with argument _O_, the following steps are taken:</p>
+        <p>The abstract operation EnumerateObjectProperties takes argument _O_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_O_) is Object.
           1. Return an Iterator object (<emu-xref href="#sec-iterator-interface"></emu-xref>) whose `next` method iterates over all the String-valued keys of enumerable properties of _O_. The iterator object is never directly accessible to ECMAScript code. The mechanics and order of enumerating the properties is not specified but must conform to the rules specified below.
@@ -18158,7 +18172,7 @@
 
         <emu-clause id="sec-createforiniterator" aoid="CreateForInIterator">
           <h1>CreateForInIterator ( _object_ )</h1>
-          <p>The abstract operation CreateForInIterator with argument _object_ is used to create a For-In Iterator object which iterates over the own and inherited enumerable string properties of _object_ in a specific order. It performs the following steps:</p>
+          <p>The abstract operation CreateForInIterator takes argument _object_. It is used to create a For-In Iterator object which iterates over the own and inherited enumerable string properties of _object_ in a specific order. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_object_) is Object.
             1. Let _iterator_ be OrdinaryObjectCreate(%ForInIteratorPrototype%, &laquo; [[Object]], [[ObjectWasVisited]], [[VisitedKeys]], [[RemainingKeys]] &raquo;).
@@ -18848,7 +18862,7 @@
 
     <emu-clause id="sec-runtime-semantics-caseclauseisselected" aoid="CaseClauseIsSelected" oldids="sec-runtime-semantics-caseselectorevaluation">
       <h1>Runtime Semantics: CaseClauseIsSelected ( _C_, _input_ )</h1>
-      <p>The abstract operation CaseClauseIsSelected, given |CaseClause| _C_ and value _input_, determines whether _C_ matches _input_.</p>
+      <p>The abstract operation CaseClauseIsSelected takes arguments _C_ (a Parse Node for |CaseClause|) and _input_ (an ECMAScript language value). It determines whether _C_ matches _input_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _C_ is an instance of the production <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>.
         1. Let _exprRef_ be the result of evaluating the |Expression| of _C_.
@@ -18975,7 +18989,7 @@
 
     <emu-clause id="sec-islabelledfunction" aoid="IsLabelledFunction">
       <h1>Static Semantics: IsLabelledFunction ( _stmt_ )</h1>
-      <p>The abstract operation IsLabelledFunction with argument _stmt_ performs the following steps:</p>
+      <p>The abstract operation IsLabelledFunction takes argument _stmt_. It performs the following steps when called:</p>
       <emu-alg>
         1. If _stmt_ is not a |LabelledStatement|, return *false*.
         1. Let _item_ be the |LabelledItem| of _stmt_.
@@ -19717,7 +19731,7 @@
 
     <emu-clause id="sec-isanonymousfunctiondefinition" aoid="IsAnonymousFunctionDefinition">
       <h1>Static Semantics: IsAnonymousFunctionDefinition ( _expr_ )</h1>
-      <p>The abstract operation IsAnonymousFunctionDefinition determines if its argument is a function definition that does not bind a name. The argument _expr_ is the result of parsing an |AssignmentExpression| or |Initializer|. The following steps are taken:</p>
+      <p>The abstract operation IsAnonymousFunctionDefinition takes argument _expr_ (a Parse Node for |AssignmentExpression| or a Parse Node for |Initializer|). It determines if its argument is a function definition that does not bind a name. It performs the following steps when called:</p>
       <emu-alg>
         1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
         1. Let _hasName_ be HasName of _expr_.
@@ -21967,7 +21981,7 @@
 
     <emu-clause id="sec-isintailposition" aoid="IsInTailPosition">
       <h1>Static Semantics: IsInTailPosition ( _call_ )</h1>
-      <p>The abstract operation IsInTailPosition with argument _call_ performs the following steps:</p>
+      <p>The abstract operation IsInTailPosition takes argument _call_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _call_ is a Parse Node.
         1. If the source code matching _call_ is non-strict code, return *false*.
@@ -22298,7 +22312,7 @@
 
     <emu-clause id="sec-preparefortailcall" aoid="PrepareForTailCall">
       <h1>Runtime Semantics: PrepareForTailCall ( )</h1>
-      <p>The abstract operation PrepareForTailCall performs the following steps:</p>
+      <p>The abstract operation PrepareForTailCall takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _leafContext_ be the running execution context.
         1. Suspend _leafContext_.
@@ -22485,8 +22499,8 @@
 
     <emu-clause id="sec-parse-script" aoid="ParseScript">
       <h1>ParseScript ( _sourceText_, _realm_, _hostDefined_ )</h1>
+      <p>The abstract operation ParseScript takes arguments _sourceText_, _realm_, and _hostDefined_. It creates a Script Record based upon the result of parsing _sourceText_ as a |Script|. It performs the following steps when called:</p>
 
-      <p>The abstract operation ParseScript with arguments _sourceText_, _realm_, and _hostDefined_ creates a Script Record based upon the result of parsing _sourceText_ as a |Script|. ParseScript performs the following steps:</p>
 
       <emu-alg>
         1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
@@ -22501,6 +22515,7 @@
 
     <emu-clause id="sec-runtime-semantics-scriptevaluation" aoid="ScriptEvaluation">
       <h1>ScriptEvaluation ( _scriptRecord_ )</h1>
+      <p>The abstract operation ScriptEvaluation takes argument _scriptRecord_. It performs the following steps when called:</p>
 
       <emu-alg>
         1. Let _globalEnv_ be _scriptRecord_.[[Realm]].[[GlobalEnv]].
@@ -22530,7 +22545,7 @@
       <emu-note>
         <p>When an execution context is established for evaluating scripts, declarations are instantiated in the current global environment. Each global binding declared in the code is instantiated.</p>
       </emu-note>
-      <p>GlobalDeclarationInstantiation is performed as follows using arguments _script_ and _env_. _script_ is the |ScriptBody| for which the execution context is being established. _env_ is the global lexical environment in which bindings are to be created.</p>
+      <p>The abstract operation GlobalDeclarationInstantiation takes arguments _script_ (a Parse Node for |ScriptBody|) and _env_ (a Lexical Environment). _script_ is the |ScriptBody| for which the execution context is being established. _env_ is the global lexical environment in which bindings are to be created. It performs the following steps when called:</p>
       <!--
         WARNING: If you add, remove, rename, or repurpose any variable names
                  within this algorithm, you may need to update
@@ -22811,7 +22826,7 @@
 
       <emu-clause id="sec-importedlocalnames" aoid="ImportedLocalNames">
         <h1>Static Semantics: ImportedLocalNames ( _importEntries_ )</h1>
-        <p>The abstract operation ImportedLocalNames with argument _importEntries_ creates a List of all of the local name bindings defined by a List of ImportEntry Records (see <emu-xref href="#table-39"></emu-xref>). ImportedLocalNames performs the following steps:</p>
+        <p>The abstract operation ImportedLocalNames takes argument _importEntries_ (a List of ImportEntry Records (see <emu-xref href="#table-39"></emu-xref>)). It creates a List of all of the local name bindings defined by _importEntries_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _localNames_ be a new empty List.
           1. For each ImportEntry Record _i_ in _importEntries_, do
@@ -23170,11 +23185,10 @@
 
         <emu-clause id="sec-moduledeclarationlinking" oldids="sec-moduledeclarationinstantiation">
           <h1>Link ( ) Concrete Method</h1>
-
           <p>The Link concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
           <p>On success, Link transitions this module's [[Status]] from ~unlinked~ to ~linked~. On failure, an exception is thrown and this module's [[Status]] remains ~unlinked~.</p>
-
           <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleLinking):</p>
+
 
           <emu-alg>
             1. Let _module_ be this Cyclic Module Record.
@@ -23197,10 +23211,8 @@
 
           <emu-clause id="sec-InnerModuleLinking" oldids="sec-innermoduleinstantiation" aoid="InnerModuleLinking">
             <h1>InnerModuleLinking ( _module_, _stack_, _index_ )</h1>
+            <p>The abstract operation InnerModuleLinking takes arguments _module_ (a Cyclic Module Record), _stack_, and _index_. It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together. It performs the following steps when called:</p>
 
-            <p>The InnerModuleLinking abstract operation is used by Link to perform the actual linking process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together.</p>
-
-            <p>This abstract operation performs the following steps:</p>
 
             <emu-alg>
               1. If _module_ is not a Cyclic Module Record, then
@@ -23240,13 +23252,11 @@
 
         <emu-clause id="sec-moduleevaluation">
           <h1>Evaluate ( ) Concrete Method</h1>
-
           <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
           <p>Evaluate transitions this module's [[Status]] from ~linked~ to ~evaluated~.</p>
-
           <p>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
-
           <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
+
 
           <emu-alg>
             1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
@@ -23268,10 +23278,8 @@
 
           <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
             <h1>InnerModuleEvaluation ( _module_, _stack_, _index_ )</h1>
+            <p>The abstract operation InnerModuleEvaluation takes arguments _module_ (a Source Text Module Record), _stack_, and _index_. It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking. It performs the following steps when called:</p>
 
-            <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Source Text Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking.</p>
-
-            <p>This abstract operation performs the following steps:</p>
 
             <emu-alg>
               1. If _module_ is not a Cyclic Module Record, then
@@ -23857,7 +23865,7 @@
 
         <emu-clause id="sec-parsemodule" aoid="ParseModule">
           <h1>ParseModule ( _sourceText_, _realm_, _hostDefined_ )</h1>
-          <p>The abstract operation ParseModule with arguments _sourceText_, _realm_, and _hostDefined_ creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. ParseModule performs the following steps:</p>
+          <p>The abstract operation ParseModule takes arguments _sourceText_ (ECMAScript source text), _realm_, and _hostDefined_. It creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
             1. Parse _sourceText_ using |Module| as the goal symbol and analyse the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation-dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-dependent, but at least one must be present.
@@ -23895,7 +23903,7 @@
         <emu-clause id="sec-getexportednames">
           <h1>GetExportedNames ( [ _exportStarSet_ ] ) Concrete Method</h1>
           <p>The GetExportedNames concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
-          <p>It performs the following steps:</p>
+          <p>It performs the following steps when called:</p>
           <emu-alg>
             1. If _exportStarSet_ is not present, set _exportStarSet_ to a new empty List.
             1. Assert: _exportStarSet_ is a List of Source Text Module Records.
@@ -23928,11 +23936,8 @@
         <emu-clause id="sec-resolveexport">
           <h1>ResolveExport ( _exportName_ [ , _resolveSet_ ] ) Concrete Method</h1>
           <p>The ResolveExport concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
-
           <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
-
           <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to *"\*namespace\*"*. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string *"ambiguous"* is returned.</p>
-
           <p>This abstract method performs the following steps:</p>
 
           <emu-alg>
@@ -23978,10 +23983,9 @@
 
         <emu-clause id="sec-source-text-module-record-initialize-environment" aoid="InitializeEnvironment">
           <h1>InitializeEnvironment ( ) Concrete Method</h1>
-
           <p>The InitializeEnvironment concrete method of a Source Text Module Record implements the corresponding Cyclic Module Record abstract method.</p>
-
           <p>This abstract method performs the following steps:</p>
+
 
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
@@ -24046,10 +24050,9 @@
 
         <emu-clause id="sec-source-text-module-record-execute-module" aoid="ExecuteModule">
           <h1>ExecuteModule ( ) Concrete Method</h1>
-
           <p>The ExecuteModule concrete method of a Source Text Module Record implements the corresponding Cyclic Module Record abstract method.</p>
-
           <p>This abstract method performs the following steps:</p>
+
 
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
@@ -24093,8 +24096,8 @@
 
       <emu-clause id="sec-hostimportmoduledynamically" aoid="HostImportModuleDynamically">
         <h1>Runtime Semantics: HostImportModuleDynamically ( _referencingScriptOrModule_, _specifier_, _promiseCapability_ )</h1>
-
         <p>HostImportModuleDynamically is an implementation-defined abstract operation that performs any necessary setup work in order to make available the module corresponding to the |ModuleSpecifier| String, _specifier_, occurring within the context of the script or module represented by the Script Record or Module Record _referencingScriptOrModule_. (_referencingScriptOrModule_ may also be *null*, if there is no active script or module when the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression occurs.) It then performs FinishDynamicImport to finish the dynamic import process.</p>
+
 
         <p>The implementation of HostImportModuleDynamically must conform to the following requirements:</p>
 
@@ -24139,8 +24142,8 @@
 
       <emu-clause id="sec-finishdynamicimport" aoid="FinishDynamicImport">
         <h1>Runtime Semantics: FinishDynamicImport ( _referencingScriptOrModule_, _specifier_, _promiseCapability_, _completion_ )</h1>
+        <p>The abstract operation FinishDynamicImport takes arguments _referencingScriptOrModule_, _specifier_, _promiseCapability_, and _completion_. FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically. It performs the following steps when called:</p>
 
-        <p>FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically.</p>
 
         <emu-alg>
           1. If _completion_ is an abrupt completion, then perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _completion_.[[Value]] »).
@@ -24156,10 +24159,8 @@
 
       <emu-clause id="sec-getmodulenamespace" aoid="GetModuleNamespace">
         <h1>Runtime Semantics: GetModuleNamespace ( _module_ )</h1>
+        <p>The abstract operation GetModuleNamespace takes argument _module_. It retrieves the Module Namespace Object representing _module_'s exports, lazily creating it the first time it was requested, and storing it in _module_.[[Namespace]] for future retrieval. It performs the following steps when called:</p>
 
-        <p>The GetModuleNamespace abstract operation retrieves the Module Namespace Object representing _module_'s exports, lazily creating it the first time it was requested, and storing it in _module_.[[Namespace]] for future retrieval.</p>
-
-        <p>This abstract operation performs the following steps:</p>
 
         <emu-alg>
           1. Assert: _module_ is an instance of a concrete subclass of Module Record.
@@ -24944,7 +24945,7 @@
 
       <emu-clause id="sec-performeval" aoid="PerformEval" oldids="sec-performeval-rules-outside-functions,sec-performeval-rules-outside-methods,sec-performeval-rules-outside-constructors">
         <h1>Runtime Semantics: PerformEval ( _x_, _callerRealm_, _strictCaller_, _direct_ )</h1>
-        <p>The abstract operation PerformEval with arguments _x_, _callerRealm_, _strictCaller_, and _direct_ performs the following steps:</p>
+        <p>The abstract operation PerformEval takes arguments _x_, _callerRealm_, _strictCaller_, and _direct_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
           1. If Type(_x_) is not String, return _x_.
@@ -25002,15 +25003,15 @@
 
       <emu-clause id="sec-hostensurecancompilestrings" aoid="HostEnsureCanCompileStrings">
         <h1>HostEnsureCanCompileStrings ( _callerRealm_, _calleeRealm_ )</h1>
-
         <p>HostEnsureCanCompileStrings is an implementation-defined abstract operation that allows host environments to block certain ECMAScript functions which allow developers to compile strings into ECMAScript code.</p>
+
 
         <p>An implementation of HostEnsureCanCompileStrings may complete normally or abruptly. Any abrupt completions will be propagated to its callers. The default implementation of HostEnsureCanCompileStrings is to unconditionally return an empty normal completion.</p>
       </emu-clause>
 
       <emu-clause id="sec-evaldeclarationinstantiation" aoid="EvalDeclarationInstantiation">
         <h1>Runtime Semantics: EvalDeclarationInstantiation ( _body_, _varEnv_, _lexEnv_, _strict_ )</h1>
-        <p>When the abstract operation EvalDeclarationInstantiation is called with arguments _body_, _varEnv_, _lexEnv_, and _strict_, the following steps are taken:</p>
+        <p>The abstract operation EvalDeclarationInstantiation takes arguments _body_, _varEnv_, _lexEnv_, and _strict_. It performs the following steps when called:</p>
         <!--
           WARNING: If you add, remove, rename, or repurpose any variable names
                    within this algorithm, you may need to update
@@ -25234,7 +25235,7 @@
 
         <emu-clause id="sec-encode" aoid="Encode">
           <h1>Runtime Semantics: Encode ( _string_, _unescapedSet_ )</h1>
-          <p>The encoding and escaping process is described by the abstract operation Encode taking two String arguments _string_ and _unescapedSet_.</p>
+          <p>The abstract operation Encode takes arguments _string_ (a String) and _unescapedSet_ (a String). It performs URI encoding and escaping. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _strLen_ be the number of code units in _string_.
             1. Let _R_ be the empty String.
@@ -25260,7 +25261,7 @@
 
         <emu-clause id="sec-decode" aoid="Decode">
           <h1>Runtime Semantics: Decode ( _string_, _reservedSet_ )</h1>
-          <p>The unescaping and decoding process is described by the abstract operation Decode taking two String arguments _string_ and _reservedSet_.</p>
+          <p>The abstract operation Decode takes arguments _string_ (a String) and _reservedSet_ (a String). It performs URI unescaping and decoding. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _strLen_ be the number of code units in _string_.
             1. Let _R_ be the empty String.
@@ -25829,7 +25830,7 @@
 
         <emu-clause id="sec-objectdefineproperties" aoid="ObjectDefineProperties">
           <h1>Runtime Semantics: ObjectDefineProperties ( _O_, _Properties_ )</h1>
-          <p>The abstract operation ObjectDefineProperties with arguments _O_ and _Properties_ performs the following steps:</p>
+          <p>The abstract operation ObjectDefineProperties takes arguments _O_ and _Properties_. It performs the following steps when called:</p>
           <emu-alg>
             1. If Type(_O_) is not Object, throw a *TypeError* exception.
             1. Let _props_ be ? ToObject(_Properties_).
@@ -25955,7 +25956,7 @@
 
         <emu-clause id="sec-getownpropertykeys" aoid="GetOwnPropertyKeys">
           <h1>Runtime Semantics: GetOwnPropertyKeys ( _O_, _type_ )</h1>
-          <p>The abstract operation GetOwnPropertyKeys is called with arguments _O_ and _type_ where _O_ is an Object and _type_ is one of ~string~ or ~symbol~. The following steps are taken:</p>
+          <p>The abstract operation GetOwnPropertyKeys takes arguments _O_ and _type_ (either ~string~ or ~symbol~). It performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(_O_).
             1. Let _keys_ be ? _obj_.[[OwnPropertyKeys]]().
@@ -26229,7 +26230,7 @@
 
         <emu-clause id="sec-createdynamicfunction" aoid="CreateDynamicFunction">
           <h1>Runtime Semantics: CreateDynamicFunction ( _constructor_, _newTarget_, _kind_, _args_ )</h1>
-          <p>The abstract operation CreateDynamicFunction is called with arguments _constructor_, _newTarget_, _kind_, and _args_. _constructor_ is the constructor function that is performing this action, _newTarget_ is the constructor that `new` was initially applied to, _kind_ is either ~normal~, ~generator~, ~async~, or ~asyncGenerator~, and _args_ is a List containing the actual argument values that were passed to _constructor_. The following steps are taken:</p>
+          <p>The abstract operation CreateDynamicFunction takes arguments _constructor_ (a constructor), _newTarget_ (a constructor), _kind_ (either ~normal~, ~generator~, ~async~, or ~asyncGenerator~), and _args_ (a List of ECMAScript language values). _constructor_ is the constructor function that is performing this action. _newTarget_ is the constructor that `new` was initially applied to. _args_ is the argument values that were passed to _constructor_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: The execution context stack has at least two elements.
             1. Let _callerContext_ be the second to top element of the execution context stack.
@@ -26563,8 +26564,7 @@
         <li>is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-
-      <p>The abstract operation <dfn id="sec-thisbooleanvalue" aoid="thisBooleanValue">thisBooleanValue</dfn>(_value_) performs the following steps:</p>
+      <p>The abstract operation <dfn id="sec-thisbooleanvalue" aoid="thisBooleanValue">thisBooleanValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is Boolean, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[BooleanData]] internal slot, then
@@ -26798,8 +26798,7 @@
         <li>is not a Symbol instance and does not have a [[SymbolData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-
-      <p>The abstract operation <dfn id="sec-thissymbolvalue" aoid="thisSymbolValue">thisSymbolValue</dfn>(_value_) performs the following steps:</p>
+      <p>The abstract operation <dfn id="sec-thissymbolvalue" aoid="thisSymbolValue">thisSymbolValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is Symbol, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[SymbolData]] internal slot, then
@@ -26834,7 +26833,7 @@
 
         <emu-clause id="sec-symboldescriptivestring" aoid="SymbolDescriptiveString">
           <h1>Runtime Semantics: SymbolDescriptiveString ( _sym_ )</h1>
-          <p>When the abstract operation SymbolDescriptiveString is called with argument _sym_, the following steps are taken:</p>
+          <p>The abstract operation SymbolDescriptiveString takes argument _sym_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_sym_) is Symbol.
             1. Let _desc_ be _sym_'s [[Description]] value.
@@ -27247,7 +27246,7 @@
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
-      <p>The abstract operation <dfn id="sec-thisnumbervalue" aoid="thisNumberValue">thisNumberValue</dfn>(_value_) performs the following steps:</p>
+      <p>The abstract operation <dfn id="sec-thisnumbervalue" aoid="thisNumberValue">thisNumberValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is Number, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[NumberData]] internal slot, then
@@ -27456,6 +27455,7 @@
 
         <emu-clause id="sec-numbertobigint" aoid="NumberToBigInt">
           <h1>Runtime Semantics: NumberToBigInt ( _number_ )</h1>
+          <p>The abstract operation NumberToBigInt takes argument _number_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_number_) is Number.
             1. If IsInteger(_number_) is *false*, throw a *RangeError* exception.
@@ -27505,8 +27505,7 @@
         <li>is not a BigInt object; it does not have a [[BigIntData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Object.prototype%.</li>
       </ul>
-
-      <p>The abstract operation <dfn id="sec-thisbigintvalue" aoid="thisBigIntValue">thisBigIntValue</dfn>(_value_) performs the following steps:</p>
+      <p>The abstract operation <dfn id="sec-thisbigintvalue" aoid="thisBigIntValue">thisBigIntValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is BigInt, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[BigIntData]] internal slot, then
@@ -28562,7 +28561,7 @@
 
       <emu-clause id="sec-localtime" aoid="LocalTime">
         <h1>LocalTime ( _t_ )</h1>
-        <p>The abstract operation LocalTime with argument _t_ converts _t_ from UTC to local time by performing the following steps:</p>
+        <p>The abstract operation LocalTime takes argument _t_. It converts _t_ from UTC to local time. It performs the following steps when called:</p>
         <emu-alg>
           1. Return _t_ + LocalTZA(_t_, *true*).
         </emu-alg>
@@ -28574,7 +28573,7 @@
 
       <emu-clause id="sec-utc-t" aoid="UTC">
         <h1>UTC ( _t_ )</h1>
-        <p>The abstract operation UTC with argument _t_ converts _t_ from local time to UTC by performing the following steps:</p>
+        <p>The abstract operation UTC takes argument _t_. It converts _t_ from local time to UTC. It performs the following steps when called:</p>
         <emu-alg>
           1. Return _t_ - LocalTZA(_t_, *false*).
         </emu-alg>
@@ -28601,7 +28600,7 @@
 
       <emu-clause id="sec-maketime" aoid="MakeTime">
         <h1>MakeTime ( _hour_, _min_, _sec_, _ms_ )</h1>
-        <p>The abstract operation MakeTime calculates a number of milliseconds from its four arguments, which must be ECMAScript Number values. This operator functions as follows:</p>
+        <p>The abstract operation MakeTime takes arguments _hour_ (a Number), _min_ (a Number), _sec_ (a Number), and _ms_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
         <emu-alg>
           1. If _hour_ is not finite or _min_ is not finite or _sec_ is not finite or _ms_ is not finite, return *NaN*.
           1. Let _h_ be ! ToInteger(_hour_).
@@ -28615,7 +28614,7 @@
 
       <emu-clause id="sec-makeday" aoid="MakeDay">
         <h1>MakeDay ( _year_, _month_, _date_ )</h1>
-        <p>The abstract operation MakeDay calculates a number of days from its three arguments, which must be ECMAScript Number values. This operator functions as follows:</p>
+        <p>The abstract operation MakeDay takes arguments _year_ (a Number), _month_ (a Number), and _date_ (a Number). It calculates a number of days. It performs the following steps when called:</p>
         <emu-alg>
           1. If _year_ is not finite or _month_ is not finite or _date_ is not finite, return *NaN*.
           1. Let _y_ be ! ToInteger(_year_).
@@ -28630,7 +28629,7 @@
 
       <emu-clause id="sec-makedate" aoid="MakeDate">
         <h1>MakeDate ( _day_, _time_ )</h1>
-        <p>The abstract operation MakeDate calculates a number of milliseconds from its two arguments, which must be ECMAScript Number values. This operator functions as follows:</p>
+        <p>The abstract operation MakeDate takes arguments _day_ (a Number) and _time_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
         <emu-alg>
           1. If _day_ is not finite or _time_ is not finite, return *NaN*.
           1. Return _day_ &times; msPerDay + _time_.
@@ -28639,7 +28638,7 @@
 
       <emu-clause id="sec-timeclip" aoid="TimeClip">
         <h1>TimeClip ( _time_ )</h1>
-        <p>The abstract operation TimeClip calculates a number of milliseconds from its argument, which must be an ECMAScript Number value. This operator functions as follows:</p>
+        <p>The abstract operation TimeClip takes argument _time_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
         <emu-alg>
           1. If _time_ is not finite, return *NaN*.
           1. If abs(_time_) &gt; 8.64 &times; 10<sup>15</sup>, return *NaN*.
@@ -28977,7 +28976,7 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly defined otherwise, the methods of the Date prototype object defined below are not generic and the *this* value passed to them must be an object that has a [[DateValue]] internal slot that has been initialized to a time value.</p>
-      <p>The abstract operation <dfn id="sec-thistimevalue" aoid="thisTimeValue">thisTimeValue</dfn>(_value_) performs the following steps:</p>
+      <p>The abstract operation <dfn id="sec-thistimevalue" aoid="thisTimeValue">thisTimeValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is Object and _value_ has a [[DateValue]] internal slot, then
           1. Return _value_.[[DateValue]].
@@ -29502,7 +29501,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-timestring" aoid="TimeString">
           <h1>Runtime Semantics: TimeString ( _tv_ )</h1>
-          <p>The following steps are performed:</p>
+          <p>The abstract operation TimeString takes argument _tv_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
@@ -29515,7 +29514,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-datestring" aoid="DateString">
           <h1>Runtime Semantics: DateString ( _tv_ )</h1>
-          <p>The following steps are performed:</p>
+          <p>The abstract operation DateString takes argument _tv_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
@@ -29712,7 +29711,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-timezoneestring" aoid="TimeZoneString">
           <h1>Runtime Semantics: TimeZoneString ( _tv_ )</h1>
-          <p>The following steps are performed:</p>
+          <p>The abstract operation TimeZoneString takes argument _tv_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
@@ -29727,7 +29726,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-todatestring" aoid="ToDateString">
           <h1>Runtime Semantics: ToDateString ( _tv_ )</h1>
-          <p>The following steps are performed:</p>
+          <p>The abstract operation ToDateString takes argument _tv_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. If _tv_ is *NaN*, return *"Invalid Date"*.
@@ -29751,7 +29750,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toutcstring">
         <h1>Date.prototype.toUTCString ( )</h1>
-        <p>The `toUTCString` method returns a String value representing the instance in time corresponding to this time value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Date objects. It performs the following steps:</p>
+        <p>The `toUTCString` method returns a String value representing the instance in time corresponding to this time value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Date objects. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
@@ -29925,7 +29924,7 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
-      <p>The abstract operation <dfn id="sec-thisstringvalue" aoid="thisStringValue">thisStringValue</dfn>(_value_) performs the following steps:</p>
+      <p>The abstract operation <dfn id="sec-thisstringvalue" aoid="thisStringValue">thisStringValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is String, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[StringData]] internal slot, then
@@ -30167,10 +30166,9 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.matchall">
         <h1>String.prototype.matchAll ( _regexp_ )</h1>
-
         <p>Performs a regular expression match of the String representing the *this* value against _regexp_ and returns an iterator. Each iteration result's value is an Array object containing the results of the match, or *null* if the String did not match.</p>
-
         <p>When the `matchAll` method is called, the following steps are taken:</p>
+
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _regexp_ is neither *undefined* nor *null*, then
@@ -30226,7 +30224,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-stringpad" aoid="StringPad">
           <h1>Runtime Semantics: StringPad ( _O_, _maxLength_, _fillString_, _placement_ )</h1>
-          <p>When the abstract operation StringPad is called with arguments _O_, _maxLength_, _fillString_, and _placement_, the following steps are taken:</p>
+          <p>The abstract operation StringPad takes arguments _O_, _maxLength_, _fillString_, and _placement_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _placement_ is ~start~ or ~end~.
             1. Let _S_ be ? ToString(_O_).
@@ -30301,7 +30299,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-getsubstitution" aoid="GetSubstitution">
           <h1>Runtime Semantics: GetSubstitution ( _matched_, _str_, _position_, _captures_, _namedCaptures_, _replacement_ )</h1>
-          <p>The abstract operation GetSubstitution performs the following steps:</p>
+          <p>The abstract operation GetSubstitution takes arguments _matched_, _str_, _position_, _captures_, _namedCaptures_, and _replacement_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_matched_) is String.
             1. Let _matchLength_ be the number of code units in _matched_.
@@ -30539,7 +30537,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-splitmatch" aoid="SplitMatch">
           <h1>Runtime Semantics: SplitMatch ( _S_, _q_, _R_ )</h1>
-          <p>The abstract operation SplitMatch takes three parameters, a String _S_, an integer _q_, and a String _R_, and performs the following steps in order to return either *false* or the end index of a match:</p>
+          <p>The abstract operation SplitMatch takes arguments _S_ (a String), _q_ (an integer), and _R_ (a String). It returns either *false* or the end index of a match. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_R_) is String.
             1. Let _r_ be the number of code units in _R_.
@@ -30679,7 +30677,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-trimstring" aoid="TrimString">
           <h1>Runtime Semantics: TrimString ( _string_, _where_ )</h1>
-          <p>The abstract operation TrimString is called with arguments _string_ and _where_, and interprets the String value _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps:</p>
+          <p>The abstract operation TrimString takes arguments _string_ and _where_. It interprets _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _str_ be ? RequireObjectCoercible(_string_).
             1. Let _S_ be ? ToString(_str_).
@@ -30758,7 +30756,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-createstringiterator" aoid="CreateStringIterator">
         <h1>CreateStringIterator ( _string_ )</h1>
-        <p>Several methods of String objects return Iterator objects. The abstract operation CreateStringIterator with argument _string_ is used to create such iterator objects. It performs the following steps:</p>
+        <p>The abstract operation CreateStringIterator takes argument _string_. This operation is used to create iterator objects for String methods which return such iterators. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_string_) is String.
           1. Let _iterator_ be OrdinaryObjectCreate(%StringIteratorPrototype%, &laquo; [[IteratedString]], [[StringNextIndex]] &raquo;).
@@ -31586,7 +31584,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" aoid="RepeatMatcher">
           <h1>Runtime Semantics: RepeatMatcher ( _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_ )</h1>
-          <p>The abstract operation RepeatMatcher takes eight parameters, a Matcher _m_, an integer _min_, an integer (or &infin;) _max_, a Boolean _greedy_, a State _x_, a Continuation _c_, an integer _parenIndex_, and an integer _parenCount_, and performs the following steps:</p>
+          <p>The abstract operation RepeatMatcher takes arguments _m_ (a Matcher), _min_ (an integer), _max_ (an integer or &infin;), _greedy_ (a Boolean), _x_ (a State), _c_ (a Continuation), _parenIndex_ (an integer), and _parenCount_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
             1. If _max_ is zero, return _c_(_x_).
             1. Let _d_ be a new Continuation with parameters (_y_) that captures _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, and _parenCount_ and performs the following steps when called:
@@ -31763,7 +31761,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-runtime-semantics-wordcharacters-abstract-operation" aoid="WordCharacters">
           <h1>Runtime Semantics: WordCharacters ( )</h1>
-          <p>The abstract operation WordCharacters performs the following steps:</p>
+          <p>The abstract operation WordCharacters takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _A_ be a set of characters containing the sixty-three characters:
             <figure>
@@ -32006,7 +32004,7 @@ THH:mm:ss.sss
         </emu-clause>
         <emu-clause id="sec-runtime-semantics-iswordchar-abstract-operation" aoid="IsWordChar">
           <h1>Runtime Semantics: IsWordChar ( _e_ )</h1>
-          <p>The abstract operation IsWordChar takes an integer parameter _e_ and performs the following steps:</p>
+          <p>The abstract operation IsWordChar takes argument _e_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
             1. If _e_ is -1 or _e_ is _InputLength_, return *false*.
             1. Let _c_ be the character _Input_[_e_].
@@ -32114,7 +32112,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" aoid="CharacterSetMatcher">
           <h1>Runtime Semantics: CharacterSetMatcher ( _A_, _invert_, _direction_ )</h1>
-          <p>The abstract operation CharacterSetMatcher takes three arguments, a CharSet _A_, a Boolean flag _invert_, and an integer _direction_, and performs the following steps:</p>
+          <p>The abstract operation CharacterSetMatcher takes arguments _A_ (a CharSet), _invert_ (a Boolean), and _direction_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
             1. Return a new Matcher with parameters (_x_, _c_) that captures _A_, _invert_, and _direction_ and performs the following steps when called:
               1. Assert: _x_ is a State.
@@ -32138,7 +32136,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-runtime-semantics-canonicalize-ch" aoid="Canonicalize">
           <h1>Runtime Semantics: Canonicalize ( _ch_ )</h1>
-          <p>The abstract operation Canonicalize takes a character parameter _ch_ and performs the following steps:</p>
+          <p>The abstract operation Canonicalize takes argument _ch_ (a character). It performs the following steps when called:</p>
           <emu-alg>
             1. If _IgnoreCase_ is *false*, return _ch_.
             1. If _Unicode_ is *true*, then
@@ -32182,7 +32180,7 @@ THH:mm:ss.sss
         </emu-clause>
         <emu-clause id="sec-runtime-semantics-unicodematchproperty-p" aoid="UnicodeMatchProperty">
           <h1>Runtime Semantics: UnicodeMatchProperty ( _p_ )</h1>
-          <p>The abstract operation UnicodeMatchProperty takes a parameter _p_ that is a List of Unicode code points and performs the following steps:</p>
+          <p>The abstract operation UnicodeMatchProperty takes argument _p_ (a List of Unicode code points). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _p_ is a List of Unicode code points that is identical to a List of Unicode code points that is a Unicode <emu-not-ref>property name</emu-not-ref> or property alias listed in the &ldquo;<emu-not-ref>Property name</emu-not-ref> and aliases&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref> or <emu-xref href="#table-binary-unicode-properties"></emu-xref>.
             1. Let _c_ be the canonical <emu-not-ref>property name</emu-not-ref> of _p_ as given in the &ldquo;Canonical <emu-not-ref>property name</emu-not-ref>&rdquo; column of the corresponding row.
@@ -32200,7 +32198,7 @@ THH:mm:ss.sss
         </emu-clause>
         <emu-clause id="sec-runtime-semantics-unicodematchpropertyvalue-p-v" aoid="UnicodeMatchPropertyValue">
           <h1>Runtime Semantics: UnicodeMatchPropertyValue ( _p_, _v_ )</h1>
-          <p>The abstract operation UnicodeMatchPropertyValue takes two parameters _p_ and _v_, each of which is a List of Unicode code points, and performs the following steps:</p>
+          <p>The abstract operation UnicodeMatchPropertyValue takes arguments _p_ (a List of Unicode code points) and _v_ (a List of Unicode code points). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _p_ is a List of Unicode code points that is identical to a List of Unicode code points that is a canonical, unaliased Unicode property name listed in the &ldquo;Canonical property name&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
             1. Assert: _v_ is a List of Unicode code points that is identical to a List of Unicode code points that is a property value or property value alias for Unicode property _p_ listed in the &ldquo;Property value and aliases&rdquo; column of <emu-xref href="#table-unicode-general-category-values"></emu-xref> or <emu-xref href="#table-unicode-script-values"></emu-xref>.
@@ -32252,7 +32250,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-backreference-matcher" aoid="BackreferenceMatcher">
           <h1>Runtime Semantics: BackreferenceMatcher ( _n_, _direction_ )</h1>
-          <p>The abstract operation BackreferenceMatcher takes two arguments, an integer _n_ and an integer _direction_, and performs the following steps:</p>
+          <p>The abstract operation BackreferenceMatcher takes arguments _n_ (an integer) and _direction_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
             1. Return a new Matcher with parameters (_x_, _c_) that captures _n_ and _direction_ and performs the following steps when called:
               1. Assert: _x_ is a State.
@@ -32405,7 +32403,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-runtime-semantics-characterrange-abstract-operation" aoid="CharacterRange">
           <h1>Runtime Semantics: CharacterRange ( _A_, _B_ )</h1>
-          <p>The abstract operation CharacterRange takes two CharSet parameters _A_ and _B_ and performs the following steps:</p>
+          <p>The abstract operation CharacterRange takes arguments _A_ (a CharSet) and _B_ (a CharSet). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _A_ and _B_ each contain exactly one character.
             1. Let _a_ be the one character in CharSet _A_.
@@ -32546,7 +32544,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-regexpalloc" aoid="RegExpAlloc">
           <h1>Runtime Semantics: RegExpAlloc ( _newTarget_ )</h1>
-          <p>When the abstract operation RegExpAlloc with argument _newTarget_ is called, the following steps are taken:</p>
+          <p>The abstract operation RegExpAlloc takes argument _newTarget_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%RegExp.prototype%"*, &laquo; [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] &raquo;).
             1. Perform ! DefinePropertyOrThrow(_obj_, *"lastIndex"*, PropertyDescriptor { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
@@ -32556,7 +32554,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-regexpinitialize" aoid="RegExpInitialize">
           <h1>Runtime Semantics: RegExpInitialize ( _obj_, _pattern_, _flags_ )</h1>
-          <p>When the abstract operation RegExpInitialize with arguments _obj_, _pattern_, and _flags_ is called, the following steps are taken:</p>
+          <p>The abstract operation RegExpInitialize takes arguments _obj_, _pattern_, and _flags_. It performs the following steps when called:</p>
           <emu-alg>
             1. If _pattern_ is *undefined*, let _P_ be the empty String.
             1. Else, let _P_ be ? ToString(_pattern_).
@@ -32582,7 +32580,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-regexpcreate" aoid="RegExpCreate">
           <h1>Runtime Semantics: RegExpCreate ( _P_, _F_ )</h1>
-          <p>When the abstract operation RegExpCreate with arguments _P_ and _F_ is called, the following steps are taken:</p>
+          <p>The abstract operation RegExpCreate takes arguments _P_ and _F_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? RegExpAlloc(%RegExp%).
             1. Return ? RegExpInitialize(_obj_, _P_, _F_).
@@ -32591,7 +32589,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-escaperegexppattern" aoid="EscapeRegExpPattern">
           <h1>Runtime Semantics: EscapeRegExpPattern ( _P_, _F_ )</h1>
-          <p>When the abstract operation EscapeRegExpPattern with arguments _P_ and _F_ is called, the following occurs:</p>
+          <p>The abstract operation EscapeRegExpPattern takes arguments _P_ and _F_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _S_ be a String in the form of a |Pattern[~U]| (|Pattern[+U]| if _F_ contains *"u"*) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the abstract closure that would result from evaluating _S_ as a |Pattern[~U]| (|Pattern[+U]| if _F_ contains *"u"*) must behave identically to the abstract closure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
             1. The code points `/` or any |LineTerminator| occurring in the pattern shall be escaped in _S_ as necessary to ensure that the string-concatenation of *"/"*, _S_, *"/"*, and _F_ can be parsed (in an appropriate lexical context) as a |RegularExpressionLiteral| that behaves identically to the constructed regular expression. For example, if _P_ is *"/"*, then _S_ could be *"\\/"* or *"\\u002F"*, among other possibilities, but not *"/"*, because `///` followed by _F_ would be parsed as a |SingleLineComment| rather than a |RegularExpressionLiteral|. If _P_ is the empty String, this specification can be met by letting _S_ be *"(?:)"*.
@@ -32659,7 +32657,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-regexpexec" aoid="RegExpExec">
           <h1>Runtime Semantics: RegExpExec ( _R_, _S_ )</h1>
-          <p>The abstract operation RegExpExec with arguments _R_ and _S_ performs the following steps:</p>
+          <p>The abstract operation RegExpExec takes arguments _R_ and _S_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_R_) is Object.
             1. Assert: Type(_S_) is String.
@@ -32678,7 +32676,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-regexpbuiltinexec" aoid="RegExpBuiltinExec">
           <h1>Runtime Semantics: RegExpBuiltinExec ( _R_, _S_ )</h1>
-          <p>The abstract operation RegExpBuiltinExec with arguments _R_ and _S_ performs the following steps:</p>
+          <p>The abstract operation RegExpBuiltinExec takes arguments _R_ and _S_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _R_ is an initialized RegExp instance.
             1. Assert: Type(_S_) is String.
@@ -32744,7 +32742,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-advancestringindex" aoid="AdvanceStringIndex">
           <h1>AdvanceStringIndex ( _S_, _index_, _unicode_ )</h1>
-          <p>The abstract operation AdvanceStringIndex with arguments _S_, _index_, and _unicode_ performs the following steps:</p>
+          <p>The abstract operation AdvanceStringIndex takes arguments _S_, _index_, and _unicode_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_S_) is String.
             1. Assert: 0 &le; _index_ &le; 2<sup>53</sup> - 1 and ! IsInteger(_index_) is *true*.
@@ -32864,8 +32862,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp-prototype-matchall">
         <h1>RegExp.prototype [ @@matchAll ] ( _string_ )</h1>
-
         <p>When the `@@matchAll` method is called with argument _string_, the following steps are taken:</p>
+
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
@@ -32885,8 +32883,6 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-createregexpstringiterator" aoid="CreateRegExpStringIterator">
           <h1>CreateRegExpStringIterator ( _R_, _S_, _global_, _fullUnicode_ )</h1>
-
-          <p>The abstract operation CreateRegExpStringIterator is used to create such iterator objects. It performs the following steps:</p>
           <emu-alg>
             1. Assert: Type(_S_) is String.
             1. Assert: Type(_global_) is Boolean.
@@ -33508,7 +33504,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-isconcatspreadable" aoid="IsConcatSpreadable">
           <h1>Runtime Semantics: IsConcatSpreadable ( _O_ )</h1>
-          <p>The abstract operation IsConcatSpreadable with argument _O_ performs the following steps:</p>
+          <p>The abstract operation IsConcatSpreadable takes argument _O_. It performs the following steps when called:</p>
           <emu-alg>
             1. If Type(_O_) is not Object, return *false*.
             1. Let _spreadable_ be ? Get(_O_, @@isConcatSpreadable).
@@ -33738,6 +33734,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-flattenintoarray" aoid="FlattenIntoArray">
           <h1>FlattenIntoArray ( _target_, _source_, _sourceLen_, _start_, _depth_ [ , _mapperFunction_, _thisArg_ ] )</h1>
+          <p>The abstract operation FlattenIntoArray takes arguments _target_, _source_, _sourceLen_, _start_, and _depth_ and optional arguments _mapperFunction_ and _thisArg_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_target_) is Object.
             1. Assert: Type(_source_) is Object.
@@ -33820,8 +33817,8 @@ THH:mm:ss.sss
 
           <p>The optional second argument _fromIndex_ defaults to 0 (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *false* is returned, i.e. the array will not be searched. If it is negative, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than 0, the whole array will be searched.</p>
         </emu-note>
-
         <p>When the `includes` method is called, the following steps are taken:</p>
+
 
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
@@ -34611,7 +34608,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-createarrayiterator" aoid="CreateArrayIterator">
         <h1>CreateArrayIterator ( _array_, _kind_ )</h1>
-        <p>Several methods of Array objects return Iterator objects. The abstract operation CreateArrayIterator with arguments _array_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
+        <p>The abstract operation CreateArrayIterator takes arguments _array_ and _kind_. This operation is used to create iterator objects for Array methods which return such iterators. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_array_) is Object.
           1. Assert: _kind_ is ~key+value~, ~key~, or ~value~.
@@ -35025,7 +35022,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-iterabletolist" aoid="IterableToList">
           <h1>Runtime Semantics: IterableToList ( _items_, _method_ )</h1>
-          <p>The abstract operation IterableToList performs the following steps:</p>
+          <p>The abstract operation IterableToList takes arguments _items_ and _method_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~, _method_).
             1. Let _values_ be a new empty List.
@@ -35177,7 +35174,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-validatetypedarray" aoid="ValidateTypedArray">
           <h1>Runtime Semantics: ValidateTypedArray ( _O_ )</h1>
-          <p>When called with argument _O_, the following steps are taken:</p>
+          <p>The abstract operation ValidateTypedArray takes argument _O_. It performs the following steps when called:</p>
           <emu-alg>
             1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
             1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
@@ -35650,7 +35647,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
           <h1>Runtime Semantics: AllocateTypedArray ( _constructorName_, _newTarget_, _defaultProto_ [ , _length_ ] )</h1>
-          <p>The abstract operation AllocateTypedArray with arguments _constructorName_, _newTarget_, _defaultProto_ and optional argument _length_ is used to validate and create an instance of a TypedArray constructor. _constructorName_ is required to be the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypedArray_ overloads. AllocateTypedArray performs the following steps:</p>
+          <p>The abstract operation AllocateTypedArray takes arguments _constructorName_ (a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>), _newTarget_, and _defaultProto_ and optional argument _length_. It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypedArray_ overloads. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
             1. Let _obj_ be ! IntegerIndexedObjectCreate(_proto_).
@@ -35670,7 +35667,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-allocatetypedarraybuffer" aoid="AllocateTypedArrayBuffer">
           <h1>Runtime Semantics: AllocateTypedArrayBuffer ( _O_, _length_ )</h1>
-          <p>The abstract operation AllocateTypedArrayBuffer with arguments _O_ and _length_ allocates and associates an ArrayBuffer with the TypedArray instance _O_. It performs the following steps:</p>
+          <p>The abstract operation AllocateTypedArrayBuffer takes arguments _O_ (a TypedArray object) and _length_. It allocates and associates an ArrayBuffer with _O_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
             1. Assert: _O_.[[ViewedArrayBuffer]] is *undefined*.
@@ -35804,7 +35801,7 @@ THH:mm:ss.sss
 
       <emu-clause id="typedarray-create" aoid="TypedArrayCreate">
         <h1>TypedArrayCreate ( _constructor_, _argumentList_ )</h1>
-        <p>The abstract operation TypedArrayCreate with arguments _constructor_ and _argumentList_ is used to specify the creation of a new TypedArray object using a constructor function. It performs the following steps:</p>
+        <p>The abstract operation TypedArrayCreate takes arguments _constructor_ and _argumentList_. It is used to specify the creation of a new TypedArray object using a constructor function. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
           1. Perform ? ValidateTypedArray(_newTypedArray_).
@@ -35816,7 +35813,7 @@ THH:mm:ss.sss
 
       <emu-clause id="typedarray-species-create" aoid="TypedArraySpeciesCreate">
         <h1>TypedArraySpeciesCreate ( _exemplar_, _argumentList_ )</h1>
-        <p>The abstract operation TypedArraySpeciesCreate with arguments _exemplar_ and _argumentList_ is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps:</p>
+        <p>The abstract operation TypedArraySpeciesCreate takes arguments _exemplar_ and _argumentList_. It is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _exemplar_ is an Object that has [[TypedArrayName]] and [[ContentType]] internal slots.
           1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _exemplar_.[[TypedArrayName]].
@@ -35916,7 +35913,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-add-entries-from-iterable" aoid="AddEntriesFromIterable">
         <h1>AddEntriesFromIterable ( _target_, _iterable_, _adder_ )</h1>
-        <p>The abstract operation AddEntriesFromIterable accepts a _target_ object, an _iterable_ of entries, and an _adder_ function to be invoked, with _target_ as the receiver.</p>
+        <p>The abstract operation AddEntriesFromIterable takes arguments _target_, _iterable_, and _adder_ (a function object). _adder_ will be invoked, with _target_ as the receiver. It performs the following steps when called:</p>
         <emu-alg>
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Assert: _iterable_ is present, and is neither *undefined* nor *null*.
@@ -36148,7 +36145,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-createmapiterator" aoid="CreateMapIterator">
         <h1>CreateMapIterator ( _map_, _kind_ )</h1>
-        <p>Several methods of Map objects return Iterator objects. The abstract operation CreateMapIterator with arguments _map_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
+        <p>The abstract operation CreateMapIterator takes arguments _map_ and _kind_. This operation is used to create iterator objects for Map methods which return such iterators. It performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
           1. Let _iterator_ be OrdinaryObjectCreate(%MapIteratorPrototype%, &laquo; [[IteratedMap]], [[MapNextIndex]], [[MapIterationKind]] &raquo;).
@@ -36482,7 +36479,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-createsetiterator" aoid="CreateSetIterator">
         <h1>CreateSetIterator ( _set_, _kind_ )</h1>
-        <p>Several methods of Set objects return Iterator objects. The abstract operation CreateSetIterator with arguments _set_ and _kind_ is used to create such iterator objects. It performs the following steps:</p>
+        <p>The abstract operation CreateSetIterator takes arguments _set_ and _kind_. This operation is used to create iterator objects for Set methods which return such iterators. It performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_set_, [[SetData]]).
           1. Let _iterator_ be OrdinaryObjectCreate(%SetIteratorPrototype%, &laquo; [[IteratedSet]], [[SetNextIndex]], [[SetIterationKind]] &raquo;).
@@ -36876,7 +36873,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-allocatearraybuffer" aoid="AllocateArrayBuffer">
         <h1>AllocateArrayBuffer ( _constructor_, _byteLength_ )</h1>
-        <p>The abstract operation AllocateArrayBuffer with arguments _constructor_ and _byteLength_ is used to create an ArrayBuffer object. It performs the following steps:</p>
+        <p>The abstract operation AllocateArrayBuffer takes arguments _constructor_ and _byteLength_. It is used to create an ArrayBuffer object. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%ArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] &raquo;).
           1. Assert: ! IsNonNegativeInteger(_byteLength_) is *true*.
@@ -36889,7 +36886,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-isdetachedbuffer" aoid="IsDetachedBuffer">
         <h1>IsDetachedBuffer ( _arrayBuffer_ )</h1>
-        <p>The abstract operation IsDetachedBuffer with argument _arrayBuffer_ performs the following steps:</p>
+        <p>The abstract operation IsDetachedBuffer takes argument _arrayBuffer_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_arrayBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
           1. If _arrayBuffer_.[[ArrayBufferData]] is *null*, return *true*.
@@ -36899,7 +36896,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-detacharraybuffer" aoid="DetachArrayBuffer">
         <h1>DetachArrayBuffer ( _arrayBuffer_ [ , _key_ ] )</h1>
-        <p>The abstract operation DetachArrayBuffer with argument _arrayBuffer_ and optional argument _key_ performs the following steps:</p>
+        <p>The abstract operation DetachArrayBuffer takes argument _arrayBuffer_ and optional argument _key_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_arrayBuffer_) is Object and it has [[ArrayBufferData]], [[ArrayBufferByteLength]], and [[ArrayBufferDetachKey]] internal slots.
           1. Assert: IsSharedArrayBuffer(_arrayBuffer_) is *false*.
@@ -36916,7 +36913,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-clonearraybuffer" aoid="CloneArrayBuffer">
         <h1>CloneArrayBuffer ( _srcBuffer_, _srcByteOffset_, _srcLength_, _cloneConstructor_ )</h1>
-        <p>The abstract operation CloneArrayBuffer takes four parameters, an ArrayBuffer _srcBuffer_, an integer offset _srcByteOffset_, an integer length _srcLength_, and a constructor function _cloneConstructor_. It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. This operation performs the following steps:</p>
+        <p>The abstract operation CloneArrayBuffer takes arguments _srcBuffer_ (an ArrayBuffer object), _srcByteOffset_ (an integer), _srcLength_ (an integer), and _cloneConstructor_ (a constructor). It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_srcBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
           1. Assert: IsConstructor(_cloneConstructor_) is *true*.
@@ -36931,7 +36928,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-isunsignedelementtype" aoid="IsUnsignedElementType">
         <h1>IsUnsignedElementType ( _type_ )</h1>
-        <p>The abstract operation IsUnsignedElementType verifies if the argument _type_ is an unsigned TypedArray element type. This operation performs the following steps:</p>
+        <p>The abstract operation IsUnsignedElementType takes argument _type_. It verifies if the argument _type_ is an unsigned TypedArray element type. It performs the following steps when called:</p>
         <emu-alg>
           1. If _type_ is ~Uint8~, ~Uint8C~, ~Uint16~, ~Uint32~, or ~BigUint64~, return *true*.
           1. Return *false*.
@@ -36940,7 +36937,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-isunclampedintegerelementtype" aoid="IsUnclampedIntegerElementType">
         <h1>IsUnclampedIntegerElementType ( _type_ )</h1>
-        <p>The abstract operation IsUnclampedIntegerElementType verifies if the argument _type_ is an Integer TypedArray element type not including ~Uint8C~. This operation performs the following steps:</p>
+        <p>The abstract operation IsUnclampedIntegerElementType takes argument _type_. It verifies if the argument _type_ is an Integer TypedArray element type not including ~Uint8C~. It performs the following steps when called:</p>
         <emu-alg>
           1. If _type_ is ~Int8~, ~Uint8~, ~Int16~, ~Uint16~, ~Int32~, or ~Uint32~, return *true*.
           1. Return *false*.
@@ -36949,7 +36946,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-isbigintelementtype" aoid="IsBigIntElementType">
         <h1>IsBigIntElementType ( _type_ )</h1>
-        <p>The abstract operation IsBigIntElementType verifies if the argument _type_ is a BigInt TypedArray element type. This operation performs the following steps:</p>
+        <p>The abstract operation IsBigIntElementType takes argument _type_. It verifies if the argument _type_ is a BigInt TypedArray element type. It performs the following steps when called:</p>
         <emu-alg>
           1. If _type_ is ~BigUint64~ or ~BigInt64~, return *true*.
           1. Return *false*.
@@ -36958,7 +36955,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-isnotearconfiguration" aoid="IsNoTearConfiguration">
         <h1>IsNoTearConfiguration ( _type_, _order_ )</h1>
-        <p>The abstract operation IsNoTearConfiguration with arguments _type_ and _order_ performs the following steps:</p>
+        <p>The abstract operation IsNoTearConfiguration takes arguments _type_ and _order_. It performs the following steps when called:</p>
         <emu-alg>
           1. If ! IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
           1. If ! IsBigIntElementType(_type_) is *true* and _order_ is not ~Init~ or ~Unordered~, return *true*.
@@ -36968,7 +36965,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-rawbytestonumeric" aoid="RawBytesToNumeric" oldids="sec-rawbytestonumber">
         <h1>RawBytesToNumeric ( _type_, _rawBytes_, _isLittleEndian_ )</h1>
-        <p>The abstract operation RawBytesToNumeric takes three parameters, a TypedArray element type _type_, a List _rawBytes_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation RawBytesToNumeric takes arguments _type_ (a TypedArray element type), _rawBytes_ (a List), and _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is *false*, reverse the order of the elements of _rawBytes_.
@@ -36991,7 +36988,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-getvaluefrombuffer" aoid="GetValueFromBuffer">
         <h1>GetValueFromBuffer ( _arrayBuffer_, _byteIndex_, _type_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation GetValueFromBuffer takes six parameters, an ArrayBuffer or SharedArrayBuffer _arrayBuffer_, an integer _byteIndex_, a TypedArray element type _type_, a Boolean _isTypedArray_, _order_ which is one of (~SeqCst~, ~Unordered~), and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation GetValueFromBuffer takes arguments _arrayBuffer_ (an ArrayBuffer or SharedArrayBuffer), _byteIndex_ (an integer), _type_ (a TypedArray element type), _isTypedArray_ (a Boolean), and _order_ (either ~SeqCst~ or ~Unordered~) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -37015,7 +37012,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-numerictorawbytes" aoid="NumericToRawBytes" oldids="sec-numbertorawbytes">
         <h1>NumericToRawBytes ( _type_, _value_, _isLittleEndian_ )</h1>
-        <p>The abstract operation NumericToRawBytes takes three parameters, a TypedArray element type _type_, a BigInt or a Number _value_, and a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation NumericToRawBytes takes arguments _type_ (a TypedArray element type), _value_ (a BigInt or a Number), and _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. If _type_ is ~Float32~, then
             1. Let _rawBytes_ be a List containing the 4 bytes that are the result of converting _value_ to IEEE 754-2019 binary32 format using roundTiesToEven mode. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary32 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
@@ -37035,7 +37032,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-setvalueinbuffer" aoid="SetValueInBuffer">
         <h1>SetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation SetValueInBuffer takes seven parameters, an ArrayBuffer or SharedArrayBuffer _arrayBuffer_, an integer _byteIndex_, a TypedArray element type _type_, a Number or BigInt _value_, a Boolean _isTypedArray_, _order_ which is one of (~SeqCst~, ~Unordered~, ~Init~), and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation SetValueInBuffer takes arguments _arrayBuffer_ (an ArrayBuffer or SharedArrayBuffer), _byteIndex_ (an integer), _type_ (a TypedArray element type), _value_ (a Number or a BigInt), _isTypedArray_ (a Boolean), and _order_ (one of ~SeqCst~, ~Unordered~, or ~Init~) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -37057,7 +37054,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-getmodifysetvalueinbuffer" aoid="GetModifySetValueInBuffer">
         <h1>GetModifySetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_, _op_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation GetModifySetValueInBuffer takes six parameters, a SharedArrayBuffer _arrayBuffer_, a nonnegative integer _byteIndex_, a TypedArray element type _type_, a Number or BigInt _value_, a semantic function _op_, and optionally a Boolean _isLittleEndian_. This operation performs the following steps:</p>
+        <p>The abstract operation GetModifySetValueInBuffer takes arguments _arrayBuffer_ (a SharedArrayBuffer object), _byteIndex_ (a non-negative integer), _type_ (a TypedArray element type), _value_ (a Number or a BigInt), and _op_ (a semantic function) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsSharedArrayBuffer(_arrayBuffer_) is *true*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
@@ -37219,7 +37216,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-allocatesharedarraybuffer" aoid="AllocateSharedArrayBuffer">
         <h1>AllocateSharedArrayBuffer ( _constructor_, _byteLength_ )</h1>
-        <p>The abstract operation AllocateSharedArrayBuffer with arguments _constructor_ and _byteLength_ is used to create a SharedArrayBuffer object. It performs the following steps:</p>
+        <p>The abstract operation AllocateSharedArrayBuffer takes arguments _constructor_ and _byteLength_. It is used to create a SharedArrayBuffer object. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%SharedArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
           1. Assert: ! IsNonNegativeInteger(_byteLength_) is *true*.
@@ -37232,7 +37229,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-issharedarraybuffer" aoid="IsSharedArrayBuffer">
         <h1>IsSharedArrayBuffer ( _obj_ )</h1>
-        <p>IsSharedArrayBuffer tests whether an object is an ArrayBuffer, a SharedArrayBuffer, or a subtype of either. It performs the following steps:</p>
+        <p>The abstract operation IsSharedArrayBuffer takes argument _obj_. It tests whether an object is an ArrayBuffer, a SharedArrayBuffer, or a subtype of either. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_obj_) is Object and it has an [[ArrayBufferData]] internal slot.
           1. Let _bufferData_ be _obj_.[[ArrayBufferData]].
@@ -37372,7 +37369,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-getviewvalue" aoid="GetViewValue">
         <h1>GetViewValue ( _view_, _requestIndex_, _isLittleEndian_, _type_ )</h1>
-        <p>The abstract operation GetViewValue with arguments _view_, _requestIndex_, _isLittleEndian_, and _type_ is used by functions on DataView instances to retrieve values from the view's buffer. It performs the following steps:</p>
+        <p>The abstract operation GetViewValue takes arguments _view_, _requestIndex_, _isLittleEndian_, and _type_. It is used by functions on DataView instances to retrieve values from the view's buffer. It performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
@@ -37391,7 +37388,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-setviewvalue" aoid="SetViewValue">
         <h1>SetViewValue ( _view_, _requestIndex_, _isLittleEndian_, _type_, _value_ )</h1>
-        <p>The abstract operation SetViewValue with arguments _view_, _requestIndex_, _isLittleEndian_, _type_, and _value_ is used by functions on DataView instances to store values into the view's buffer. It performs the following steps:</p>
+        <p>The abstract operation SetViewValue takes arguments _view_, _requestIndex_, _isLittleEndian_, _type_, and _value_. It is used by functions on DataView instances to store values into the view's buffer. It performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
@@ -37750,7 +37747,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-validatesharedintegertypedarray" aoid="ValidateSharedIntegerTypedArray">
         <h1>ValidateSharedIntegerTypedArray ( _typedArray_ [ , _waitable_ ] )</h1>
-        <p>The abstract operation ValidateSharedIntegerTypedArray takes one argument _typedArray_ and an optional Boolean _waitable_. It performs the following steps:</p>
+        <p>The abstract operation ValidateSharedIntegerTypedArray takes argument _typedArray_ and optional argument _waitable_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. If _waitable_ is not present, set _waitable_ to *false*.
           1. Perform ? RequireInternalSlot(_typedArray_, [[TypedArrayName]]).
@@ -37769,7 +37766,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-validateatomicaccess" aoid="ValidateAtomicAccess">
         <h1>ValidateAtomicAccess ( _typedArray_, _requestIndex_ )</h1>
-        <p>The abstract operation ValidateAtomicAccess takes two arguments, _typedArray_ and _requestIndex_. It performs the following steps:</p>
+        <p>The abstract operation ValidateAtomicAccess takes arguments _typedArray_ and _requestIndex_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _typedArray_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
           1. Let _accessIndex_ be ? ToIndex(_requestIndex_).
@@ -37786,7 +37783,7 @@ THH:mm:ss.sss
         <p>Initially a WaiterList object has an empty list and no Synchronize event.</p>
         <p>The agent cluster has a store of WaiterList objects; the store is indexed by (_block_, _i_). WaiterLists are agent-independent: a lookup in the store of WaiterLists by (_block_, _i_) will result in the same WaiterList object in any agent in the agent cluster.</p>
         <p>Each WaiterList has a <dfn>critical section</dfn> that controls exclusive access to that WaiterList during evaluation. Only a single agent may enter a WaiterList's critical section at one time. Entering and leaving a WaiterList's critical section is controlled by the abstract operations EnterCriticalSection and LeaveCriticalSection. Operations on a WaiterList&mdash;adding and removing waiting agents, traversing the list of agents, suspending and notifying agents on the list, setting and retrieving the Synchronize event&mdash;may only be performed by agents that have entered the WaiterList's critical section.</p>
-        <p>The abstract operation GetWaiterList takes two arguments, a Shared Data Block _block_ and a nonnegative integer _i_. It performs the following steps:</p>
+        <p>The abstract operation GetWaiterList takes arguments _block_ (a Shared Data Block) and _i_ (a non-negative integer). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _block_ is a Shared Data Block.
           1. Assert: _i_ and _i_ + 3 are valid byte offsets within the memory of _block_.
@@ -37797,7 +37794,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-entercriticalsection" aoid="EnterCriticalSection">
         <h1>EnterCriticalSection ( _WL_ )</h1>
-        <p>The abstract operation EnterCriticalSection takes one argument, a WaiterList _WL_. It performs the following steps:</p>
+        <p>The abstract operation EnterCriticalSection takes argument _WL_ (a WaiterList). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is not in the critical section for any WaiterList.
           1. Wait until no agent is in the critical section for _WL_, then enter the critical section for _WL_ (without allowing any other agent to enter).
@@ -37816,7 +37813,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-leavecriticalsection" aoid="LeaveCriticalSection">
         <h1>LeaveCriticalSection ( _WL_ )</h1>
-        <p>The abstract operation LeaveCriticalSection takes one argument, a WaiterList _WL_. It performs the following steps:</p>
+        <p>The abstract operation LeaveCriticalSection takes argument _WL_ (a WaiterList). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Let _execution_ be the [[CandidateExecution]] field of the calling surrounding's Agent Record.
@@ -37831,7 +37828,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-addwaiter" aoid="AddWaiter">
         <h1>AddWaiter ( _WL_, _W_ )</h1>
-        <p>The abstract operation AddWaiter takes two arguments, a WaiterList _WL_ and an agent signifier _W_. It performs the following steps:</p>
+        <p>The abstract operation AddWaiter takes arguments _WL_ (a WaiterList) and _W_ (an agent signifier). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is not on the list of waiters in any WaiterList.
@@ -37841,7 +37838,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-removewaiter" aoid="RemoveWaiter">
         <h1>RemoveWaiter ( _WL_, _W_ )</h1>
-        <p>The abstract operation RemoveWaiter takes two arguments, a WaiterList _WL_ and an agent signifier _W_. It performs the following steps:</p>
+        <p>The abstract operation RemoveWaiter takes arguments _WL_ (a WaiterList) and _W_ (an agent signifier). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is on the list of waiters in _WL_.
@@ -37851,7 +37848,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-removewaiters" aoid="RemoveWaiters">
         <h1>RemoveWaiters ( _WL_, _c_ )</h1>
-        <p>The abstract operation RemoveWaiters takes two arguments, a WaiterList _WL_ and nonnegative integer _c_. It performs the following steps:</p>
+        <p>The abstract operation RemoveWaiters takes arguments _WL_ (a WaiterList) and _c_ (a non-negative integer). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Let _L_ be a new empty List.
@@ -37867,7 +37864,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-suspend" aoid="Suspend">
         <h1>Suspend ( _WL_, _W_, _timeout_ )</h1>
-        <p>The abstract operation Suspend takes three arguments, a WaiterList _WL_, an agent signifier _W_, and a nonnegative, non-*NaN* Number _timeout_. It performs the following steps:</p>
+        <p>The abstract operation Suspend takes arguments _WL_ (a WaiterList), _W_ (an agent signifier), and _timeout_ (a Number). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is equal to AgentSignifier().
@@ -37882,7 +37879,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-notifywaiter" aoid="NotifyWaiter">
         <h1>NotifyWaiter ( _WL_, _W_ )</h1>
-        <p>The abstract operation NotifyWaiter takes two arguments, a WaiterList _WL_ and an agent signifier _W_. It performs the following steps:</p>
+        <p>The abstract operation NotifyWaiter takes arguments _WL_ (a WaiterList) and _W_ (an agent signifier). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Notify the agent _W_.
@@ -37894,7 +37891,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-atomicreadmodifywrite" aoid="AtomicReadModifyWrite">
         <h1>AtomicReadModifyWrite ( _typedArray_, _index_, _value_, _op_ )</h1>
-        <p>The abstract operation AtomicReadModifyWrite takes four arguments, _typedArray_, _index_, _value_, and a pure combining operation _op_. The pure combining operation _op_ takes two List of byte values arguments and returns a List of byte values. The operation atomically loads a value, combines it with another value, and stores the result of the combination. It returns the loaded value. It performs the following steps:</p>
+        <p>The abstract operation AtomicReadModifyWrite takes arguments _typedArray_, _index_, _value_, and _op_ (a pure combining operation). _op_ takes two List of byte values arguments and returns a List of byte values. This operation atomically loads a value, combines it with another value, and stores the result of the combination. It returns the loaded value. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
           1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
@@ -37911,7 +37908,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-atomicload" aoid="AtomicLoad">
         <h1>AtomicLoad ( _typedArray_, _index_ )</h1>
-        <p>The abstract operation AtomicLoad takes two arguments, _typedArray_, _index_. The operation atomically loads a value and returns the loaded value. It performs the following steps:</p>
+        <p>The abstract operation AtomicLoad takes arguments _typedArray_ and _index_. It atomically loads a value and returns the loaded value. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _buffer_ be ? ValidateSharedIntegerTypedArray(_typedArray_).
           1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
@@ -38160,7 +38157,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">
         <h1>Runtime Semantics: InternalizeJSONProperty ( _holder_, _name_, _reviver_ )</h1>
-        <p>The abstract operation InternalizeJSONProperty is a recursive abstract operation that takes three parameters: a _holder_ object, the String _name_ of a property in that object, and a _reviver_ function.</p>
+        <p>The abstract operation InternalizeJSONProperty takes arguments _holder_ (an Object), _name_ (a String), and _reviver_ (a function object). It performs the following steps when called:</p>
         <emu-note>
           <p>This algorithm intentionally does not throw an exception if either [[Delete]] or CreateDataProperty return *false*.</p>
         </emu-note>
@@ -38281,7 +38278,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-serializejsonproperty" aoid="SerializeJSONProperty">
         <h1>Runtime Semantics: SerializeJSONProperty ( _state_, _key_, _holder_ )</h1>
-        <p>The abstract operation SerializeJSONProperty with arguments _state_, _key_, and _holder_ performs the following steps:</p>
+        <p>The abstract operation SerializeJSONProperty takes arguments _state_, _key_, and _holder_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _value_ be ? Get(_holder_, _key_).
           1. If Type(_value_) is Object or BigInt, then
@@ -38317,8 +38314,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-quotejsonstring" aoid="QuoteJSONString">
         <h1>Runtime Semantics: QuoteJSONString ( _value_ )</h1>
-        <p>The abstract operation QuoteJSONString with argument _value_ wraps a String value in QUOTATION MARK code units and escapes certain other code units within it.</p>
-        <p>This operation interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>The abstract operation QuoteJSONString takes argument _value_. It wraps _value_ in 0x0022 (QUOTATION MARK) code units and escapes certain other code units within it. This operation interprets _value_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
           1. For each code point _C_ in ! UTF16DecodeString(_value_), do
@@ -38430,7 +38426,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-unicodeescape" aoid="UnicodeEscape">
         <h1>Runtime Semantics: UnicodeEscape ( _C_ )</h1>
-        <p>The abstract operation UnicodeEscape takes a code unit argument _C_ and represents it as a Unicode escape sequence.</p>
+        <p>The abstract operation UnicodeEscape takes argument _C_ (a code unit). It represents _C_ as a Unicode escape sequence. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be the numeric value of _C_.
           1. Assert: _n_ &le; 0xFFFF.
@@ -38443,7 +38439,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-serializejsonobject" aoid="SerializeJSONObject">
         <h1>Runtime Semantics: SerializeJSONObject ( _state_, _value_ )</h1>
-        <p>The abstract operation SerializeJSONObject with arguments _state_ and _value_ serializes an object. It performs the following steps:</p>
+        <p>The abstract operation SerializeJSONObject takes arguments _state_ and _value_. It serializes an object. It performs the following steps when called:</p>
         <emu-alg>
           1. If _state_.[[Stack]] contains _value_, throw a *TypeError* exception because the structure is cyclical.
           1. Append _value_ to _state_.[[Stack]].
@@ -38481,7 +38477,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-serializejsonarray" aoid="SerializeJSONArray">
         <h1>Runtime Semantics: SerializeJSONArray ( _state_, _value_ )</h1>
-        <p>The abstract operation SerializeJSONArray with arguments _state_ and _value_ serializes an array. It performs the following steps:</p>
+        <p>The abstract operation SerializeJSONArray takes arguments _state_ and _value_. It serializes an array. It performs the following steps when called:</p>
         <emu-alg>
           1. If _state_.[[Stack]] contains _value_, throw a *TypeError* exception because the structure is cyclical.
           1. Append _value_ to _state_.[[Stack]].
@@ -38822,7 +38818,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-createasyncfromsynciterator" aoid="CreateAsyncFromSyncIterator">
         <h1>CreateAsyncFromSyncIterator ( _syncIteratorRecord_ )</h1>
-        <p>The abstract operation CreateAsyncFromSyncIterator is used to create an async iterator Record from a synchronous iterator Record. It performs the following steps:</p>
+        <p>The abstract operation CreateAsyncFromSyncIterator takes argument _syncIteratorRecord_. It is used to create an async iterator Record from a synchronous iterator Record. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _asyncIterator_ be ! OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
           1. Set _asyncIterator_.[[SyncIteratorRecord]] to _syncIteratorRecord_.
@@ -38902,10 +38898,9 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-async-from-sync-iterator-value-unwrap-functions">
           <h1>Async-from-Sync Iterator Value Unwrap Functions</h1>
-
           <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by AsyncFromSyncIteratorContinuation when processing the *"value"* property of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async-from-sync iterator value unwrap function has a [[Done]] internal slot.</p>
-
           <p>When an async-from-sync iterator value unwrap function is called with argument _value_, the following steps are taken:</p>
+
 
           <emu-alg>
             1. Let _F_ be the active function object.
@@ -38945,6 +38940,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncfromsynciteratorcontinuation" aoid="AsyncFromSyncIteratorContinuation">
         <h1>AsyncFromSyncIteratorContinuation ( _result_, _promiseCapability_ )</h1>
+        <p>The abstract operation AsyncFromSyncIteratorContinuation takes arguments _result_ and _promiseCapability_. It performs the following steps when called:</p>
 
         <emu-alg>
           1. Let _done_ be IteratorComplete(_result_).
@@ -39278,7 +39274,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorstart" aoid="GeneratorStart">
         <h1>GeneratorStart ( _generator_, _generatorBody_ )</h1>
-        <p>The abstract operation GeneratorStart with arguments _generator_ and _generatorBody_ performs the following steps:</p>
+        <p>The abstract operation GeneratorStart takes arguments _generator_ and _generatorBody_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
           1. Let _genContext_ be the running execution context.
@@ -39303,7 +39299,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorvalidate" aoid="GeneratorValidate">
         <h1>GeneratorValidate ( _generator_ )</h1>
-        <p>The abstract operation GeneratorValidate with argument _generator_ performs the following steps:</p>
+        <p>The abstract operation GeneratorValidate takes argument _generator_. It performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_generator_, [[GeneratorState]]).
           1. Assert: _generator_ also has a [[GeneratorContext]] internal slot.
@@ -39315,7 +39311,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorresume" aoid="GeneratorResume">
         <h1>GeneratorResume ( _generator_, _value_ )</h1>
-        <p>The abstract operation GeneratorResume with arguments _generator_ and _value_ performs the following steps:</p>
+        <p>The abstract operation GeneratorResume takes arguments _generator_ and _value_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _state_ be ? GeneratorValidate(_generator_).
           1. If _state_ is ~completed~, return CreateIterResultObject(*undefined*, *true*).
@@ -39333,7 +39329,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorresumeabrupt" aoid="GeneratorResumeAbrupt">
         <h1>GeneratorResumeAbrupt ( _generator_, _abruptCompletion_ )</h1>
-        <p>The abstract operation GeneratorResumeAbrupt with arguments _generator_ and _abruptCompletion_ performs the following steps:</p>
+        <p>The abstract operation GeneratorResumeAbrupt takes arguments _generator_ and _abruptCompletion_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _state_ be ? GeneratorValidate(_generator_).
           1. If _state_ is ~suspendedStart~, then
@@ -39358,6 +39354,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-getgeneratorkind" aoid="GetGeneratorKind">
         <h1>GetGeneratorKind ( )</h1>
+        <p>The abstract operation GetGeneratorKind takes no arguments. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. If _genContext_ does not have a Generator component, return ~non-generator~.
@@ -39369,7 +39366,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatoryield" aoid="GeneratorYield">
         <h1>GeneratorYield ( _iterNextObj_ )</h1>
-        <p>The abstract operation GeneratorYield with argument _iterNextObj_ performs the following steps:</p>
+        <p>The abstract operation GeneratorYield takes argument _iterNextObj_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _iterNextObj_ is an Object that implements the <i>IteratorResult</i> interface.
           1. Let _genContext_ be the running execution context.
@@ -39505,6 +39502,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorstart" aoid="AsyncGeneratorStart">
         <h1>AsyncGeneratorStart ( _generator_, _generatorBody_ )</h1>
+        <p>The abstract operation AsyncGeneratorStart takes arguments _generator_ and _generatorBody_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _generator_ is an AsyncGenerator instance.
           1. Assert: _generator_.[[AsyncGeneratorState]] is *undefined*.
@@ -39530,6 +39528,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorresolve" aoid="AsyncGeneratorResolve">
         <h1>AsyncGeneratorResolve ( _generator_, _value_, _done_ )</h1>
+        <p>The abstract operation AsyncGeneratorResolve takes arguments _generator_, _value_, and _done_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _generator_ is an AsyncGenerator instance.
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
@@ -39545,6 +39544,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorreject" aoid="AsyncGeneratorReject">
         <h1>AsyncGeneratorReject ( _generator_, _exception_ )</h1>
+        <p>The abstract operation AsyncGeneratorReject takes arguments _generator_ and _exception_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _generator_ is an AsyncGenerator instance.
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
@@ -39559,6 +39559,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorresumenext" aoid="AsyncGeneratorResumeNext">
         <h1>AsyncGeneratorResumeNext ( _generator_ )</h1>
+        <p>The abstract operation AsyncGeneratorResumeNext takes argument _generator_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _generator_ is an AsyncGenerator instance.
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
@@ -39604,10 +39605,9 @@ THH:mm:ss.sss
 
         <emu-clause id="async-generator-resume-next-return-processor-fulfilled">
           <h1>AsyncGeneratorResumeNext Return Processor Fulfilled Functions</h1>
-
           <p>An AsyncGeneratorResumeNext return processor fulfilled function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor fulfilled function has a [[Generator]] internal slot.</p>
-
           <p>When an AsyncGeneratorResumeNext return processor fulfilled function is called with argument _value_, the following steps are taken:</p>
+
 
           <emu-alg>
             1. Let _F_ be the active function object.
@@ -39620,10 +39620,9 @@ THH:mm:ss.sss
 
         <emu-clause id="async-generator-resume-next-return-processor-rejected">
           <h1>AsyncGeneratorResumeNext Return Processor Rejected Functions</h1>
-
           <p>An AsyncGeneratorResumeNext return processor rejected function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor rejected function has a [[Generator]] internal slot.</p>
-
           <p>When an AsyncGeneratorResumeNext return processor rejected function is called with argument _reason_, the following steps are taken:</p>
+
 
           <emu-alg>
             1. Let _F_ be the active function object.
@@ -39637,6 +39636,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorenqueue" aoid="AsyncGeneratorEnqueue">
         <h1>AsyncGeneratorEnqueue ( _generator_, _completion_ )</h1>
+        <p>The abstract operation AsyncGeneratorEnqueue takes arguments _generator_ and _completion_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _completion_ is a Completion Record.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
@@ -39656,7 +39656,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratoryield" aoid="AsyncGeneratorYield">
         <h1>AsyncGeneratorYield ( _value_ )</h1>
-        <p>The abstract operation AsyncGeneratorYield with argument _value_ performs the following steps:</p>
+        <p>The abstract operation AsyncGeneratorYield takes argument _value_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
@@ -39829,7 +39829,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-createresolvingfunctions" aoid="CreateResolvingFunctions">
         <h1>CreateResolvingFunctions ( _promise_ )</h1>
-        <p>When CreateResolvingFunctions is performed with argument _promise_, the following steps are taken:</p>
+        <p>The abstract operation CreateResolvingFunctions takes argument _promise_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _alreadyResolved_ be the Record { [[Value]]: *false* }.
           1. Let _stepsResolve_ be the algorithm steps defined in <emu-xref href="#sec-promise-resolve-functions" title></emu-xref>.
@@ -39891,7 +39891,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-fulfillpromise" aoid="FulfillPromise">
         <h1>FulfillPromise ( _promise_, _value_ )</h1>
-        <p>When the FulfillPromise abstract operation is called with arguments _promise_ and _value_, the following steps are taken:</p>
+        <p>The abstract operation FulfillPromise takes arguments _promise_ and _value_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The value of _promise_.[[PromiseState]] is ~pending~.
           1. Let _reactions_ be _promise_.[[PromiseFulfillReactions]].
@@ -39905,7 +39905,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-newpromisecapability" aoid="NewPromiseCapability">
         <h1>NewPromiseCapability ( _C_ )</h1>
-        <p>The abstract operation NewPromiseCapability takes a constructor function, and attempts to use that constructor function in the fashion of the built-in `Promise` constructor to create a Promise object and extract its resolve and reject functions. The promise plus the resolve and reject functions are used to initialize a new PromiseCapability Record which is returned as the value of this abstract operation.</p>
+        <p>The abstract operation NewPromiseCapability takes argument _C_. It attempts to use _C_ as a constructor in the fashion of the built-in `Promise` constructor to create a Promise object and extract its `resolve` and `reject` functions. The Promise object plus the `resolve` and `reject` functions are used to initialize a new PromiseCapability Record. It performs the following steps when called:</p>
         <emu-alg>
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
           1. NOTE: _C_ is assumed to be a constructor function that supports the parameter conventions of the `Promise` constructor (see <emu-xref href="#sec-promise-executor"></emu-xref>).
@@ -39943,7 +39943,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-ispromise" aoid="IsPromise">
         <h1>IsPromise ( _x_ )</h1>
-        <p>The abstract operation IsPromise checks for the promise brand on an object.</p>
+        <p>The abstract operation IsPromise takes argument _x_. It checks for the promise brand on an object. It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_x_) is not Object, return *false*.
           1. If _x_ does not have a [[PromiseState]] internal slot, return *false*.
@@ -39953,7 +39953,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-rejectpromise" aoid="RejectPromise">
         <h1>RejectPromise ( _promise_, _reason_ )</h1>
-        <p>When the RejectPromise abstract operation is called with arguments _promise_ and _reason_, the following steps are taken:</p>
+        <p>The abstract operation RejectPromise takes arguments _promise_ and _reason_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The value of _promise_.[[PromiseState]] is ~pending~.
           1. Let _reactions_ be _promise_.[[PromiseRejectReactions]].
@@ -39968,7 +39968,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-triggerpromisereactions" aoid="TriggerPromiseReactions">
         <h1>TriggerPromiseReactions ( _reactions_, _argument_ )</h1>
-        <p>The abstract operation TriggerPromiseReactions takes a collection of PromiseReactionRecords and enqueues a new Job for each record. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReactionRecord, and if the [[Handler]] is a function, calls it passing the given argument. If the [[Handler]] is *undefined*, the behaviour is determined by the [[Type]].</p>
+        <p>The abstract operation TriggerPromiseReactions takes arguments _reactions_ (a collection of PromiseReaction Records) and _argument_. It enqueues a new Job for each record in _reactions_. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReaction Record, and if the [[Handler]] is a function, calls it passing the given argument. If the [[Handler]] is *undefined*, the behaviour is determined by the [[Type]]. It performs the following steps when called:</p>
         <emu-alg>
           1. For each _reaction_ in _reactions_, in original insertion order, do
             1. Let _job_ be NewPromiseReactionJob(_reaction_, _argument_).
@@ -39979,8 +39979,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-host-promise-rejection-tracker" aoid="HostPromiseRejectionTracker">
         <h1>HostPromiseRejectionTracker ( _promise_, _operation_ )</h1>
-
         <p>HostPromiseRejectionTracker is an implementation-defined abstract operation that allows host environments to track promise rejections.</p>
+
 
         <p>An implementation of HostPromiseRejectionTracker must complete normally in all cases. The default implementation of HostPromiseRejectionTracker is to unconditionally return an empty normal completion.</p>
 
@@ -40006,7 +40006,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-newpromisereactionjob" aoid="NewPromiseReactionJob" oldids="sec-promisereactionjob">
         <h1>NewPromiseReactionJob ( _reaction_, _argument_ )</h1>
-        <p>The abstract operation NewPromiseReactionJob takes two arguments, _reaction_ and _argument_ and returns a new Job abstract closure that applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler. It performs the following steps:</p>
+        <p>The abstract operation NewPromiseReactionJob takes arguments _reaction_ and _argument_. It returns a new Job abstract closure that applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _job_ be a new Job abstract closure with no parameters that captures _reaction_ and _argument_ and performs the following steps when called:
             1. Assert: _reaction_ is a PromiseReaction Record.
@@ -40037,7 +40037,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-newpromiseresolvethenablejob" aoid="NewPromiseResolveThenableJob" oldids="sec-promiseresolvethenablejob">
         <h1>NewPromiseResolveThenableJob ( _promiseToResolve_, _thenable_, _then_ )</h1>
-        <p>The abstract operation NewPromiseResolveThenableJob takes three arguments, _promiseToResolve_, _thenable_, and _then_, and performs the following steps:</p>
+        <p>The abstract operation NewPromiseResolveThenableJob takes arguments _promiseToResolve_, _thenable_, and _then_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _job_ be a new Job abstract closure with no parameters that captures _promiseToResolve_, _thenable_, and _then_ and performs the following steps when called:
             1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promiseToResolve_).
@@ -40123,7 +40123,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-performpromiseall" aoid="PerformPromiseAll">
           <h1>Runtime Semantics: PerformPromiseAll ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
-          <p>When the PerformPromiseAll abstract operation is called with arguments _iteratorRecord_, _constructor_, and _resultCapability_, the following steps are taken:</p>
+          <p>The abstract operation PerformPromiseAll takes arguments _iteratorRecord_, _constructor_, and _resultCapability_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
             1. Assert: _resultCapability_ is a PromiseCapability Record.
@@ -40205,7 +40205,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-performpromiseallsettled" aoid="PerformPromiseAllSettled">
           <h1>Runtime Semantics: PerformPromiseAllSettled ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
-          <p>When the PerformPromiseAllSettled abstract operation is called with arguments _iteratorRecord_, _constructor_, and _resultCapability_, the following steps are taken:</p>
+          <p>The abstract operation PerformPromiseAllSettled takes arguments _iteratorRecord_, _constructor_, and _resultCapability_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: ! IsConstructor(_constructor_) is *true*.
             1. Assert: _resultCapability_ is a PromiseCapability Record.
@@ -40333,7 +40333,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-performpromiserace" aoid="PerformPromiseRace">
           <h1>Runtime Semantics: PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_ )</h1>
-          <p>When the PerformPromiseRace abstract operation is called with arguments _iteratorRecord_, _constructor_, and _resultCapability_, the following steps are taken:</p>
+          <p>The abstract operation PerformPromiseRace takes arguments _iteratorRecord_, _constructor_, and _resultCapability_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
             1. Assert: _resultCapability_ is a PromiseCapability Record.
@@ -40385,7 +40385,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-promise-resolve" aoid="PromiseResolve">
           <h1>PromiseResolve ( _C_, _x_ )</h1>
-          <p>The abstract operation PromiseResolve, given a constructor _C_ and a value _x_, returns a new promise resolved with _x_.</p>
+          <p>The abstract operation PromiseResolve takes arguments _C_ (a constructor) and _x_ (an ECMAScript language value). It returns a new promise resolved with _x_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_C_) is Object.
             1. If IsPromise(_x_) is *true*, then
@@ -40509,7 +40509,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-performpromisethen" aoid="PerformPromiseThen">
           <h1>PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_ [ , _resultCapability_ ] )</h1>
-          <p>The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. If _resultCapability_ is passed, the result is stored by updating _resultCapability_'s promise. (If it is not passed, then PerformPromiseThen is being called by a specification-internal operation where the result does not matter.)</p>
+          <p>The abstract operation PerformPromiseThen takes arguments _promise_, _onFulfilled_, and _onRejected_ and optional argument _resultCapability_. It performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. If _resultCapability_ is passed, the result is stored by updating _resultCapability_'s promise. If it is not passed, then PerformPromiseThen is being called by a specification-internal operation where the result does not matter. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsPromise(_promise_) is *true*.
             1. If _resultCapability_ is present, then
@@ -40628,10 +40628,9 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-async-function-constructor-arguments">
         <h1>AsyncFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
-
         <p>The last argument specifies the body (executable code) of an async function. Any preceding arguments specify formal parameters.</p>
-
         <p>When the `AsyncFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no _p_ arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+
 
         <emu-alg>
           1. Let _C_ be the active function object.
@@ -40714,6 +40713,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-async-functions-abstract-operations-async-function-start" aoid="AsyncFunctionStart">
         <h1>AsyncFunctionStart ( _promiseCapability_, _asyncFunctionBody_ )</h1>
+        <p>The abstract operation AsyncFunctionStart takes arguments _promiseCapability_ and _asyncFunctionBody_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _runningContext_ be the running execution context.
           1. Let _asyncContext_ be a copy of _runningContext_.
@@ -41246,7 +41246,7 @@ THH:mm:ss.sss
     <h1>Abstract Operations for the Memory Model</h1>
     <emu-clause id="sec-event-set" aoid="EventSet">
       <h1>EventSet ( _execution_ )</h1>
-      <p>The abstract operation EventSet takes one argument, a candidate execution _execution_. It performs the following steps:</p>
+      <p>The abstract operation EventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _events_ be an empty Set.
         1. For each Agent Events Record _aer_ in _execution_.[[EventsRecords]], do
@@ -41258,7 +41258,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-sharedatablockeventset" aoid="SharedDataBlockEventSet">
       <h1>SharedDataBlockEventSet ( _execution_ )</h1>
-      <p>The abstract operation SharedDataBlockEventSet takes one argument, a candidate execution _execution_. It performs the following steps:</p>
+      <p>The abstract operation SharedDataBlockEventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _events_ be an empty Set.
         1. For each event _E_ in EventSet(_execution_), do
@@ -41269,7 +41269,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-hosteventset" aoid="HostEventSet">
       <h1>HostEventSet ( _execution_ )</h1>
-      <p>The abstract operation HostEventSet takes one argument, a candidate execution _execution_. It performs the following steps:</p>
+      <p>The abstract operation HostEventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _events_ be an empty Set.
         1. For each event _E_ in EventSet(_execution_), do
@@ -41280,7 +41280,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-composewriteeventbytes" aoid="ComposeWriteEventBytes">
       <h1>ComposeWriteEventBytes ( _execution_, _byteIndex_, _Ws_ )</h1>
-      <p>The abstract operation ComposeWriteEventBytes takes four arguments, a candidate execution _execution_, a nonnegative integer _byteIndex_, and a List _Ws_ of WriteSharedMemory or ReadModifyWriteSharedMemory events. It performs the following steps:</p>
+      <p>The abstract operation ComposeWriteEventBytes takes arguments _execution_ (a candidate execution), _byteIndex_ (a non-negative integer), and _Ws_ (a List of WriteSharedMemory or ReadModifyWriteSharedMemory events). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _byteLocation_ be _byteIndex_.
         1. Let _bytesRead_ be a new empty List.
@@ -41308,7 +41308,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-valueofreadevent" aoid="ValueOfReadEvent">
       <h1>ValueOfReadEvent ( _execution_, _R_ )</h1>
-      <p>The abstract operation ValueOfReadEvent takes two arguments, a candidate execution _execution_ and a ReadSharedMemory or ReadModifyWriteSharedMemory event _R_. It performs the following steps:</p>
+      <p>The abstract operation ValueOfReadEvent takes arguments _execution_ (a candidate execution) and _R_ (a ReadSharedMemory or ReadModifyWriteSharedMemory event). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _R_ is a ReadSharedMemory or ReadModifyWriteSharedMemory event.
         1. Let _Ws_ be _execution_.[[ReadsBytesFrom]](_R_).
@@ -42425,7 +42425,7 @@ THH:mm:ss.sss
 
         <emu-annex id="sec-runtime-semantics-characterrangeorunion-abstract-operation" aoid="CharacterRangeOrUnion">
           <h1>Runtime Semantics: CharacterRangeOrUnion ( _A_, _B_ )</h1>
-          <p>The abstract operation CharacterRangeOrUnion takes two CharSet parameters _A_ and _B_ and performs the following steps:</p>
+          <p>The abstract operation CharacterRangeOrUnion takes arguments _A_ (a CharSet) and _B_ (a CharSet). It performs the following steps when called:</p>
           <emu-alg>
             1. If _Unicode_ is *false*, then
               1. If _A_ does not contain exactly one character or _B_ does not contain exactly one character, then
@@ -42553,7 +42553,7 @@ THH:mm:ss.sss
 
         <emu-annex id="sec-get-object.prototype.__proto__">
           <h1>get Object.prototype.__proto__</h1>
-          <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps:</p>
+          <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? ToObject(*this* value).
             1. Return ? _O_.[[GetPrototypeOf]]().
@@ -42562,7 +42562,7 @@ THH:mm:ss.sss
 
         <emu-annex id="sec-set-object.prototype.__proto__">
           <h1>set Object.prototype.__proto__</h1>
-          <p>The value of the [[Set]] attribute is a built-in function that takes an argument _proto_. It performs the following steps:</p>
+          <p>The value of the [[Set]] attribute is a built-in function that takes an argument _proto_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? RequireObjectCoercible(*this* value).
             1. If Type(_proto_) is neither Object nor Null, return *undefined*.
@@ -42665,7 +42665,7 @@ THH:mm:ss.sss
 
         <emu-annex id="sec-createhtml" aoid="CreateHTML">
           <h1>Runtime Semantics: CreateHTML ( _string_, _tag_, _attribute_, _value_ )</h1>
-          <p>The abstract operation CreateHTML is called with arguments _string_, _tag_, _attribute_, and _value_. The arguments _tag_ and _attribute_ must be String values. The following steps are taken:</p>
+          <p>The abstract operation CreateHTML takes arguments _string_, _tag_ (a String), _attribute_ (a String), and _value_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _str_ be ? RequireObjectCoercible(_string_).
             1. Let _S_ be ? ToString(_str_).


### PR DESCRIPTION
This unifies the wording used to introduce abstract operations. The intent is that the new wording should provide all and only the information in the current wording (except in a couple cases where the existing wording is obviously wrong). This is a step towards #545 (structured headers could be used to generate this text) and #1796 (which wants a consistent place to describe the return type of abstract operations).

We're wildly inconsistent about what information we bother to include in these descriptions. This is more obvious after this PR because the wording is now consistent, but since it doesn't actually make the information included any less consistent, I would prefer we not try to address that here.

~This PR also removes abstract operation preambles entirely when they contain no information other than the name of the operation and its arguments (though I am open to going the other direction and such adding introductions everywhere they are currently absent).~ Edit: went the other direction, this PR now add such introductions to abstract operations which were missing them.

After we land this I will try to make a PR to ecmarkup which enforces this style, at least to some extent.

Thanks to @jmdyck for [ecmaspeak-py](https://github.com/jmdyck/ecmaspeak-py), which has hardcoded all the many, many forms of preamble currently in use and allowed me to extract the information I needed from them.