### PR TITLE
Editorial: Fix indirect eval environment check

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24955,16 +24955,16 @@
           1. If Type(_x_) is not String, return _x_.
           1. Let _evalRealm_ be the current Realm Record.
           1. Perform ? HostEnsureCanCompileStrings(_callerRealm_, _evalRealm_).
-          1. Let _thisEnvRec_ be ! GetThisEnvironment().
-          1. If _thisEnvRec_ is a function Environment Record, then
-            1. Let _F_ be _thisEnvRec_.[[FunctionObject]].
-            1. Let _inFunction_ be *true*.
-            1. Let _inMethod_ be _thisEnvRec_.HasSuperBinding().
-            1. If _F_.[[ConstructorKind]] is ~derived~, let _inDerivedConstructor_ be *true*; otherwise, let _inDerivedConstructor_ be *false*.
-          1. Else,
-            1. Let _inFunction_ be *false*.
-            1. Let _inMethod_ be *false*.
-            1. Let _inDerivedConstructor_ be *false*.
+          1. Let _inFunction_ be *false*.
+          1. Let _inMethod_ be *false*.
+          1. Let _inDerivedConstructor_ be *false*.
+          1. If _direct_ is *true*, then
+            1. Let _thisEnvRec_ be ! GetThisEnvironment().
+            1. If _thisEnvRec_ is a function Environment Record, then
+              1. Let _F_ be _thisEnvRec_.[[FunctionObject]].
+              1. Set _inFunction_ to *true*.
+              1. Set _inMethod_ to _thisEnvRec_.HasSuperBinding().
+              1. If _F_.[[ConstructorKind]] is ~derived~, set _inDerivedConstructor_ to *true*.
           1. Perform the following substeps in an implementation-dependent order, possibly interleaving parsing and error detection:
             1. Let _script_ be the ECMAScript code that is the result of parsing ! UTF16DecodeString(_x_), for the goal symbol |Script|. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* exception (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>).
             1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.


### PR DESCRIPTION
indirect eval should not allow `new.target`, `super`, etc., and `GetThisEnvironment` is not defined in terms of non-ecmascript execution contexts.