### PR TITLE
Editorial: Restriction on [[Prototype]] of the global object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24800,6 +24800,7 @@
     <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
     <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     <li>has a [[Prototype]] internal slot whose value is implementation-dependent.</li>
+    <li>is an instance of the standard built-in Object constructor.</li>
     <li>may have host defined properties in addition to the properties defined in this specification. This may include a property whose value is the global object itself.</li>
   </ul>
 


### PR DESCRIPTION
According to the [issue](https://github.com/tc39/test262/issues/2593) in Test262 repository, Test262 provides the following tests that assume that the global object is an instance of the built-in Object constructor:

- [/test/built-ins/Object/defineProperty/15.2.3.6-4-625gs.js](https://github.com/tc39/test262/blob/master/test/built-ins/Object/defineProperty/15.2.3.6-4-625gs.js)
- [/test/built-ins/Object/getPrototypeOf/15.2.3.2-2-30.js](https://github.com/tc39/test262/blob/master/test/built-ins/Object/getPrototypeOf/15.2.3.2-2-30.js)
- [/test/built-ins/decodeURI/S15.1.3.1_A5.5.js](https://github.com/tc39/test262/blob/master/test/built-ins/decodeURI/S15.1.3.1_A5.5.js)
- [/test/built-ins/decodeURIComponent/S15.1.3.2_A5.5.js](https://github.com/tc39/test262/blob/master/test/built-ins/decodeURIComponent/S15.1.3.2_A5.5.js)
- [/test/built-ins/encodeURI/S15.1.3.3_A5.5.js](https://github.com/tc39/test262/blob/master/test/built-ins/encodeURI/S15.1.3.3_A5.5.js)
- [/test/built-ins/encodeURIComponent/S15.1.3.4_A5.5.js](https://github.com/tc39/test262/blob/master/test/built-ins/encodeURIComponent/S15.1.3.4_A5.5.js)
- [/test/built-ins/eval/prop-desc-enumerable.js](https://github.com/tc39/test262/blob/master/test/built-ins/eval/prop-desc-enumerable.js)
- [/test/built-ins/parseFloat/S15.1.2.3_A7.5.js](https://github.com/tc39/test262/blob/master/test/built-ins/parseFloat/S15.1.2.3_A7.5.js)
- [/test/built-ins/parseInt/S15.1.2.2_A9.5.js](https://github.com/tc39/test262/blob/master/test/built-ins/parseInt/S15.1.2.2_A9.5.js)
- [/test/language/global-code/decl-lex.js](https://github.com/tc39/test262/blob/master/test/language/global-code/decl-lex.js)

@ljharb said in the [comment](https://github.com/tc39/test262/issues/2593#issuecomment-618179987):
```
That seems somewhat like a spec issue to me than a test issue;
web reality is that the global inherits from Object.prototype,
so at least web browsers (Annex B) would have to have that be true.
```

Thus, I added one restriction to the global object which is "the global object should be an instance of the standard built-in Object constructor.
