### PR TITLE
Editorial: added ~async-iterate~ in assertion of ForIn/OfHeadEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17935,7 +17935,7 @@
             1. Let _obj_ be ! ToObject(_exprValue_).
             1. Return ? EnumerateObjectProperties(_obj_).
           1. Else,
-            1. Assert: _iterationKind_ is ~iterate~.
+            1. Assert: _iterationKind_ is ~iterate~ or ~async-iterate~.
             1. If _iterationKind_ is ~async-iterate~, let _iteratorHint_ be ~async~.
             1. Else, let _iteratorHint_ be ~sync~.
             1. Return ? GetIterator(_exprValue_, _iteratorHint_).


### PR DESCRIPTION
The abstract algorithm [`ForIn/OfHeadEvaluation`](https://tc39.es/ecma262/#sec-runtime-semantics-forinofheadevaluation) has an assertion is the step 7-a for checking whether the variable _iterationKind_ points to `iterate`. However, I think that _iterationKind_ might be `async-iterate` when the algorithm is invoked by `for await (...) ...` syntax. In [`Runtime Semantics: LabelledEvaluation`](https://tc39.es/ecma262/#sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation), `ForIn/OfHeadEvaluation` is called with `enumerate`, `iterate`, and `async-iterate` for the parameter _iterationKind_. In the `ForIn/OfHeadEvaluation` algorithm, the `enumerate` case is already consumed in step 6. Thus, I think that both `iterate` and `async-iterate` are possible values of _iterationKind_ in step 7-a. Moreover, if _iterationKind_ must be `iterate` in step 7-a, the true branch of the condition "_iterationKind_ is `async-iterate`" in step 7-b is unreachable.

Fixes #1812.