### PR TITLE
Editorial: Add <dfn> to well‑known symbols

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1006,7 +1006,7 @@
             </tr>
             <tr>
               <td>
-                @@asyncIterator
+                <dfn>@@asyncIterator</dfn>
               </td>
               <td>
                 *"Symbol.asyncIterator"*
@@ -1017,7 +1017,7 @@
             </tr>
             <tr>
               <td>
-                @@hasInstance
+                <dfn>@@hasInstance</dfn>
               </td>
               <td>
                 *"Symbol.hasInstance"*
@@ -1028,7 +1028,7 @@
             </tr>
             <tr>
               <td>
-                @@isConcatSpreadable
+                <dfn>@@isConcatSpreadable</dfn>
               </td>
               <td>
                 *"Symbol.isConcatSpreadable"*
@@ -1039,7 +1039,7 @@
             </tr>
             <tr>
               <td>
-                @@iterator
+                <dfn>@@iterator</dfn>
               </td>
               <td>
                 *"Symbol.iterator"*
@@ -1050,7 +1050,7 @@
             </tr>
             <tr>
               <td>
-                @@match
+                <dfn>@@match</dfn>
               </td>
               <td>
                 *"Symbol.match"*
@@ -1061,7 +1061,7 @@
             </tr>
             <tr>
               <td>
-                @@matchAll
+                <dfn>@@matchAll</dfn>
               </td>
               <td>
                 *"Symbol.matchAll"*
@@ -1072,7 +1072,7 @@
             </tr>
             <tr>
               <td>
-                @@replace
+                <dfn>@@replace</dfn>
               </td>
               <td>
                 *"Symbol.replace"*
@@ -1083,7 +1083,7 @@
             </tr>
             <tr>
               <td>
-                @@search
+                <dfn>@@search</dfn>
               </td>
               <td>
                 *"Symbol.search"*
@@ -1094,7 +1094,7 @@
             </tr>
             <tr>
               <td>
-                @@species
+                <dfn>@@species</dfn>
               </td>
               <td>
                 *"Symbol.species"*
@@ -1105,7 +1105,7 @@
             </tr>
             <tr>
               <td>
-                @@split
+                <dfn>@@split</dfn>
               </td>
               <td>
                 *"Symbol.split"*
@@ -1116,7 +1116,7 @@
             </tr>
             <tr>
               <td>
-                @@toPrimitive
+                <dfn>@@toPrimitive</dfn>
               </td>
               <td>
                 *"Symbol.toPrimitive"*
@@ -1127,7 +1127,7 @@
             </tr>
             <tr>
               <td>
-                @@toStringTag
+                <dfn>@@toStringTag</dfn>
               </td>
               <td>
                 *"Symbol.toStringTag"*
@@ -1138,7 +1138,7 @@
             </tr>
             <tr>
               <td>
-                @@unscopables
+                <dfn>@@unscopables</dfn>
               </td>
               <td>
                 *"Symbol.unscopables"*
@@ -26669,7 +26669,7 @@
 
       <emu-clause id="sec-symbol.matchall">
         <h1>Symbol.matchAll</h1>
-        <p>The initial value of `Symbol.matchAll` is the well-known symbol @@matchAll (<emu-xref href="#table-2"></emu-xref>).</p>
+        <p>The initial value of `Symbol.matchAll` is the well-known symbol @@matchAll (<emu-xref href="#table-1"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 


### PR DESCRIPTION
Fixes <https://github.com/tc39/ecma262/issues/385>

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/1996) ([#sec-well-known-symbols](https://ci.tc39.es/preview/tc39/ecma262/pull/1996#sec-well-known-symbols))