### PR TITLE
Editorial: Reorder a few steps in String.prototype.split

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30389,18 +30389,18 @@ THH:mm:ss.sss
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _lengthA_ be 0.
           1. If _limit_ is *undefined*, let _lim_ be 2<sup>32</sup> - 1; else let _lim_ be ? ToUint32(_limit_).
-          1. Let _s_ be the length of _S_.
-          1. Let _p_ be 0.
           1. Let _R_ be ? ToString(_separator_).
           1. If _lim_ = 0, return _A_.
           1. If _separator_ is *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
             1. Return _A_.
+          1. Let _s_ be the length of _S_.
           1. If _s_ = 0, then
             1. Let _z_ be SplitMatch(_S_, 0, _R_).
             1. If _z_ is not *false*, return _A_.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
             1. Return _A_.
+          1. Let _p_ be 0.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &ne; _s_
             1. Let _e_ be SplitMatch(_S_, _q_, _R_).
@@ -32929,14 +32929,14 @@ THH:mm:ss.sss
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _lengthA_ be 0.
           1. If _limit_ is *undefined*, let _lim_ be 2<sup>32</sup> - 1; else let _lim_ be ? ToUint32(_limit_).
-          1. Let _size_ be the length of _S_.
-          1. Let _p_ be 0.
           1. If _lim_ = 0, return _A_.
+          1. Let _size_ be the length of _S_.
           1. If _size_ = 0, then
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is not *null*, return _A_.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
             1. Return _A_.
+          1. Let _p_ be 0.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &lt; _size_
             1. Perform ? Set(_splitter_, *"lastIndex"*, _q_, *true*).


### PR DESCRIPTION
Proposed change couples definitions and checks of `limit` and `size`, making 1:1 implementations with the spec a little bit nicer.

<details>

<summary>
Relevant part of current <code>RegExp.prototype[@@split]</code> implementation in JSC ... <br>(please note "Defered from" comments)
</summary>

```js
// 11. Let A be ArrayCreate(0).
// 12. Let lengthA be 0.
var result = [];

// 13. If limit is undefined, let lim be 2^32-1; else var lim be ? ToUint32(limit).
limit = (limit === @undefined) ? 0xffffffff : limit >>> 0;

// 16. If lim = 0, return A.
if (!limit)
    return result;

// 14. [Defered from above] Let size be the number of elements in S.
var size = str.length;

// 17. If size = 0, then
if (!size) {
    // a. Let z be ? RegExpExec(splitter, S).
    var z = @regExpExec(splitter, str);
    // b. If z is not null, return A.
    if (z != null)
        return result;
    // c. Perform ! CreateDataProperty(A, "0", S).
    @putByValDirect(result, 0, str);
    // d. Return A.
    return result;
}

// 15. [Defered from above] Let p be 0.
var position = 0;
// 18. Let q be p.
var matchPosition = 0;

// 19. Repeat, while q < size
while (matchPosition < size) {
```

</details>