### PR TITLE
Editorial: Remove extra "to" in Abstract Operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4533,7 +4533,7 @@
 
 <emu-clause id="sec-abstract-operations">
   <h1>Abstract Operations</h1>
-  <p>These operations are not a part of the ECMAScript language; they are defined here to solely to aid the specification of the semantics of the ECMAScript language. Other, more specialized abstract operations are defined throughout this specification.</p>
+  <p>These operations are not a part of the ECMAScript language; they are defined here solely to aid the specification of the semantics of the ECMAScript language. Other, more specialized abstract operations are defined throughout this specification.</p>
 
   <emu-clause id="sec-type-conversion">
     <h1>Type Conversion</h1>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->

Fixes an extra word in the opening paragraph of the Abstract Operations section.
