### PR TITLE
Editorial: Using `is -0` instead of `= -0` in StringGetOwnProperty

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9075,7 +9075,7 @@
           1. Let _index_ be ! CanonicalNumericIndexString(_P_).
           1. If _index_ is *undefined*, return *undefined*.
           1. If IsInteger(_index_) is *false*, return *undefined*.
-          1. If _index_ = *-0*, return *undefined*.
+          1. If _index_ is *-0*, return *undefined*.
           1. Let _str_ be _S_.[[StringData]].
           1. Assert: Type(_str_) is String.
           1. Let _len_ be the length of _str_.


### PR DESCRIPTION
I revised a small part in [`StringGetOwnProperty`](https://tc39.es/ecma262/#sec-stringgetownproperty) to use `is -0` instead of `= -0` to correctly represent the semantics. The expression `index = -0` denotes that `index` is `-0` or `+0` because the `=` operator is floating point equality operator. Thus, instead, I think that it should be revised to `index is -0`.