### PR TITLE
Editorial: Standardize preambles for internal methods and concrete methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5932,9 +5932,8 @@
 
         <emu-clause id="sec-declarative-environment-records-hasbinding-n">
           <h1>HasBinding ( _N_ )</h1>
-          <p>The concrete Environment Record method HasBinding for declarative Environment Records simply determines if the argument identifier is one of the identifiers bound by the record:</p>
+          <p>The HasBinding concrete method of a declarative Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier is one of the identifiers bound by the record. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. If _envRec_ has a binding for the name that is the value of _N_, return *true*.
             1. Return *false*.
           </emu-alg>
@@ -5942,9 +5941,8 @@
 
         <emu-clause id="sec-declarative-environment-records-createmutablebinding-n-d">
           <h1>CreateMutableBinding ( _N_, _D_ )</h1>
-          <p>The concrete Environment Record method CreateMutableBinding for declarative Environment Records creates a new mutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If Boolean argument _D_ has the value *true* the new binding is marked as being subject to deletion.</p>
+          <p>The CreateMutableBinding concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String) and _D_ (a Boolean). It creates a new mutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _D_ has the value *true*, the new binding is marked as being subject to deletion. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Create a mutable binding in _envRec_ for _N_ and record that it is uninitialized. If _D_ is *true*, record that the newly created binding may be deleted by a subsequent DeleteBinding call.
             1. Return NormalCompletion(~empty~).
@@ -5953,9 +5951,8 @@
 
         <emu-clause id="sec-declarative-environment-records-createimmutablebinding-n-s">
           <h1>CreateImmutableBinding ( _N_, _S_ )</h1>
-          <p>The concrete Environment Record method CreateImmutableBinding for declarative Environment Records creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If the Boolean argument _S_ has the value *true* the new binding is marked as a strict binding.</p>
+          <p>The CreateImmutableBinding concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _S_ has the value *true*, the new binding is marked as a strict binding. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Create an immutable binding in _envRec_ for _N_ and record that it is uninitialized. If _S_ is *true*, record that the newly created binding is a strict binding.
             1. Return NormalCompletion(~empty~).
@@ -5964,9 +5961,8 @@
 
         <emu-clause id="sec-declarative-environment-records-initializebinding-n-v">
           <h1>InitializeBinding ( _N_, _V_ )</h1>
-          <p>The concrete Environment Record method InitializeBinding for declarative Environment Records is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</p>
+          <p>The InitializeBinding concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String) and _V_ (an ECMAScript language value). It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. Assert: _envRec_ must have an uninitialized binding for _N_.
             1. Set the bound value for _N_ in _envRec_ to _V_.
             1. <emu-not-ref>Record</emu-not-ref> that the binding for _N_ in _envRec_ has been initialized.
@@ -5976,9 +5972,8 @@
 
         <emu-clause id="sec-declarative-environment-records-setmutablebinding-n-v-s">
           <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
-          <p>The concrete Environment Record method SetMutableBinding for declarative Environment Records attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. A binding for _N_ normally already exists, but in rare cases it may not. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*.</p>
+          <p>The SetMutableBinding concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String), _V_ (an ECMAScript language value), and _S_ (a Boolean). It attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. A binding for _N_ normally already exists, but in rare cases it may not. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. [id="step-setmutablebinding-missing-binding"] If _envRec_ does not have a binding for _N_, then
               1. If _S_ is *true*, throw a *ReferenceError* exception.
               1. Perform _envRec_.CreateMutableBinding(_N_, *true*).
@@ -6000,9 +5995,8 @@
 
         <emu-clause id="sec-declarative-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue ( _N_, _S_ )</h1>
-          <p>The concrete Environment Record method GetBindingValue for declarative Environment Records simply returns the value of its bound identifier whose name is the value of the argument _N_. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.</p>
+          <p>The GetBindingValue concrete method of a declarative Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It returns the value of its bound identifier whose name is the value of the argument _N_. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. Assert: _envRec_ has a binding for _N_.
             1. If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.
             1. Return the value currently bound to _N_ in _envRec_.
@@ -6011,9 +6005,8 @@
 
         <emu-clause id="sec-declarative-environment-records-deletebinding-n">
           <h1>DeleteBinding ( _N_ )</h1>
-          <p>The concrete Environment Record method DeleteBinding for declarative Environment Records can only delete bindings that have been explicitly designated as being subject to deletion.</p>
+          <p>The DeleteBinding concrete method of a declarative Environment Record _envRec_ takes argument _N_ (a String). It can only delete bindings that have been explicitly designated as being subject to deletion. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
             1. Assert: _envRec_ has a binding for the name that is the value of _N_.
             1. If the binding for _N_ in _envRec_ cannot be deleted, return *false*.
             1. Remove the binding for _N_ from _envRec_.
@@ -6023,23 +6016,29 @@
 
         <emu-clause id="sec-declarative-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
-          <p>Regular declarative Environment Records do not provide a `this` binding.</p>
+          <p>The HasThisBinding concrete method of a declarative Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
+          <emu-note>
+            <p>A regular declarative Environment Record (i.e., one that is neither a function Environment Record nor a module Environment Record) does not provide a `this` binding.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-declarative-environment-records-hassuperbinding">
           <h1>HasSuperBinding ( )</h1>
-          <p>Regular declarative Environment Records do not provide a `super` binding.</p>
+          <p>The HasSuperBinding concrete method of a declarative Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
+          <emu-note>
+            <p>A regular declarative Environment Record (i.e., one that is neither a function Environment Record nor a module Environment Record) does not provide a `super` binding.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-declarative-environment-records-withbaseobject">
           <h1>WithBaseObject ( )</h1>
-          <p>Declarative Environment Records always return *undefined* as their WithBaseObject.</p>
+          <p>The WithBaseObject concrete method of a declarative Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *undefined*.
           </emu-alg>
@@ -6054,9 +6053,8 @@
 
         <emu-clause id="sec-object-environment-records-hasbinding-n">
           <h1>HasBinding ( _N_ )</h1>
-          <p>The concrete Environment Record method HasBinding for object Environment Records determines if its associated binding object has a property whose name is the value of the argument _N_:</p>
+          <p>The HasBinding concrete method of an object Environment Record _envRec_ takes argument _N_ (a String). It determines if its associated binding object has a property whose name is the value of the argument _N_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the object Environment Record for which the method was invoked.
             1. Let _bindings_ be the binding object for _envRec_.
             1. Let _foundBinding_ be ? HasProperty(_bindings_, _N_).
             1. If _foundBinding_ is *false*, return *false*.
@@ -6071,9 +6069,8 @@
 
         <emu-clause id="sec-object-environment-records-createmutablebinding-n-d">
           <h1>CreateMutableBinding ( _N_, _D_ )</h1>
-          <p>The concrete Environment Record method CreateMutableBinding for object Environment Records creates in an Environment Record's associated binding object a property whose name is the String value and initializes it to the value *undefined*. If Boolean argument _D_ has the value *true* the new property's [[Configurable]] attribute is set to *true*; otherwise it is set to *false*.</p>
+          <p>The CreateMutableBinding concrete method of an object Environment Record _envRec_ takes arguments _N_ (a String) and _D_ (a Boolean). It creates in an Environment Record's associated binding object a property whose name is the String value and initializes it to the value *undefined*. If _D_ has the value *true*, the new property's [[Configurable]] attribute is set to *true*; otherwise it is set to *false*. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the object Environment Record for which the method was invoked.
             1. Let _bindings_ be the binding object for _envRec_.
             1. Return ? DefinePropertyOrThrow(_bindings_, _N_, PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: _D_ }).
           </emu-alg>
@@ -6084,14 +6081,13 @@
 
         <emu-clause id="sec-object-environment-records-createimmutablebinding-n-s">
           <h1>CreateImmutableBinding ( _N_, _S_ )</h1>
-          <p>The concrete Environment Record method CreateImmutableBinding is never used within this specification in association with object Environment Records.</p>
+          <p>The CreateImmutableBinding concrete method of an object Environment Record is never used within this specification.</p>
         </emu-clause>
 
         <emu-clause id="sec-object-environment-records-initializebinding-n-v">
           <h1>InitializeBinding ( _N_, _V_ )</h1>
-          <p>The concrete Environment Record method InitializeBinding for object Environment Records is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_.</p>
+          <p>The InitializeBinding concrete method of an object Environment Record _envRec_ takes arguments _N_ (a String) and _V_ (an ECMAScript language value). It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the object Environment Record for which the method was invoked.
             1. Return ? _envRec_.SetMutableBinding(_N_, _V_, *false*).
           </emu-alg>
           <emu-note>
@@ -6101,9 +6097,8 @@
 
         <emu-clause id="sec-object-environment-records-setmutablebinding-n-v-s">
           <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
-          <p>The concrete Environment Record method SetMutableBinding for object Environment Records attempts to set the value of the Environment Record's associated binding object's property whose name is the value of the argument _N_ to the value of argument _V_. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by the value of the Boolean argument _S_.</p>
+          <p>The SetMutableBinding concrete method of an object Environment Record _envRec_ takes arguments _N_ (a String), _V_ (an ECMAScript language value), and _S_ (a Boolean). It attempts to set the value of the Environment Record's associated binding object's property whose name is the value of the argument _N_ to the value of argument _V_. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the object Environment Record for which the method was invoked.
             1. Let _bindings_ be the binding object for _envRec_.
             1. Let _stillExists_ be ? HasProperty(_bindings_, _N_).
             1. If _stillExists_ is *false* and _S_ is *true*, throw a *ReferenceError* exception.
@@ -6113,9 +6108,8 @@
 
         <emu-clause id="sec-object-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue ( _N_, _S_ )</h1>
-          <p>The concrete Environment Record method GetBindingValue for object Environment Records returns the value of its associated binding object's property whose name is the String value of the argument identifier _N_. The property should already exist but if it does not the result depends upon the value of the _S_ argument:</p>
+          <p>The GetBindingValue concrete method of an object Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It returns the value of its associated binding object's property whose name is the String value of the argument identifier _N_. The property should already exist but if it does not the result depends upon _S_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the object Environment Record for which the method was invoked.
             1. Let _bindings_ be the binding object for _envRec_.
             1. Let _value_ be ? HasProperty(_bindings_, _N_).
             1. If _value_ is *false*, then
@@ -6126,9 +6120,8 @@
 
         <emu-clause id="sec-object-environment-records-deletebinding-n">
           <h1>DeleteBinding ( _N_ )</h1>
-          <p>The concrete Environment Record method DeleteBinding for object Environment Records can only delete bindings that correspond to properties of the environment object whose [[Configurable]] attribute have the value *true*.</p>
+          <p>The DeleteBinding concrete method of an object Environment Record _envRec_ takes argument _N_ (a String). It can only delete bindings that correspond to properties of the environment object whose [[Configurable]] attribute have the value *true*. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the object Environment Record for which the method was invoked.
             1. Let _bindings_ be the binding object for _envRec_.
             1. Return ? _bindings_.[[Delete]](_N_).
           </emu-alg>
@@ -6136,25 +6129,30 @@
 
         <emu-clause id="sec-object-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
-          <p>Regular object Environment Records do not provide a `this` binding.</p>
+          <p>The HasThisBinding concrete method of an object Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
+          <emu-note>
+            <p>Object Environment Records do not provide a `this` binding.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-object-environment-records-hassuperbinding">
           <h1>HasSuperBinding ( )</h1>
-          <p>Regular object Environment Records do not provide a `super` binding.</p>
+          <p>The HasSuperBinding concrete method of an object Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
+          <emu-note>
+            <p>Object Environment Records do not provide a `super` binding.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-object-environment-records-withbaseobject">
           <h1>WithBaseObject ( )</h1>
-          <p>Object Environment Records return *undefined* as their WithBaseObject unless their _withEnvironment_ flag is *true*.</p>
+          <p>The WithBaseObject concrete method of an object Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the object Environment Record for which the method was invoked.
             1. If the _withEnvironment_ flag of _envRec_ is *true*, return the binding object for _envRec_.
             1. Otherwise, return *undefined*.
           </emu-alg>
@@ -6269,8 +6267,8 @@
 
         <emu-clause id="sec-bindthisvalue">
           <h1>BindThisValue ( _V_ )</h1>
+          <p>The BindThisValue concrete method of a function Environment Record _envRec_ takes argument _V_ (an ECMAScript language value). It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the function Environment Record for which the method was invoked.
             1. Assert: _envRec_.[[ThisBindingStatus]] is not ~lexical~.
             1. If _envRec_.[[ThisBindingStatus]] is ~initialized~, throw a *ReferenceError* exception.
             1. Set _envRec_.[[ThisValue]] to _V_.
@@ -6281,16 +6279,16 @@
 
         <emu-clause id="sec-function-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
+          <p>The HasThisBinding concrete method of a function Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the function Environment Record for which the method was invoked.
             1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*; otherwise, return *true*.
           </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-function-environment-records-hassuperbinding">
           <h1>HasSuperBinding ( )</h1>
+          <p>The HasSuperBinding concrete method of a function Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the function Environment Record for which the method was invoked.
             1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*.
             1. If _envRec_.[[FunctionObject]].[[HomeObject]] has the value *undefined*, return *false*; otherwise, return *true*.
           </emu-alg>
@@ -6298,8 +6296,8 @@
 
         <emu-clause id="sec-function-environment-records-getthisbinding">
           <h1>GetThisBinding ( )</h1>
+          <p>The GetThisBinding concrete method of a function Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the function Environment Record for which the method was invoked.
             1. Assert: _envRec_.[[ThisBindingStatus]] is not ~lexical~.
             1. If _envRec_.[[ThisBindingStatus]] is ~uninitialized~, throw a *ReferenceError* exception.
             1. Return _envRec_.[[ThisValue]].
@@ -6308,8 +6306,8 @@
 
         <emu-clause id="sec-getsuperbase">
           <h1>GetSuperBase ( )</h1>
+          <p>The GetSuperBase concrete method of a function Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the function Environment Record for which the method was invoked.
             1. Let _home_ be _envRec_.[[FunctionObject]].[[HomeObject]].
             1. If _home_ has the value *undefined*, return *undefined*.
             1. Assert: Type(_home_) is Object.
@@ -6467,9 +6465,8 @@
 
         <emu-clause id="sec-global-environment-records-hasbinding-n">
           <h1>HasBinding ( _N_ )</h1>
-          <p>The concrete Environment Record method HasBinding for global Environment Records simply determines if the argument identifier is one of the identifiers bound by the record:</p>
+          <p>The HasBinding concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier is one of the identifiers bound by the record. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, return *true*.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
@@ -6479,9 +6476,8 @@
 
         <emu-clause id="sec-global-environment-records-createmutablebinding-n-d">
           <h1>CreateMutableBinding ( _N_, _D_ )</h1>
-          <p>The concrete Environment Record method CreateMutableBinding for global Environment Records creates a new mutable binding for the name _N_ that is uninitialized. The binding is created in the associated DeclarativeRecord. A binding for _N_ must not already exist in the DeclarativeRecord. If Boolean argument _D_ has the value *true* the new binding is marked as being subject to deletion.</p>
+          <p>The CreateMutableBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _D_ (a Boolean). It creates a new mutable binding for the name _N_ that is uninitialized. The binding is created in the associated DeclarativeRecord. A binding for _N_ must not already exist in the DeclarativeRecord. If _D_ has the value *true*, the new binding is marked as being subject to deletion. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, throw a *TypeError* exception.
             1. Return _DclRec_.CreateMutableBinding(_N_, _D_).
@@ -6490,9 +6486,8 @@
 
         <emu-clause id="sec-global-environment-records-createimmutablebinding-n-s">
           <h1>CreateImmutableBinding ( _N_, _S_ )</h1>
-          <p>The concrete Environment Record method CreateImmutableBinding for global Environment Records creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If the Boolean argument _S_ has the value *true* the new binding is marked as a strict binding.</p>
+          <p>The CreateImmutableBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It creates a new immutable binding for the name _N_ that is uninitialized. A binding must not already exist in this Environment Record for _N_. If _S_ has the value *true*, the new binding is marked as a strict binding. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, throw a *TypeError* exception.
             1. Return _DclRec_.CreateImmutableBinding(_N_, _S_).
@@ -6501,9 +6496,8 @@
 
         <emu-clause id="sec-global-environment-records-initializebinding-n-v">
           <h1>InitializeBinding ( _N_, _V_ )</h1>
-          <p>The concrete Environment Record method InitializeBinding for global Environment Records is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</p>
+          <p>The InitializeBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _V_ (an ECMAScript language value). It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, then
               1. Return _DclRec_.InitializeBinding(_N_, _V_).
@@ -6515,9 +6509,8 @@
 
         <emu-clause id="sec-global-environment-records-setmutablebinding-n-v-s">
           <h1>SetMutableBinding ( _N_, _V_, _S_ )</h1>
-          <p>The concrete Environment Record method SetMutableBinding for global Environment Records attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by the value of the Boolean argument _S_.</p>
+          <p>The SetMutableBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String), _V_ (an ECMAScript language value), and _S_ (a Boolean). It attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, then
               1. Return _DclRec_.SetMutableBinding(_N_, _V_, _S_).
@@ -6528,9 +6521,8 @@
 
         <emu-clause id="sec-global-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue ( _N_, _S_ )</h1>
-          <p>The concrete Environment Record method GetBindingValue for global Environment Records returns the value of its bound identifier whose name is the value of the argument _N_. If the binding is an uninitialized binding throw a *ReferenceError* exception. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by the value of the Boolean argument _S_.</p>
+          <p>The GetBindingValue concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It returns the value of its bound identifier whose name is the value of the argument _N_. If the binding is an uninitialized binding throw a *ReferenceError* exception. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, then
               1. Return _DclRec_.GetBindingValue(_N_, _S_).
@@ -6541,9 +6533,8 @@
 
         <emu-clause id="sec-global-environment-records-deletebinding-n">
           <h1>DeleteBinding ( _N_ )</h1>
-          <p>The concrete Environment Record method DeleteBinding for global Environment Records can only delete bindings that have been explicitly designated as being subject to deletion.</p>
+          <p>The DeleteBinding concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It can only delete bindings that have been explicitly designated as being subject to deletion. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, then
               1. Return _DclRec_.DeleteBinding(_N_).
@@ -6562,21 +6553,29 @@
 
         <emu-clause id="sec-global-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
+          <p>The HasThisBinding concrete method of a global Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *true*.
           </emu-alg>
+          <emu-note>
+            <p>Global Environment Records always provide a `this` binding.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-global-environment-records-hassuperbinding">
           <h1>HasSuperBinding ( )</h1>
+          <p>The HasSuperBinding concrete method of a global Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *false*.
           </emu-alg>
+          <emu-note>
+            <p>Global Environment Records do not provide a `super` binding.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-global-environment-records-withbaseobject">
           <h1>WithBaseObject ( )</h1>
-          <p>Global Environment Records always return *undefined* as their WithBaseObject.</p>
+          <p>The WithBaseObject concrete method of a global Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *undefined*.
           </emu-alg>
@@ -6584,17 +6583,16 @@
 
         <emu-clause id="sec-global-environment-records-getthisbinding">
           <h1>GetThisBinding ( )</h1>
+          <p>The GetThisBinding concrete method of a global Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Return _envRec_.[[GlobalThisValue]].
           </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-hasvardeclaration">
           <h1>HasVarDeclaration ( _N_ )</h1>
-          <p>The concrete Environment Record method HasVarDeclaration for global Environment Records determines if the argument identifier has a binding in this record that was created using a |VariableStatement| or a |FunctionDeclaration|:</p>
+          <p>The HasVarDeclaration concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier has a binding in this record that was created using a |VariableStatement| or a |FunctionDeclaration|. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
             1. If _varDeclaredNames_ contains _N_, return *true*.
             1. Return *false*.
@@ -6603,9 +6601,8 @@
 
         <emu-clause id="sec-haslexicaldeclaration">
           <h1>HasLexicalDeclaration ( _N_ )</h1>
-          <p>The concrete Environment Record method HasLexicalDeclaration for global Environment Records determines if the argument identifier has a binding in this record that was created using a lexical declaration such as a |LexicalDeclaration| or a |ClassDeclaration|:</p>
+          <p>The HasLexicalDeclaration concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier has a binding in this record that was created using a lexical declaration such as a |LexicalDeclaration| or a |ClassDeclaration|. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. Return _DclRec_.HasBinding(_N_).
           </emu-alg>
@@ -6613,9 +6610,8 @@
 
         <emu-clause id="sec-hasrestrictedglobalproperty">
           <h1>HasRestrictedGlobalProperty ( _N_ )</h1>
-          <p>The concrete Environment Record method HasRestrictedGlobalProperty for global Environment Records determines if the argument identifier is the name of a property of the global object that must not be shadowed by a global lexical binding:</p>
+          <p>The HasRestrictedGlobalProperty concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if the argument identifier is the name of a property of the global object that must not be shadowed by a global lexical binding. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be the binding object for _ObjRec_.
             1. Let _existingProp_ be ? _globalObject_.[[GetOwnProperty]](_N_).
@@ -6630,9 +6626,8 @@
 
         <emu-clause id="sec-candeclareglobalvar">
           <h1>CanDeclareGlobalVar ( _N_ )</h1>
-          <p>The concrete Environment Record method CanDeclareGlobalVar for global Environment Records determines if a corresponding CreateGlobalVarBinding call would succeed if called for the same argument _N_. Redundant var declarations and var declarations for pre-existing global object properties are allowed.</p>
+          <p>The CanDeclareGlobalVar concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if a corresponding CreateGlobalVarBinding call would succeed if called for the same argument _N_. Redundant var declarations and var declarations for pre-existing global object properties are allowed. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be the binding object for _ObjRec_.
             1. Let _hasProperty_ be ? HasOwnProperty(_globalObject_, _N_).
@@ -6643,9 +6638,8 @@
 
         <emu-clause id="sec-candeclareglobalfunction">
           <h1>CanDeclareGlobalFunction ( _N_ )</h1>
-          <p>The concrete Environment Record method CanDeclareGlobalFunction for global Environment Records determines if a corresponding CreateGlobalFunctionBinding call would succeed if called for the same argument _N_.</p>
+          <p>The CanDeclareGlobalFunction concrete method of a global Environment Record _envRec_ takes argument _N_ (a String). It determines if a corresponding CreateGlobalFunctionBinding call would succeed if called for the same argument _N_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be the binding object for _ObjRec_.
             1. Let _existingProp_ be ? _globalObject_.[[GetOwnProperty]](_N_).
@@ -6658,9 +6652,8 @@
 
         <emu-clause id="sec-createglobalvarbinding">
           <h1>CreateGlobalVarBinding ( _N_, _D_ )</h1>
-          <p>The concrete Environment Record method CreateGlobalVarBinding for global Environment Records creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is reused and assumed to be initialized.</p>
+          <p>The CreateGlobalVarBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String) and _D_ (a Boolean). It creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is reused and assumed to be initialized. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be the binding object for _ObjRec_.
             1. Let _hasProperty_ be ? HasOwnProperty(_globalObject_, _N_).
@@ -6677,9 +6670,8 @@
 
         <emu-clause id="sec-createglobalfunctionbinding">
           <h1>CreateGlobalFunctionBinding ( _N_, _V_, _D_ )</h1>
-          <p>The concrete Environment Record method CreateGlobalFunctionBinding for global Environment Records creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is replaced.</p>
+          <p>The CreateGlobalFunctionBinding concrete method of a global Environment Record _envRec_ takes arguments _N_ (a String), _V_ (an ECMAScript language value), and _D_ (a Boolean). It creates and initializes a mutable binding in the associated object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is replaced. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the global Environment Record for which the method was invoked.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be the binding object for _ObjRec_.
             1. Let _existingProp_ be ? _globalObject_.[[GetOwnProperty]](_N_).
@@ -6738,10 +6730,9 @@
 
         <emu-clause id="sec-module-environment-records-getbindingvalue-n-s">
           <h1>GetBindingValue ( _N_, _S_ )</h1>
-          <p>The concrete Environment Record method GetBindingValue for module Environment Records returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown.</p>
+          <p>The GetBindingValue concrete method of a module Environment Record _envRec_ takes arguments _N_ (a String) and _S_ (a Boolean). It returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _S_ is *true*.
-            1. Let _envRec_ be the module Environment Record for which the method was invoked.
             1. Assert: _envRec_ has a binding for _N_.
             1. If the binding for _N_ is an indirect binding, then
               1. Let _M_ and _N2_ be the indirection values provided when this binding for _N_ was created.
@@ -6758,10 +6749,7 @@
 
         <emu-clause id="sec-module-environment-records-deletebinding-n">
           <h1>DeleteBinding ( _N_ )</h1>
-          <p>The concrete Environment Record method DeleteBinding for module Environment Records refuses to delete bindings.</p>
-          <emu-alg>
-            1. Assert: This method is never invoked. See <emu-xref href="#sec-delete-operator-static-semantics-early-errors"></emu-xref>.
-          </emu-alg>
+          <p>The DeleteBinding concrete method of a module Environment Record is never used within this specification.</p>
           <emu-note>
             <p>Module Environment Records are only used within strict code and an early error rule prevents the delete operator, in strict code, from being applied to a Reference Record that would resolve to a module Environment Record binding. See <emu-xref href="#sec-delete-operator-static-semantics-early-errors"></emu-xref>.</p>
           </emu-note>
@@ -6769,14 +6757,18 @@
 
         <emu-clause id="sec-module-environment-records-hasthisbinding">
           <h1>HasThisBinding ( )</h1>
-          <p>Module Environment Records provide a `this` binding.</p>
+          <p>The HasThisBinding concrete method of a module Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *true*.
           </emu-alg>
+          <emu-note>
+            <p>Module Environment Records always provide a `this` binding.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-module-environment-records-getthisbinding">
           <h1>GetThisBinding ( )</h1>
+          <p>The GetThisBinding concrete method of a module Environment Record _envRec_ takes no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Return *undefined*.
           </emu-alg>
@@ -6784,9 +6776,8 @@
 
         <emu-clause id="sec-createimportbinding">
           <h1>CreateImportBinding ( _N_, _M_, _N2_ )</h1>
-          <p>The concrete Environment Record method CreateImportBinding for module Environment Records creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _M_ is a Module Record, and _N2_ is the name of a binding that exists in _M_'s module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding.</p>
+          <p>The CreateImportBinding concrete method of a module Environment Record _envRec_ takes arguments _N_ (a String), _M_ (a Module Record), and _N2_ (a String). It creates a new initialized immutable indirect binding for the name _N_. A binding must not already exist in this Environment Record for _N_. _N2_ is the name of a binding that exists in _M_'s module Environment Record. Accesses to the value of the new binding will indirectly access the bound value of the target binding. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _envRec_ be the module Environment Record for which the method was invoked.
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Assert: _M_ is a Module Record.
             1. Assert: When _M_.[[Environment]] is instantiated it will have a direct binding for _N2_.

--- a/spec.html
+++ b/spec.html
@@ -23034,12 +23034,9 @@
 
         <emu-clause id="sec-moduledeclarationlinking" oldids="sec-moduledeclarationinstantiation">
           <h1>Link ( ) Concrete Method</h1>
-          <p>The Link concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-          <p>On success, Link transitions this module's [[Status]] from ~unlinked~ to ~linked~. On failure, an exception is thrown and this module's [[Status]] remains ~unlinked~.</p>
-          <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleLinking):</p>
+          <p>The Link concrete method of a Cyclic Module Record _module_ takes no arguments. On success, Link transitions this module's [[Status]] from ~unlinked~ to ~linked~. On failure, an exception is thrown and this module's [[Status]] remains ~unlinked~. (Most of the work is done by the auxiliary function InnerModuleLinking.) It performs the following steps when called:</p>
 
           <emu-alg>
-            1. Let _module_ be this Cyclic Module Record.
             1. Assert: _module_.[[Status]] is not ~linking~ or ~evaluating~.
             1. Let _stack_ be a new empty List.
             1. Let _result_ be InnerModuleLinking(_module_, _stack_, 0).
@@ -23099,14 +23096,10 @@
 
         <emu-clause id="sec-moduleevaluation">
           <h1>Evaluate ( ) Concrete Method</h1>
-          <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-          <p>Evaluate transitions this module's [[Status]] from ~linked~ to ~evaluated~.</p>
-          <p>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
-          <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
+          <p>The Evaluate concrete method of a Cyclic Module Record _module_ takes no arguments. Evaluate transitions this module's [[Status]] from ~linked~ to ~evaluated~. If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate. (Most of the work is done by the auxiliary function InnerModuleEvaluation.) It performs the following steps when called:</p>
 
           <emu-alg>
             1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
-            1. Let _module_ be this Cyclic Module Record.
             1. Assert: _module_.[[Status]] is ~linked~ or ~evaluated~.
             1. Let _stack_ be a new empty List.
             1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
@@ -23747,12 +23740,10 @@
 
         <emu-clause id="sec-getexportednames">
           <h1>GetExportedNames ( [ _exportStarSet_ ] ) Concrete Method</h1>
-          <p>The GetExportedNames concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
-          <p>It performs the following steps when called:</p>
+          <p>The GetExportedNames concrete method of a Source Text Module Record _module_ takes optional argument _exportStarSet_. It performs the following steps when called:</p>
           <emu-alg>
             1. If _exportStarSet_ is not present, set _exportStarSet_ to a new empty List.
             1. Assert: _exportStarSet_ is a List of Source Text Module Records.
-            1. Let _module_ be this Source Text Module Record.
             1. If _exportStarSet_ contains _module_, then
               1. Assert: We've reached the starting point of an `export *` circularity.
               1. Return a new empty List.
@@ -23780,15 +23771,14 @@
 
         <emu-clause id="sec-resolveexport">
           <h1>ResolveExport ( _exportName_ [ , _resolveSet_ ] ) Concrete Method</h1>
-          <p>The ResolveExport concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
+          <p>The ResolveExport concrete method of a Source Text Module Record _module_ takes argument _exportName_ (a String) and optional argument _resolveSet_.</p>
           <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
           <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to *"\*namespace\*"*. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string *"ambiguous"* is returned.</p>
-          <p>This abstract method performs the following steps:</p>
+          <p>This concrete method performs the following steps when called:</p>
 
           <emu-alg>
             1. If _resolveSet_ is not present, set _resolveSet_ to a new empty List.
             1. Assert: _resolveSet_ is a List of Record { [[Module]], [[ExportName]] }.
-            1. Let _module_ be this Source Text Module Record.
             1. For each Record { [[Module]], [[ExportName]] } _r_ of _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
                 1. Assert: This is a circular import request.
@@ -23828,11 +23818,9 @@
 
         <emu-clause id="sec-source-text-module-record-initialize-environment" aoid="InitializeEnvironment">
           <h1>InitializeEnvironment ( ) Concrete Method</h1>
-          <p>The InitializeEnvironment concrete method of a Source Text Module Record implements the corresponding Cyclic Module Record abstract method.</p>
-          <p>This abstract method performs the following steps:</p>
+          <p>The InitializeEnvironment concrete method of a Source Text Module Record _module_ takes no arguments. It performs the following steps when called:</p>
 
           <emu-alg>
-            1. Let _module_ be this Source Text Module Record.
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]]).
               1. If _resolution_ is *null* or *"ambiguous"*, throw a *SyntaxError* exception.
@@ -23893,11 +23881,9 @@
 
         <emu-clause id="sec-source-text-module-record-execute-module" aoid="ExecuteModule">
           <h1>ExecuteModule ( ) Concrete Method</h1>
-          <p>The ExecuteModule concrete method of a Source Text Module Record implements the corresponding Cyclic Module Record abstract method.</p>
-          <p>This abstract method performs the following steps:</p>
+          <p>The ExecuteModule concrete method of a Source Text Module Record _module_ takes no arguments. It performs the following steps when called:</p>
 
           <emu-alg>
-            1. Let _module_ be this Source Text Module Record.
             1. Suspend the currently running execution context.
             1. Let _moduleContext_ be _module_.[[Context]].
             1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.

--- a/spec.html
+++ b/spec.html
@@ -7684,7 +7684,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof">
       <h1>[[GetPrototypeOf]] ( )</h1>
-      <p>When the [[GetPrototypeOf]] internal method of _O_ is called, the following steps are taken:</p>
+      <p>The [[GetPrototypeOf]] internal method of an ordinary object _O_ takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Return ! OrdinaryGetPrototypeOf(_O_).
       </emu-alg>
@@ -7700,7 +7700,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v">
       <h1>[[SetPrototypeOf]] ( _V_ )</h1>
-      <p>When the [[SetPrototypeOf]] internal method of _O_ is called with argument _V_, the following steps are taken:</p>
+      <p>The [[SetPrototypeOf]] internal method of an ordinary object _O_ takes argument _V_ (an Object or *null*). It performs the following steps when called:</p>
       <emu-alg>
         1. Return ! OrdinarySetPrototypeOf(_O_, _V_).
       </emu-alg>
@@ -7733,7 +7733,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-isextensible">
       <h1>[[IsExtensible]] ( )</h1>
-      <p>When the [[IsExtensible]] internal method of _O_ is called, the following steps are taken:</p>
+      <p>The [[IsExtensible]] internal method of an ordinary object _O_ takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Return ! OrdinaryIsExtensible(_O_).
       </emu-alg>
@@ -7749,7 +7749,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-preventextensions">
       <h1>[[PreventExtensions]] ( )</h1>
-      <p>When the [[PreventExtensions]] internal method of _O_ is called, the following steps are taken:</p>
+      <p>The [[PreventExtensions]] internal method of an ordinary object _O_ takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Return ! OrdinaryPreventExtensions(_O_).
       </emu-alg>
@@ -7766,7 +7766,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p">
       <h1>[[GetOwnProperty]] ( _P_ )</h1>
-      <p>When the [[GetOwnProperty]] internal method of _O_ is called with property key _P_, the following steps are taken:</p>
+      <p>The [[GetOwnProperty]] internal method of an ordinary object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
       <emu-alg>
         1. Return ! OrdinaryGetOwnProperty(_O_, _P_).
       </emu-alg>
@@ -7795,7 +7795,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">
       <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-      <p>When the [[DefineOwnProperty]] internal method of _O_ is called with property key _P_ and Property Descriptor _Desc_, the following steps are taken:</p>
+      <p>The [[DefineOwnProperty]] internal method of an ordinary object _O_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
       <emu-alg>
         1. Return ? OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
       </emu-alg>
@@ -7867,7 +7867,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p">
       <h1>[[HasProperty]] ( _P_ )</h1>
-      <p>When the [[HasProperty]] internal method of _O_ is called with property key _P_, the following steps are taken:</p>
+      <p>The [[HasProperty]] internal method of an ordinary object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
       <emu-alg>
         1. Return ? OrdinaryHasProperty(_O_, _P_).
       </emu-alg>
@@ -7889,7 +7889,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">
       <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-      <p>When the [[Get]] internal method of _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
+      <p>The [[Get]] internal method of an ordinary object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
 
       <emu-alg>
         1. Return ? OrdinaryGet(_O_, _P_, _Receiver_).
@@ -7917,7 +7917,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver">
       <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-      <p>When the [[Set]] internal method of _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
+      <p>The [[Set]] internal method of an ordinary object _O_ takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
       <emu-alg>
         1. Return ? OrdinarySet(_O_, _P_, _V_, _Receiver_).
       </emu-alg>
@@ -7968,7 +7968,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-delete-p">
       <h1>[[Delete]] ( _P_ )</h1>
-      <p>When the [[Delete]] internal method of _O_ is called with property key _P_, the following steps are taken:</p>
+      <p>The [[Delete]] internal method of an ordinary object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
       <emu-alg>
         1. Return ? OrdinaryDelete(_O_, _P_).
       </emu-alg>
@@ -7990,7 +7990,7 @@
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">
       <h1>[[OwnPropertyKeys]] ( )</h1>
-      <p>When the [[OwnPropertyKeys]] internal method of _O_ is called, the following steps are taken:</p>
+      <p>The [[OwnPropertyKeys]] internal method of an ordinary object _O_ takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Return ! OrdinaryOwnPropertyKeys(_O_).
       </emu-alg>
@@ -8211,7 +8211,7 @@
 
     <emu-clause id="sec-ecmascript-function-objects-call-thisargument-argumentslist">
       <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
-      <p>The [[Call]] internal method for an ECMAScript function object _F_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
+      <p>The [[Call]] internal method of an ECMAScript function object _F_ takes arguments _thisArgument_ (an ECMAScript language value) and _argumentsList_ (a List of ECMAScript language values). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. If _F_.[[IsClassConstructor]] is *true*, throw a *TypeError* exception.
@@ -8284,7 +8284,7 @@
 
     <emu-clause id="sec-ecmascript-function-objects-construct-argumentslist-newtarget">
       <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-      <p>The [[Construct]] internal method for an ECMAScript function object _F_ is called with parameters _argumentsList_ and _newTarget_. _argumentsList_ is a possibly empty List of ECMAScript language values. The following steps are taken:</p>
+      <p>The [[Construct]] internal method of an ECMAScript function object _F_ takes arguments _argumentsList_ (a List of ECMAScript language values) and _newTarget_ (a constructor). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _F_ is an ECMAScript function object.
         1. Assert: Type(_newTarget_) is Object.
@@ -8568,7 +8568,7 @@
 
     <emu-clause id="sec-built-in-function-objects-call-thisargument-argumentslist">
       <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
-      <p>The [[Call]] internal method for a built-in function object _F_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
+      <p>The [[Call]] internal method of a built-in function object _F_ takes arguments _thisArgument_ (an ECMAScript language value) and _argumentsList_ (a List of ECMAScript language values). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
         1. If _callerContext_ is not already suspended, suspend _callerContext_.
@@ -8590,7 +8590,7 @@
 
     <emu-clause id="sec-built-in-function-objects-construct-argumentslist-newtarget">
       <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-      <p>The [[Construct]] internal method for built-in function object _F_ is called with parameters _argumentsList_ and _newTarget_. The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step <emu-xref href="#step-call-builtin-function-result"></emu-xref> is replaced by:</p>
+      <p>The [[Construct]] internal method of a built-in function object _F_ takes arguments _argumentsList_ (a List of ECMAScript language values) and _newTarget_ (a constructor). The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step <emu-xref href="#step-call-builtin-function-result"></emu-xref> is replaced by:</p>
       <emu-alg replaces-step="step-call-builtin-function-result">
         1. Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. The *this* value is uninitialized, _argumentsList_ provides the named parameters, and _newTarget_ provides the NewTarget value.
       </emu-alg>
@@ -8679,7 +8679,7 @@
 
       <emu-clause id="sec-bound-function-exotic-objects-call-thisargument-argumentslist">
         <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
-        <p>When the [[Call]] internal method of a bound function exotic object, _F_, which was created using the bind function is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values, the following steps are taken:</p>
+        <p>The [[Call]] internal method of a bound function exotic object _F_ takes arguments _thisArgument_ (an ECMAScript language value) and _argumentsList_ (a List of ECMAScript language values). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _target_ be _F_.[[BoundTargetFunction]].
           1. Let _boundThis_ be _F_.[[BoundThis]].
@@ -8691,7 +8691,7 @@
 
       <emu-clause id="sec-bound-function-exotic-objects-construct-argumentslist-newtarget">
         <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-        <p>When the [[Construct]] internal method of a bound function exotic object, _F_ that was created using the bind function is called with a list of arguments _argumentsList_ and _newTarget_, the following steps are taken:</p>
+        <p>The [[Construct]] internal method of a bound function exotic object _F_ takes arguments _argumentsList_ (a List of ECMAScript language values) and _newTarget_ (a constructor). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _target_ be _F_.[[BoundTargetFunction]].
           1. Assert: IsConstructor(_target_) is *true*.
@@ -8733,7 +8733,7 @@
 
       <emu-clause id="sec-array-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>When the [[DefineOwnProperty]] internal method of an Array exotic object _A_ is called with property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The [[DefineOwnProperty]] internal method of an Array exotic object _A_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If _P_ is *"length"*, then
@@ -8848,7 +8848,7 @@
 
       <emu-clause id="sec-string-exotic-objects-getownproperty-p">
         <h1>[[GetOwnProperty]] ( _P_ )</h1>
-        <p>When the [[GetOwnProperty]] internal method of a String exotic object _S_ is called with property key _P_, the following steps are taken:</p>
+        <p>The [[GetOwnProperty]] internal method of a String exotic object _S_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Let _desc_ be OrdinaryGetOwnProperty(_S_, _P_).
@@ -8859,7 +8859,7 @@
 
       <emu-clause id="sec-string-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>When the [[DefineOwnProperty]] internal method of a String exotic object _S_ is called with property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The [[DefineOwnProperty]] internal method of a String exotic object _S_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Let _stringDesc_ be ! StringGetOwnProperty(_S_, _P_).
@@ -8872,7 +8872,7 @@
 
       <emu-clause id="sec-string-exotic-objects-ownpropertykeys">
         <h1>[[OwnPropertyKeys]] ( )</h1>
-        <p>When the [[OwnPropertyKeys]] internal method of a String exotic object _O_ is called, the following steps are taken:</p>
+        <p>The [[OwnPropertyKeys]] internal method of a String exotic object _O_ takes no arguments. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _keys_ be a new empty List.
           1. Let _str_ be _O_.[[StringData]].
@@ -8955,9 +8955,8 @@
 
       <emu-clause id="sec-arguments-exotic-objects-getownproperty-p">
         <h1>[[GetOwnProperty]] ( _P_ )</h1>
-        <p>The [[GetOwnProperty]] internal method of an arguments exotic object when called with a property key _P_ performs the following steps:</p>
+        <p>The [[GetOwnProperty]] internal method of an arguments exotic object _args_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _args_ be the arguments object.
           1. Let _desc_ be OrdinaryGetOwnProperty(_args_, _P_).
           1. If _desc_ is *undefined*, return _desc_.
           1. Let _map_ be _args_.[[ParameterMap]].
@@ -8970,9 +8969,8 @@
 
       <emu-clause id="sec-arguments-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>The [[DefineOwnProperty]] internal method of an arguments exotic object when called with a property key _P_ and Property Descriptor _Desc_ performs the following steps:</p>
+        <p>The [[DefineOwnProperty]] internal method of an arguments exotic object _args_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _args_ be the arguments object.
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be HasOwnProperty(_map_, _P_).
           1. Let _newArgDesc_ be _Desc_.
@@ -8997,9 +8995,8 @@
 
       <emu-clause id="sec-arguments-exotic-objects-get-p-receiver">
         <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-        <p>The [[Get]] internal method of an arguments exotic object when called with a property key _P_ and ECMAScript language value _Receiver_ performs the following steps:</p>
+        <p>The [[Get]] internal method of an arguments exotic object _args_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _args_ be the arguments object.
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If _isMapped_ is *false*, then
@@ -9012,9 +9009,8 @@
 
       <emu-clause id="sec-arguments-exotic-objects-set-p-v-receiver">
         <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-        <p>The [[Set]] internal method of an arguments exotic object when called with property key _P_, value _V_, and ECMAScript language value _Receiver_ performs the following steps:</p>
+        <p>The [[Set]] internal method of an arguments exotic object _args_ takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _args_ be the arguments object.
           1. If SameValue(_args_, _Receiver_) is *false*, then
             1. Let _isMapped_ be *false*.
           1. Else,
@@ -9029,9 +9025,8 @@
 
       <emu-clause id="sec-arguments-exotic-objects-delete-p">
         <h1>[[Delete]] ( _P_ )</h1>
-        <p>The [[Delete]] internal method of an arguments exotic object when called with a property key _P_ performs the following steps:</p>
+        <p>The [[Delete]] internal method of an arguments exotic object _args_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _args_ be the arguments object.
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. Let _result_ be ? OrdinaryDelete(_args_, _P_).
@@ -9153,7 +9148,7 @@
 
       <emu-clause id="sec-integer-indexed-exotic-objects-getownproperty-p">
         <h1>[[GetOwnProperty]] ( _P_ )</h1>
-        <p>When the [[GetOwnProperty]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+        <p>The [[GetOwnProperty]] internal method of an Integer-Indexed exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -9169,7 +9164,7 @@
 
       <emu-clause id="sec-integer-indexed-exotic-objects-hasproperty-p">
         <h1>[[HasProperty]] ( _P_ )</h1>
-        <p>When the [[HasProperty]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+        <p>The [[HasProperty]] internal method of an Integer-Indexed exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -9182,7 +9177,7 @@
 
       <emu-clause id="sec-integer-indexed-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>When the [[DefineOwnProperty]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, and Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The [[DefineOwnProperty]] internal method of an Integer-Indexed exotic object _O_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -9204,7 +9199,7 @@
 
       <emu-clause id="sec-integer-indexed-exotic-objects-get-p-receiver">
         <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-        <p>When the [[Get]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
+        <p>The [[Get]] internal method of an Integer-Indexed exotic object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is String, then
@@ -9217,7 +9212,7 @@
 
       <emu-clause id="sec-integer-indexed-exotic-objects-set-p-v-receiver">
         <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-        <p>When the [[Set]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
+        <p>The [[Set]] internal method of an Integer-Indexed exotic object _O_ takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is String, then
@@ -9230,7 +9225,7 @@
 
       <emu-clause id="sec-integer-indexed-exotic-objects-delete-p">
         <h1>[[Delete]] ( _P_ )</h1>
-        <p>When the [[Delete]] internal method of an Integer-Indexed exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+        <p>The [[Delete]] internal method of an Integer-Indexed exotic object _O_ takes arguments _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -9244,7 +9239,7 @@
 
       <emu-clause id="sec-integer-indexed-exotic-objects-ownpropertykeys">
         <h1>[[OwnPropertyKeys]] ( )</h1>
-        <p>When the [[OwnPropertyKeys]] internal method of an Integer-Indexed exotic object _O_ is called, the following steps are taken:</p>
+        <p>The [[OwnPropertyKeys]] internal method of an Integer-Indexed exotic object _O_ takes no arguments. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _keys_ be a new empty List.
           1. Assert: _O_ is an Integer-Indexed exotic object.
@@ -9383,7 +9378,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-setprototypeof-v">
         <h1>[[SetPrototypeOf]] ( _V_ )</h1>
-        <p>When the [[SetPrototypeOf]] internal method of a module namespace exotic object _O_ is called with argument _V_, the following steps are taken:</p>
+        <p>The [[SetPrototypeOf]] internal method of a module namespace exotic object _O_ takes argument _V_ (an Object or *null*). It performs the following steps when called:</p>
         <emu-alg>
           1. Return ? SetImmutablePrototype(_O_, _V_).
         </emu-alg>
@@ -9391,7 +9386,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-isextensible">
         <h1>[[IsExtensible]] ( )</h1>
-        <p>When the [[IsExtensible]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
+        <p>The [[IsExtensible]] internal method of a module namespace exotic object takes no arguments. It performs the following steps when called:</p>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
@@ -9399,7 +9394,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-preventextensions">
         <h1>[[PreventExtensions]] ( )</h1>
-        <p>When the [[PreventExtensions]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
+        <p>The [[PreventExtensions]] internal method of a module namespace exotic object takes no arguments. It performs the following steps when called:</p>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
@@ -9407,7 +9402,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-getownproperty-p">
         <h1>[[GetOwnProperty]] ( _P_ )</h1>
-        <p>When the [[GetOwnProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+        <p>The [[GetOwnProperty]] internal method of a module namespace exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryGetOwnProperty(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
@@ -9419,7 +9414,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-defineownproperty-p-desc">
         <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-        <p>When the [[DefineOwnProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_ and Property Descriptor _Desc_, the following steps are taken:</p>
+        <p>The [[DefineOwnProperty]] internal method of a module namespace exotic object _O_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
           1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
@@ -9435,7 +9430,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-hasproperty-p">
         <h1>[[HasProperty]] ( _P_ )</h1>
-        <p>When the [[HasProperty]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+        <p>The [[HasProperty]] internal method of a module namespace exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_P_) is Symbol, return OrdinaryHasProperty(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
@@ -9446,7 +9441,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-get-p-receiver">
         <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-        <p>When the [[Get]] internal method of a module namespace exotic object _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
+        <p>The [[Get]] internal method of a module namespace exotic object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is Symbol, then
@@ -9471,7 +9466,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-set-p-v-receiver">
         <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-        <p>When the [[Set]] internal method of a module namespace exotic object _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
+        <p>The [[Set]] internal method of a module namespace exotic object takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
           1. Return *false*.
         </emu-alg>
@@ -9479,7 +9474,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-delete-p">
         <h1>[[Delete]] ( _P_ )</h1>
-        <p>When the [[Delete]] internal method of a module namespace exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+        <p>The [[Delete]] internal method of a module namespace exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is Symbol, then
@@ -9492,7 +9487,7 @@
 
       <emu-clause id="sec-module-namespace-exotic-objects-ownpropertykeys">
         <h1>[[OwnPropertyKeys]] ( )</h1>
-        <p>When the [[OwnPropertyKeys]] internal method of a module namespace exotic object _O_ is called, the following steps are taken:</p>
+        <p>The [[OwnPropertyKeys]] internal method of a module namespace exotic object _O_ takes no arguments. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _exports_ be a copy of _O_.[[Exports]].
           1. Let _symbolKeys_ be ! OrdinaryOwnPropertyKeys(_O_).
@@ -9534,7 +9529,7 @@
 
       <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v">
         <h1>[[SetPrototypeOf]] ( _V_ )</h1>
-        <p>When the [[SetPrototypeOf]] internal method of an immutable prototype exotic object _O_ is called with argument _V_, the following steps are taken:</p>
+        <p>The [[SetPrototypeOf]] internal method of an immutable prototype exotic object _O_ takes argument _V_ (an Object or *null*). It performs the following steps when called:</p>
         <emu-alg>
           1. Return ? SetImmutablePrototype(_O_, _V_).
         </emu-alg>
@@ -9684,7 +9679,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getprototypeof">
       <h1>[[GetPrototypeOf]] ( )</h1>
-      <p>When the [[GetPrototypeOf]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
+      <p>The [[GetPrototypeOf]] internal method of a Proxy exotic object _O_ takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -9716,7 +9711,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v">
       <h1>[[SetPrototypeOf]] ( _V_ )</h1>
-      <p>When the [[SetPrototypeOf]] internal method of a Proxy exotic object _O_ is called with argument _V_, the following steps are taken:</p>
+      <p>The [[SetPrototypeOf]] internal method of a Proxy exotic object _O_ takes argument _V_ (an Object or *null*). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Either Type(_V_) is Object or Type(_V_) is Null.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -9749,7 +9744,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-isextensible">
       <h1>[[IsExtensible]] ( )</h1>
-      <p>When the [[IsExtensible]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
+      <p>The [[IsExtensible]] internal method of a Proxy exotic object _O_ takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -9778,7 +9773,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-preventextensions">
       <h1>[[PreventExtensions]] ( )</h1>
-      <p>When the [[PreventExtensions]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
+      <p>The [[PreventExtensions]] internal method of a Proxy exotic object _O_ takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -9808,7 +9803,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p">
       <h1>[[GetOwnProperty]] ( _P_ )</h1>
-      <p>When the [[GetOwnProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+      <p>The [[GetOwnProperty]] internal method of a Proxy exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -9866,7 +9861,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc">
       <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
-      <p>When the [[DefineOwnProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_ and Property Descriptor _Desc_, the following steps are taken:</p>
+      <p>The [[DefineOwnProperty]] internal method of a Proxy exotic object _O_ takes arguments _P_ (a property key) and _Desc_ (a Property Descriptor). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -9918,7 +9913,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p">
       <h1>[[HasProperty]] ( _P_ )</h1>
-      <p>When the [[HasProperty]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+      <p>The [[HasProperty]] internal method of a Proxy exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -9955,7 +9950,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver">
       <h1>[[Get]] ( _P_, _Receiver_ )</h1>
-      <p>When the [[Get]] internal method of a Proxy exotic object _O_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
+      <p>The [[Get]] internal method of a Proxy exotic object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -9989,7 +9984,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver">
       <h1>[[Set]] ( _P_, _V_, _Receiver_ )</h1>
-      <p>When the [[Set]] internal method of a Proxy exotic object _O_ is called with property key _P_, value _V_, and ECMAScript language value _Receiver_, the following steps are taken:</p>
+      <p>The [[Set]] internal method of a Proxy exotic object _O_ takes arguments _P_ (a property key), _V_ (an ECMAScript language value), and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -10027,7 +10022,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-delete-p">
       <h1>[[Delete]] ( _P_ )</h1>
-      <p>When the [[Delete]] internal method of a Proxy exotic object _O_ is called with property key _P_, the following steps are taken:</p>
+      <p>The [[Delete]] internal method of a Proxy exotic object _O_ takes argument _P_ (a property key). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: IsPropertyKey(_P_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
@@ -10064,7 +10059,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">
       <h1>[[OwnPropertyKeys]] ( )</h1>
-      <p>When the [[OwnPropertyKeys]] internal method of a Proxy exotic object _O_ is called, the following steps are taken:</p>
+      <p>The [[OwnPropertyKeys]] internal method of a Proxy exotic object _O_ takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -10125,7 +10120,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist">
       <h1>[[Call]] ( _thisArgument_, _argumentsList_ )</h1>
-      <p>The [[Call]] internal method of a Proxy exotic object _O_ is called with parameters _thisArgument_ and _argumentsList_, a List of ECMAScript language values. The following steps are taken:</p>
+      <p>The [[Call]] internal method of a Proxy exotic object _O_ takes arguments _thisArgument_ (an ECMAScript language value) and _argumentsList_ (a List of ECMAScript language values). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.
@@ -10144,7 +10139,7 @@
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget">
       <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-      <p>The [[Construct]] internal method of a Proxy exotic object _O_ is called with parameters _argumentsList_ which is a possibly empty List of ECMAScript language values and _newTarget_. The following steps are taken:</p>
+      <p>The [[Construct]] internal method of a Proxy exotic object _O_ takes arguments _argumentsList_ (a List of ECMAScript language values) and _newTarget_ (a constructor). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. If _handler_ is *null*, throw a *TypeError* exception.


### PR DESCRIPTION
... according to the format set out in PR #1981.

(GitHub lists the commits out of order, but `git log` gets it right.)

----

The first 6 commits are for internal methods:
- The first 2 are a some preparatory work.
- The third is the main conversion.
- The next 3 fill in some missing parameter types.
  For the last of these (`[[Construct]]`'s `_newTarget_`), I said "an Object", but we could use the more precise "a constructor function object".

----

The next 4 are for Environment Record concrete methods:
- The first two are some preparatory work.
- The third is the main conversion.
- The fourth moves the target-alias declaration from the algorithm up to the preamble.

----

The last 2 are for Module Record concrete methods:
- The first is the main conversion.
- The second moves the target-alias declaration from the algorithm up to the preamble.

Notes:

- I'm doubtful that the statements such as:
  "It implements the corresponding Module Record abstract method."
  are useful. (Note that the concrete methods for Environment Records don't have them.) But I left them in anyway. [Now: I've eliminated them.]

- For most of these methods, I collapsed multiple preamble-paragraphs into a single one, as the result seemed okay.
  But for ResolveExport(), I think that would have been too much, so the resulting preamble is not in the standard form.

- Most of these concrete methods have a sentence:
  "This abstract method performs the following steps."
  This is an inconsistent use of the term "abstract method".
  Most of these disappeared in the above collapsing, so it was only left for ResolveExport.
  There, I changed "abstract method" to "concrete method".

---

Resolves #1981.