### PR TITLE
Editorial: use real table rows instead of ULs in Unicode tables

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42,10 +42,6 @@
     width: 100%;
     font-size: 80%;
   }
-  .unicode-property-table ul {
-    padding-left: 0;
-    list-style: none;
-  }
   /* the following overrides need to be moved into ecmarkup itself */
   emu-note {
     color: inherit;

--- a/table-binary-unicode-properties.html
+++ b/table-binary-unicode-properties.html
@@ -12,22 +12,18 @@
       <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`ASCII`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`ASCII_Hex_Digit`</li>
-          <li>`AHex`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#ASCII_Hex_Digit">`ASCII_Hex_Digit`</a></td>
+      <td>`ASCII_Hex_Digit`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#ASCII_Hex_Digit">`ASCII_Hex_Digit`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Alphabetic`</li>
-          <li>`Alpha`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Alphabetic">`Alphabetic`</a></td>
+      <td>`AHex`</td>
+    </tr>
+    <tr>
+      <td>`Alphabetic`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Alphabetic">`Alphabetic`</a></td>
+    </tr>
+    <tr>
+      <td>`Alpha`</td>
     </tr>
     <tr>
       <td>`Any`</td>
@@ -38,120 +34,96 @@
       <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`Assigned`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Bidi_Control`</li>
-          <li>`Bidi_C`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Bidi_Control">`Bidi_Control`</a></td>
+      <td>`Bidi_Control`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Bidi_Control">`Bidi_Control`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Bidi_Mirrored`</li>
-          <li>`Bidi_M`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Bidi_Mirrored">`Bidi_Mirrored`</a></td>
+      <td>`Bidi_C`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Case_Ignorable`</li>
-          <li>`CI`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Case_Ignorable">`Case_Ignorable`</a></td>
+      <td>`Bidi_Mirrored`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Bidi_Mirrored">`Bidi_Mirrored`</a></td>
+    </tr>
+    <tr>
+      <td>`Bidi_M`</td>
+    </tr>
+    <tr>
+      <td>`Case_Ignorable`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Case_Ignorable">`Case_Ignorable`</a></td>
+    </tr>
+    <tr>
+      <td>`CI`</td>
     </tr>
     <tr>
       <td>`Cased`</td>
       <td><a href="https://unicode.org/reports/tr44/#Cased">`Cased`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Changes_When_Casefolded`</li>
-          <li>`CWCF`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWCF">`Changes_When_Casefolded`</a></td>
+      <td>`Changes_When_Casefolded`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#CWCF">`Changes_When_Casefolded`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Changes_When_Casemapped`</li>
-          <li>`CWCM`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWCM">`Changes_When_Casemapped`</a></td>
+      <td>`CWCF`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Changes_When_Lowercased`</li>
-          <li>`CWL`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWL">`Changes_When_Lowercased`</a></td>
+      <td>`Changes_When_Casemapped`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#CWCM">`Changes_When_Casemapped`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Changes_When_NFKC_Casefolded`</li>
-          <li>`CWKCF`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWKCF">`Changes_When_NFKC_Casefolded`</a></td>
+      <td>`CWCM`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Changes_When_Titlecased`</li>
-          <li>`CWT`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWT">`Changes_When_Titlecased`</a></td>
+      <td>`Changes_When_Lowercased`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#CWL">`Changes_When_Lowercased`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Changes_When_Uppercased`</li>
-          <li>`CWU`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#CWU">`Changes_When_Uppercased`</a></td>
+      <td>`CWL`</td>
+    </tr>
+    <tr>
+      <td>`Changes_When_NFKC_Casefolded`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#CWKCF">`Changes_When_NFKC_Casefolded`</a></td>
+    </tr>
+    <tr>
+      <td>`CWKCF`</td>
+    </tr>
+    <tr>
+      <td>`Changes_When_Titlecased`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#CWT">`Changes_When_Titlecased`</a></td>
+    </tr>
+    <tr>
+      <td>`CWT`</td>
+    </tr>
+    <tr>
+      <td>`Changes_When_Uppercased`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#CWU">`Changes_When_Uppercased`</a></td>
+    </tr>
+    <tr>
+      <td>`CWU`</td>
     </tr>
     <tr>
       <td>`Dash`</td>
       <td><a href="https://unicode.org/reports/tr44/#Dash">`Dash`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Default_Ignorable_Code_Point`</li>
-          <li>`DI`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Default_Ignorable_Code_Point">`Default_Ignorable_Code_Point`</a></td>
+      <td>`Default_Ignorable_Code_Point`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Default_Ignorable_Code_Point">`Default_Ignorable_Code_Point`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Deprecated`</li>
-          <li>`Dep`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Deprecated">`Deprecated`</a></td>
+      <td>`DI`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Diacritic`</li>
-          <li>`Dia`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Diacritic">`Diacritic`</a></td>
+      <td>`Deprecated`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Deprecated">`Deprecated`</a></td>
+    </tr>
+    <tr>
+      <td>`Dep`</td>
+    </tr>
+    <tr>
+      <td>`Diacritic`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Diacritic">`Diacritic`</a></td>
+    </tr>
+    <tr>
+      <td>`Dia`</td>
     </tr>
     <tr>
       <td>`Emoji`</td>
@@ -178,246 +150,194 @@
       <td><a href="https://unicode.org/reports/tr51/#Emoji_Properties">`Extended_Pictographic`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Extender`</li>
-          <li>`Ext`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Extender">`Extender`</a></td>
+      <td>`Extender`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Extender">`Extender`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Grapheme_Base`</li>
-          <li>`Gr_Base`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Grapheme_Base">`Grapheme_Base`</a></td>
+      <td>`Ext`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Grapheme_Extend`</li>
-          <li>`Gr_Ext`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Grapheme_Extend">`Grapheme_Extend`</a></td>
+      <td>`Grapheme_Base`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Grapheme_Base">`Grapheme_Base`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Hex_Digit`</li>
-          <li>`Hex`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Hex_Digit">`Hex_Digit`</a></td>
+      <td>`Gr_Base`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`IDS_Binary_Operator`</li>
-          <li>`IDSB`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#IDS_Binary_Operator">`IDS_Binary_Operator`</a></td>
+      <td>`Grapheme_Extend`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Grapheme_Extend">`Grapheme_Extend`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`IDS_Trinary_Operator`</li>
-          <li>`IDST`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#IDS_Trinary_Operator">`IDS_Trinary_Operator`</a></td>
+      <td>`Gr_Ext`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`ID_Continue`</li>
-          <li>`IDC`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#ID_Continue">`ID_Continue`</a></td>
+      <td>`Hex_Digit`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Hex_Digit">`Hex_Digit`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`ID_Start`</li>
-          <li>`IDS`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#ID_Start">`ID_Start`</a></td>
+      <td>`Hex`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Ideographic`</li>
-          <li>`Ideo`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Ideographic">`Ideographic`</a></td>
+      <td>`IDS_Binary_Operator`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#IDS_Binary_Operator">`IDS_Binary_Operator`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Join_Control`</li>
-          <li>`Join_C`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Join_Control">`Join_Control`</a></td>
+      <td>`IDSB`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Logical_Order_Exception`</li>
-          <li>`LOE`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Logical_Order_Exception">`Logical_Order_Exception`</a></td>
+      <td>`IDS_Trinary_Operator`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#IDS_Trinary_Operator">`IDS_Trinary_Operator`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Lowercase`</li>
-          <li>`Lower`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Lowercase">`Lowercase`</a></td>
+      <td>`IDST`</td>
+    </tr>
+    <tr>
+      <td>`ID_Continue`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#ID_Continue">`ID_Continue`</a></td>
+    </tr>
+    <tr>
+      <td>`IDC`</td>
+    </tr>
+    <tr>
+      <td>`ID_Start`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#ID_Start">`ID_Start`</a></td>
+    </tr>
+    <tr>
+      <td>`IDS`</td>
+    </tr>
+    <tr>
+      <td>`Ideographic`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Ideographic">`Ideographic`</a></td>
+    </tr>
+    <tr>
+      <td>`Ideo`</td>
+    </tr>
+    <tr>
+      <td>`Join_Control`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Join_Control">`Join_Control`</a></td>
+    </tr>
+    <tr>
+      <td>`Join_C`</td>
+    </tr>
+    <tr>
+      <td>`Logical_Order_Exception`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Logical_Order_Exception">`Logical_Order_Exception`</a></td>
+    </tr>
+    <tr>
+      <td>`LOE`</td>
+    </tr>
+    <tr>
+      <td>`Lowercase`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Lowercase">`Lowercase`</a></td>
+    </tr>
+    <tr>
+      <td>`Lower`</td>
     </tr>
     <tr>
       <td>`Math`</td>
       <td><a href="https://unicode.org/reports/tr44/#Math">`Math`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Noncharacter_Code_Point`</li>
-          <li>`NChar`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Noncharacter_Code_Point">`Noncharacter_Code_Point`</a></td>
+      <td>`Noncharacter_Code_Point`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Noncharacter_Code_Point">`Noncharacter_Code_Point`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Pattern_Syntax`</li>
-          <li>`Pat_Syn`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Pattern_Syntax">`Pattern_Syntax`</a></td>
+      <td>`NChar`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Pattern_White_Space`</li>
-          <li>`Pat_WS`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Pattern_White_Space">`Pattern_White_Space`</a></td>
+      <td>`Pattern_Syntax`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Pattern_Syntax">`Pattern_Syntax`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Quotation_Mark`</li>
-          <li>`QMark`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Quotation_Mark">`Quotation_Mark`</a></td>
+      <td>`Pat_Syn`</td>
+    </tr>
+    <tr>
+      <td>`Pattern_White_Space`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Pattern_White_Space">`Pattern_White_Space`</a></td>
+    </tr>
+    <tr>
+      <td>`Pat_WS`</td>
+    </tr>
+    <tr>
+      <td>`Quotation_Mark`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Quotation_Mark">`Quotation_Mark`</a></td>
+    </tr>
+    <tr>
+      <td>`QMark`</td>
     </tr>
     <tr>
       <td>`Radical`</td>
       <td><a href="https://unicode.org/reports/tr44/#Radical">`Radical`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Regional_Indicator`</li>
-          <li>`RI`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Regional_Indicator">`Regional_Indicator`</a></td>
+      <td>`Regional_Indicator`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Regional_Indicator">`Regional_Indicator`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Sentence_Terminal`</li>
-          <li>`STerm`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#STerm">`Sentence_Terminal`</a></td>
+      <td>`RI`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Soft_Dotted`</li>
-          <li>`SD`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Soft_Dotted">`Soft_Dotted`</a></td>
+      <td>`Sentence_Terminal`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#STerm">`Sentence_Terminal`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Terminal_Punctuation`</li>
-          <li>`Term`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Terminal_Punctuation">`Terminal_Punctuation`</a></td>
+      <td>`STerm`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Unified_Ideograph`</li>
-          <li>`UIdeo`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Unified_Ideograph">`Unified_Ideograph`</a></td>
+      <td>`Soft_Dotted`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Soft_Dotted">`Soft_Dotted`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Uppercase`</li>
-          <li>`Upper`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Uppercase">`Uppercase`</a></td>
+      <td>`SD`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Variation_Selector`</li>
-          <li>`VS`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#Variation_Selector">`Variation_Selector`</a></td>
+      <td>`Terminal_Punctuation`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Terminal_Punctuation">`Terminal_Punctuation`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`White_Space`</li>
-          <li>`space`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#White_Space">`White_Space`</a></td>
+      <td>`Term`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`XID_Continue`</li>
-          <li>`XIDC`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#XID_Continue">`XID_Continue`</a></td>
+      <td>`Unified_Ideograph`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Unified_Ideograph">`Unified_Ideograph`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`XID_Start`</li>
-          <li>`XIDS`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr44/#XID_Start">`XID_Start`</a></td>
+      <td>`UIdeo`</td>
+    </tr>
+    <tr>
+      <td>`Uppercase`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Uppercase">`Uppercase`</a></td>
+    </tr>
+    <tr>
+      <td>`Upper`</td>
+    </tr>
+    <tr>
+      <td>`Variation_Selector`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#Variation_Selector">`Variation_Selector`</a></td>
+    </tr>
+    <tr>
+      <td>`VS`</td>
+    </tr>
+    <tr>
+      <td>`White_Space`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#White_Space">`White_Space`</a></td>
+    </tr>
+    <tr>
+      <td>`space`</td>
+    </tr>
+    <tr>
+      <td>`XID_Continue`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#XID_Continue">`XID_Continue`</a></td>
+    </tr>
+    <tr>
+      <td>`XIDC`</td>
+    </tr>
+    <tr>
+      <td>`XID_Start`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr44/#XID_Start">`XID_Start`</a></td>
+    </tr>
+    <tr>
+      <td>`XIDS`</td>
     </tr>
   </table>
 </emu-table>

--- a/table-nonbinary-unicode-properties.html
+++ b/table-nonbinary-unicode-properties.html
@@ -8,31 +8,25 @@
       </tr>
     </thead>
     <tr>
-      <td>
-        <ul>
-          <li>`General_Category`</li>
-          <li>`gc`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr18/#General_Category_Property">`General_Category`</a></td>
+      <td>`General_Category`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr18/#General_Category_Property">`General_Category`</a></td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Script`</li>
-          <li>`sc`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr24/#Script">`Script`</a></td>
+      <td>`gc`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Script_Extensions`</li>
-          <li>`scx`</li>
-        </ul>
-      </td>
-      <td><a href="https://unicode.org/reports/tr24/#Script_Extensions">`Script_Extensions`</a></td>
+      <td>`Script`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr24/#Script">`Script`</a></td>
+    </tr>
+    <tr>
+      <td>`sc`</td>
+    </tr>
+    <tr>
+      <td>`Script_Extensions`</td>
+      <td rowspan="2"><a href="https://unicode.org/reports/tr24/#Script_Extensions">`Script_Extensions`</a></td>
+    </tr>
+    <tr>
+      <td>`scx`</td>
     </tr>
   </table>
 </emu-table>

--- a/table-unicode-general-category-values.html
+++ b/table-unicode-general-category-values.html
@@ -8,350 +8,282 @@
       </tr>
     </thead>
     <tr>
-      <td>
-        <ul>
-          <li>`Cased_Letter`</li>
-          <li>`LC`</li>
-        </ul>
-      </td>
       <td>`Cased_Letter`</td>
+      <td rowspan="2">`Cased_Letter`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Close_Punctuation`</li>
-          <li>`Pe`</li>
-        </ul>
-      </td>
+      <td>`LC`</td>
+    </tr>
+    <tr>
       <td>`Close_Punctuation`</td>
+      <td rowspan="2">`Close_Punctuation`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Connector_Punctuation`</li>
-          <li>`Pc`</li>
-        </ul>
-      </td>
+      <td>`Pe`</td>
+    </tr>
+    <tr>
       <td>`Connector_Punctuation`</td>
+      <td rowspan="2">`Connector_Punctuation`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Control`</li>
-          <li>`Cc`</li>
-          <li>`cntrl`</li>
-        </ul>
-      </td>
+      <td>`Pc`</td>
+    </tr>
+    <tr>
       <td>`Control`</td>
+      <td rowspan="3">`Control`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Currency_Symbol`</li>
-          <li>`Sc`</li>
-        </ul>
-      </td>
+      <td>`Cc`</td>
+    </tr>
+    <tr>
+      <td>`cntrl`</td>
+    </tr>
+    <tr>
       <td>`Currency_Symbol`</td>
+      <td rowspan="2">`Currency_Symbol`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Dash_Punctuation`</li>
-          <li>`Pd`</li>
-        </ul>
-      </td>
+      <td>`Sc`</td>
+    </tr>
+    <tr>
       <td>`Dash_Punctuation`</td>
+      <td rowspan="2">`Dash_Punctuation`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Decimal_Number`</li>
-          <li>`Nd`</li>
-          <li>`digit`</li>
-        </ul>
-      </td>
+      <td>`Pd`</td>
+    </tr>
+    <tr>
       <td>`Decimal_Number`</td>
+      <td rowspan="3">`Decimal_Number`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Enclosing_Mark`</li>
-          <li>`Me`</li>
-        </ul>
-      </td>
+      <td>`Nd`</td>
+    </tr>
+    <tr>
+      <td>`digit`</td>
+    </tr>
+    <tr>
       <td>`Enclosing_Mark`</td>
+      <td rowspan="2">`Enclosing_Mark`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Final_Punctuation`</li>
-          <li>`Pf`</li>
-        </ul>
-      </td>
+      <td>`Me`</td>
+    </tr>
+    <tr>
       <td>`Final_Punctuation`</td>
+      <td rowspan="2">`Final_Punctuation`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Format`</li>
-          <li>`Cf`</li>
-        </ul>
-      </td>
+      <td>`Pf`</td>
+    </tr>
+    <tr>
       <td>`Format`</td>
+      <td rowspan="2">`Format`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Initial_Punctuation`</li>
-          <li>`Pi`</li>
-        </ul>
-      </td>
+      <td>`Cf`</td>
+    </tr>
+    <tr>
       <td>`Initial_Punctuation`</td>
+      <td rowspan="2">`Initial_Punctuation`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Letter`</li>
-          <li>`L`</li>
-        </ul>
-      </td>
+      <td>`Pi`</td>
+    </tr>
+    <tr>
       <td>`Letter`</td>
+      <td rowspan="2">`Letter`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Letter_Number`</li>
-          <li>`Nl`</li>
-        </ul>
-      </td>
+      <td>`L`</td>
+    </tr>
+    <tr>
       <td>`Letter_Number`</td>
+      <td rowspan="2">`Letter_Number`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Line_Separator`</li>
-          <li>`Zl`</li>
-        </ul>
-      </td>
+      <td>`Nl`</td>
+    </tr>
+    <tr>
       <td>`Line_Separator`</td>
+      <td rowspan="2">`Line_Separator`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Lowercase_Letter`</li>
-          <li>`Ll`</li>
-        </ul>
-      </td>
+      <td>`Zl`</td>
+    </tr>
+    <tr>
       <td>`Lowercase_Letter`</td>
+      <td rowspan="2">`Lowercase_Letter`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Mark`</li>
-          <li>`M`</li>
-          <li>`Combining_Mark`</li>
-        </ul>
-      </td>
+      <td>`Ll`</td>
+    </tr>
+    <tr>
       <td>`Mark`</td>
+      <td rowspan="3">`Mark`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Math_Symbol`</li>
-          <li>`Sm`</li>
-        </ul>
-      </td>
+      <td>`M`</td>
+    </tr>
+    <tr>
+      <td>`Combining_Mark`</td>
+    </tr>
+    <tr>
       <td>`Math_Symbol`</td>
+      <td rowspan="2">`Math_Symbol`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Modifier_Letter`</li>
-          <li>`Lm`</li>
-        </ul>
-      </td>
+      <td>`Sm`</td>
+    </tr>
+    <tr>
       <td>`Modifier_Letter`</td>
+      <td rowspan="2">`Modifier_Letter`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Modifier_Symbol`</li>
-          <li>`Sk`</li>
-        </ul>
-      </td>
+      <td>`Lm`</td>
+    </tr>
+    <tr>
       <td>`Modifier_Symbol`</td>
+      <td rowspan="2">`Modifier_Symbol`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Nonspacing_Mark`</li>
-          <li>`Mn`</li>
-        </ul>
-      </td>
+      <td>`Sk`</td>
+    </tr>
+    <tr>
       <td>`Nonspacing_Mark`</td>
+      <td rowspan="2">`Nonspacing_Mark`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Number`</li>
-          <li>`N`</li>
-        </ul>
-      </td>
+      <td>`Mn`</td>
+    </tr>
+    <tr>
       <td>`Number`</td>
+      <td rowspan="2">`Number`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Open_Punctuation`</li>
-          <li>`Ps`</li>
-        </ul>
-      </td>
+      <td>`N`</td>
+    </tr>
+    <tr>
       <td>`Open_Punctuation`</td>
+      <td rowspan="2">`Open_Punctuation`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Other`</li>
-          <li>`C`</li>
-        </ul>
-      </td>
+      <td>`Ps`</td>
+    </tr>
+    <tr>
       <td>`Other`</td>
+      <td rowspan="2">`Other`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Other_Letter`</li>
-          <li>`Lo`</li>
-        </ul>
-      </td>
+      <td>`C`</td>
+    </tr>
+    <tr>
       <td>`Other_Letter`</td>
+      <td rowspan="2">`Other_Letter`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Other_Number`</li>
-          <li>`No`</li>
-        </ul>
-      </td>
+      <td>`Lo`</td>
+    </tr>
+    <tr>
       <td>`Other_Number`</td>
+      <td rowspan="2">`Other_Number`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Other_Punctuation`</li>
-          <li>`Po`</li>
-        </ul>
-      </td>
+      <td>`No`</td>
+    </tr>
+    <tr>
       <td>`Other_Punctuation`</td>
+      <td rowspan="2">`Other_Punctuation`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Other_Symbol`</li>
-          <li>`So`</li>
-        </ul>
-      </td>
+      <td>`Po`</td>
+    </tr>
+    <tr>
       <td>`Other_Symbol`</td>
+      <td rowspan="2">`Other_Symbol`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Paragraph_Separator`</li>
-          <li>`Zp`</li>
-        </ul>
-      </td>
+      <td>`So`</td>
+    </tr>
+    <tr>
       <td>`Paragraph_Separator`</td>
+      <td rowspan="2">`Paragraph_Separator`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Private_Use`</li>
-          <li>`Co`</li>
-        </ul>
-      </td>
+      <td>`Zp`</td>
+    </tr>
+    <tr>
       <td>`Private_Use`</td>
+      <td rowspan="2">`Private_Use`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Punctuation`</li>
-          <li>`P`</li>
-          <li>`punct`</li>
-        </ul>
-      </td>
+      <td>`Co`</td>
+    </tr>
+    <tr>
       <td>`Punctuation`</td>
+      <td rowspan="3">`Punctuation`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Separator`</li>
-          <li>`Z`</li>
-        </ul>
-      </td>
+      <td>`P`</td>
+    </tr>
+    <tr>
+      <td>`punct`</td>
+    </tr>
+    <tr>
       <td>`Separator`</td>
+      <td rowspan="2">`Separator`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Space_Separator`</li>
-          <li>`Zs`</li>
-        </ul>
-      </td>
+      <td>`Z`</td>
+    </tr>
+    <tr>
       <td>`Space_Separator`</td>
+      <td rowspan="2">`Space_Separator`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Spacing_Mark`</li>
-          <li>`Mc`</li>
-        </ul>
-      </td>
+      <td>`Zs`</td>
+    </tr>
+    <tr>
       <td>`Spacing_Mark`</td>
+      <td rowspan="2">`Spacing_Mark`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Surrogate`</li>
-          <li>`Cs`</li>
-        </ul>
-      </td>
+      <td>`Mc`</td>
+    </tr>
+    <tr>
       <td>`Surrogate`</td>
+      <td rowspan="2">`Surrogate`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Symbol`</li>
-          <li>`S`</li>
-        </ul>
-      </td>
+      <td>`Cs`</td>
+    </tr>
+    <tr>
       <td>`Symbol`</td>
+      <td rowspan="2">`Symbol`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Titlecase_Letter`</li>
-          <li>`Lt`</li>
-        </ul>
-      </td>
+      <td>`S`</td>
+    </tr>
+    <tr>
       <td>`Titlecase_Letter`</td>
+      <td rowspan="2">`Titlecase_Letter`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Unassigned`</li>
-          <li>`Cn`</li>
-        </ul>
-      </td>
+      <td>`Lt`</td>
+    </tr>
+    <tr>
       <td>`Unassigned`</td>
+      <td rowspan="2">`Unassigned`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Uppercase_Letter`</li>
-          <li>`Lu`</li>
-        </ul>
-      </td>
+      <td>`Cn`</td>
+    </tr>
+    <tr>
       <td>`Uppercase_Letter`</td>
+      <td rowspan="2">`Uppercase_Letter`</td>
+    </tr>
+    <tr>
+      <td>`Lu`</td>
     </tr>
   </table>
 </emu-table>

--- a/table-unicode-script-values.html
+++ b/table-unicode-script-values.html
@@ -8,1374 +8,1056 @@
       </tr>
     </thead>
     <tr>
-      <td>
-        <ul>
-          <li>`Adlam`</li>
-          <li>`Adlm`</li>
-        </ul>
-      </td>
       <td>`Adlam`</td>
+      <td rowspan="2">`Adlam`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Ahom`</li>
-          <li>`Ahom`</li>
-        </ul>
-      </td>
+      <td>`Adlm`</td>
+    </tr>
+    <tr>
+      <td>`Ahom`</td>
       <td>`Ahom`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Anatolian_Hieroglyphs`</li>
-          <li>`Hluw`</li>
-        </ul>
-      </td>
       <td>`Anatolian_Hieroglyphs`</td>
+      <td rowspan="2">`Anatolian_Hieroglyphs`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Arabic`</li>
-          <li>`Arab`</li>
-        </ul>
-      </td>
+      <td>`Hluw`</td>
+    </tr>
+    <tr>
       <td>`Arabic`</td>
+      <td rowspan="2">`Arabic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Armenian`</li>
-          <li>`Armn`</li>
-        </ul>
-      </td>
+      <td>`Arab`</td>
+    </tr>
+    <tr>
       <td>`Armenian`</td>
+      <td rowspan="2">`Armenian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Avestan`</li>
-          <li>`Avst`</li>
-        </ul>
-      </td>
+      <td>`Armn`</td>
+    </tr>
+    <tr>
       <td>`Avestan`</td>
+      <td rowspan="2">`Avestan`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Balinese`</li>
-          <li>`Bali`</li>
-        </ul>
-      </td>
+      <td>`Avst`</td>
+    </tr>
+    <tr>
       <td>`Balinese`</td>
+      <td rowspan="2">`Balinese`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Bamum`</li>
-          <li>`Bamu`</li>
-        </ul>
-      </td>
+      <td>`Bali`</td>
+    </tr>
+    <tr>
       <td>`Bamum`</td>
+      <td rowspan="2">`Bamum`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Bassa_Vah`</li>
-          <li>`Bass`</li>
-        </ul>
-      </td>
+      <td>`Bamu`</td>
+    </tr>
+    <tr>
       <td>`Bassa_Vah`</td>
+      <td rowspan="2">`Bassa_Vah`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Batak`</li>
-          <li>`Batk`</li>
-        </ul>
-      </td>
+      <td>`Bass`</td>
+    </tr>
+    <tr>
       <td>`Batak`</td>
+      <td rowspan="2">`Batak`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Bengali`</li>
-          <li>`Beng`</li>
-        </ul>
-      </td>
+      <td>`Batk`</td>
+    </tr>
+    <tr>
       <td>`Bengali`</td>
+      <td rowspan="2">`Bengali`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Bhaiksuki`</li>
-          <li>`Bhks`</li>
-        </ul>
-      </td>
+      <td>`Beng`</td>
+    </tr>
+    <tr>
       <td>`Bhaiksuki`</td>
+      <td rowspan="2">`Bhaiksuki`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Bopomofo`</li>
-          <li>`Bopo`</li>
-        </ul>
-      </td>
+      <td>`Bhks`</td>
+    </tr>
+    <tr>
       <td>`Bopomofo`</td>
+      <td rowspan="2">`Bopomofo`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Brahmi`</li>
-          <li>`Brah`</li>
-        </ul>
-      </td>
+      <td>`Bopo`</td>
+    </tr>
+    <tr>
       <td>`Brahmi`</td>
+      <td rowspan="2">`Brahmi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Braille`</li>
-          <li>`Brai`</li>
-        </ul>
-      </td>
+      <td>`Brah`</td>
+    </tr>
+    <tr>
       <td>`Braille`</td>
+      <td rowspan="2">`Braille`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Buginese`</li>
-          <li>`Bugi`</li>
-        </ul>
-      </td>
+      <td>`Brai`</td>
+    </tr>
+    <tr>
       <td>`Buginese`</td>
+      <td rowspan="2">`Buginese`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Buhid`</li>
-          <li>`Buhd`</li>
-        </ul>
-      </td>
+      <td>`Bugi`</td>
+    </tr>
+    <tr>
       <td>`Buhid`</td>
+      <td rowspan="2">`Buhid`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Canadian_Aboriginal`</li>
-          <li>`Cans`</li>
-        </ul>
-      </td>
+      <td>`Buhd`</td>
+    </tr>
+    <tr>
       <td>`Canadian_Aboriginal`</td>
+      <td rowspan="2">`Canadian_Aboriginal`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Carian`</li>
-          <li>`Cari`</li>
-        </ul>
-      </td>
+      <td>`Cans`</td>
+    </tr>
+    <tr>
       <td>`Carian`</td>
+      <td rowspan="2">`Carian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Caucasian_Albanian`</li>
-          <li>`Aghb`</li>
-        </ul>
-      </td>
+      <td>`Cari`</td>
+    </tr>
+    <tr>
       <td>`Caucasian_Albanian`</td>
+      <td rowspan="2">`Caucasian_Albanian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Chakma`</li>
-          <li>`Cakm`</li>
-        </ul>
-      </td>
+      <td>`Aghb`</td>
+    </tr>
+    <tr>
       <td>`Chakma`</td>
+      <td rowspan="2">`Chakma`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Cham`</li>
-          <li>`Cham`</li>
-        </ul>
-      </td>
+      <td>`Cakm`</td>
+    </tr>
+    <tr>
+      <td>`Cham`</td>
       <td>`Cham`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Cherokee`</li>
-          <li>`Cher`</li>
-        </ul>
-      </td>
       <td>`Cherokee`</td>
+      <td rowspan="2">`Cherokee`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Common`</li>
-          <li>`Zyyy`</li>
-        </ul>
-      </td>
+      <td>`Cher`</td>
+    </tr>
+    <tr>
       <td>`Common`</td>
+      <td rowspan="2">`Common`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Coptic`</li>
-          <li>`Copt`</li>
-          <li>`Qaac`</li>
-        </ul>
-      </td>
+      <td>`Zyyy`</td>
+    </tr>
+    <tr>
       <td>`Coptic`</td>
+      <td rowspan="3">`Coptic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Cuneiform`</li>
-          <li>`Xsux`</li>
-        </ul>
-      </td>
+      <td>`Copt`</td>
+    </tr>
+    <tr>
+      <td>`Qaac`</td>
+    </tr>
+    <tr>
       <td>`Cuneiform`</td>
+      <td rowspan="2">`Cuneiform`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Cypriot`</li>
-          <li>`Cprt`</li>
-        </ul>
-      </td>
+      <td>`Xsux`</td>
+    </tr>
+    <tr>
       <td>`Cypriot`</td>
+      <td rowspan="2">`Cypriot`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Cyrillic`</li>
-          <li>`Cyrl`</li>
-        </ul>
-      </td>
+      <td>`Cprt`</td>
+    </tr>
+    <tr>
       <td>`Cyrillic`</td>
+      <td rowspan="2">`Cyrillic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Deseret`</li>
-          <li>`Dsrt`</li>
-        </ul>
-      </td>
+      <td>`Cyrl`</td>
+    </tr>
+    <tr>
       <td>`Deseret`</td>
+      <td rowspan="2">`Deseret`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Devanagari`</li>
-          <li>`Deva`</li>
-        </ul>
-      </td>
+      <td>`Dsrt`</td>
+    </tr>
+    <tr>
       <td>`Devanagari`</td>
+      <td rowspan="2">`Devanagari`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Dogra`</li>
-          <li>`Dogr`</li>
-        </ul>
-      </td>
+      <td>`Deva`</td>
+    </tr>
+    <tr>
       <td>`Dogra`</td>
+      <td rowspan="2">`Dogra`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Duployan`</li>
-          <li>`Dupl`</li>
-        </ul>
-      </td>
+      <td>`Dogr`</td>
+    </tr>
+    <tr>
       <td>`Duployan`</td>
+      <td rowspan="2">`Duployan`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Egyptian_Hieroglyphs`</li>
-          <li>`Egyp`</li>
-        </ul>
-      </td>
+      <td>`Dupl`</td>
+    </tr>
+    <tr>
       <td>`Egyptian_Hieroglyphs`</td>
+      <td rowspan="2">`Egyptian_Hieroglyphs`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Elbasan`</li>
-          <li>`Elba`</li>
-        </ul>
-      </td>
+      <td>`Egyp`</td>
+    </tr>
+    <tr>
       <td>`Elbasan`</td>
+      <td rowspan="2">`Elbasan`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Elymaic`</li>
-          <li>`Elym`</li>
-        </ul>
-      </td>
+      <td>`Elba`</td>
+    </tr>
+    <tr>
       <td>`Elymaic`</td>
+      <td rowspan="2">`Elymaic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Ethiopic`</li>
-          <li>`Ethi`</li>
-        </ul>
-      </td>
+      <td>`Elym`</td>
+    </tr>
+    <tr>
       <td>`Ethiopic`</td>
+      <td rowspan="2">`Ethiopic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Georgian`</li>
-          <li>`Geor`</li>
-        </ul>
-      </td>
+      <td>`Ethi`</td>
+    </tr>
+    <tr>
       <td>`Georgian`</td>
+      <td rowspan="2">`Georgian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Glagolitic`</li>
-          <li>`Glag`</li>
-        </ul>
-      </td>
+      <td>`Geor`</td>
+    </tr>
+    <tr>
       <td>`Glagolitic`</td>
+      <td rowspan="2">`Glagolitic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Gothic`</li>
-          <li>`Goth`</li>
-        </ul>
-      </td>
+      <td>`Glag`</td>
+    </tr>
+    <tr>
       <td>`Gothic`</td>
+      <td rowspan="2">`Gothic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Grantha`</li>
-          <li>`Gran`</li>
-        </ul>
-      </td>
+      <td>`Goth`</td>
+    </tr>
+    <tr>
       <td>`Grantha`</td>
+      <td rowspan="2">`Grantha`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Greek`</li>
-          <li>`Grek`</li>
-        </ul>
-      </td>
+      <td>`Gran`</td>
+    </tr>
+    <tr>
       <td>`Greek`</td>
+      <td rowspan="2">`Greek`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Gujarati`</li>
-          <li>`Gujr`</li>
-        </ul>
-      </td>
+      <td>`Grek`</td>
+    </tr>
+    <tr>
       <td>`Gujarati`</td>
+      <td rowspan="2">`Gujarati`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Gunjala_Gondi`</li>
-          <li>`Gong`</li>
-        </ul>
-      </td>
+      <td>`Gujr`</td>
+    </tr>
+    <tr>
       <td>`Gunjala_Gondi`</td>
+      <td rowspan="2">`Gunjala_Gondi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Gurmukhi`</li>
-          <li>`Guru`</li>
-        </ul>
-      </td>
+      <td>`Gong`</td>
+    </tr>
+    <tr>
       <td>`Gurmukhi`</td>
+      <td rowspan="2">`Gurmukhi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Han`</li>
-          <li>`Hani`</li>
-        </ul>
-      </td>
+      <td>`Guru`</td>
+    </tr>
+    <tr>
       <td>`Han`</td>
+      <td rowspan="2">`Han`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Hangul`</li>
-          <li>`Hang`</li>
-        </ul>
-      </td>
+      <td>`Hani`</td>
+    </tr>
+    <tr>
       <td>`Hangul`</td>
+      <td rowspan="2">`Hangul`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Hanifi_Rohingya`</li>
-          <li>`Rohg`</li>
-        </ul>
-      </td>
+      <td>`Hang`</td>
+    </tr>
+    <tr>
       <td>`Hanifi_Rohingya`</td>
+      <td rowspan="2">`Hanifi_Rohingya`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Hanunoo`</li>
-          <li>`Hano`</li>
-        </ul>
-      </td>
+      <td>`Rohg`</td>
+    </tr>
+    <tr>
       <td>`Hanunoo`</td>
+      <td rowspan="2">`Hanunoo`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Hatran`</li>
-          <li>`Hatr`</li>
-        </ul>
-      </td>
+      <td>`Hano`</td>
+    </tr>
+    <tr>
       <td>`Hatran`</td>
+      <td rowspan="2">`Hatran`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Hebrew`</li>
-          <li>`Hebr`</li>
-        </ul>
-      </td>
+      <td>`Hatr`</td>
+    </tr>
+    <tr>
       <td>`Hebrew`</td>
+      <td rowspan="2">`Hebrew`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Hiragana`</li>
-          <li>`Hira`</li>
-        </ul>
-      </td>
+      <td>`Hebr`</td>
+    </tr>
+    <tr>
       <td>`Hiragana`</td>
+      <td rowspan="2">`Hiragana`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Imperial_Aramaic`</li>
-          <li>`Armi`</li>
-        </ul>
-      </td>
+      <td>`Hira`</td>
+    </tr>
+    <tr>
       <td>`Imperial_Aramaic`</td>
+      <td rowspan="2">`Imperial_Aramaic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Inherited`</li>
-          <li>`Zinh`</li>
-          <li>`Qaai`</li>
-        </ul>
-      </td>
+      <td>`Armi`</td>
+    </tr>
+    <tr>
       <td>`Inherited`</td>
+      <td rowspan="3">`Inherited`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Inscriptional_Pahlavi`</li>
-          <li>`Phli`</li>
-        </ul>
-      </td>
+      <td>`Zinh`</td>
+    </tr>
+    <tr>
+      <td>`Qaai`</td>
+    </tr>
+    <tr>
       <td>`Inscriptional_Pahlavi`</td>
+      <td rowspan="2">`Inscriptional_Pahlavi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Inscriptional_Parthian`</li>
-          <li>`Prti`</li>
-        </ul>
-      </td>
+      <td>`Phli`</td>
+    </tr>
+    <tr>
       <td>`Inscriptional_Parthian`</td>
+      <td rowspan="2">`Inscriptional_Parthian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Javanese`</li>
-          <li>`Java`</li>
-        </ul>
-      </td>
+      <td>`Prti`</td>
+    </tr>
+    <tr>
       <td>`Javanese`</td>
+      <td rowspan="2">`Javanese`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Kaithi`</li>
-          <li>`Kthi`</li>
-        </ul>
-      </td>
+      <td>`Java`</td>
+    </tr>
+    <tr>
       <td>`Kaithi`</td>
+      <td rowspan="2">`Kaithi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Kannada`</li>
-          <li>`Knda`</li>
-        </ul>
-      </td>
+      <td>`Kthi`</td>
+    </tr>
+    <tr>
       <td>`Kannada`</td>
+      <td rowspan="2">`Kannada`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Katakana`</li>
-          <li>`Kana`</li>
-        </ul>
-      </td>
+      <td>`Knda`</td>
+    </tr>
+    <tr>
       <td>`Katakana`</td>
+      <td rowspan="2">`Katakana`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Kayah_Li`</li>
-          <li>`Kali`</li>
-        </ul>
-      </td>
+      <td>`Kana`</td>
+    </tr>
+    <tr>
       <td>`Kayah_Li`</td>
+      <td rowspan="2">`Kayah_Li`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Kharoshthi`</li>
-          <li>`Khar`</li>
-        </ul>
-      </td>
+      <td>`Kali`</td>
+    </tr>
+    <tr>
       <td>`Kharoshthi`</td>
+      <td rowspan="2">`Kharoshthi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Khmer`</li>
-          <li>`Khmr`</li>
-        </ul>
-      </td>
+      <td>`Khar`</td>
+    </tr>
+    <tr>
       <td>`Khmer`</td>
+      <td rowspan="2">`Khmer`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Khojki`</li>
-          <li>`Khoj`</li>
-        </ul>
-      </td>
+      <td>`Khmr`</td>
+    </tr>
+    <tr>
       <td>`Khojki`</td>
+      <td rowspan="2">`Khojki`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Khudawadi`</li>
-          <li>`Sind`</li>
-        </ul>
-      </td>
+      <td>`Khoj`</td>
+    </tr>
+    <tr>
       <td>`Khudawadi`</td>
+      <td rowspan="2">`Khudawadi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Lao`</li>
-          <li>`Laoo`</li>
-        </ul>
-      </td>
+      <td>`Sind`</td>
+    </tr>
+    <tr>
       <td>`Lao`</td>
+      <td rowspan="2">`Lao`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Latin`</li>
-          <li>`Latn`</li>
-        </ul>
-      </td>
+      <td>`Laoo`</td>
+    </tr>
+    <tr>
       <td>`Latin`</td>
+      <td rowspan="2">`Latin`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Lepcha`</li>
-          <li>`Lepc`</li>
-        </ul>
-      </td>
+      <td>`Latn`</td>
+    </tr>
+    <tr>
       <td>`Lepcha`</td>
+      <td rowspan="2">`Lepcha`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Limbu`</li>
-          <li>`Limb`</li>
-        </ul>
-      </td>
+      <td>`Lepc`</td>
+    </tr>
+    <tr>
       <td>`Limbu`</td>
+      <td rowspan="2">`Limbu`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Linear_A`</li>
-          <li>`Lina`</li>
-        </ul>
-      </td>
+      <td>`Limb`</td>
+    </tr>
+    <tr>
       <td>`Linear_A`</td>
+      <td rowspan="2">`Linear_A`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Linear_B`</li>
-          <li>`Linb`</li>
-        </ul>
-      </td>
+      <td>`Lina`</td>
+    </tr>
+    <tr>
       <td>`Linear_B`</td>
+      <td rowspan="2">`Linear_B`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Lisu`</li>
-          <li>`Lisu`</li>
-        </ul>
-      </td>
+      <td>`Linb`</td>
+    </tr>
+    <tr>
+      <td>`Lisu`</td>
       <td>`Lisu`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Lycian`</li>
-          <li>`Lyci`</li>
-        </ul>
-      </td>
       <td>`Lycian`</td>
+      <td rowspan="2">`Lycian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Lydian`</li>
-          <li>`Lydi`</li>
-        </ul>
-      </td>
+      <td>`Lyci`</td>
+    </tr>
+    <tr>
       <td>`Lydian`</td>
+      <td rowspan="2">`Lydian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Mahajani`</li>
-          <li>`Mahj`</li>
-        </ul>
-      </td>
+      <td>`Lydi`</td>
+    </tr>
+    <tr>
       <td>`Mahajani`</td>
+      <td rowspan="2">`Mahajani`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Makasar`</li>
-          <li>`Maka`</li>
-        </ul>
-      </td>
+      <td>`Mahj`</td>
+    </tr>
+    <tr>
       <td>`Makasar`</td>
+      <td rowspan="2">`Makasar`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Malayalam`</li>
-          <li>`Mlym`</li>
-        </ul>
-      </td>
+      <td>`Maka`</td>
+    </tr>
+    <tr>
       <td>`Malayalam`</td>
+      <td rowspan="2">`Malayalam`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Mandaic`</li>
-          <li>`Mand`</li>
-        </ul>
-      </td>
+      <td>`Mlym`</td>
+    </tr>
+    <tr>
       <td>`Mandaic`</td>
+      <td rowspan="2">`Mandaic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Manichaean`</li>
-          <li>`Mani`</li>
-        </ul>
-      </td>
+      <td>`Mand`</td>
+    </tr>
+    <tr>
       <td>`Manichaean`</td>
+      <td rowspan="2">`Manichaean`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Marchen`</li>
-          <li>`Marc`</li>
-        </ul>
-      </td>
+      <td>`Mani`</td>
+    </tr>
+    <tr>
       <td>`Marchen`</td>
+      <td rowspan="2">`Marchen`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Medefaidrin`</li>
-          <li>`Medf`</li>
-        </ul>
-      </td>
+      <td>`Marc`</td>
+    </tr>
+    <tr>
       <td>`Medefaidrin`</td>
+      <td rowspan="2">`Medefaidrin`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Masaram_Gondi`</li>
-          <li>`Gonm`</li>
-        </ul>
-      </td>
+      <td>`Medf`</td>
+    </tr>
+    <tr>
       <td>`Masaram_Gondi`</td>
+      <td rowspan="2">`Masaram_Gondi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Meetei_Mayek`</li>
-          <li>`Mtei`</li>
-        </ul>
-      </td>
+      <td>`Gonm`</td>
+    </tr>
+    <tr>
       <td>`Meetei_Mayek`</td>
+      <td rowspan="2">`Meetei_Mayek`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Mende_Kikakui`</li>
-          <li>`Mend`</li>
-        </ul>
-      </td>
+      <td>`Mtei`</td>
+    </tr>
+    <tr>
       <td>`Mende_Kikakui`</td>
+      <td rowspan="2">`Mende_Kikakui`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Meroitic_Cursive`</li>
-          <li>`Merc`</li>
-        </ul>
-      </td>
+      <td>`Mend`</td>
+    </tr>
+    <tr>
       <td>`Meroitic_Cursive`</td>
+      <td rowspan="2">`Meroitic_Cursive`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Meroitic_Hieroglyphs`</li>
-          <li>`Mero`</li>
-        </ul>
-      </td>
+      <td>`Merc`</td>
+    </tr>
+    <tr>
       <td>`Meroitic_Hieroglyphs`</td>
+      <td rowspan="2">`Meroitic_Hieroglyphs`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Miao`</li>
-          <li>`Plrd`</li>
-        </ul>
-      </td>
+      <td>`Mero`</td>
+    </tr>
+    <tr>
       <td>`Miao`</td>
+      <td rowspan="2">`Miao`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Modi`</li>
-          <li>`Modi`</li>
-        </ul>
-      </td>
+      <td>`Plrd`</td>
+    </tr>
+    <tr>
+      <td>`Modi`</td>
       <td>`Modi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Mongolian`</li>
-          <li>`Mong`</li>
-        </ul>
-      </td>
       <td>`Mongolian`</td>
+      <td rowspan="2">`Mongolian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Mro`</li>
-          <li>`Mroo`</li>
-        </ul>
-      </td>
+      <td>`Mong`</td>
+    </tr>
+    <tr>
       <td>`Mro`</td>
+      <td rowspan="2">`Mro`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Multani`</li>
-          <li>`Mult`</li>
-        </ul>
-      </td>
+      <td>`Mroo`</td>
+    </tr>
+    <tr>
       <td>`Multani`</td>
+      <td rowspan="2">`Multani`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Myanmar`</li>
-          <li>`Mymr`</li>
-        </ul>
-      </td>
+      <td>`Mult`</td>
+    </tr>
+    <tr>
       <td>`Myanmar`</td>
+      <td rowspan="2">`Myanmar`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Nabataean`</li>
-          <li>`Nbat`</li>
-        </ul>
-      </td>
+      <td>`Mymr`</td>
+    </tr>
+    <tr>
       <td>`Nabataean`</td>
+      <td rowspan="2">`Nabataean`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Nandinagari`</li>
-          <li>`Nand`</li>
-        </ul>
-      </td>
+      <td>`Nbat`</td>
+    </tr>
+    <tr>
       <td>`Nandinagari`</td>
+      <td rowspan="2">`Nandinagari`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`New_Tai_Lue`</li>
-          <li>`Talu`</li>
-        </ul>
-      </td>
+      <td>`Nand`</td>
+    </tr>
+    <tr>
       <td>`New_Tai_Lue`</td>
+      <td rowspan="2">`New_Tai_Lue`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Newa`</li>
-          <li>`Newa`</li>
-        </ul>
-      </td>
+      <td>`Talu`</td>
+    </tr>
+    <tr>
+      <td>`Newa`</td>
       <td>`Newa`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Nko`</li>
-          <li>`Nkoo`</li>
-        </ul>
-      </td>
       <td>`Nko`</td>
+      <td rowspan="2">`Nko`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Nushu`</li>
-          <li>`Nshu`</li>
-        </ul>
-      </td>
+      <td>`Nkoo`</td>
+    </tr>
+    <tr>
       <td>`Nushu`</td>
+      <td rowspan="2">`Nushu`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Nyiakeng_Puachue_Hmong`</li>
-          <li>`Hmnp`</li>
-        </ul>
-      </td>
+      <td>`Nshu`</td>
+    </tr>
+    <tr>
       <td>`Nyiakeng_Puachue_Hmong`</td>
+      <td rowspan="2">`Nyiakeng_Puachue_Hmong`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Ogham`</li>
-          <li>`Ogam`</li>
-        </ul>
-      </td>
+      <td>`Hmnp`</td>
+    </tr>
+    <tr>
       <td>`Ogham`</td>
+      <td rowspan="2">`Ogham`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Ol_Chiki`</li>
-          <li>`Olck`</li>
-        </ul>
-      </td>
+      <td>`Ogam`</td>
+    </tr>
+    <tr>
       <td>`Ol_Chiki`</td>
+      <td rowspan="2">`Ol_Chiki`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Old_Hungarian`</li>
-          <li>`Hung`</li>
-        </ul>
-      </td>
+      <td>`Olck`</td>
+    </tr>
+    <tr>
       <td>`Old_Hungarian`</td>
+      <td rowspan="2">`Old_Hungarian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Old_Italic`</li>
-          <li>`Ital`</li>
-        </ul>
-      </td>
+      <td>`Hung`</td>
+    </tr>
+    <tr>
       <td>`Old_Italic`</td>
+      <td rowspan="2">`Old_Italic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Old_North_Arabian`</li>
-          <li>`Narb`</li>
-        </ul>
-      </td>
+      <td>`Ital`</td>
+    </tr>
+    <tr>
       <td>`Old_North_Arabian`</td>
+      <td rowspan="2">`Old_North_Arabian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Old_Permic`</li>
-          <li>`Perm`</li>
-        </ul>
-      </td>
+      <td>`Narb`</td>
+    </tr>
+    <tr>
       <td>`Old_Permic`</td>
+      <td rowspan="2">`Old_Permic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Old_Persian`</li>
-          <li>`Xpeo`</li>
-        </ul>
-      </td>
+      <td>`Perm`</td>
+    </tr>
+    <tr>
       <td>`Old_Persian`</td>
+      <td rowspan="2">`Old_Persian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Old_Sogdian`</li>
-          <li>`Sogo`</li>
-        </ul>
-      </td>
+      <td>`Xpeo`</td>
+    </tr>
+    <tr>
       <td>`Old_Sogdian`</td>
+      <td rowspan="2">`Old_Sogdian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Old_South_Arabian`</li>
-          <li>`Sarb`</li>
-        </ul>
-      </td>
+      <td>`Sogo`</td>
+    </tr>
+    <tr>
       <td>`Old_South_Arabian`</td>
+      <td rowspan="2">`Old_South_Arabian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Old_Turkic`</li>
-          <li>`Orkh`</li>
-        </ul>
-      </td>
+      <td>`Sarb`</td>
+    </tr>
+    <tr>
       <td>`Old_Turkic`</td>
+      <td rowspan="2">`Old_Turkic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Oriya`</li>
-          <li>`Orya`</li>
-        </ul>
-      </td>
+      <td>`Orkh`</td>
+    </tr>
+    <tr>
       <td>`Oriya`</td>
+      <td rowspan="2">`Oriya`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Osage`</li>
-          <li>`Osge`</li>
-        </ul>
-      </td>
+      <td>`Orya`</td>
+    </tr>
+    <tr>
       <td>`Osage`</td>
+      <td rowspan="2">`Osage`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Osmanya`</li>
-          <li>`Osma`</li>
-        </ul>
-      </td>
+      <td>`Osge`</td>
+    </tr>
+    <tr>
       <td>`Osmanya`</td>
+      <td rowspan="2">`Osmanya`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Pahawh_Hmong`</li>
-          <li>`Hmng`</li>
-        </ul>
-      </td>
+      <td>`Osma`</td>
+    </tr>
+    <tr>
       <td>`Pahawh_Hmong`</td>
+      <td rowspan="2">`Pahawh_Hmong`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Palmyrene`</li>
-          <li>`Palm`</li>
-        </ul>
-      </td>
+      <td>`Hmng`</td>
+    </tr>
+    <tr>
       <td>`Palmyrene`</td>
+      <td rowspan="2">`Palmyrene`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Pau_Cin_Hau`</li>
-          <li>`Pauc`</li>
-        </ul>
-      </td>
+      <td>`Palm`</td>
+    </tr>
+    <tr>
       <td>`Pau_Cin_Hau`</td>
+      <td rowspan="2">`Pau_Cin_Hau`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Phags_Pa`</li>
-          <li>`Phag`</li>
-        </ul>
-      </td>
+      <td>`Pauc`</td>
+    </tr>
+    <tr>
       <td>`Phags_Pa`</td>
+      <td rowspan="2">`Phags_Pa`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Phoenician`</li>
-          <li>`Phnx`</li>
-        </ul>
-      </td>
+      <td>`Phag`</td>
+    </tr>
+    <tr>
       <td>`Phoenician`</td>
+      <td rowspan="2">`Phoenician`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Psalter_Pahlavi`</li>
-          <li>`Phlp`</li>
-        </ul>
-      </td>
+      <td>`Phnx`</td>
+    </tr>
+    <tr>
       <td>`Psalter_Pahlavi`</td>
+      <td rowspan="2">`Psalter_Pahlavi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Rejang`</li>
-          <li>`Rjng`</li>
-        </ul>
-      </td>
+      <td>`Phlp`</td>
+    </tr>
+    <tr>
       <td>`Rejang`</td>
+      <td rowspan="2">`Rejang`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Runic`</li>
-          <li>`Runr`</li>
-        </ul>
-      </td>
+      <td>`Rjng`</td>
+    </tr>
+    <tr>
       <td>`Runic`</td>
+      <td rowspan="2">`Runic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Samaritan`</li>
-          <li>`Samr`</li>
-        </ul>
-      </td>
+      <td>`Runr`</td>
+    </tr>
+    <tr>
       <td>`Samaritan`</td>
+      <td rowspan="2">`Samaritan`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Saurashtra`</li>
-          <li>`Saur`</li>
-        </ul>
-      </td>
+      <td>`Samr`</td>
+    </tr>
+    <tr>
       <td>`Saurashtra`</td>
+      <td rowspan="2">`Saurashtra`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Sharada`</li>
-          <li>`Shrd`</li>
-        </ul>
-      </td>
+      <td>`Saur`</td>
+    </tr>
+    <tr>
       <td>`Sharada`</td>
+      <td rowspan="2">`Sharada`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Shavian`</li>
-          <li>`Shaw`</li>
-        </ul>
-      </td>
+      <td>`Shrd`</td>
+    </tr>
+    <tr>
       <td>`Shavian`</td>
+      <td rowspan="2">`Shavian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Siddham`</li>
-          <li>`Sidd`</li>
-        </ul>
-      </td>
+      <td>`Shaw`</td>
+    </tr>
+    <tr>
       <td>`Siddham`</td>
+      <td rowspan="2">`Siddham`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`SignWriting`</li>
-          <li>`Sgnw`</li>
-        </ul>
-      </td>
+      <td>`Sidd`</td>
+    </tr>
+    <tr>
       <td>`SignWriting`</td>
+      <td rowspan="2">`SignWriting`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Sinhala`</li>
-          <li>`Sinh`</li>
-        </ul>
-      </td>
+      <td>`Sgnw`</td>
+    </tr>
+    <tr>
       <td>`Sinhala`</td>
+      <td rowspan="2">`Sinhala`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Sogdian`</li>
-          <li>`Sogd`</li>
-        </ul>
-      </td>
+      <td>`Sinh`</td>
+    </tr>
+    <tr>
       <td>`Sogdian`</td>
+      <td rowspan="2">`Sogdian`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Sora_Sompeng`</li>
-          <li>`Sora`</li>
-        </ul>
-      </td>
+      <td>`Sogd`</td>
+    </tr>
+    <tr>
       <td>`Sora_Sompeng`</td>
+      <td rowspan="2">`Sora_Sompeng`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Soyombo`</li>
-          <li>`Soyo`</li>
-        </ul>
-      </td>
+      <td>`Sora`</td>
+    </tr>
+    <tr>
       <td>`Soyombo`</td>
+      <td rowspan="2">`Soyombo`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Sundanese`</li>
-          <li>`Sund`</li>
-        </ul>
-      </td>
+      <td>`Soyo`</td>
+    </tr>
+    <tr>
       <td>`Sundanese`</td>
+      <td rowspan="2">`Sundanese`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Syloti_Nagri`</li>
-          <li>`Sylo`</li>
-        </ul>
-      </td>
+      <td>`Sund`</td>
+    </tr>
+    <tr>
       <td>`Syloti_Nagri`</td>
+      <td rowspan="2">`Syloti_Nagri`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Syriac`</li>
-          <li>`Syrc`</li>
-        </ul>
-      </td>
+      <td>`Sylo`</td>
+    </tr>
+    <tr>
       <td>`Syriac`</td>
+      <td rowspan="2">`Syriac`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tagalog`</li>
-          <li>`Tglg`</li>
-        </ul>
-      </td>
+      <td>`Syrc`</td>
+    </tr>
+    <tr>
       <td>`Tagalog`</td>
+      <td rowspan="2">`Tagalog`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tagbanwa`</li>
-          <li>`Tagb`</li>
-        </ul>
-      </td>
+      <td>`Tglg`</td>
+    </tr>
+    <tr>
       <td>`Tagbanwa`</td>
+      <td rowspan="2">`Tagbanwa`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tai_Le`</li>
-          <li>`Tale`</li>
-        </ul>
-      </td>
+      <td>`Tagb`</td>
+    </tr>
+    <tr>
       <td>`Tai_Le`</td>
+      <td rowspan="2">`Tai_Le`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tai_Tham`</li>
-          <li>`Lana`</li>
-        </ul>
-      </td>
+      <td>`Tale`</td>
+    </tr>
+    <tr>
       <td>`Tai_Tham`</td>
+      <td rowspan="2">`Tai_Tham`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tai_Viet`</li>
-          <li>`Tavt`</li>
-        </ul>
-      </td>
+      <td>`Lana`</td>
+    </tr>
+    <tr>
       <td>`Tai_Viet`</td>
+      <td rowspan="2">`Tai_Viet`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Takri`</li>
-          <li>`Takr`</li>
-        </ul>
-      </td>
+      <td>`Tavt`</td>
+    </tr>
+    <tr>
       <td>`Takri`</td>
+      <td rowspan="2">`Takri`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tamil`</li>
-          <li>`Taml`</li>
-        </ul>
-      </td>
+      <td>`Takr`</td>
+    </tr>
+    <tr>
       <td>`Tamil`</td>
+      <td rowspan="2">`Tamil`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tangut`</li>
-          <li>`Tang`</li>
-        </ul>
-      </td>
+      <td>`Taml`</td>
+    </tr>
+    <tr>
       <td>`Tangut`</td>
+      <td rowspan="2">`Tangut`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Telugu`</li>
-          <li>`Telu`</li>
-        </ul>
-      </td>
+      <td>`Tang`</td>
+    </tr>
+    <tr>
       <td>`Telugu`</td>
+      <td rowspan="2">`Telugu`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Thaana`</li>
-          <li>`Thaa`</li>
-        </ul>
-      </td>
+      <td>`Telu`</td>
+    </tr>
+    <tr>
       <td>`Thaana`</td>
+      <td rowspan="2">`Thaana`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Thai`</li>
-          <li>`Thai`</li>
-        </ul>
-      </td>
+      <td>`Thaa`</td>
+    </tr>
+    <tr>
+      <td>`Thai`</td>
       <td>`Thai`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tibetan`</li>
-          <li>`Tibt`</li>
-        </ul>
-      </td>
       <td>`Tibetan`</td>
+      <td rowspan="2">`Tibetan`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tifinagh`</li>
-          <li>`Tfng`</li>
-        </ul>
-      </td>
+      <td>`Tibt`</td>
+    </tr>
+    <tr>
       <td>`Tifinagh`</td>
+      <td rowspan="2">`Tifinagh`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Tirhuta`</li>
-          <li>`Tirh`</li>
-        </ul>
-      </td>
+      <td>`Tfng`</td>
+    </tr>
+    <tr>
       <td>`Tirhuta`</td>
+      <td rowspan="2">`Tirhuta`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Ugaritic`</li>
-          <li>`Ugar`</li>
-        </ul>
-      </td>
+      <td>`Tirh`</td>
+    </tr>
+    <tr>
       <td>`Ugaritic`</td>
+      <td rowspan="2">`Ugaritic`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Vai`</li>
-          <li>`Vaii`</li>
-        </ul>
-      </td>
+      <td>`Ugar`</td>
+    </tr>
+    <tr>
       <td>`Vai`</td>
+      <td rowspan="2">`Vai`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Wancho`</li>
-          <li>`Wcho`</li>
-        </ul>
-      </td>
+      <td>`Vaii`</td>
+    </tr>
+    <tr>
       <td>`Wancho`</td>
+      <td rowspan="2">`Wancho`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Warang_Citi`</li>
-          <li>`Wara`</li>
-        </ul>
-      </td>
+      <td>`Wcho`</td>
+    </tr>
+    <tr>
       <td>`Warang_Citi`</td>
+      <td rowspan="2">`Warang_Citi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Yi`</li>
-          <li>`Yiii`</li>
-        </ul>
-      </td>
+      <td>`Wara`</td>
+    </tr>
+    <tr>
       <td>`Yi`</td>
+      <td rowspan="2">`Yi`</td>
     </tr>
     <tr>
-      <td>
-        <ul>
-          <li>`Zanabazar_Square`</li>
-          <li>`Zanb`</li>
-        </ul>
-      </td>
+      <td>`Yiii`</td>
+    </tr>
+    <tr>
       <td>`Zanabazar_Square`</td>
+      <td rowspan="2">`Zanabazar_Square`</td>
+    </tr>
+    <tr>
+      <td>`Zanb`</td>
     </tr>
   </table>
 </emu-table>


### PR DESCRIPTION
Compare [current](https://tc39.es/ecma262/#table-binary-unicode-properties) with [updated](https://ci.tc39.es/preview/tc39/ecma262/pull/1992/#table-binary-unicode-properties).

I also removed a few duplicate entries from Table 58: `Cham`, `Lisu`, `Modi`, `Newa`, and `Thai`.

FYI @mathiasbynens this would require a rebase of #1896 and #1939. I'm happy to do it for you if we merge this first.