### PR TITLE
Editorial: Tweak Array exotic object internal methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8893,7 +8893,8 @@
             1. Return ? ArraySetLength(_A_, _Desc_).
           1. Else if _P_ is an array index, then
             1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
-            1. Assert: _oldLenDesc_ will never be *undefined* or an accessor descriptor because Array objects are created with a length data property that cannot be deleted or reconfigured.
+            1. Assert: ! IsDataDescriptor(_oldLenDesc_) is *true*.
+            1. Assert: _oldLenDesc_.[[Configurable]] is *false*.
             1. Let _oldLen_ be _oldLenDesc_.[[Value]].
             1. Assert: IsNonNegativeInteger(_oldLen_) is *true*.
             1. Let _index_ be ! ToUint32(_P_).
@@ -8963,14 +8964,15 @@
           1. If _newLen_ &ne; _numberLen_, throw a *RangeError* exception.
           1. Set _newLenDesc_.[[Value]] to _newLen_.
           1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
-          1. Assert: _oldLenDesc_ will never be *undefined* or an accessor descriptor because Array objects are created with a length data property that cannot be deleted or reconfigured.
+          1. Assert: ! IsDataDescriptor(_oldLenDesc_) is *true*.
+          1. Assert: _oldLenDesc_.[[Configurable]] is *false*.
           1. Let _oldLen_ be _oldLenDesc_.[[Value]].
           1. If _newLen_ &ge; _oldLen_, then
             1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
           1. If _oldLenDesc_.[[Writable]] is *false*, return *false*.
           1. If _newLenDesc_.[[Writable]] is absent or has the value *true*, let _newWritable_ be *true*.
           1. Else,
-            1. Need to defer setting the [[Writable]] attribute to *false* in case any elements cannot be deleted.
+            1. NOTE: Setting the [[Writable]] attribute to *false* is deferred in case any elements cannot be deleted.
             1. Let _newWritable_ be *false*.
             1. Set _newLenDesc_.[[Writable]] to *true*.
           1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
@@ -8983,7 +8985,8 @@
               1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
               1. Return *false*.
           1. If _newWritable_ is *false*, then
-            1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Writable]]: *false* }). This call will always return *true*.
+            1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Writable]]: *false* }).
+            1. Assert: _succeeded_ is *true*.
           1. Return *true*.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
This change replaces prose in normative steps with [`IsDataDescriptor`](https://tc39.es/ecma262/#sec-isdatadescriptor) abstract op, explicitly marks a `NOTE:` and result of `OrdinaryDefineOwnProperty` call.