### PR TITLE
Editorial: use correct check in B.3.3.6

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43142,7 +43142,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>During BlockDeclarationInstantiation the following steps are performed in place of step 4.b.iii:</p>
         <emu-alg>
-          1. If _envRec_.HasBinding(_fn_) is *false*, then
+          1. If the binding for _fn_ in _envRec_ is an uninitialized binding, then
             1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
           1. Else,
             1. Assert: _d_ is a |FunctionDeclaration|.


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/1942. See that issue for context.

Marked as a spec bug because the algorithm violates assertions as written (and also didn't really make sense; the `_envRec_.HasBinding(_fn_)` check could never actually return `*false*`).

cc @littledan @anba @syg