### PR TITLE
Editorial: Align wording of [[OwnPropertyKeys]] methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8144,11 +8144,11 @@
 
         <emu-alg>
           1. Let _keys_ be a new empty List.
-          1. For each own property key _P_ of _O_ that is an array index, in ascending numeric index order, do
+          1. For each own property key _P_ of _O_ such that _P_ is an array index, in ascending numeric index order, do
             1. Add _P_ as the last element of _keys_.
-          1. For each own property key _P_ of _O_ that is a String but is not an array index, in ascending chronological order of property creation, do
+          1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an array index, in ascending chronological order of property creation, do
             1. Add _P_ as the last element of _keys_.
-          1. For each own property key _P_ of _O_ that is a Symbol, in ascending chronological order of property creation, do
+          1. For each own property key _P_ of _O_ such that Type(_P_) is Symbol, in ascending chronological order of property creation, do
             1. Add _P_ as the last element of _keys_.
           1. Return _keys_.
         </emu-alg>
@@ -31358,7 +31358,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Evaluate |Disjunction| with +1 as its _direction_ argument to obtain a Matcher _m_.
           1. Return a new abstract closure with parameters (_str_, _index_) that captures _m_ and performs the following steps when called:
-            1. Assert: _str_ is a String.
+            1. Assert: Type(_str_) is String.
             1. Assert: ! IsNonNegativeInteger(_index_) is *true* and _index_ &le; the length of _str_.
             1. If _Unicode_ is *true*, let _Input_ be a List consisting of the sequence of code points of ! UTF16DecodeString(_str_). Otherwise, let _Input_ be a List consisting of the sequence of code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
             1. Let _InputLength_ be the number of characters contained in _Input_. This variable will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.


### PR DESCRIPTION
This change aligns wording of [`OrdinaryOwnPropertyKeys`](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys) with String's [`[[OwnPropertyKeys]]`](https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys) and [`[[OwnPropertyKeys]]`](https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-ownpropertykeys) method of typed arrays, preferring more explicit `Type(X) is Y` notation.