### PR TITLE
Editorial: make `NumberBitwiseOp`, `BigIntBitwiseOp`, `ByteListBitwiseOp` consistent

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1766,8 +1766,9 @@
 
         <emu-clause id="sec-numberbitwiseop" aoid="NumberBitwiseOp">
           <h1>NumberBitwiseOp ( _op_, _x_, _y_ )</h1>
-          <p>The abstract operation NumberBitwiseOp takes arguments _op_, _x_, and _y_. It performs the following steps when called:</p>
+          <p>The abstract operation NumberBitwiseOp takes arguments _op_ (a sequence of Unicode code points), _x_, and _y_. It performs the following steps when called:</p>
           <emu-alg>
+            1. Assert: _op_ is `&amp;`, `^`, or `|`.
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToInt32(_y_).
             1. Return the result of applying the bitwise operator _op_ to _lnum_ and _rnum_. The result is a signed 32-bit integer.
@@ -2019,26 +2020,26 @@
 
         <emu-clause id="sec-bigintbitwiseop" aoid="BigIntBitwiseOp">
           <h1>BigIntBitwiseOp ( _op_, _x_, _y_ )</h1>
-          <p>The abstract operation BigIntBitwiseOp takes arguments _op_, _x_, and _y_. It performs the following steps when called:</p>
+          <p>The abstract operation BigIntBitwiseOp takes arguments _op_ (a sequence of Unicode code points), _x_, and _y_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Assert: _op_ is *"&amp;"*, *"|"*, or *"^"*.
+            1. Assert: _op_ is `&amp;`, `^`, or `|`.
             1. Let _result_ be *0n*.
             1. Let _shift_ be 0.
             1. Repeat, until (_x_ = 0 or _x_ = -1) and (_y_ = 0 or _y_ = -1),
               1. Let _xDigit_ be _x_ modulo 2.
               1. Let _yDigit_ be _y_ modulo 2.
-              1. If _op_ is *"&amp;"*, set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryAnd(_xDigit_, _yDigit_).
-              1. Else if _op_ is *"|"*, set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryOr(_xDigit_, _yDigit_).
+              1. If _op_ is `&amp;`, set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryAnd(_xDigit_, _yDigit_).
+              1. Else if _op_ is `|`, set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryOr(_xDigit_, _yDigit_).
               1. Else,
-                1. Assert: _op_ is *"^"*.
+                1. Assert: _op_ is `^`.
                 1. Set _result_ to _result_ + 2<sup>_shift_</sup> &times; BinaryXor(_xDigit_, _yDigit_).
               1. Set _shift_ to _shift_ + 1.
               1. Set _x_ to (_x_ - _xDigit_) / 2.
               1. Set _y_ to (_y_ - _yDigit_) / 2.
-            1. If _op_ is *"&amp;"*, let _tmp_ be BinaryAnd(_x_ modulo 2, _y_ modulo 2).
-            1. Else if _op_ is *"|"*, let _tmp_ be BinaryOr(_x_ modulo 2, _y_ modulo 2).
+            1. If _op_ is `&amp;`, let _tmp_ be BinaryAnd(_x_ modulo 2, _y_ modulo 2).
+            1. Else if _op_ is `|`, let _tmp_ be BinaryOr(_x_ modulo 2, _y_ modulo 2).
             1. Else,
-              1. Assert: _op_ is *"^"*.
+              1. Assert: _op_ is `^`.
               1. Let _tmp_ be BinaryXor(_x_ modulo 2, _y_ modulo 2).
             1. If _tmp_ &ne; 0, then
               1. Set _result_ to _result_ - 2<sup>_shift_</sup>.
@@ -2051,7 +2052,7 @@
           <h1>BigInt::bitwiseAND ( _x_, _y_ )</h1>
           <p>The abstract operation BigInt::bitwiseAND takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
-            1. Return BigIntBitwiseOp(*"&amp;"*, _x_, _y_).
+            1. Return BigIntBitwiseOp(`&amp;`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
@@ -2059,7 +2060,7 @@
           <h1>BigInt::bitwiseXOR ( _x_, _y_ )</h1>
           <p>The abstract operation BigInt::bitwiseXOR takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
-            1. Return BigIntBitwiseOp(*"^"*, _x_, _y_).
+            1. Return BigIntBitwiseOp(`^`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
@@ -2067,7 +2068,7 @@
           <h1>BigInt::bitwiseOR ( _x_, _y_ )</h1>
           <p>The abstract operation BigInt::bitwiseOR takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
-            1. Return BigIntBitwiseOp(*"|"*, _x_, _y_).
+            1. Return BigIntBitwiseOp(`|`, _x_, _y_).
           </emu-alg>
         </emu-clause>
 
@@ -37868,9 +37869,10 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-bytelistbitwiseop" aoid="ByteListBitwiseOp">
-        <h1>ByteListBitwiseOp( _op_, _xBytes_, _yBytes_ )</h1>
-        <p>The abstract operation ByteListBitwiseOp takes arguments _op_ (a read-modify-write modification function), _xBytes_ (a List of byte values), and _yBytes_ (a List of byte values). The operation atomically performs a bitwise operation on all byte values of the arguments and returns a List of byte values. It performs the following steps when called:</p>
+        <h1>ByteListBitwiseOp ( _op_, _xBytes_, _yBytes_ )</h1>
+        <p>The abstract operation ByteListBitwiseOp takes arguments _op_ (a sequence of Unicode code points), _xBytes_ (a List of byte values), and _yBytes_ (a List of byte values). The operation atomically performs a bitwise operation on all byte values of the arguments and returns a List of byte values. It performs the following steps when called:</p>
         <emu-alg>
+          1. Assert: _op_ is `&amp;`, `^`, or `|`.
           1. Assert: _xBytes_ and _yBytes_ have the same number of elements.
           1. Let _result_ be a new empty List.
           1. Let _i_ be 0.
@@ -37921,7 +37923,7 @@ THH:mm:ss.sss
       <p>The following steps are taken:</p>
       <emu-alg>
         1. Let _and_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures nothing and performs the following steps atomically when called:
-          1. Return ByteListBitwiseOp(`&`, _xBytes_, _yBytes_).
+          1. Return ByteListBitwiseOp(`&amp;`, _xBytes_, _yBytes_).
         1. Return ? AtomicReadModifyWrite(_typedArray_, _index_, _value_, _and_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Ensure `op` is a String in all cases, and ensure all three operations assert on the contents of `op`.

Previously, `NumberBitwiseOp` and `ByteListBitwiseOp ` did not assert on `op`, and they were passing an operator as if it was a first-class value. Instead, I made all three use the approach of `BigIntBitwiseOp`.

An alternative to strings would be to use `~^~` etc; happy to switch them all to that form if that's preferred.