### PR TITLE
Editorial: rename LeadSurrgate, TrailSurrogate, and NonSurrogate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30893,10 +30893,10 @@ THH:mm:ss.sss
           &lt;ZWJ&gt;
 
         RegExpUnicodeEscapeSequence[U] ::
-          [+U] `u` LeadSurrogate `\u` TrailSurrogate
-          [+U] `u` LeadSurrogate
-          [+U] `u` TrailSurrogate
-          [+U] `u` NonSurrogate
+          [+U] `u` HexLeadSurrogate `\u` HexTrailSurrogate
+          [+U] `u` HexLeadSurrogate
+          [+U] `u` HexTrailSurrogate
+          [+U] `u` HexNonSurrogate
           [~U] `u` Hex4Digits
           [+U] `u{` CodePoint `}`
 
@@ -30906,15 +30906,15 @@ THH:mm:ss.sss
         UnicodeTrailSurrogate ::
           &gt; any Unicode code point in the inclusive range 0xDC00 to 0xDFFF
       </emu-grammar>
-      <p>Each `\\u` |TrailSurrogate| for which the choice of associated `u` |LeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |LeadSurrogate| that would otherwise have no corresponding `\\u` |TrailSurrogate|.</p>
+      <p>Each `\\u` |HexTrailSurrogate| for which the choice of associated `u` |HexLeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |HexLeadSurrogate| that would otherwise have no corresponding `\\u` |HexTrailSurrogate|.</p>
       <emu-grammar type="definition">
-        LeadSurrogate ::
+        HexLeadSurrogate ::
           Hex4Digits [> but only if the SV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
 
-        TrailSurrogate ::
+        HexTrailSurrogate ::
           Hex4Digits [> but only if the SV of |Hex4Digits| is in the inclusive range 0xDC00 to 0xDFFF]
 
-        NonSurrogate ::
+        HexNonSurrogate ::
           Hex4Digits [> but only if the SV of |Hex4Digits| is not in the inclusive range 0xD800 to 0xDFFF]
 
         IdentityEscape[U] ::
@@ -31275,10 +31275,10 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return the numeric value of the code unit that is the SV of |HexEscapeSequence|.
         </emu-alg>
-        <emu-grammar>RegExpUnicodeEscapeSequence :: `u` LeadSurrogate `\u` TrailSurrogate</emu-grammar>
+        <emu-grammar>RegExpUnicodeEscapeSequence :: `u` HexLeadSurrogate `\u` HexTrailSurrogate</emu-grammar>
         <emu-alg>
-          1. Let _lead_ be the CharacterValue of |LeadSurrogate|.
-          1. Let _trail_ be the CharacterValue of |TrailSurrogate|.
+          1. Let _lead_ be the CharacterValue of |HexLeadSurrogate|.
+          1. Let _trail_ be the CharacterValue of |HexTrailSurrogate|.
           1. Let _cp_ be UTF16DecodeSurrogatePair(_lead_, _trail_).
           1. Return the code point value of _cp_.
         </emu-alg>
@@ -31291,11 +31291,11 @@ THH:mm:ss.sss
           1. Return the Number value for the MV of |CodePoint|.
         </emu-alg>
         <emu-grammar>
-          LeadSurrogate :: Hex4Digits
+          HexLeadSurrogate :: Hex4Digits
 
-          TrailSurrogate :: Hex4Digits
+          HexTrailSurrogate :: Hex4Digits
 
-          NonSurrogate :: Hex4Digits
+          HexNonSurrogate :: Hex4Digits
         </emu-grammar>
         <emu-alg>
           1. Return the Number value for the MV of |HexDigits|.
@@ -41971,11 +41971,11 @@ THH:mm:ss.sss
     <emu-prodref name="RegExpUnicodeEscapeSequence"></emu-prodref>
     <emu-prodref name="UnicodeLeadSurrogate"></emu-prodref>
     <emu-prodref name="UnicodeTrailSurrogate"></emu-prodref>
-    <p>Each `\\u` |TrailSurrogate| for which the choice of associated `u` |LeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |LeadSurrogate| that would otherwise have no corresponding `\\u` |TrailSurrogate|.</p>
+    <p>Each `\\u` |HexTrailSurrogate| for which the choice of associated `u` |HexLeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |HexLeadSurrogate| that would otherwise have no corresponding `\\u` |HexTrailSurrogate|.</p>
     <p>&nbsp;</p>
-    <emu-prodref name="LeadSurrogate"></emu-prodref>
-    <emu-prodref name="TrailSurrogate"></emu-prodref>
-    <emu-prodref name="NonSurrogate"></emu-prodref>
+    <emu-prodref name="HexLeadSurrogate"></emu-prodref>
+    <emu-prodref name="HexTrailSurrogate"></emu-prodref>
+    <emu-prodref name="HexNonSurrogate"></emu-prodref>
     <emu-prodref name="IdentityEscape"></emu-prodref>
     <emu-prodref name="DecimalEscape"></emu-prodref>
     <emu-prodref name="CharacterClassEscape"></emu-prodref>


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/1932 introduced `UnicodeLeadSurrogate` to refer to a Unicode code point in the range of lead surrogates (0xD800 to 0xDBFF). The spec already has `LeadSurrogate` meaning four hex digits which represent a number that range. This PR renames the latter production to `HexLeadSurrogate` to be more explicitly distinguished from the former.