### PR TITLE
Editorial: Early return & throw in Number.prototype.to* methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27210,14 +27210,12 @@
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToInteger(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
-          1. If _x_ is *NaN*, return the String *"NaN"*.
+          1. If _x_ is not finite, return ! Number::toString(_x_).
+          1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
             1. Set _s_ to *"-"*.
             1. Set _x_ to -_x_.
-          1. If _x_ = *+&infin;*, then
-            1. Return the string-concatenation of _s_ and *"Infinity"*.
-          1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ = 0, then
             1. Let _m_ be the String value consisting of _f_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.
@@ -27262,7 +27260,7 @@
           1. Let _f_ be ? ToInteger(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
           1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
-          1. If _x_ is *NaN*, return the String *"NaN"*.
+          1. If _x_ is not finite, return ! Number::toString(_x_).
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
             1. Set _s_ to *"-"*.
@@ -27304,14 +27302,12 @@
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. If _precision_ is *undefined*, return ! ToString(_x_).
           1. Let _p_ be ? ToInteger(_precision_).
-          1. If _x_ is *NaN*, return the String *"NaN"*.
+          1. If _x_ is not finite, return ! Number::toString(_x_).
+          1. If _p_ &lt; 1 or _p_ &gt; 100, throw a *RangeError* exception.
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
             1. Set _s_ to the code unit 0x002D (HYPHEN-MINUS).
             1. Set _x_ to -_x_.
-          1. If _x_ = *+&infin;*, then
-            1. Return the string-concatenation of _s_ and *"Infinity"*.
-          1. If _p_ &lt; 1 or _p_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ = 0, then
             1. Let _m_ be the String value consisting of _p_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.


### PR DESCRIPTION
This change makes handling of non-finite `this` values more concise (by using [`Number::toString`](https://tc39.es/ecma262/#sec-numeric-types-number-tostring)) and moves it earlier in steps, as well as argument range checks. This makes observable steps grouped and order of observable steps easier to read (especially if a runtime uses something like `std::isfinite` as JSC does).