### PR TITLE
Editorial: Remove [[HomeObject]] from function Environments

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6198,17 +6198,6 @@
             </tr>
             <tr>
               <td>
-                [[HomeObject]]
-              </td>
-              <td>
-                Object | *undefined*
-              </td>
-              <td>
-                If the associated function has `super` property accesses and is not an |ArrowFunction|, [[HomeObject]] is the object that the function is bound to as a method. The default value for [[HomeObject]] is *undefined*.
-              </td>
-            </tr>
-            <tr>
-              <td>
                 [[NewTarget]]
               </td>
               <td>
@@ -6254,7 +6243,7 @@
                 GetSuperBase()
               </td>
               <td>
-                Return the object that is the base for `super` property accesses bound in this Environment Record. The object is derived from this Environment Record's [[HomeObject]] field. The value *undefined* indicates that `super` property accesses will produce runtime errors.
+                Return the object that is the base for `super` property accesses bound in this Environment Record. The value *undefined* indicates that `super` property accesses will produce runtime errors.
               </td>
             </tr>
             </tbody>
@@ -6287,7 +6276,7 @@
           <emu-alg>
             1. Let _envRec_ be the function Environment Record for which the method was invoked.
             1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*.
-            1. If _envRec_.[[HomeObject]] has the value *undefined*, return *false*; otherwise, return *true*.
+            1. If _envRec_.[[FunctionObject]].[[HomeObject]] has the value *undefined*, return *false*; otherwise, return *true*.
           </emu-alg>
         </emu-clause>
 
@@ -6305,7 +6294,7 @@
           <h1>GetSuperBase ( )</h1>
           <emu-alg>
             1. Let _envRec_ be the function Environment Record for which the method was invoked.
-            1. Let _home_ be _envRec_.[[HomeObject]].
+            1. Let _home_ be _envRec_.[[FunctionObject]].[[HomeObject]].
             1. If _home_ has the value *undefined*, return *undefined*.
             1. Assert: Type(_home_) is Object.
             1. Return ? _home_.[[GetPrototypeOf]]().
@@ -6841,8 +6830,6 @@
           1. Set _env_.[[FunctionObject]] to _F_.
           1. If _F_.[[ThisMode]] is ~lexical~, set _env_.[[ThisBindingStatus]] to ~lexical~.
           1. Else, set _env_.[[ThisBindingStatus]] to ~uninitialized~.
-          1. Let _home_ be _F_.[[HomeObject]].
-          1. Set _env_.[[HomeObject]] to _home_.
           1. Set _env_.[[NewTarget]] to _newTarget_.
           1. Set _env_.[[OuterEnv]] to _F_.[[Environment]].
           1. Return _env_.


### PR DESCRIPTION
envRec.[[HomeObject]] was always equal to envRec.[[FunctionObject]].[[HomeObject]], so the field was redundant.

Fixes #1358.