### PR TITLE
Editorial: use correct source text for IsValidRegularExpressionLiteral

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13025,7 +13025,9 @@
           1. Let _P_ be BodyText of _literal_.
           1. If FlagText of _literal_ contains `u`, then
             1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[+U, +N]|. If _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist, return *false*. Otherwise, return *true*.
-          1. Parse _P_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]|. If _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist, return *false*. Otherwise, return *true*.
+          1. Let _stringValue_ be UTF16Encode(_P_).
+          1. Let _pText_ be the sequence of code points resulting from interpreting each of the 16-bit elements of _stringValue_ as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
+          1. Parse _pText_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]|. If _P_ did not conform to the grammar, if any elements of _P_ were not matched by the parse, or if any Early Error conditions exist, return *false*. Otherwise, return *true*.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
The rules for parsing non-`u` patterns are such that the source text is parsed by treating each half of a surrogate pair as an individual code point. But [IsValidRegularExpressionLiteral](https://tc39.es/ecma262/#sec-isvalidregularexpressionliteral) was applying the parsing rules for non-`u` patterns to the actual code points in the source text, rather than first splitting non-BMP code points into two surrogate code units and then interpreting those as code points.