### PR TITLE
Editorial: refactoring the evaluation semantics of compound assignment

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15075,13 +15075,29 @@
 
     <emu-clause id="sec-binary-bitwise-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <p>The production <emu-grammar>A : A @ B</emu-grammar>, where @ is one of the bitwise operators in the productions above, is evaluated as follows:</p>
+      <emu-grammar>BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating _A_.
+        1. Let _lref_ be the result of evaluating |BitwiseANDExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating _B_.
+        1. Let _rref_ be the result of evaluating |EqualityExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, @, _rval_).
+        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `&amp;`, _rval_).
+      </emu-alg>
+      <emu-grammar>BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression</emu-grammar>
+      <emu-alg>
+        1. Let _lref_ be the result of evaluating |BitwiseXORExpression|.
+        1. Let _lval_ be ? GetValue(_lref_).
+        1. Let _rref_ be the result of evaluating |BitwiseANDExpression|.
+        1. Let _rval_ be ? GetValue(_rref_).
+        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `^`, _rval_).
+      </emu-alg>
+      <emu-grammar>BitwiseORExpression : BitwiseORExpression `|` BitwiseXORExpression</emu-grammar>
+      <emu-alg>
+        1. Let _lref_ be the result of evaluating |BitwiseORExpression|.
+        1. Let _lval_ be ? GetValue(_lref_).
+        1. Let _rref_ be the result of evaluating |BitwiseXORExpression|.
+        1. Let _rval_ be ? GetValue(_rref_).
+        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `|`, _rval_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -5593,7 +5593,7 @@
           1. If the mathematical value of _nx_ is less than the mathematical value of _ny_, return *true*; otherwise return *false*.
       </emu-alg>
       <emu-note>
-        <p>Step 3 differs from step 7 in the algorithm for the addition operator `+` (<emu-xref href="#sec-addition-operator-plus"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
+        <p>Step 3 differs from step 1.c in the algorithm that handles the addition operator `+` (<emu-xref href="#sec-applystringornumericbinaryoperator"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
       </emu-note>
       <emu-note>
         <p>The comparison of Strings uses a simple lexicographic ordering on sequences of code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or string equality and collating order defined in the Unicode specification. Therefore String values that are canonically equal according to the Unicode standard could test as unequal. In effect this algorithm assumes that both Strings are already in normalized form. Also, note that for strings containing supplementary characters, lexicographic ordering on sequences of UTF-16 code unit values differs from that on sequences of code point values.</p>
@@ -14551,10 +14551,7 @@
         1. Let _leftValue_ be ? GetValue(_left_).
         1. Let _right_ be the result of evaluating |ExponentiationExpression|.
         1. Let _rightValue_ be ? GetValue(_right_).
-        1. Let _base_ be ? ToNumeric(_leftValue_).
-        1. Let _exponent_ be ? ToNumeric(_rightValue_).
-        1. If Type(_base_) is different from Type(_exponent_), throw a *TypeError* exception.
-        1. Return ? Type(_base_)::exponentiate(_base_, _exponent_).
+        1. Return ? ApplyStringOrNumericBinaryOperator(_leftValue_, `**`, _rightValue_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -14597,15 +14594,8 @@
         1. Let _leftValue_ be ? GetValue(_left_).
         1. Let _right_ be the result of evaluating |ExponentiationExpression|.
         1. Let _rightValue_ be ? GetValue(_right_).
-        1. Let _lnum_ be ? ToNumeric(_leftValue_).
-        1. Let _rnum_ be ? ToNumeric(_rightValue_).
-        1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-        1. Let _T_ be Type(_lnum_).
-        1. If |MultiplicativeOperator| is `*`, return _T_::multiply(_lnum_, _rnum_).
-        1. If |MultiplicativeOperator| is `/`, return _T_::divide(_lnum_, _rnum_).
-        1. Else,
-          1. Assert: |MultiplicativeOperator| is `%`.
-          1. Return _T_::remainder(_lnum_, _rnum_).
+        1. Let _opText_ be the source text matched by |MultiplicativeOperator|.
+        1. Return ? ApplyStringOrNumericBinaryOperator(_leftValue_, _opText_, _rightValue_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -14660,24 +14650,8 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |MultiplicativeExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lprim_ be ? ToPrimitive(_lval_).
-          1. Let _rprim_ be ? ToPrimitive(_rval_).
-          1. If Type(_lprim_) is String or Type(_rprim_) is String, then
-            1. Let _lstr_ be ? ToString(_lprim_).
-            1. Let _rstr_ be ? ToString(_rprim_).
-            1. Return the string-concatenation of _lstr_ and _rstr_.
-          1. Let _lnum_ be ? ToNumeric(_lprim_).
-          1. Let _rnum_ be ? ToNumeric(_rprim_).
-          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-          1. Let _T_ be Type(_lnum_).
-          1. Return _T_::add(_lnum_, _rnum_).
+          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `+`, _rval_).
         </emu-alg>
-        <emu-note>
-          <p>No hint is provided in the calls to ToPrimitive in steps 5 and 6. All standard objects except Date objects handle the absence of a hint as if the hint Number were given; Date objects handle the absence of a hint as if the hint String were given. Exotic objects may handle the absence of a hint in some other manner.</p>
-        </emu-note>
-        <emu-note>
-          <p>Step 7 differs from step 3 of the Abstract Relational Comparison algorithm, by using the logical-or operation instead of the logical-and operation.</p>
-        </emu-note>
       </emu-clause>
     </emu-clause>
 
@@ -14692,11 +14666,7 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |MultiplicativeExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lnum_ be ? ToNumeric(_lval_).
-          1. Let _rnum_ be ? ToNumeric(_rval_).
-          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-          1. Let _T_ be Type(_lnum_).
-          1. Return _T_::subtract(_lnum_, _rnum_).
+          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `-`, _rval_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -14755,11 +14725,7 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |AdditiveExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lnum_ be ? ToNumeric(_lval_).
-          1. Let _rnum_ be ? ToNumeric(_rval_).
-          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-          1. Let _T_ be Type(_lnum_).
-          1. Return _T_::leftShift(_lnum_, _rnum_).
+          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `&lt;&lt;`, _rval_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -14778,11 +14744,7 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |AdditiveExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lnum_ be ? ToNumeric(_lval_).
-          1. Let _rnum_ be ? ToNumeric(_rval_).
-          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-          1. Let _T_ be Type(_lnum_).
-          1. Return _T_::signedRightShift(_lnum_, _rnum_).
+          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `&gt;&gt;`, _rval_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -14801,11 +14763,7 @@
           1. Let _lval_ be ? GetValue(_lref_).
           1. Let _rref_ be the result of evaluating |AdditiveExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
-          1. Let _lnum_ be ? ToNumeric(_lval_).
-          1. Let _rnum_ be ? ToNumeric(_rval_).
-          1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-          1. Let _T_ be Type(_lnum_).
-          1. Return _T_::unsignedRightShift(_lnum_, _rnum_).
+          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `&gt;&gt;&gt;`, _rval_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -15123,15 +15081,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating _B_.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _lnum_ be ? ToNumeric(_lval_).
-        1. Let _rnum_ be ? ToNumeric(_rval_).
-        1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-        1. Let _T_ be Type(_lnum_).
-        1. If @ is `&amp;`, return _T_::bitwiseAND(_lnum_, _rnum_).
-        1. If @ is `|`, return _T_::bitwiseOR(_lnum_, _rnum_).
-        1. Else,
-          1. Assert: @ is `^`.
-          1. Return _T_::bitwiseXOR(_lnum_, _rnum_).
+        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, @, _rval_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -15377,13 +15327,81 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |AssignmentExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _op_ be the `@` where |AssignmentOperator| is `@=`.
-        1. Let _r_ be the result of applying _op_ to _lval_ and _rval_ as if evaluating the expression _lval_ _op_ _rval_.
+        1. Let _assignmentOpText_ be the source text matched by |AssignmentOperator|.
+        1. Let _opText_ be the sequence of Unicode code points associated with _assignmentOpText_ in the following table:
+          <figure>
+            <table class="lightweight-table">
+              <tbody>
+                <tr><th> _assignmentOpText_ </th><th> _opText_       </th></tr>
+                <tr><td> `**=`              </td><td> `**`           </td></tr>
+                <tr><td> `*=`               </td><td> `*`            </td></tr>
+                <tr><td> `/=`               </td><td> `/`            </td></tr>
+                <tr><td> `%=`               </td><td> `%`            </td></tr>
+                <tr><td> `+=`               </td><td> `+`            </td></tr>
+                <tr><td> `-=`               </td><td> `-`            </td></tr>
+                <tr><td> `&lt;&lt;=`        </td><td> `&lt;&lt;`     </td></tr>
+                <tr><td> `&gt;&gt;=`        </td><td> `&gt;&gt;`     </td></tr>
+                <tr><td> `&gt;&gt;&gt;=`    </td><td> `&gt;&gt;&gt;` </td></tr>
+                <tr><td> `&amp;=`           </td><td> `&amp;`        </td></tr>
+                <tr><td> `^=`               </td><td> `^`            </td></tr>
+                <tr><td> `|=`               </td><td> `|`            </td></tr>
+              </tbody>
+            </table>
+          </figure>
+        1. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
         1. Perform ? PutValue(_lref_, _r_).
         1. Return _r_.
       </emu-alg>
       <emu-note>
-        <p>When an assignment occurs within strict mode code, it is a runtime error if _lref_ in step 1.e of the first algorithm or step 7 of the second algorithm is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, nor to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
+        <p>When an assignment occurs within strict mode code, it is a runtime error if _lref_ in step 1.e of the first algorithm or step 8 of the second algorithm is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, nor to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-applystringornumericbinaryoperator" aoid="ApplyStringOrNumericBinaryOperator">
+      <h1>Runtime Semantics: ApplyStringOrNumericBinaryOperator ( _lval_, _opText_, _rval_ )</h1>
+      <p>The abstract operation ApplyStringOrNumericBinaryOperator takes arguments _lval_ (an ECMAScript language value), _opText_ (a sequence of Unicode code points), and _rval_ (an ECMAScript language value). It performs the following steps when called:</p>
+      <emu-alg>
+        1. If _opText_ is `+`, then
+          1. Let _lprim_ be ? ToPrimitive(_lval_).
+          1. Let _rprim_ be ? ToPrimitive(_rval_).
+          1. If Type(_lprim_) is String or Type(_rprim_) is String, then
+            1. Let _lstr_ be ? ToString(_lprim_).
+            1. Let _rstr_ be ? ToString(_rprim_).
+            1. Return the string-concatenation of _lstr_ and _rstr_.
+          1. Set _lval_ to _lprim_.
+          1. Set _rval_ to _rprim_.
+        1. NOTE: At this point, it must be a numeric operation.
+        1. Let _lnum_ be ? ToNumeric(_lval_).
+        1. Let _rnum_ be ? ToNumeric(_rval_).
+        1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+        1. Let _T_ be Type(_lnum_).
+        1. Let _operation_ be the abstract operation associated with _opText_ in the following table:
+          <figure>
+            <table class="lightweight-table">
+              <tbody>
+                <tr><th> _opText_       </th><th> _operation_             </th></tr>
+                <tr><td> `**`           </td><td> _T_::exponentiate       </td></tr>
+                <tr><td> `*`            </td><td> _T_::multiply           </td></tr>
+                <tr><td> `/`            </td><td> _T_::divide             </td></tr>
+                <tr><td> `%`            </td><td> _T_::remainder          </td></tr>
+                <tr><td> `+`            </td><td> _T_::add                </td></tr>
+                <tr><td> `-`            </td><td> _T_::subtract           </td></tr>
+                <tr><td> `&lt;&lt;`     </td><td> _T_::leftShift          </td></tr>
+                <tr><td> `&gt;&gt;`     </td><td> _T_::signedRightShift   </td></tr>
+                <tr><td> `&gt;&gt;&gt;` </td><td> _T_::unsignedRightShift </td></tr>
+                <tr><td> `&amp;`        </td><td> _T_::bitwiseAND         </td></tr>
+                <tr><td> `^`            </td><td> _T_::bitwiseXOR         </td></tr>
+                <tr><td> `|`            </td><td> _T_::bitwiseOR          </td></tr>
+              </tbody>
+            </table>
+          </figure>
+        1. Return ? _operation_(_lnum_, _rnum_).
+      </emu-alg>
+      <emu-note>
+        <p>No hint is provided in the calls to ToPrimitive in steps 1.a and 1.b. All standard objects except Date objects handle the absence of a hint as if the hint Number were given; Date objects handle the absence of a hint as if the hint String were given. Exotic objects may handle the absence of a hint in some other manner.</p>
+      </emu-note>
+      <emu-note>
+        <p>Step 1.c differs from step 3 of the Abstract Relational Comparison algorithm, by using the logical-or operation instead of the logical-and operation.</p>
       </emu-note>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -14547,11 +14547,7 @@
         ExponentiationExpression : UpdateExpression `**` ExponentiationExpression
       </emu-grammar>
       <emu-alg>
-        1. Let _left_ be the result of evaluating |UpdateExpression|.
-        1. Let _leftValue_ be ? GetValue(_left_).
-        1. Let _right_ be the result of evaluating |ExponentiationExpression|.
-        1. Let _rightValue_ be ? GetValue(_right_).
-        1. Return ? ApplyStringOrNumericBinaryOperator(_leftValue_, `**`, _rightValue_).
+        1. Return ? EvaluateStringOrNumericBinaryExpression(|UpdateExpression|, `**`, |ExponentiationExpression|).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -14590,12 +14586,8 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
-        1. Let _left_ be the result of evaluating |MultiplicativeExpression|.
-        1. Let _leftValue_ be ? GetValue(_left_).
-        1. Let _right_ be the result of evaluating |ExponentiationExpression|.
-        1. Let _rightValue_ be ? GetValue(_right_).
         1. Let _opText_ be the source text matched by |MultiplicativeOperator|.
-        1. Return ? ApplyStringOrNumericBinaryOperator(_leftValue_, _opText_, _rightValue_).
+        1. Return ? EvaluateStringOrNumericBinaryExpression(|MultiplicativeExpression|, _opText_, |ExponentiationExpression|).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -14646,11 +14638,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>AdditiveExpression : AdditiveExpression `+` MultiplicativeExpression</emu-grammar>
         <emu-alg>
-          1. Let _lref_ be the result of evaluating |AdditiveExpression|.
-          1. Let _lval_ be ? GetValue(_lref_).
-          1. Let _rref_ be the result of evaluating |MultiplicativeExpression|.
-          1. Let _rval_ be ? GetValue(_rref_).
-          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `+`, _rval_).
+          1. Return ? EvaluateStringOrNumericBinaryExpression(|AdditiveExpression|, `+`, |MultiplicativeExpression|).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -14662,11 +14650,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>AdditiveExpression : AdditiveExpression `-` MultiplicativeExpression</emu-grammar>
         <emu-alg>
-          1. Let _lref_ be the result of evaluating |AdditiveExpression|.
-          1. Let _lval_ be ? GetValue(_lref_).
-          1. Let _rref_ be the result of evaluating |MultiplicativeExpression|.
-          1. Let _rval_ be ? GetValue(_rref_).
-          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `-`, _rval_).
+          1. Return ? EvaluateStringOrNumericBinaryExpression(|AdditiveExpression|, `-`, |MultiplicativeExpression|).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -14721,11 +14705,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&lt;&lt;` AdditiveExpression</emu-grammar>
         <emu-alg>
-          1. Let _lref_ be the result of evaluating |ShiftExpression|.
-          1. Let _lval_ be ? GetValue(_lref_).
-          1. Let _rref_ be the result of evaluating |AdditiveExpression|.
-          1. Let _rval_ be ? GetValue(_rref_).
-          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `&lt;&lt;`, _rval_).
+          1. Return ? EvaluateStringOrNumericBinaryExpression(|ShiftExpression|, `&lt;&lt;`, |AdditiveExpression|).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -14740,11 +14720,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;` AdditiveExpression</emu-grammar>
         <emu-alg>
-          1. Let _lref_ be the result of evaluating |ShiftExpression|.
-          1. Let _lval_ be ? GetValue(_lref_).
-          1. Let _rref_ be the result of evaluating |AdditiveExpression|.
-          1. Let _rval_ be ? GetValue(_rref_).
-          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `&gt;&gt;`, _rval_).
+          1. Return ? EvaluateStringOrNumericBinaryExpression(|ShiftExpression|, `&gt;&gt;`, |AdditiveExpression|).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -14759,11 +14735,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;&gt;` AdditiveExpression</emu-grammar>
         <emu-alg>
-          1. Let _lref_ be the result of evaluating |ShiftExpression|.
-          1. Let _lval_ be ? GetValue(_lref_).
-          1. Let _rref_ be the result of evaluating |AdditiveExpression|.
-          1. Let _rval_ be ? GetValue(_rref_).
-          1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `&gt;&gt;&gt;`, _rval_).
+          1. Return ? EvaluateStringOrNumericBinaryExpression(|ShiftExpression|, `&gt;&gt;&gt;`, |AdditiveExpression|).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -15077,27 +15049,15 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |BitwiseANDExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |EqualityExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `&amp;`, _rval_).
+        1. Return ? EvaluateStringOrNumericBinaryExpression(|BitwiseANDExpression|, `&amp;`, |EqualityExpression|).
       </emu-alg>
       <emu-grammar>BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |BitwiseXORExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |BitwiseANDExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `^`, _rval_).
+        1. Return ? EvaluateStringOrNumericBinaryExpression(|BitwiseXORExpression|, `^`, |BitwiseANDExpression|).
       </emu-alg>
       <emu-grammar>BitwiseORExpression : BitwiseORExpression `|` BitwiseXORExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |BitwiseORExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |BitwiseXORExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, `|`, _rval_).
+        1. Return ? EvaluateStringOrNumericBinaryExpression(|BitwiseORExpression|, `|`, |BitwiseXORExpression|).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -15419,6 +15379,18 @@
       <emu-note>
         <p>Step 1.c differs from step 3 of the Abstract Relational Comparison algorithm, by using the logical-or operation instead of the logical-and operation.</p>
       </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-evaluatestringornumericbinaryexpression" aoid="EvaluateStringOrNumericBinaryExpression">
+      <h1>Runtime Semantics: EvaluateStringOrNumericBinaryExpression ( _leftOperand_, _opText_, _rightOperand_ )</h1>
+      <p>The abstract operation EvaluateStringOrNumericBinaryExpression takes arguments _leftOperand_ (a Parse Node), _opText_ (a sequence of Unicode code points), and _rightOperand_ (a Parse Node). It performs the following steps when called:</p>
+      <emu-alg>
+        1. Let _lref_ be the result of evaluating _leftOperand_.
+        1. Let _lval_ be ? GetValue(_lref_).
+        1. Let _rref_ be the result of evaluating _rightOperand_.
+        1. Let _rval_ be ? GetValue(_rref_).
+        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-destructuring-assignment">


### PR DESCRIPTION
... and numeric binary expressions in general.

Resolves #1561.

The first commit does what I suggested [here](https://github.com/tc39/ecma262/issues/1561#issuecomment-497365930), except:
- I called it `ApplyNumericBinaryOperator` because `ApplyBinaryOperator` was over-claiming. (Even "NumericBinaryOperator" is a bit much, since one could reasonably expect that to include relational operators.)
- I didn't factor out the `ApplyPlusOperator`/`Plus` operation, as it didn't seem that useful to me. (The BigInt refactoring probably made a difference.)

The second commit does what @michaelficarra requested [here](https://github.com/tc39/ecma262/issues/1561#issuecomment-616748116).

The third commit is just a suggestion. *I* like it, but it might be an acquired taste. If you do like it, `EvaluateNumericBinaryExpression` (suitably renamed) *could* be extended to the Relational and Equality operators.