### PR TITLE
Editorial: Complete standard preambles for numeric methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1491,6 +1491,7 @@
 
         <emu-clause id="sec-numeric-types-number-unaryMinus">
           <h1>Number::unaryMinus ( _x_ )</h1>
+          <p>The abstract operation Number::unaryMinus takes argument _x_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *NaN*, return *NaN*.
             1. Return the result of negating _x_; that is, compute a Number with the same magnitude but opposite sign.
@@ -1499,6 +1500,7 @@
 
         <emu-clause id="sec-numeric-types-number-bitwiseNOT">
           <h1>Number::bitwiseNOT ( _x_ )</h1>
+          <p>The abstract operation Number::bitwiseNOT takes argument _x_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. Let _oldValue_ be ! ToInt32(_x_).
             1. Return the result of applying bitwise complement to _oldValue_. The result is a signed 32-bit integer.
@@ -1507,9 +1509,7 @@
 
         <emu-clause id="sec-numeric-types-number-exponentiate" oldids="sec-applying-the-exp-operator">
           <h1>Number::exponentiate ( _base_, _exponent_ )</h1>
-          <p>
-            Returns an implementation-dependent approximation of the result of raising _base_ to the power _exponent_.
-          </p>
+          <p>The abstract operation Number::exponentiate takes arguments _base_ (a Number) and _exponent_ (a Number). It returns an implementation-dependent approximation of the result of raising _base_ to the power _exponent_, subject to the following requirements:</p>
           <ul>
             <li>If _exponent_ is *NaN*, the result is *NaN*.</li>
             <li>If _exponent_ is *+0*, the result is 1, even if _base_ is *NaN*.</li>
@@ -1542,8 +1542,7 @@
 
         <emu-clause id="sec-numeric-types-number-multiply" oldids="sec-applying-the-mul-operator">
           <h1>Number::multiply ( _x_, _y_ )</h1>
-          <p>The `*` |MultiplicativeOperator| performs multiplication, producing the product of _x_ and _y_. Multiplication is commutative. Multiplication is not always associative in ECMAScript, because of finite precision.</p>
-          <p>The result of a floating-point multiplication is governed by the rules of IEEE 754-2019 binary double-precision arithmetic:</p>
+          <p>The abstract operation Number::multiply takes arguments _x_ (a Number) and _y_ (a Number). It performs multiplication, producing the product of _x_ and _y_, as determined by the rules of IEEE 754-2019 binary double-precision arithmetic:</p>
           <ul>
             <li>
               If either operand is *NaN*, the result is *NaN*.
@@ -1564,11 +1563,14 @@
               In the remaining cases, where neither an infinity nor *NaN* is involved, the product is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode. If the magnitude is too large to represent, the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the result is then a zero of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2019.
             </li>
           </ul>
+          <emu-note>
+            <p>Finite-precision multiplication is commutative, but not always associative.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-number-divide" oldids="sec-applying-the-div-operator">
           <h1>Number::divide ( _x_, _y_ )</h1>
-          <p>The `/` |MultiplicativeOperator| performs division, producing the quotient of _x_ and _y_. _x_ is the dividend and _y_ is the divisor. ECMAScript does not perform integer division. The operands and result of all division operations are double-precision floating-point numbers. The result of division is determined by the specification of IEEE 754-2019 arithmetic:</p>
+          <p>The abstract operation Number::divide takes arguments _x_ (a Number) and _y_ (a Number). It performs division, producing the quotient of _x_ and _y_; _x_ is the dividend and _y_ is the divisor. The result is determined by the specification of IEEE 754-2019 arithmetic:</p>
           <ul>
             <li>
               If either operand is *NaN*, the result is *NaN*.
@@ -1602,7 +1604,7 @@
 
         <emu-clause id="sec-numeric-types-number-remainder" oldids="sec-applying-the-mod-operator">
           <h1>Number::remainder ( _n_, _d_ )</h1>
-          <p>The `%` |MultiplicativeOperator| yields the remainder of its operands from an implied division; _n_ is the dividend and _d_ is the divisor.</p>
+          <p>The abstract operation Number::remainder takes arguments _n_ (a Number) and _d_ (a Number). It yields the remainder of its operands from an implied division; _n_ is the dividend and _d_ is the divisor.</p>
           <emu-note>
             <p>In C and C++, the remainder operator accepts only integral operands; in ECMAScript, it also accepts floating-point operands.</p>
           </emu-note>
@@ -1632,9 +1634,7 @@
 
         <emu-clause id="sec-numeric-types-number-add" oldids="sec-applying-the-additive-operators-to-numbers">
           <h1>Number::add ( _x_, _y_ )</h1>
-          <p>The `+` operator performs addition when applied to _x_ and _y_, producing the sum of the operands.</p>
-          <p>Addition is a commutative operation, but not always associative.</p>
-          <p>The result of an addition is determined using the rules of IEEE 754-2019 binary double-precision arithmetic:</p>
+          <p>The abstract operation Number::add takes arguments _x_ (a Number) and _y_ (a Number). It performs addition, producing the sum of _x_ and _y_ as determined using the rules of IEEE 754-2019 binary double-precision arithmetic:</p>
           <ul>
             <li>
               If either operand is *NaN*, the result is *NaN*.
@@ -1661,16 +1661,25 @@
               In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, and the operands have the same sign or have different magnitudes, the sum is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows and the result is then an infinity of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2019.
             </li>
           </ul>
+          <emu-note>
+            <p>Finite-precision addition is commutative, but not always associative.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-number-subtract">
           <h1>Number::subtract ( _x_, _y_ )</h1>
-          <p>The `-` operator performs subtraction when applied to two operands of numeric type, producing the difference of its operands; _x_ is the minuend and _y_ is the subtrahend. It is always the case that `x - y` produces the same result as `x + (-y)`.</p>
-          <p>The result of `-` operator is then _x_ + (-_y_).</p>
+          <p>The abstract operation Number::subtract takes arguments _x_ (a Number) and _y_ (a Number). It performs subtraction, producing the difference of its operands; _x_ is the minuend and _y_ is the subtrahend. It performs the following steps when called:</p>
+          <emu-alg>
+            1. Return Number::add(_x_, Number::unaryMinus(_y_)).
+          </emu-alg>
+          <emu-note>
+            <p>It is always the case that `x - y` produces the same result as `x + (-y)`.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-number-leftShift">
           <h1>Number::leftShift ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::leftShift takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
@@ -1681,6 +1690,7 @@
 
         <emu-clause id="sec-numeric-types-number-signedRightShift">
           <h1>Number::signedRightShift ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::signedRightShift takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
@@ -1691,6 +1701,7 @@
 
         <emu-clause id="sec-numeric-types-number-unsignedRightShift">
           <h1>Number::unsignedRightShift ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::unsignedRightShift takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. Let _lnum_ be ! ToUint32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
@@ -1701,6 +1712,7 @@
 
         <emu-clause id="sec-numeric-types-number-lessThan">
           <h1>Number::lessThan ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::lessThan takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *NaN*, return *undefined*.
             1. If _y_ is *NaN*, return *undefined*.
@@ -1717,6 +1729,7 @@
 
         <emu-clause id="sec-numeric-types-number-equal">
           <h1>Number::equal ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::equal takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *NaN*, return *false*.
             1. If _y_ is *NaN*, return *false*.
@@ -1729,6 +1742,7 @@
 
         <emu-clause id="sec-numeric-types-number-sameValue">
           <h1>Number::sameValue ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::sameValue takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
             1. If _x_ is *+0* and _y_ is *-0*, return *false*.
@@ -1740,6 +1754,7 @@
 
         <emu-clause id="sec-numeric-types-number-sameValueZero">
           <h1>Number::sameValueZero ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::sameValueZero takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
             1. If _x_ is *+0* and _y_ is *-0*, return *true*.
@@ -1761,6 +1776,7 @@
 
         <emu-clause id="sec-numeric-types-number-bitwiseAND">
           <h1>Number::bitwiseAND ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::bitwiseAND takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. Return NumberBitwiseOp(`&amp;`, _x_, _y_).
           </emu-alg>
@@ -1768,6 +1784,7 @@
 
         <emu-clause id="sec-numeric-types-number-bitwiseXOR">
           <h1>Number::bitwiseXOR ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::bitwiseXOR takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. Return NumberBitwiseOp(`^`, _x_, _y_).
           </emu-alg>
@@ -1775,6 +1792,7 @@
 
         <emu-clause id="sec-numeric-types-number-bitwiseOR">
           <h1>Number::bitwiseOR ( _x_, _y_ )</h1>
+          <p>The abstract operation Number::bitwiseOR takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. Return NumberBitwiseOp(`|`, _x_, _y_).
           </emu-alg>
@@ -1852,6 +1870,7 @@
 
         <emu-clause id="sec-numeric-types-bigint-unaryMinus">
           <h1>BigInt::unaryMinus ( _x_ )</h1>
+          <p>The abstract operation BigInt::unaryMinus takes argument _x_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *0n*, return *0n*.
             1. Return the BigInt value that represents the mathematical value of negating _x_.
@@ -1865,6 +1884,7 @@
 
         <emu-clause id="sec-numeric-types-bigint-exponentiate">
           <h1>BigInt::exponentiate ( _base_, _exponent_ )</h1>
+          <p>The abstract operation BigInt::exponentiate takes arguments _base_ (a BigInt) and _exponent_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. If _exponent_ &lt; *0n*, throw a *RangeError* exception.
             1. If _base_ is *0n* and _exponent_ is *0n*, return *1n*.
@@ -1880,6 +1900,7 @@
 
         <emu-clause id="sec-numeric-types-bigint-divide">
           <h1>BigInt::divide ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::divide takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. If _y_ is *0n*, throw a *RangeError* exception.
             1. Let _quotient_ be the mathematical value of _x_ divided by _y_.
@@ -1889,6 +1910,7 @@
 
         <emu-clause id="sec-numeric-types-bigint-remainder">
           <h1>BigInt::remainder ( _n_, _d_ )</h1>
+          <p>The abstract operation BigInt::remainder takes arguments _n_ (a BigInt) and _d_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. If _d_ is *0n*, throw a *RangeError* exception.
             1. If _n_ is *0n*, return *0n*.
@@ -2027,6 +2049,7 @@
 
         <emu-clause id="sec-numeric-types-bigint-bitwiseAND">
           <h1>BigInt::bitwiseAND ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::bitwiseAND takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. Return BigIntBitwiseOp(*"&amp;"*, _x_, _y_).
           </emu-alg>
@@ -2034,6 +2057,7 @@
 
         <emu-clause id="sec-numeric-types-bigint-bitwiseXOR">
           <h1>BigInt::bitwiseXOR ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::bitwiseXOR takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. Return BigIntBitwiseOp(*"^"*, _x_, _y_).
           </emu-alg>
@@ -2041,6 +2065,7 @@
 
         <emu-clause id="sec-numeric-types-bigint-bitwiseOR">
           <h1>BigInt::bitwiseOR ( _x_, _y_ )</h1>
+          <p>The abstract operation BigInt::bitwiseOR takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. Return BigIntBitwiseOp(*"|"*, _x_, _y_).
           </emu-alg>
@@ -14566,6 +14591,13 @@
       MultiplicativeOperator : one of
         `*` `/` `%`
     </emu-grammar>
+    <emu-note>
+      <ul>
+        <li>The `*` operator performs multiplication, producing the product of its operands.</li>
+        <li>The `/` operator performs division, producing the quotient of its operands.</li>
+        <li>The `%` operator yields the remainder of its operands from an implied division.</li>
+      </ul>
+    </emu-note>
 
     <emu-clause id="sec-multiplicative-operators-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
@@ -14648,6 +14680,9 @@
 
     <emu-clause id="sec-subtraction-operator-minus">
       <h1>The Subtraction Operator ( `-` )</h1>
+      <emu-note>
+        <p>The `-` operator performs subtraction, producing the difference of its operands.</p>
+      </emu-note>
 
       <emu-clause id="sec-subtraction-operator-minus-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>


### PR DESCRIPTION
(This is a follow-up to #1953, which was a follow-up to #1914.)

This PR ensures that every numeric method (Number::foo and BigInt::foo) has a preamble that is in the standard form.

- The first 4 commits deal with the 6 Number methods that have non-standard preambles (exponentiate, multiply, divide, remainder, add, subtract):
  - Commits 1-3 move out some wording that I don't think belongs in the preambles.
  - Commit 4 converts what's left to standard form.
- Commit 5 goes to every numeric method that doesn't have a preamble, and adds a standard one.
