### PR TITLE
Editorial: add prefix '?' on calling ToPrimitive in Abstract Equality Comparison

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5617,8 +5617,8 @@
         1. If Type(_x_) is String and Type(_y_) is BigInt, return the result of the comparison _y_ == _x_.
         1. If Type(_x_) is Boolean, return the result of the comparison ! ToNumber(_x_) == _y_.
         1. If Type(_y_) is Boolean, return the result of the comparison _x_ == ! ToNumber(_y_).
-        1. If Type(_x_) is either String, Number, BigInt, or Symbol and Type(_y_) is Object, return the result of the comparison _x_ == ToPrimitive(_y_).
-        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt, or Symbol, return the result of the comparison ToPrimitive(_x_) == _y_.
+        1. If Type(_x_) is either String, Number, BigInt, or Symbol and Type(_y_) is Object, return the result of the comparison _x_ == ? ToPrimitive(_y_).
+        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt, or Symbol, return the result of the comparison ? ToPrimitive(_x_) == _y_.
         1. If Type(_x_) is BigInt and Type(_y_) is Number, or if Type(_x_) is Number and Type(_y_) is BigInt, then
           1. If _x_ or _y_ are any of *NaN*, *+&infin;*, or *-&infin;*, return *false*.
           1. If the mathematical value of _x_ is equal to the mathematical value of _y_, return *true*; otherwise return *false*.


### PR DESCRIPTION
In step 10 and step 11 of [`Abstract Equality Comparison`](https://tc39.es/ecma262/#sec-abstract-equality-comparison) operation, return value of [`ToPrimitive`](https://tc39.es/ecma262/#sec-toprimitive) operation is directly used. However, [`ToPrimitive`](https://tc39.es/ecma262/#sec-toprimitive) operation may return abrupt completion record and adding prefix '?' on calling [`ToPrimitive`](https://tc39.es/ecma262/#sec-toprimitive) operation seems to be proper way of handle this problem.