### PR TITLE
Editorial: Return an iterator *record* for for...in heads

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17923,7 +17923,9 @@
             1. If _exprValue_ is *undefined* or *null*, then
               1. Return Completion { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
             1. Let _obj_ be ! ToObject(_exprValue_).
-            1. Return ? EnumerateObjectProperties(_obj_).
+            1. Let _iterator_ be ? EnumerateObjectProperties(_obj_).
+            1. Let _nextMethod_ be ! GetV(_iterator_, *"next"*).
+            1. Return the Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
           1. Else,
             1. Assert: _iterationKind_ is ~iterate~ or ~async-iterate~.
             1. If _iterationKind_ is ~async-iterate~, let _iteratorHint_ be ~async~.


### PR DESCRIPTION
[ForIn/OfBodyEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset) expects an iterator Record of the sort returned by [GetIterator](https://tc39.es/ecma262/#sec-getiterator) (with [[Iterator]] and [[NextMethod]] slots) from [ForIn/OfHeadEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-forinofheadevaluation), but the `for...in` ("enumerate") branch was instead returning an Iterator _object_ (with a `next` method) from [EnumerateObjectProperties](https://tc39.es/ecma262/#sec-enumerate-object-properties). This corrects the mistake by passing that object to GetIterator.