### PR TITLE
Editorial: Unambiguous grammar for IfStatement

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17043,9 +17043,9 @@
     <emu-grammar type="definition">
       IfStatement[Yield, Await, Return] :
         `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] `else` Statement[?Yield, ?Await, ?Return]
-        `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+        `if` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return] [lookahead != `else`]
     </emu-grammar>
-    <p>Each `else` for which the choice of associated `if` is ambiguous shall be associated with the nearest possible `if` that would otherwise have no corresponding `else`.</p>
+    <emu-note>The lookahead-restriction [lookahead &ne; `else`] resolves the classic "dangling else" problem in the usual way. That is, when the choice of associated `if` is otherwise ambiguous, the `else` is associated with the nearest (innermost) of the candidate `if`s</emu-note>
 
     <emu-clause id="sec-if-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>


### PR DESCRIPTION
The original grammar of `IfStatement` is ambiguous thus the specification describes the following additional note:

- Each `else` for which the choice of associated `if` is ambiguous shall be associated with the nearest possible `if` that would otherwise have no corresponding `else`.

Thus, I introduced a new parameter `Else` for `Statement` and `IfStatement` to remove unambiguity in the grammar of `IfStatement`. Only if `Else` is false, the second alternative of `IfStatement` could be selected, which is an `if` statement without `else` block.

- `if s_1 else s_2`

Thus, in the above statement, if `s_1` is an `IfStatement` then `s_1` always has `else` block. I believe that it could remove the unambiguity in the grammar of `IfStatement`.