### PR TITLE
Editorial: end all 'Repeat' steps with commas

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4478,7 +4478,7 @@
           1. Assert: _fromIndex_ + _count_ &le; _fromSize_.
           1. Let _toSize_ be the number of bytes in _toBlock_.
           1. Assert: _toIndex_ + _count_ &le; _toSize_.
-          1. Repeat, while _count_ &gt; 0
+          1. Repeat, while _count_ &gt; 0,
             1. If _fromBlock_ is a Shared Data Block, then
               1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
               1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
@@ -5907,7 +5907,7 @@
         1. Let _len_ be ? LengthOfArrayLike(_obj_).
         1. Let _list_ be a new empty List.
         1. Let _index_ be 0.
-        1. Repeat, while _index_ &lt; _len_
+        1. Repeat, while _index_ &lt; _len_,
           1. Let _indexName_ be ! ToString(_index_).
           1. Let _next_ be ? Get(_obj_, _indexName_).
           1. If Type(_next_) is not an element of _elementTypes_, throw a *TypeError* exception.
@@ -13128,7 +13128,7 @@
           1. Let _template_ be ! ArrayCreate(_count_).
           1. Let _rawObj_ be ! ArrayCreate(_count_).
           1. Let _index_ be 0.
-          1. Repeat, while _index_ &lt; _count_
+          1. Repeat, while _index_ &lt; _count_,
             1. Let _prop_ be ! ToString(_index_).
             1. Let _cookedValue_ be the String value _cookedStrings_[_index_].
             1. Call _template_.[[DefineOwnProperty]](_prop_, PropertyDescriptor { [[Value]]: _cookedValue_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }).
@@ -25200,7 +25200,7 @@
                   1. Set _Octets_[0] to _B_.
                   1. If _k_ + (3 &times; (_n_ - 1)) is greater than or equal to _strLen_, throw a *URIError* exception.
                   1. Let _j_ be 1.
-                  1. Repeat, while _j_ &lt; _n_
+                  1. Repeat, while _j_ &lt; _n_,
                     1. Set _k_ to _k_ + 1.
                     1. If the code unit at index _k_ within _string_ is not the code unit 0x0025 (PERCENT SIGN), throw a *URIError* exception.
                     1. If the code units at index (_k_ + 1) and (_k_ + 2) within _string_ do not represent hexadecimal digits, throw a *URIError* exception.
@@ -26173,7 +26173,7 @@
               1. Let _firstArg_ be _args_[0].
               1. Set _P_ to ? ToString(_firstArg_).
               1. Let _k_ be 1.
-              1. Repeat, while _k_ &lt; _argCount_ - 1
+              1. Repeat, while _k_ &lt; _argCount_ - 1,
                 1. Let _nextArg_ be _args_[_k_].
                 1. Let _nextArgString_ be ? ToString(_nextArg_).
                 1. Set _P_ to the string-concatenation of the previous value of _P_, *","* (a comma), and _nextArgString_.
@@ -29753,7 +29753,7 @@ THH:mm:ss.sss
           1. Let _length_ be the number of elements in _codeUnits_.
           1. Let _elements_ be a new empty List.
           1. Let _nextIndex_ be 0.
-          1. Repeat, while _nextIndex_ &lt; _length_
+          1. Repeat, while _nextIndex_ &lt; _length_,
             1. Let _next_ be _codeUnits_[_nextIndex_].
             1. Let _nextCU_ be ? ToUint16(_next_).
             1. Append _nextCU_ to the end of _elements_.
@@ -29771,7 +29771,7 @@ THH:mm:ss.sss
           1. Let _length_ be the number of elements in _codePoints_.
           1. Let _elements_ be a new empty List.
           1. Let _nextIndex_ be 0.
-          1. Repeat, while _nextIndex_ &lt; _length_
+          1. Repeat, while _nextIndex_ &lt; _length_,
             1. Let _next_ be _codePoints_[_nextIndex_].
             1. Let _nextCP_ be ? ToNumber(_next_).
             1. If ! IsInteger(_nextCP_) is *false*, throw a *RangeError* exception.
@@ -29910,7 +29910,7 @@ THH:mm:ss.sss
           1. Let _S_ be ? ToString(_O_).
           1. Let _args_ be a List whose elements are the arguments passed to this function.
           1. Let _R_ be _S_.
-          1. Repeat, while _args_ is not empty
+          1. Repeat, while _args_ is not empty,
             1. Remove the first element from _args_ and let _next_ be the value of that element.
             1. Let _nextString_ be ? ToString(_next_).
             1. Set _R_ to the string-concatenation of the previous value of _R_ and _nextString_.
@@ -30415,7 +30415,7 @@ THH:mm:ss.sss
             1. Return _A_.
           1. Let _p_ be 0.
           1. Let _q_ be _p_.
-          1. Repeat, while _q_ &ne; _s_
+          1. Repeat, while _q_ &ne; _s_,
             1. Let _e_ be SplitMatch(_S_, _q_, _R_).
             1. If _e_ is *false*, set _q_ to _q_ + 1.
             1. Else,
@@ -32583,7 +32583,7 @@ THH:mm:ss.sss
             1. Let _matcher_ be _R_.[[RegExpMatcher]].
             1. If _flags_ contains *"u"*, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
             1. Let _matchSucceeded_ be *false*.
-            1. Repeat, while _matchSucceeded_ is *false*
+            1. Repeat, while _matchSucceeded_ is *false*,
               1. If _lastIndex_ &gt; _length_, then
                 1. If _global_ is *true* or _sticky_ is *true*, then
                   1. Perform ? Set(_R_, *"lastIndex"*, 0, *true*).
@@ -32824,7 +32824,7 @@ THH:mm:ss.sss
             1. Perform ? Set(_rx_, *"lastIndex"*, 0, *true*).
           1. Let _results_ be a new empty List.
           1. Let _done_ be *false*.
-          1. Repeat, while _done_ is *false*
+          1. Repeat, while _done_ is *false*,
             1. Let _result_ be ? RegExpExec(_rx_, _S_).
             1. If _result_ is *null*, set _done_ to *true*.
             1. Else,
@@ -32847,7 +32847,7 @@ THH:mm:ss.sss
             1. Set _position_ to max(min(_position_, _lengthS_), 0).
             1. Let _n_ be 1.
             1. Let _captures_ be a new empty List.
-            1. Repeat, while _n_ &le; _nCaptures_
+            1. Repeat, while _n_ &le; _nCaptures_,
               1. Let _capN_ be ? Get(_result_, ! ToString(_n_)).
               1. If _capN_ is not *undefined*, then
                 1. Set _capN_ to ? ToString(_capN_).
@@ -32951,7 +32951,7 @@ THH:mm:ss.sss
             1. Return _A_.
           1. Let _p_ be 0.
           1. Let _q_ be _p_.
-          1. Repeat, while _q_ &lt; _size_
+          1. Repeat, while _q_ &lt; _size_,
             1. Perform ? Set(_splitter_, *"lastIndex"*, _q_, *true*).
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is *null*, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
@@ -33210,7 +33210,7 @@ THH:mm:ss.sss
           1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
           1. Let _k_ be 0.
           1. Let _items_ be a zero-origined List containing the argument items in order.
-          1. Repeat, while _k_ &lt; _numberOfArgs_
+          1. Repeat, while _k_ &lt; _numberOfArgs_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _itemK_ be _items_[_k_].
             1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
@@ -33272,7 +33272,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _A_ be ? ArrayCreate(_len_).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. If _mapping_ is *true*, then
@@ -33308,7 +33308,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _A_ be ? ArrayCreate(_len_).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _kValue_ be _items_[_k_].
             1. Let _Pk_ be ! ToString(_k_).
             1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _kValue_).
@@ -33365,14 +33365,14 @@ THH:mm:ss.sss
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _n_ be 0.
           1. Let _items_ be a List whose first element is _O_ and whose subsequent elements are, in left to right order, the arguments that were passed to this function invocation.
-          1. Repeat, while _items_ is not empty
+          1. Repeat, while _items_ is not empty,
             1. Remove the first element from _items_ and let _E_ be the value of the element.
             1. Let _spreadable_ be ? IsConcatSpreadable(_E_).
             1. If _spreadable_ is *true*, then
               1. Let _k_ be 0.
               1. Let _len_ be ? LengthOfArrayLike(_E_).
               1. If _n_ + _len_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
-              1. Repeat, while _k_ &lt; _len_
+              1. Repeat, while _k_ &lt; _len_,
                 1. Let _P_ be ! ToString(_k_).
                 1. Let _exists_ be ? HasProperty(_E_, _P_).
                 1. If _exists_ is *true*, then
@@ -33436,7 +33436,7 @@ THH:mm:ss.sss
             1. Set _to_ to _to_ + _count_ - 1.
           1. Else,
             1. Let _direction_ be 1.
-          1. Repeat, while _count_ &gt; 0
+          1. Repeat, while _count_ &gt; 0,
             1. Let _fromKey_ be ! ToString(_from_).
             1. Let _toKey_ be ! ToString(_to_).
             1. Let _fromPresent_ be ? HasProperty(_O_, _fromKey_).
@@ -33481,7 +33481,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
@@ -33510,7 +33510,7 @@ THH:mm:ss.sss
           1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
           1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
-          1. Repeat, while _k_ &lt; _final_
+          1. Repeat, while _k_ &lt; _final_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Perform ? Set(_O_, _Pk_, _value_, *true*).
             1. Set _k_ to _k_ + 1.
@@ -33538,7 +33538,7 @@ THH:mm:ss.sss
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
@@ -33571,7 +33571,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
             1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
@@ -33599,7 +33599,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
             1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
@@ -33638,7 +33638,7 @@ THH:mm:ss.sss
             1. Assert: If _mapperFunction_ is present, then ! IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is *1*.
             1. Let _targetIndex_ be _start_.
             1. Let _sourceIndex_ be 0.
-            1. Repeat, while _sourceIndex_ &lt; _sourceLen_
+            1. Repeat, while _sourceIndex_ &lt; _sourceLen_,
               1. Let _P_ be ! ToString(_sourceIndex_).
               1. Let _exists_ be ? HasProperty(_source_, _P_).
               1. If _exists_ is *true*, then
@@ -33688,7 +33688,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
@@ -33725,7 +33725,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _k_ be _len_ + _n_.
             1. If _k_ &lt; 0, set _k_ to 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _elementK_ be the result of ? Get(_O_, ! ToString(_k_)).
             1. If SameValueZero(_searchElement_, _elementK_) is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
@@ -33760,7 +33760,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _k_ be _len_ + _n_.
             1. If _k_ &lt; 0, set _k_ to 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(_k_)).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ? Get(_O_, ! ToString(_k_)).
@@ -33787,7 +33787,7 @@ THH:mm:ss.sss
           1. Else, let _sep_ be ? ToString(_separator_).
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. If _k_ &gt; 0, set _R_ to the string-concatenation of _R_ and _sep_.
             1. Let _element_ be ? Get(_O_, ! ToString(_k_)).
             1. If _element_ is *undefined* or *null*, let _next_ be the empty String; otherwise, let _next_ be ? ToString(_element_).
@@ -33826,7 +33826,7 @@ THH:mm:ss.sss
             1. Let _k_ be min(_n_, _len_ - 1).
           1. Else,
             1. Let _k_ be _len_ + _n_.
-          1. Repeat, while _k_ &ge; 0
+          1. Repeat, while _k_ &ge; 0,
             1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(_k_)).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ? Get(_O_, ! ToString(_k_)).
@@ -33856,7 +33856,7 @@ THH:mm:ss.sss
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _len_).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
@@ -33909,7 +33909,7 @@ THH:mm:ss.sss
           1. Let _items_ be a List whose elements are, in left to right order, the arguments that were passed to this function invocation.
           1. Let _argCount_ be the number of elements in _items_.
           1. If _len_ + _argCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
-          1. Repeat, while _items_ is not empty
+          1. Repeat, while _items_ is not empty,
             1. Remove the first element from _items_ and let _E_ be the value of the element.
             1. Perform ? Set(_O_, ! ToString(_len_), _E_, *true*).
             1. Set _len_ to _len_ + 1.
@@ -33942,14 +33942,14 @@ THH:mm:ss.sss
             1. Set _accumulator_ to _initialValue_.
           1. Else,
             1. Let _kPresent_ be *false*.
-            1. Repeat, while _kPresent_ is *false* and _k_ &lt; _len_
+            1. Repeat, while _kPresent_ is *false* and _k_ &lt; _len_,
               1. Let _Pk_ be ! ToString(_k_).
               1. Set _kPresent_ to ? HasProperty(_O_, _Pk_).
               1. If _kPresent_ is *true*, then
                 1. Set _accumulator_ to ? Get(_O_, _Pk_).
               1. Set _k_ to _k_ + 1.
             1. If _kPresent_ is *false*, throw a *TypeError* exception.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
@@ -33983,14 +33983,14 @@ THH:mm:ss.sss
             1. Set _accumulator_ to _initialValue_.
           1. Else,
             1. Let _kPresent_ be *false*.
-            1. Repeat, while _kPresent_ is *false* and _k_ &ge; 0
+            1. Repeat, while _kPresent_ is *false* and _k_ &ge; 0,
               1. Let _Pk_ be ! ToString(_k_).
               1. Set _kPresent_ to ? HasProperty(_O_, _Pk_).
               1. If _kPresent_ is *true*, then
                 1. Set _accumulator_ to ? Get(_O_, _Pk_).
               1. Set _k_ to _k_ - 1.
             1. If _kPresent_ is *false*, throw a *TypeError* exception.
-          1. Repeat, while _k_ &ge; 0
+          1. Repeat, while _k_ &ge; 0,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
@@ -34015,7 +34015,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _middle_ be floor(_len_ / 2).
           1. Let _lower_ be 0.
-          1. Repeat, while _lower_ &ne; _middle_
+          1. Repeat, while _lower_ &ne; _middle_,
             1. Let _upper_ be _len_ - _lower_ - 1.
             1. Let _upperP_ be ! ToString(_upper_).
             1. Let _lowerP_ be ! ToString(_lower_).
@@ -34059,7 +34059,7 @@ THH:mm:ss.sss
             1. Return *undefined*.
           1. Let _first_ be ? Get(_O_, *"0"*).
           1. Let _k_ be 1.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _from_ be ! ToString(_k_).
             1. Let _to_ be ! ToString(_k_ - 1).
             1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
@@ -34095,7 +34095,7 @@ THH:mm:ss.sss
           1. Let _count_ be max(_final_ - _k_, 0).
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _count_).
           1. Let _n_ be 0.
-          1. Repeat, while _k_ &lt; _final_
+          1. Repeat, while _k_ &lt; _final_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
@@ -34129,7 +34129,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
@@ -34301,7 +34301,7 @@ THH:mm:ss.sss
           1. If _len_ + _insertCount_ - _actualDeleteCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _actualDeleteCount_).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _actualDeleteCount_
+          1. Repeat, while _k_ &lt; _actualDeleteCount_,
             1. Let _from_ be ! ToString(_actualStart_ + _k_).
             1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
             1. If _fromPresent_ is *true*, then
@@ -34313,7 +34313,7 @@ THH:mm:ss.sss
           1. Let _itemCount_ be the number of elements in _items_.
           1. If _itemCount_ &lt; _actualDeleteCount_, then
             1. Set _k_ to _actualStart_.
-            1. Repeat, while _k_ &lt; (_len_ - _actualDeleteCount_)
+            1. Repeat, while _k_ &lt; (_len_ - _actualDeleteCount_),
               1. Let _from_ be ! ToString(_k_ + _actualDeleteCount_).
               1. Let _to_ be ! ToString(_k_ + _itemCount_).
               1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
@@ -34325,12 +34325,12 @@ THH:mm:ss.sss
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Set _k_ to _k_ + 1.
             1. Set _k_ to _len_.
-            1. Repeat, while _k_ &gt; (_len_ - _actualDeleteCount_ + _itemCount_)
+            1. Repeat, while _k_ &gt; (_len_ - _actualDeleteCount_ + _itemCount_),
               1. Perform ? DeletePropertyOrThrow(_O_, ! ToString(_k_ - 1)).
               1. Set _k_ to _k_ - 1.
           1. Else if _itemCount_ &gt; _actualDeleteCount_, then
             1. Set _k_ to (_len_ - _actualDeleteCount_).
-            1. Repeat, while _k_ &gt; _actualStart_
+            1. Repeat, while _k_ &gt; _actualStart_,
               1. Let _from_ be ! ToString(_k_ + _actualDeleteCount_ - 1).
               1. Let _to_ be ! ToString(_k_ + _itemCount_ - 1).
               1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
@@ -34342,7 +34342,7 @@ THH:mm:ss.sss
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Set _k_ to _k_ - 1.
           1. Set _k_ to _actualStart_.
-          1. Repeat, while _items_ is not empty
+          1. Repeat, while _items_ is not empty,
             1. Remove the first element from _items_ and let _E_ be the value of that element.
             1. Perform ? Set(_O_, ! ToString(_k_), _E_, *true*).
             1. Set _k_ to _k_ + 1.
@@ -34371,7 +34371,7 @@ THH:mm:ss.sss
           1. Let _separator_ be the String value for the list-separator String appropriate for the host environment's current locale (this is derived in an implementation-defined way).
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. If _k_ &gt; 0, then
               1. Set _R_ to the string-concatenation of _R_ and _separator_.
             1. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
@@ -34429,7 +34429,7 @@ THH:mm:ss.sss
               1. Set _k_ to _k_ - 1.
             1. Let _j_ be 0.
             1. Let _items_ be a List whose elements are, in left to right order, the arguments that were passed to this function invocation.
-            1. Repeat, while _items_ is not empty
+            1. Repeat, while _items_ is not empty,
               1. Remove the first element from _items_ and let _E_ be the value of that element.
               1. Perform ? Set(_O_, ! ToString(_j_), _E_, *true*).
               1. Set _j_ to _j_ + 1.
@@ -34888,7 +34888,7 @@ THH:mm:ss.sss
             1. Let _len_ be the number of elements in _values_.
             1. Let _targetObj_ be ? TypedArrayCreate(_C_, &laquo; _len_ &raquo;).
             1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _len_
+            1. Repeat, while _k_ &lt; _len_,
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
               1. If _mapping_ is *true*, then
@@ -34903,7 +34903,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_arrayLike_).
           1. Let _targetObj_ be ? TypedArrayCreate(_C_, &laquo; _len_ &raquo;).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. If _mapping_ is *true*, then
@@ -34921,7 +34921,7 @@ THH:mm:ss.sss
             1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~, _method_).
             1. Let _values_ be a new empty List.
             1. Let _next_ be *true*.
-            1. Repeat, while _next_ is not *false*
+            1. Repeat, while _next_ is not *false*,
               1. Set _next_ to ? IteratorStep(_iteratorRecord_).
               1. If _next_ is not *false*, then
                 1. Let _nextValue_ be ? IteratorValue(_next_).
@@ -34941,7 +34941,7 @@ THH:mm:ss.sss
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
           1. Let _newObj_ be ? TypedArrayCreate(_C_, &laquo; _len_ &raquo;).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _kValue_ be _items_[_k_].
             1. Let _Pk_ be ! ToString(_k_).
             1. Perform ? Set(_newObj_, _Pk_, _kValue_, *true*).
@@ -35057,7 +35057,7 @@ THH:mm:ss.sss
               1. Set _toByteIndex_ to _toByteIndex_ + _countBytes_ - 1.
             1. Else,
               1. Let _direction_ be 1.
-            1. Repeat, while _countBytes_ &gt; 0
+            1. Repeat, while _countBytes_ &gt; 0,
               1. Let _value_ be GetValueFromBuffer(_buffer_, _fromByteIndex_, ~Uint8~, *true*, ~Unordered~).
               1. Perform SetValueInBuffer(_buffer_, _toByteIndex_, ~Uint8~, _value_, *true*, ~Unordered~).
               1. Set _fromByteIndex_ to _fromByteIndex_ + _direction_.
@@ -35110,7 +35110,7 @@ THH:mm:ss.sss
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
           1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
-          1. Repeat, while _k_ &lt; _final_
+          1. Repeat, while _k_ &lt; _final_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Perform ! Set(_O_, _Pk_, _value_, *true*).
             1. Set _k_ to _k_ + 1.
@@ -35130,7 +35130,7 @@ THH:mm:ss.sss
           1. Let _kept_ be a new empty List.
           1. Let _k_ be 0.
           1. Let _captured_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
             1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
@@ -35226,7 +35226,7 @@ THH:mm:ss.sss
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _len_ &raquo;).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
             1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;).
@@ -35283,7 +35283,7 @@ THH:mm:ss.sss
             1. Let _targetByteIndex_ be _targetOffset_ &times; _targetElementSize_ + _targetByteOffset_.
             1. Let _k_ be 0.
             1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ &times; _srcLength_.
-            1. Repeat, while _targetByteIndex_ &lt; _limit_
+            1. Repeat, while _targetByteIndex_ &lt; _limit_,
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _value_ be ? Get(_src_, _Pk_).
               1. If _target_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
@@ -35335,13 +35335,13 @@ THH:mm:ss.sss
             1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ &times; _srcLength_.
             1. If _srcType_ is the same as _targetType_, then
               1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
-              1. Repeat, while _targetByteIndex_ &lt; _limit_
+              1. Repeat, while _targetByteIndex_ &lt; _limit_,
                 1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, ~Uint8~, *true*, ~Unordered~).
                 1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~Uint8~, _value_, *true*, ~Unordered~).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + 1.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + 1.
             1. Else,
-              1. Repeat, while _targetByteIndex_ &lt; _limit_
+              1. Repeat, while _targetByteIndex_ &lt; _limit_,
                 1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, _srcType_, *true*, ~Unordered~).
                 1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
@@ -35370,7 +35370,7 @@ THH:mm:ss.sss
           1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
           1. If _srcType_ is different from _targetType_, then
             1. Let _n_ be 0.
-            1. Repeat, while _k_ &lt; _final_
+            1. Repeat, while _k_ &lt; _final_,
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _kValue_ be ? Get(_O_, _Pk_).
               1. Perform ! Set(_A_, ! ToString(_n_), _kValue_, *true*).
@@ -35386,7 +35386,7 @@ THH:mm:ss.sss
             1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
             1. Let _srcByteIndex_ be (_k_ &times; _elementSize_) + _srcByteOffet_.
             1. Let _limit_ be _targetByteIndex_ + _count_ &times; _elementSize_.
-            1. Repeat, while _targetByteIndex_ &lt; _limit_
+            1. Repeat, while _targetByteIndex_ &lt; _limit_,
               1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, ~Uint8~, *true*, ~Unordered~).
               1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~Uint8~, _value_, *true*, ~Unordered~).
               1. Set _srcByteIndex_ to _srcByteIndex_ + 1.
@@ -35612,7 +35612,7 @@ THH:mm:ss.sss
             1. Let _srcByteIndex_ be _srcByteOffset_.
             1. Let _targetByteIndex_ be 0.
             1. Let _count_ be _elementLength_.
-            1. Repeat, while _count_ &gt; 0
+            1. Repeat, while _count_ &gt; 0,
               1. Let _value_ be GetValueFromBuffer(_srcData_, _srcByteIndex_, _srcType_, *true*, ~Unordered~).
               1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_, *true*, ~Unordered~).
               1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
@@ -35641,7 +35641,7 @@ THH:mm:ss.sss
             1. Let _len_ be the number of elements in _values_.
             1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
             1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _len_
+            1. Repeat, while _k_ &lt; _len_,
               1. Let _Pk_ be ! ToString(_k_).
               1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
               1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
@@ -35653,7 +35653,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_arrayLike_).
           1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
@@ -38380,7 +38380,7 @@ THH:mm:ss.sss
           1. Let _partial_ be a new empty List.
           1. Let _len_ be ? LengthOfArrayLike(_value_).
           1. Let _index_ be 0.
-          1. Repeat, while _index_ &lt; _len_
+          1. Repeat, while _index_ &lt; _len_,
             1. Let _strP_ be ? SerializeJSONProperty(_state_, ! ToString(_index_), _value_).
             1. If _strP_ is *undefined*, then
               1. Append *"null"* to _partial_.
@@ -42426,7 +42426,7 @@ THH:mm:ss.sss
           1. Let _length_ be the number of code units in _string_.
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &ne; _length_
+          1. Repeat, while _k_ &ne; _length_,
             1. Let _c_ be the code unit at index _k_ within _string_.
             1. If _c_ is the code unit 0x0025 (PERCENT SIGN), then
               1. If _k_ &le; _length_ - 6 and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U) and the four code units at indices _k_ + 2, _k_ + 3, _k_ + 4, and _k_ + 5 within _string_ are all hexadecimal digits, then


### PR DESCRIPTION
There are currently 21 places in the spec where we say something like `Repeat, while x,` (with a trailing comma) and 65 where we say something like `Repeat, while x` (without it). I would like us to be consistent.

I've chosen to have trailing commas in all cases, rather than none. This is a larger change, but I think more consistent with the rest of the specification given that when we repeat without condition we say `Repeat,` with the trailing comma. (We also say `Else,` rather than `Else`.)

But if there is a compelling reason to omit these I am happy to go the other direction and delete the 19 existing trailing commas instead.

I intend to introduce tooling to enforce this as soon as I can.