### PR TITLE
Editorial: sunk note for null

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -209,6 +209,9 @@
       <emu-note>
         <p>A primitive value is a datum that is represented directly at the lowest level of the language implementation.</p>
       </emu-note>
+      <emu-note>
+        <p>The value of Null type has additional usage besides being one of primitive values: <emu-xref href="#sec-ecmascript-language-types-null-type"></emu-xref></p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-terms-and-definitions-object">
@@ -943,6 +946,9 @@
     <emu-clause id="sec-ecmascript-language-types-null-type">
       <h1>The Null Type</h1>
       <p>The Null type has exactly one value, called *null*.</p>
+      <emu-note>
+        <p>Value *null* used as a root of prototype chain if there is no inheritance. Keep in mind *typeof* operator also returns "object" for *null* value: <emu-xref href="#sec-typeof-operator"></emu-xref>. A careless combination of these facts can be dangerous.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-ecmascript-language-types-boolean-type">
@@ -14438,6 +14444,11 @@
           </table>
         </emu-table>
       </emu-clause>
+
+      <emu-note>
+        <p>Backing to the history the result of typeof *null* is "object" was mostly used for backward compatibility requirements. Meanwhile other additions allowed to express some parts of inheritance model throgh the value *null*. Today *null* used as a root of prototype chain for objects not being inherited from anything else. And since we maintain connection between *null* and *object*, we caution you against looking for some deep meaning in this behavior. Although it may in fact satisfy the reasons you need, careless combination of these capabilities might cause sunk cost.</p>
+      </emu-note>
+
     </emu-clause>
 
 


### PR DESCRIPTION
Summary of facts caused this PR.
Most of modern javascript engines can give us the following checking capabilities:

1. object has no inherited ancestor via:

```javascript
// if it returns null, then there is no inheritance
Object.getPrototypeOf(object_we_are_checking);
```

2. `Object.prototype` is `null`:

```javascript
Object.getPrototypeOf(Object.prototype); // null
```
3. `typeof` operator applied to `null` value returns `"object"`:

```javascript
typeof null === 'object'; // true
```

Combining the facts someone can get a conclusion all of them are connected.

But, the events that triggered these additives as standard were random and not related. Despite the fact that someone may find it useful to have such a connection, its careless use can lead to the creation of [sunk cost](https://en.wikipedia.org/wiki/Sunk_cost). This PR is an attempt to leave a warning and continues the discussion begun in #1913.