### PR TITLE
Editorial: Use DefinePropertyOrThrow and ! prefix in GetTemplateObject

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13131,13 +13131,13 @@
           1. Repeat, while _index_ &lt; _count_,
             1. Let _prop_ be ! ToString(_index_).
             1. Let _cookedValue_ be the String value _cookedStrings_[_index_].
-            1. Call _template_.[[DefineOwnProperty]](_prop_, PropertyDescriptor { [[Value]]: _cookedValue_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }).
+            1. Perform ! DefinePropertyOrThrow(_template_, _prop_, PropertyDescriptor { [[Value]]: _cookedValue_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }).
             1. Let _rawValue_ be the String value _rawStrings_[_index_].
-            1. Call _rawObj_.[[DefineOwnProperty]](_prop_, PropertyDescriptor { [[Value]]: _rawValue_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }).
+            1. Perform ! DefinePropertyOrThrow(_rawObj_, _prop_, PropertyDescriptor { [[Value]]: _rawValue_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }).
             1. Set _index_ to _index_ + 1.
-          1. Perform SetIntegrityLevel(_rawObj_, ~frozen~).
-          1. Call _template_.[[DefineOwnProperty]](*"raw"*, PropertyDescriptor { [[Value]]: _rawObj_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-          1. Perform SetIntegrityLevel(_template_, ~frozen~).
+          1. Perform ! SetIntegrityLevel(_rawObj_, ~frozen~).
+          1. Perform ! DefinePropertyOrThrow(_template_, *"raw"*, PropertyDescriptor { [[Value]]: _rawObj_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ! SetIntegrityLevel(_template_, ~frozen~).
           1. Append the Record { [[Site]]: _templateLiteral_, [[Array]]: _template_ } to _templateRegistry_.
           1. Return _template_.
         </emu-alg>


### PR DESCRIPTION
While we have a note stating "template object cannot result in an abrupt completion", it would be nice to assert that `[[DefineOwnProperty]]` calls are successful.