### PR TITLE
fixes #2003: consistent wording of "two's complement"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34678,7 +34678,7 @@ THH:mm:ss.sss
             ToInt8
           </td>
           <td>
-            8-bit 2's complement signed integer
+            8-bit two's complement signed integer
           </td>
         </tr>
         <tr>
@@ -34735,7 +34735,7 @@ THH:mm:ss.sss
             ToInt16
           </td>
           <td>
-            16-bit 2's complement signed integer
+            16-bit two's complement signed integer
           </td>
         </tr>
         <tr>
@@ -34773,7 +34773,7 @@ THH:mm:ss.sss
             ToInt32
           </td>
           <td>
-            32-bit 2's complement signed integer
+            32-bit two's complement signed integer
           </td>
         </tr>
         <tr>
@@ -36924,7 +36924,7 @@ THH:mm:ss.sss
           1. If ! IsUnsignedElementType(_type_) is *true*, then
             1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of an unsigned little-endian binary number.
           1. Else,
-            1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of a binary little-endian 2's complement number of bit length _elementSize_ &times; 8.
+            1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of a binary little-endian two's complement number of bit length _elementSize_ &times; 8.
           1. If ! IsBigIntElementType(_type_) is *true*, return the BigInt value that corresponds to _intValue_.
           1. Otherwise, return the Number value that corresponds to _intValue_.
         </emu-alg>
@@ -36969,7 +36969,7 @@ THH:mm:ss.sss
             1. If _intValue_ &ge; 0<sub>ℝ</sub>, then
               1. Let _rawBytes_ be a List containing the _n_-byte binary encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
             1. Else,
-              1. Let _rawBytes_ be a List containing the _n_-byte binary 2's complement encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
+              1. Let _rawBytes_ be a List containing the _n_-byte binary two's complement encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
           1. Return _rawBytes_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Fixes #2003.