### PR TITLE
Editorial: Fixup grammatical parameters

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31083,13 +31083,13 @@ THH:mm:ss.sss
             It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false* and IsCharacterClass of |ClassAtom| is *false* and the CharacterValue of |ClassAtomNoDash| is larger than the CharacterValue of |ClassAtom|.
           </li>
         </ul>
-        <emu-grammar>RegExpIdentifierStart[U] :: `\` RegExpUnicodeEscapeSequence[?U]</emu-grammar>
+        <emu-grammar>RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence[+U]</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is none of *"$"*, or *"_"*, or the UTF16Encoding of a code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
-        <emu-grammar>RegExpIdentifierPart[U] :: `\` RegExpUnicodeEscapeSequence[?U]</emu-grammar>
+        <emu-grammar>RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence[+U]</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is none of *"$"*, or *"_"*, or the UTF16Encoding of either &lt;ZWNJ&gt; or &lt;ZWJ&gt;, or the UTF16Encoding of a Unicode code point that would be matched by the |UnicodeIDContinue| lexical grammar production.
@@ -31364,9 +31364,9 @@ THH:mm:ss.sss
         <h1>Static Semantics: StringValue</h1>
         <emu-see-also-para op="StringValue"></emu-see-also-para>
         <emu-grammar>
-          RegExpIdentifierName[U] ::
-            RegExpIdentifierStart[?U]
-            RegExpIdentifierName[?U] RegExpIdentifierPart[?U]
+          RegExpIdentifierName ::
+            RegExpIdentifierStart
+            RegExpIdentifierName RegExpIdentifierPart
         </emu-grammar>
         <emu-alg>
           1. Let _idText_ be the source text matched by |RegExpIdentifierName|.
@@ -42220,7 +42220,7 @@ THH:mm:ss.sss
           [~U] DecimalEscape [> but only if the CapturingGroupNumber of |DecimalEscape| is &lt;= _NcapturingParens_]
           CharacterClassEscape[?U]
           CharacterEscape[~U, ?N]
-          [+N] `k` GroupName[?U]
+          [+N] `k` GroupName
 
         CharacterEscape[U, N] ::
           ControlEscape


### PR DESCRIPTION
PR #1869 removed/changed the [U] parameter in certain defining productions, but missed some collateral changes in referring productions.