### PR TITLE
Editorial: Align wording of The *Function Constructor sections

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38987,6 +38987,7 @@ THH:mm:ss.sss
       <p>The GeneratorFunction constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%GeneratorFunction%</dfn>.</li>
+        <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new GeneratorFunction object when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.</li>
       </ul>
@@ -39093,6 +39094,7 @@ THH:mm:ss.sss
       <p>The AsyncGeneratorFunction constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%AsyncGeneratorFunction%</dfn>.</li>
+        <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new AsyncGeneratorFunction object when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncGeneratorFunction behaviour must include a `super` call to the AsyncGeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of AsyncGeneratorFunction. There is no syntactic means to create instances of AsyncGeneratorFunction subclasses.</li>
       </ul>
@@ -40639,7 +40641,7 @@ THH:mm:ss.sss
         <li>is the intrinsic object <dfn>%AsyncFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new AsyncFunction object when called as a function rather than as a constructor. Thus the function call `AsyncFunction(&hellip;)` is equivalent to the object creation expression `new AsyncFunction(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the AsyncFunction constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the AsyncFunction constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour. All ECMAScript syntactic forms for defining async function objects create direct instances of AsyncFunction. There is no syntactic means to create instances of AsyncFunction subclasses.</li>
       </ul>
 
       <emu-clause id="sec-async-function-constructor-arguments">


### PR DESCRIPTION
Noticed during review of #1860.
The wording of 25.7.1 seems to differ needlessly from 25.2.1 and 25.3.1.