### PR TITLE
Normative: Generically forbid 402 method extensions in Forbidden Extensions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24737,7 +24737,7 @@
         Neither mapped nor unmapped arguments objects may be created with an own property named *"caller"*.
       </li>
       <li>
-        The behaviour of the following methods must not be extended except as specified in ECMA-402: `Object.prototype.toLocaleString`, `Array.prototype.toLocaleString`, `Number.prototype.toLocaleString`, `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, `Date.prototype.toLocaleTimeString`, `String.prototype.localeCompare`, %TypedArray%`.prototype.toLocaleString`.
+        The behaviour of built-in methods which are specified in ECMA-402, such as those named `toLocaleString`, must not be extended except as specified in ECMA-402.
       </li>
       <li>
         The RegExp pattern grammars in <emu-xref href="#sec-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[+U]| when the <sub>[U]</sub> grammar parameter is present.


### PR DESCRIPTION
[Forbidden Extensions](https://tc39.es/ecma262/#sec-forbidden-extensions) has a list of methods which are specified in ECMA-402 instead, but a few are missing; this PR rectifies that.