### PR TITLE
Unify phrasing of lexical environment selection

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19831,7 +19831,7 @@
       </emu-alg>
       <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform _funcEnv_.CreateImmutableBinding(_name_, *false*).
@@ -20255,7 +20255,7 @@
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. If _functionPrototype_ is present as a parameter, then
           1. Let _prototype_ be _functionPrototype_.
         1. Else,
@@ -20282,7 +20282,7 @@
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
@@ -20295,7 +20295,7 @@
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
@@ -20541,7 +20541,7 @@
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _closure_ be OrdinaryFunctionCreate(%Generator%, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_).
@@ -20576,7 +20576,7 @@
       </emu-alg>
       <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform _funcEnv_.CreateImmutableBinding(_name_, *false*).
@@ -20870,7 +20870,7 @@
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |PropertyName|.
         1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGenerator%, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform ! MakeMethod(_closure_, _object_).
         1. Perform ! SetFunctionName(_closure_, _propKey_).
@@ -20913,7 +20913,7 @@
         AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->

While looking at proposal, and trying to evaluate it, I realized that there's two different phrasings of the same operation. This unifies the two phrasings for consistency. 