### PR TITLE
Editorial: added prefix ! when calling OrdinaryGetOwnProperty

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9101,7 +9101,7 @@
         <p>The [[GetOwnProperty]] internal method of an arguments exotic object when called with a property key _P_ performs the following steps:</p>
         <emu-alg>
           1. Let _args_ be the arguments object.
-          1. Let _desc_ be OrdinaryGetOwnProperty(_args_, _P_).
+          1. Let _desc_ be ! OrdinaryGetOwnProperty(_args_, _P_).
           1. If _desc_ is *undefined*, return _desc_.
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).


### PR DESCRIPTION
I added prefix ! when calling [`OrdinaryGetOwnProperty`](https://tc39.es/ecma262/#sec-ordinarygetownproperty) in [`[[GetOwnProperty]]`](https://tc39.es/ecma262/#sec-arguments-exotic-objects-getownproperty-p) of arguments exotic object.

[`OrdinaryGetOwnProperty`](https://tc39.es/ecma262/#sec-ordinarygetownproperty) is a runtime semantics thus it always return a completion record (Actually, in this case `OrdinaryGetOwnProperty` always return normal completion). In step 2 of [`[[GetOwnProperty]]`](https://tc39.es/ecma262/#sec-arguments-exotic-objects-getownproperty-p) of arguments exotic object, _desc_ points to a completion record. I know there exists a implicit coercion rule for `[[Value]]` of completion record in [5.2.3.1](https://tc39.es/ecma262/#sec-implicit-completion-values) through #1664.

However, in step 6-a, it tries to access `[[Value]]` field of _desc_. It seems to access the `[[Value]]` of completion record but the actually meaning is to access the `[[Value]]` field of a data property in _desc_.`[[Value]]` (simply _desc_.`[[Value]]`.`[[Value]`).

I think it is ambiguous thus I think the prefix `!` should be added for function call of [`OrdinaryGetOwnProperty`](https://tc39.es/ecma262/#sec-ordinarygetownproperty) in [`[[GetOwnProperty]]`](https://tc39.es/ecma262/#sec-arguments-exotic-objects-getownproperty-p) of arguments exotic object.