### PR TITLE
Editorial: Ambiguous notation `≠` in ArraySetLength

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8975,7 +8975,7 @@
           1. Let _newLenDesc_ be a copy of _Desc_.
           1. Let _newLen_ be ? ToUint32(_Desc_.[[Value]]).
           1. Let _numberLen_ be ? ToNumber(_Desc_.[[Value]]).
-          1. If _newLen_ &ne; _numberLen_, throw a *RangeError* exception.
+          1. If Number::equal(_newLen_, _numberLen_) is *false*, throw a *RangeError* exception.
           1. Set _newLenDesc_.[[Value]] to _newLen_.
           1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
           1. Assert: ! IsDataDescriptor(_oldLenDesc_) is *true*.


### PR DESCRIPTION
In the [ArraySetLength](https://tc39.es/ecma262/#sec-arraysetlength) algorithm, the operator `≠` is ambiguous. According to the following test262 tests,

- [test262/test/built-ins/Object/defineProperties/15.2.3.7-6-a-127.js](https://github.com/tc39/test262/blob/master/test/built-ins/Object/defineProperties/15.2.3.7-6-a-127.js)
- [test262/test/built-ins/Object/defineProperty/15.2.3.6-4-131.js](https://github.com/tc39/test262/blob/master/test/built-ins/Object/defineProperty/15.2.3.6-4-131.js)

the algorithm should not throw the RangeError exception when `newLen` is +0 and `numberLen` is -0. However, the ArraySetLength algorithm throws a RangeError exception when `newLen ≠ numberLen`. According, to the [`Number::equal`](https://tc39.es/ecma262/#sec-numeric-types-number-equal) algorithm, +0 and -0 is not the same Number value. Therefore, I revised the fifth line to use [`Number::equal`](https://tc39.es/ecma262/#sec-numeric-types-number-equal) instead fo the ambiguous notation `≠` for clarity.