### PR TITLE
Normative: Fixed bug in NumberBitwiseOp

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1754,7 +1754,7 @@
           <p>The abstract operation NumberBitwiseOp takes arguments _op_, _x_, and _y_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _lnum_ be ! ToInt32(_x_).
-            1. Let _rnum_ be ! ToUint32(_y_).
+            1. Let _rnum_ be ! ToInt32(_y_).
             1. Return the result of applying the bitwise operator _op_ to _lnum_ and _rnum_. The result is a signed 32-bit integer.
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
In the previous version ES2019, The [Evaluation](https://www.ecma-international.org/ecma-262/#sec-binary-bitwise-operators-runtime-semantics-evaluation) of binary bitwise operators utilize [`ToInt32`](https://www.ecma-international.org/ecma-262/#sec-toint32) for both left and right expressions. However, the current version apply [`ToInt32`](https://tc39.es/ecma262/#sec-toint32) for only the left number value but use [`ToUint32`](https://tc39.es/ecma262/#sec-touint32) for the right number value in [`NumberBitwiseOp`](https://tc39.es/ecma262/#sec-numberbitwiseop). I think it breaks the backward compatibility thus I revised the semantics of [`NumberBitwiseOp`](https://tc39.es/ecma262/#sec-numberbitwiseop) to use [`ToInt32`](https://tc39.es/ecma262/#sec-toint32) for both left and right number values.