### PR TITLE
Editorial: Make numeric values and operations default to mathematical values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -941,27 +941,29 @@
     </emu-clause>
     <emu-clause id="sec-mathematical-operations">
       <h1>Mathematical Operations</h1>
-      <p>This specification makes reference to two kinds of numeric values:</p>
+      <p>This specification makes reference to these kinds of numeric values:</p>
       <ul>
-        <li><em>Number</em>: IEEE 754-2019 double-precision floating point values, used as the default numeric type.</li>
-        <li><em>Mathematical value</em>: Arbitrary real numbers, used for specific situations.</li>
+        <li><em>Mathematical values</em>: Arbitrary real numbers, used as the default numeric type.</li>
+        <li><em>Extended mathematical values</em>: Mathematical values together with +&infin; and -&infin;.</li>
+        <li><em>Numbers</em>: IEEE 754-2019 double-precision floating point values.</li>
+        <li><em>BigInts</em>: ECMAScript values representing arbritary integers in a one-to-one correspondence.</li>
       </ul>
 
-      <p>In the language of this specification, numerical values and operations (including addition, subtraction, negation, multiplication, division, and comparison) are distinguished among different numeric kinds using subscripts. The subscript <sub><dfn id="𝔽">𝔽</dfn></sub> refers to Numbers, and the subscript <sub><dfn id="ℝ">ℝ</dfn></sub> refers to mathematical values. A subscript is used following each numeric value and operation.</p>
-      <p>For brevity, the <sub>𝔽</sub> subscript can be omitted on Number values&mdash;a numeric value with no subscript is interpreted to be a Number. An operation with no subscript is interpreted to be a Number operation, unless one of the parameters has a particular subscript, in which case the operation adopts that subscript. For example, 1<sub>ℝ</sub> + 2<sub>ℝ</sub> = 3<sub>ℝ</sub> is a statement about mathematical values, and 1 + 2 = 3 is a statement about Numbers.</p>
-      <p>In general, when this specification refers to a numerical value, such as in the phrase, "the length of _y_" or "the integer represented by the four hexadecimal digits ...", without explicitly specifying a numeric kind, the phrase refers to a Number. Phrases which refer to a mathematical value are explicitly annotated as such; for example, "the mathematical value of the number of code points in ...".</p>
-      <p>It is not defined to mix Numbers and mathematical values in either arithmetic or comparison operations, and any such undefined operation would be an editorial error in this specification text.</p>
-      <p>The Number value 0, alternatively written 0<sub>𝔽</sub>, is defined as the double-precision floating point positive zero value. In certain contexts, it may also be written as *+0* for clarity.</p>
+      <p>In the language of this specification, numerical values are distinguished among different numeric kinds using subscript suffixes. The subscript <sub>𝔽</sub> refers to Numbers, and the subscript <sub>ℤ</sub> refers to BigInts. Numeric values without a subscript suffix refer to mathematical values.</p>
+      <p>Numeric operators such as +, &times;, =, and &ge; refer to those operations as determined by the type of the operands. When applied to mathematical values, the operators refer to the usual mathematical operations. When applied to Numbers, the operators refer to the relevant operations within IEEE 754-2019. When applied to BigInts, the operators refer to the usual mathematical operations applied to the mathematical value of the BigInt.</p>
+      <p>In general, when this specification refers to a numerical value, such as in the phrase, "the length of _y_" or "the integer represented by the four hexadecimal digits ...", without explicitly specifying a numeric kind, the phrase refers to a mathematical value. Phrases which refer to a Number or a BigInt value are explicitly annotated as such; for example, "the Number value for the number of code points in &hellip;" or "the BigInt value for &hellip;".</p>
+      <p>Numeric operators applied to mixed-type operands (such as a Number and a mathematical value) are not defined and should be considered an editorial error in this specification.</p>
       <p>This specification denotes most numeric values in base 10; it also uses numeric values of the form 0x followed by digits 0-9 or A-F as base-16 values.</p>
-      <p>In certain contexts, an operation is specified which is generic between Numbers and mathematical values. In these cases, the subscript can be a variable; _t_ is often used for this purpose, for example 5<sub>_t_</sub> &times; 10<sub>_t_</sub> = 50<sub>_t_</sub> for any _t_ ranging over ℝ and 𝔽, since the values involved are within the range where the semantics coincide.</p>
-      <p>Conversions between mathematical values and numbers are never implicit, and always explicit in this document. A conversion from a mathematical value to a Number is denoted as "the Number value for _x_", and is defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>. A conversion from a Number to a mathematical value is denoted as "the <dfn id="mathematical-value">mathematical value</dfn> of _x_", or ℝ(_x_). Note that the mathematical value of non-finite values is not defined, and the mathematical value of *+0* and *-0* is the mathematical value 0<sub>ℝ</sub>.</p>
-      <p>When the term <dfn id="integer">integer</dfn> is used in this specification, it refers to a Number value whose mathematical value is in the set of integers, unless otherwise stated: when the term <dfn id="mathematical integer">mathematical integer</dfn> is used in this specification, it refers to a mathematical value which is in the set of integers. As shorthand, integer<sub>_t_</sub> can be used to refer to either of the two, as determined by _t_.</p>
-      <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs">abs<sub>_t_</sub>(_x_)</emu-eqn> produces the absolute value of _x_, which is <emu-eqn>-<sub>_t_</sub>_x_</emu-eqn> if _x_ &lt;<sub>_t_</sub> 0<sub>_t_</sub> and otherwise is _x_ itself.</p>
-      <p>The mathematical function <emu-eqn id="eqn-min" aoid="min">min<sub>_t_</sub>(_x1_, _x2_, &hellip; , _xN_)</emu-eqn> produces the mathematically smallest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max">max<sub>_t_</sub>(_x1_, _x2_, ..., _xN_)</emu-eqn> produces the mathematically largest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The domain and range of these mathematical functions include *+&infin;* and *-&infin;*.</p>
-      <p>The notation &ldquo;<emu-eqn id="eqn-modulo" aoid="modulo">_x_ modulo<sub>_t_</sub> _y_</emu-eqn>&rdquo; (_y_ must be finite and nonzero) computes a value _k_ of the same sign as _y_ (or zero) such that <emu-eqn>abs<sub>_t_</sub>(_k_) &lt;<sub>_t_</sub> abs<sub>_t_</sub>(_y_) and _x_-<sub>_t_</sub>_k_ = _q_ &times;<sub>_t_</sub> _y_</emu-eqn> for some integer<sub>_t_</sub> _q_.</p>
-      <p>The mathematical function <emu-eqn id="eqn-floor" aoid="floor">floor<sub>_t_</sub>(_x_)</emu-eqn> produces the largest integer<sub>_t_</sub> (closest to positive infinity) that is not larger than _x_.</p>
+      <p>When the term <dfn id="integer" oldids="mathematical integer">integer</dfn> is used in this specification, it refers to a mathematical value which is in the set of integers, unless otherwise stated. When the term <dfn id="integral-number">integral Number</dfn> is used in this specification, it refers to a Number value whose mathematical value is in the set of integers.</p>
+      <p>Conversions between mathematical values and Numbers or BigInts are always explicit in this document. A conversion from a mathematical value or extended mathematical value _x_ to a Number is denoted as "the Number value for _x_" or <dfn id="𝔽">𝔽</dfn>(_x_), and is defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>. A conversion from an integer _x_ to a BigInt is denoted as "the BigInt value for _x_" or <dfn id="ℤ">ℤ</dfn>(_x_). A conversion from a Number or BigInt _x_ to a mathematical value is denoted as "the <dfn id="mathematical-value">mathematical value</dfn> of _x_", or <dfn id="ℝ">ℝ</dfn>(_x_). The mathematical value of *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub> is the mathematical value 0. The mathematical value of non-finite values is not defined. The <dfn id="extended-mathematical-value">extended mathematical value</dfn> of _x_ is the mathematical value of _x_ for finite values, and is +&infin; and -&infin; for *+&infin;*<sub>𝔽</sub> and *-&infin;*<sub>𝔽</sub> respectively; it is not defined for *NaN*.</p>
+      <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs">abs(_x_)</emu-eqn> produces the absolute value of _x_, which is <emu-eqn>-_x_</emu-eqn> if _x_ &lt; 0 and otherwise is _x_ itself.</p>
+      <p>The mathematical function <emu-eqn id="eqn-min" aoid="min">min(_x1_, _x2_, &hellip; , _xN_)</emu-eqn> produces the mathematically smallest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max">max(_x1_, _x2_, ..., _xN_)</emu-eqn> produces the mathematically largest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The domain and range of these mathematical functions are the extended mathematical values.</p>
+      <p>The notation &ldquo;<emu-eqn id="eqn-modulo" aoid="modulo">_x_ modulo _y_</emu-eqn>&rdquo; (_y_ must be finite and non-zero) computes a value _k_ of the same sign as _y_ (or zero) such that <emu-eqn>abs(_k_) &lt; abs(_y_) and _x_ - _k_ = _q_ &times; _y_</emu-eqn> for some integer _q_.</p>
+      <p>The phrase "the result of <dfn id="clamping">clamping</dfn> _x_ between _lower_ and _upper_" (where _x_ is an extended mathematical value and _lower_ and _upper_ are mathematical values such that _lower_ &le; _upper_) produces _lower_ if _x_ &lt; _lower_, produces _upper_ if _x_ &gt; _upper_, and otherwise produces _x_.</p>
+      <p>The mathematical function <emu-eqn id="eqn-floor" aoid="floor">floor(_x_)</emu-eqn> produces the largest integer (closest to +&infin;) that is not larger than _x_.</p>
+      <p>Mathematical functions min, max, abs, and floor are not defined for Numbers and BigInts, and any usage of those methods that have non-mathematical value arguments would be an editorial error in this specification.</p>
       <emu-note>
-        <p><emu-eqn>floor<sub>_t_</sub>(_x_) = _x_ -<sub>_t_</sub> (_x_ modulo<sub>_t_</sub> 1<sub>_t_</sub>)</emu-eqn>.</p>
+        <p><emu-eqn>floor(_x_) = _x_ - (_x_ modulo 1)</emu-eqn>.</p>
       </emu-note>
     </emu-clause>
     <emu-clause id="sec-value-notation">
@@ -998,7 +1000,7 @@
 
     <emu-clause id="sec-ecmascript-language-types-string-type">
       <h1>The String Type</h1>
-      <p>The String type is the set of all ordered sequences of zero or more 16-bit unsigned integer values (&ldquo;elements&rdquo;) up to a maximum length of 2<sup>53</sup> - 1 elements. The String type is generally used to represent textual data in a running ECMAScript program, in which case each element in the String is treated as a UTF-16 code unit value. Each element is regarded as occupying a position within the sequence. These positions are indexed with nonnegative integers. The first element (if any) is at index 0, the next element (if any) at index 1, and so on. The length of a String is the number of elements (i.e., 16-bit values) within it. The empty String has length zero and therefore contains no elements.</p>
+      <p>The String type is the set of all ordered sequences of zero or more 16-bit unsigned integer values (&ldquo;elements&rdquo;) up to a maximum length of 2<sup>53</sup> - 1 elements. The String type is generally used to represent textual data in a running ECMAScript program, in which case each element in the String is treated as a UTF-16 code unit value. Each element is regarded as occupying a position within the sequence. These positions are indexed with non-negative integers. The first element (if any) is at index 0, the next element (if any) at index 1, and so on. The length of a String is the number of elements (i.e., 16-bit values) within it. The empty String has length zero and therefore contains no elements.</p>
       <p>ECMAScript operations that do not interpret String contents apply no further semantics. Operations that do interpret String values treat each element as a single UTF-16 code unit. However, ECMAScript does not restrict the value of or relationships between these code units, so operations that further interpret String contents as sequences of Unicode code points encoded in UTF-16 must account for ill-formed subsequences. Such operations apply special treatment to every code unit with a numeric value in the inclusive range 0xD800 to 0xDBFF (defined by the Unicode Standard as a <dfn id="leading-surrogate">leading surrogate</dfn>, or more formally as a <dfn id="high-surrogate-code-unit">high-surrogate code unit</dfn>) and every code unit with a numeric value in the inclusive range 0xDC00 to 0xDFFF (defined as a <dfn id="trailing-surrogate">trailing surrogate</dfn>, or more formally as a <dfn id="low-surrogate-code-unit">low-surrogate code unit</dfn>) using the following rules:</p>
       <ul>
         <li>
@@ -1024,11 +1026,11 @@
         <emu-alg>
           1. Assert: Type(_string_) is String.
           1. Assert: Type(_searchValue_) is String.
-          1. Assert: ! IsNonNegativeInteger(_fromIndex_) is *true*.
+          1. Assert: _fromIndex_ is a non-negative integer.
           1. Let _len_ be the length of _string_.
           1. If _searchValue_ is the empty String and _fromIndex_ &le; _len_, return _fromIndex_.
           1. Let _searchLen_ be the length of _searchValue_.
-          1. If there exists any integer _k_ such that _fromIndex_ &le; _k_ &le; _len_ - _searchLen_ and for all nonnegative integers _j_ less than _searchLen_, the code unit at index _k_ + _j_ within _string_ is the same as the code unit at index _j_ within _searchValue_, let _pos_ be the smallest (closest to *-&infin;*) such integer. Otherwise, let _pos_ be -1.
+          1. If there exists any integer _k_ such that _fromIndex_ &le; _k_ &le; _len_ - _searchLen_ and for all non-negative integers _j_ such that _j_ &lt; _searchLen_, the code unit at index _k_ + _j_ within _string_ is the same as the code unit at index _j_ within _searchValue_, let _pos_ be the smallest (closest to -&infin;) such integer. Otherwise, let _pos_ be -1.
           1. Return _pos_.
         </emu-alg>
         <emu-note>
@@ -1446,7 +1448,7 @@
             <td>
               Array, Map, and Set methods,
               via <emu-xref href="#sec-samevaluezero" title></emu-xref>,
-              to test value equality ignoring differences among members of the zero cohort (e.g., *-0* and *+0*)
+              to test value equality ignoring differences among members of the zero cohort (i.e., *-0*<sub>𝔽</sub> and *+0*<sub>𝔽</sub>)
             </td>
             <td>
               Boolean
@@ -1520,30 +1522,31 @@
 
       <emu-clause id="sec-ecmascript-language-types-number-type">
         <h1>The Number Type</h1>
-        <p>The Number type has exactly 18437736874454810627<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> + 3<sub>ℝ</sub></emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2019 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9007199254740990<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-defined; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+        <p>The Number type has exactly 18,437,736,874,454,810,627 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> + 3</emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2019 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9,007,199,254,740,990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) distinct &ldquo;Not-a-Number&rdquo; values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-defined; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
         <emu-note>
           <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
         </emu-note>
-        <p>There are two other special values, called *positive Infinity* and *negative Infinity*. For brevity, these values are also referred to for expository purposes by the symbols *+&infin;* and *-&infin;*, respectively. (Note that these two infinite Number values are produced by the program expressions `+Infinity` (or simply `Infinity`) and `-Infinity`.)</p>
-        <p>The other 18437736874454810624<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
-        <p>Note that there is both a *positive zero* and a *negative zero*. For brevity, these values are also referred to for expository purposes by the symbols *+0* and *-0*, respectively. (Note that these two different zero Number values are produced by the program expressions `+0` (or simply `0`) and `-0`.)</p>
-        <p>The 18437736874454810622<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) finite nonzero values are of two kinds:</p>
-        <p>18428729675200069632<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>64<sub>ℝ</sub></sup> - 2<sub>ℝ</sub><sup>54<sub>ℝ</sub></sup></emu-eqn>) of them are normalized, having the form</p>
+        <p>There are two other special values, called *positive Infinity* and *negative Infinity*. For brevity, these values are also referred to for expository purposes by the symbols *+&infin;*<sub>𝔽</sub> and *-&infin;*<sub>𝔽</sub>, respectively. (Note that these two infinite Number values are produced by the program expressions `+Infinity` (or simply `Infinity`) and `-Infinity`.)</p>
+        <p>The other 18,437,736,874,454,810,624 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
+        <p>Note that there is both a *positive zero* and a *negative zero*. For brevity, these values are also referred to for expository purposes by the symbols *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>, respectively. (Note that these two different zero Number values are produced by the program expressions `+0` (or simply `0`) and `-0`.)</p>
+        <p>The 18,437,736,874,454,810,622 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> - 2</emu-eqn>) finite non-zero values are of two kinds:</p>
+        <p>18,428,729,675,200,069,632 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>54</sup></emu-eqn>) of them are normalized, having the form</p>
         <div class="math-display">
           _s_ &times; _m_ &times; 2<sup>_e_</sup>
         </div>
-        <p>where _s_ is +1<sub>ℝ</sub> or -1<sub>ℝ</sub>, _m_ is a positive mathematical integer less than 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> but not less than 2<sub>ℝ</sub><sup>52<sub>ℝ</sub></sup>, and _e_ is a mathematical integer ranging from -1074<sub>ℝ</sub> to 971<sub>ℝ</sub>, inclusive.</p>
-        <p>The remaining 9007199254740990<sub>ℝ</sub> (that is, <emu-eqn>2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> - 2<sub>ℝ</sub></emu-eqn>) values are denormalized, having the form</p>
+        <p>where _s_ is 1 or -1, _m_ is an integer such that 2<sup>52</sup> &le; _m_ &lt; 2<sup>53</sup>, and _e_ is an integer such that -1074 &le; _e_ &le; 971.</p>
+        <p>The remaining 9,007,199,254,740,990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) values are denormalized, having the form</p>
         <div class="math-display">
           _s_ &times; _m_ &times; 2<sup>_e_</sup>
         </div>
-        <p>where _s_ is +1<sub>ℝ</sub> or -1<sub>ℝ</sub>, _m_ is a positive mathematical integer less than 2<sub>ℝ</sub><sup>52<sub>ℝ</sub></sup>, and _e_ is -1074<sub>ℝ</sub>.</p>
-        <p>Note that all the positive and negative mathematical integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type (indeed, the mathematical integer 0 has two representations, *+0* and *-0*).</p>
-        <p>A finite number has an <em>odd significand</em> if it is nonzero and the mathematical integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
-        <p>In this specification, the phrase &ldquo;the <dfn id="number-value">Number value</dfn> for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0* removed and with two additional values added to it that are not representable in the Number type, namely 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> (which is <emu-eqn>+1<sub>ℝ</sub> &times; 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> &times; 2<sub>ℝ</sub><sup>971<sub>ℝ</sub></sup></emu-eqn>) and <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> (which is <emu-eqn>-1<sub>ℝ</sub> &times; 2<sub>ℝ</sub><sup>53<sub>ℝ</sub></sup> &times; 2<sub>ℝ</sub><sup>971<sub>ℝ</sub></sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> and <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> are considered to have even significands. Finally, if 2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup> was chosen, replace it with *+&infin;*; if <emu-eqn>-2<sub>ℝ</sub><sup>1024<sub>ℝ</sub></sup></emu-eqn> was chosen, replace it with *-&infin;*; if *+0* was chosen, replace it with *-0* if and only if _x_ is less than zero; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2019 roundTiesToEven mode.)</p>
+        <p>where _s_ is 1 or -1, _m_ is an integer such that 0 &lt; _m_ &lt; 2<sup>52</sup>, and _e_ is -1074.</p>
+        <p>Note that all the positive and negative integers whose magnitude is no greater than 2<sup>53</sup> are representable in the Number type. The integer 0 has two representations in the Number type: *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>.</p>
+        <p>A finite number has an <em>odd significand</em> if it is non-zero and the integer _m_ used to express it (in one of the two forms shown above) is odd. Otherwise, it has an <em>even significand</em>.</p>
+        <p>In this specification, the phrase &ldquo;the <dfn id="number-value">Number value</dfn> for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0*<sub>𝔽</sub> removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*<sub>𝔽</sub>; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*<sub>𝔽</sub>; if *+0*<sub>𝔽</sub> was chosen, replace it with *-0*<sub>𝔽</sub> if and only if _x_ &lt; 0; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2019 roundTiesToEven mode.)</p>
+        <p>The Number value for +&infin; is *+&infin;*<sub>𝔽</sub>, and the Number value for -&infin; is *-&infin;*<sub>𝔽</sub>.</p>
         <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
 
-        <p>The Number::unit value is *1*.</p>
+        <p>The Number::unit value is *1*<sub>𝔽</sub>.</p>
 
         <emu-clause id="sec-numeric-types-number-unaryMinus">
           <h1>Number::unaryMinus ( _x_ )</h1>
@@ -1559,7 +1562,7 @@
           <p>The abstract operation Number::bitwiseNOT takes argument _x_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. Let _oldValue_ be ! ToInt32(_x_).
-            1. Return the result of applying bitwise complement to _oldValue_. The result is a signed 32-bit integer.
+            1. Return the result of applying bitwise complement to _oldValue_. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
           </emu-alg>
         </emu-clause>
 
@@ -1568,31 +1571,31 @@
           <p>The abstract operation Number::exponentiate takes arguments _base_ (a Number) and _exponent_ (a Number). It returns an implementation-approximated value representing the result of raising _base_ to the power _exponent_, subject to the following requirements:</p>
           <ul>
             <li>If _exponent_ is *NaN*, the result is *NaN*.</li>
-            <li>If _exponent_ is *+0*, the result is 1, even if _base_ is *NaN*.</li>
-            <li>If _exponent_ is *-0*, the result is 1, even if _base_ is *NaN*.</li>
-            <li>If _base_ is *NaN* and _exponent_ is nonzero, the result is *NaN*.</li>
-            <li>If abs(_base_) &gt; 1 and _exponent_ is *+&infin;*, the result is *+&infin;*.</li>
-            <li>If abs(_base_) &gt; 1 and _exponent_ is *-&infin;*, the result is *+0*.</li>
-            <li>If abs(_base_) is 1 and _exponent_ is *+&infin;*, the result is *NaN*.</li>
-            <li>If abs(_base_) is 1 and _exponent_ is *-&infin;*, the result is *NaN*.</li>
-            <li>If abs(_base_) &lt; 1 and _exponent_ is *+&infin;*, the result is *+0*.</li>
-            <li>If abs(_base_) &lt; 1 and _exponent_ is *-&infin;*, the result is *+&infin;*.</li>
-            <li>If _base_ is *+&infin;* and _exponent_ &gt; 0, the result is *+&infin;*.</li>
-            <li>If _base_ is *+&infin;* and _exponent_ &lt; 0, the result is *+0*.</li>
-            <li>If _base_ is *-&infin;* and _exponent_ &gt; 0 and _exponent_ is an odd integer, the result is *-&infin;*.</li>
-            <li>If _base_ is *-&infin;* and _exponent_ &gt; 0 and _exponent_ is not an odd integer, the result is *+&infin;*.</li>
-            <li>If _base_ is *-&infin;* and _exponent_ &lt; 0 and _exponent_ is an odd integer, the result is *-0*.</li>
-            <li>If _base_ is *-&infin;* and _exponent_ &lt; 0 and _exponent_ is not an odd integer, the result is *+0*.</li>
-            <li>If _base_ is *+0* and _exponent_ &gt; 0, the result is *+0*.</li>
-            <li>If _base_ is *+0* and _exponent_ &lt; 0, the result is *+&infin;*.</li>
-            <li>If _base_ is *-0* and _exponent_ &gt; 0 and _exponent_ is an odd integer, the result is *-0*.</li>
-            <li>If _base_ is *-0* and _exponent_ &gt; 0 and _exponent_ is not an odd integer, the result is *+0*.</li>
-            <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is an odd integer, the result is *-&infin;*.</li>
-            <li>If _base_ is *-0* and _exponent_ &lt; 0 and _exponent_ is not an odd integer, the result is *+&infin;*.</li>
-            <li>If _base_ &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integer, the result is *NaN*.</li>
+            <li>If _exponent_ is *+0*<sub>𝔽</sub>, the result is *1*<sub>𝔽</sub>, even if _base_ is *NaN*.</li>
+            <li>If _exponent_ is *-0*<sub>𝔽</sub>, the result is *1*<sub>𝔽</sub>, even if _base_ is *NaN*.</li>
+            <li>If _base_ is *NaN* and _exponent_ is non-zero, the result is *NaN*.</li>
+            <li>If abs(ℝ(_base_)) &gt; 1 and _exponent_ is *+&infin;*<sub>𝔽</sub>, the result is *+&infin;*<sub>𝔽</sub>.</li>
+            <li>If abs(ℝ(_base_)) &gt; 1 and _exponent_ is *-&infin;*<sub>𝔽</sub>, the result is *+0*<sub>𝔽</sub>.</li>
+            <li>If abs(ℝ(_base_)) is 1 and _exponent_ is *+&infin;*<sub>𝔽</sub>, the result is *NaN*.</li>
+            <li>If abs(ℝ(_base_)) is 1 and _exponent_ is *-&infin;*<sub>𝔽</sub>, the result is *NaN*.</li>
+            <li>If abs(ℝ(_base_)) &lt; 1 and _exponent_ is *+&infin;*<sub>𝔽</sub>, the result is *+0*<sub>𝔽</sub>.</li>
+            <li>If abs(ℝ(_base_)) &lt; 1 and _exponent_ is *-&infin;*<sub>𝔽</sub>, the result is *+&infin;*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *+&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0, the result is *+&infin;*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *+&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0, the result is *+0*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *-&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0 and _exponent_ is an odd integral Number, the result is *-&infin;*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *-&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0 and _exponent_ is not an odd integral Number, the result is *+&infin;*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *-&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0 and _exponent_ is an odd integral Number, the result is *-0*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *-&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0 and _exponent_ is not an odd integral Number, the result is *+0*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *+0*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0, the result is *+0*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *+0*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0, the result is *+&infin;*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *-0*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0 and _exponent_ is an odd integral Number, the result is *-0*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *-0*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0 and _exponent_ is not an odd integral Number, the result is *+0*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *-0*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0 and _exponent_ is an odd integral Number, the result is *-&infin;*<sub>𝔽</sub>.</li>
+            <li>If _base_ is *-0*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0 and _exponent_ is not an odd integral Number, the result is *+&infin;*<sub>𝔽</sub>.</li>
+            <li>If ℝ(_base_) &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integral Number, the result is *NaN*.</li>
           </ul>
           <emu-note>
-            <p>The result of _base_ `**` _exponent_ when _base_ is *1* or *-1* and _exponent_ is *+Infinity* or *-Infinity*, or when _base_ is *1* and _exponent_ is *NaN*, differs from IEEE 754-2019. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2019 specified *1*. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
+            <p>The result of _base_ `**` _exponent_ when _base_ is *1*<sub>𝔽</sub> or *-1*<sub>𝔽</sub> and _exponent_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, or when _base_ is *1*<sub>𝔽</sub> and _exponent_ is *NaN*, differs from IEEE 754-2019. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2019 specified *1*<sub>𝔽</sub>. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
           </emu-note>
         </emu-clause>
 
@@ -1613,7 +1616,7 @@
               Multiplication of an infinity by an infinity results in an infinity. The sign is determined by the rule already stated above.
             </li>
             <li>
-              Multiplication of an infinity by a finite nonzero value results in a signed infinity. The sign is determined by the rule already stated above.
+              Multiplication of an infinity by a finite non-zero value results in a signed infinity. The sign is determined by the rule already stated above.
             </li>
             <li>
               In the remaining cases, where neither an infinity nor *NaN* is involved, the product is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode. If the magnitude is too large to represent, the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the result is then a zero of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2019.
@@ -1641,7 +1644,7 @@
               Division of an infinity by a zero results in an infinity. The sign is determined by the rule already stated above.
             </li>
             <li>
-              Division of an infinity by a nonzero finite value results in a signed infinity. The sign is determined by the rule already stated above.
+              Division of an infinity by a non-zero finite value results in a signed infinity. The sign is determined by the rule already stated above.
             </li>
             <li>
               Division of a finite value by an infinity results in zero. The sign is determined by the rule already stated above.
@@ -1650,7 +1653,7 @@
               Division of a zero by a zero results in *NaN*; division of zero by any other finite value results in zero, with the sign determined by the rule already stated above.
             </li>
             <li>
-              Division of a nonzero finite value by a zero results in a signed infinity. The sign is determined by the rule already stated above.
+              Division of a non-zero finite value by a zero results in a signed infinity. The sign is determined by the rule already stated above.
             </li>
             <li>
               In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the quotient is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows; the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the operation underflows and the result is a zero of the appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2019.
@@ -1664,7 +1667,7 @@
           <emu-note>
             <p>In C and C++, the remainder operator accepts only integral operands; in ECMAScript, it also accepts floating-point operands.</p>
           </emu-note>
-          <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2019. The IEEE 754-2019 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual integer remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java integer remainder operator; this may be compared with the C library function fmod.</p>
+          <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2019. The IEEE 754-2019 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual <emu-not-ref>integer</emu-not-ref> remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java <emu-not-ref>integer</emu-not-ref> remainder operator; this may be compared with the C library function fmod.</p>
           <p>The result of an ECMAScript floating-point remainder operation is determined by the rules of IEEE arithmetic:</p>
           <ul>
             <li>
@@ -1680,7 +1683,7 @@
               If the dividend is finite and the divisor is an infinity, the result equals the dividend.
             </li>
             <li>
-              If the dividend is a zero and the divisor is nonzero and finite, the result is the same as the dividend.
+              If the dividend is a zero and the divisor is non-zero and finite, the result is the same as the dividend.
             </li>
             <li>
               In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the floating-point remainder _r_ from a dividend _n_ and a divisor _d_ is defined by the mathematical relation _r_ = _n_ - (_d_ &times; _q_) where _q_ is an integer that is negative only if _n_/_d_ is negative and positive only if _n_/_d_ is positive, and whose magnitude is as large as possible without exceeding the magnitude of the true mathematical quotient of _n_ and _d_. _r_ is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode.
@@ -1702,16 +1705,16 @@
               The sum of two infinities of the same sign is the infinity of that sign.
             </li>
             <li>
-              The sum of an infinity and a finite value is equal to the infinite operand.
+              The sum of an infinity and a finite value is the infinite operand.
             </li>
             <li>
-              The sum of two negative zeroes is *-0*. The sum of two positive zeroes, or of two zeroes of opposite sign, is *+0*.
+              The sum of two negative zeroes is *-0*<sub>𝔽</sub>. The sum of two positive zeroes, or of two zeroes of opposite sign, is *+0*<sub>𝔽</sub>.
             </li>
             <li>
-              The sum of a zero and a nonzero finite value is equal to the nonzero operand.
+              The sum of a zero and a non-zero finite value is the non-zero operand.
             </li>
             <li>
-              The sum of two nonzero finite values of the same magnitude and opposite sign is *+0*.
+              The sum of two non-zero finite values of the same magnitude and opposite sign is *+0*<sub>𝔽</sub>.
             </li>
             <li>
               In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, and the operands have the same sign or have different magnitudes, the sum is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows and the result is then an infinity of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2019.
@@ -1739,8 +1742,8 @@
           <emu-alg>
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
-            1. Let _shiftCount_ be _rnum_ modulo 32.
-            1. Return the result of left shifting _lnum_ by _shiftCount_ bits. The result is a signed 32-bit integer.
+            1. Let _shiftCount_ be ℝ(_rnum_) modulo 32.
+            1. Return the Number value for the result of left shifting _lnum_ by _shiftCount_ bits. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
           </emu-alg>
         </emu-clause>
 
@@ -1750,8 +1753,8 @@
           <emu-alg>
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
-            1. Let _shiftCount_ be _rnum_ modulo 32.
-            1. Return the result of performing a sign-extending right shift of _lnum_ by _shiftCount_ bits. The most significant bit is propagated. The result is a signed 32-bit integer.
+            1. Let _shiftCount_ be ℝ(_rnum_) modulo 32.
+            1. Return the result of performing a sign-extending right shift of _lnum_ by _shiftCount_ bits. The most significant bit is propagated. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
           </emu-alg>
         </emu-clause>
 
@@ -1761,8 +1764,8 @@
           <emu-alg>
             1. Let _lnum_ be ! ToUint32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
-            1. Let _shiftCount_ be _rnum_ modulo 32.
-            1. Return the result of performing a zero-filling right shift of _lnum_ by _shiftCount_ bits. Vacated bits are filled with zero. The result is an unsigned 32-bit integer.
+            1. Let _shiftCount_ be ℝ(_rnum_) modulo 32.
+            1. Return the result of performing a zero-filling right shift of _lnum_ by _shiftCount_ bits. Vacated bits are filled with zero. The mathematical value of the result is exactly representable as a 32-bit unsigned bit string.
           </emu-alg>
         </emu-clause>
 
@@ -1773,13 +1776,14 @@
             1. If _x_ is *NaN*, return *undefined*.
             1. If _y_ is *NaN*, return *undefined*.
             1. If _x_ and _y_ are the same Number value, return *false*.
-            1. If _x_ is *+0* and _y_ is *-0*, return *false*.
-            1. If _x_ is *-0* and _y_ is *+0*, return *false*.
-            1. If _x_ is *+&infin;*, return *false*.
-            1. If _y_ is *+&infin;*, return *true*.
-            1. If _y_ is *-&infin;*, return *false*.
-            1. If _x_ is *-&infin;*, return *true*.
-            1. If the mathematical value of _x_ is less than the mathematical value of _y_&mdash;note that these mathematical values are both finite and not both zero&mdash;return *true*. Otherwise, return *false*.
+            1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *false*.
+            1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *false*.
+            1. If _x_ is *+&infin;*<sub>𝔽</sub>, return *false*.
+            1. If _y_ is *+&infin;*<sub>𝔽</sub>, return *true*.
+            1. If _y_ is *-&infin;*<sub>𝔽</sub>, return *false*.
+            1. If _x_ is *-&infin;*<sub>𝔽</sub>, return *true*.
+            1. Assert: _x_ and _y_ are finite and non-zero.
+            1. If ℝ(_x_) &lt; ℝ(_y_), return *true*. Otherwise, return *false*.
           </emu-alg>
         </emu-clause>
 
@@ -1790,8 +1794,8 @@
             1. If _x_ is *NaN*, return *false*.
             1. If _y_ is *NaN*, return *false*.
             1. If _x_ is the same Number value as _y_, return *true*.
-            1. If _x_ is *+0* and _y_ is *-0*, return *true*.
-            1. If _x_ is *-0* and _y_ is *+0*, return *true*.
+            1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *true*.
+            1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *true*.
             1. Return *false*.
           </emu-alg>
         </emu-clause>
@@ -1801,8 +1805,8 @@
           <p>The abstract operation Number::sameValue takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
-            1. If _x_ is *+0* and _y_ is *-0*, return *false*.
-            1. If _x_ is *-0* and _y_ is *+0*, return *false*.
+            1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *false*.
+            1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *false*.
             1. If _x_ is the same Number value as _y_, return *true*.
             1. Return *false*.
           </emu-alg>
@@ -1813,8 +1817,8 @@
           <p>The abstract operation Number::sameValueZero takes arguments _x_ (a Number) and _y_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
-            1. If _x_ is *+0* and _y_ is *-0*, return *true*.
-            1. If _x_ is *-0* and _y_ is *+0*, return *true*.
+            1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *true*.
+            1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *true*.
             1. If _x_ is the same Number value as _y_, return *true*.
             1. Return *false*.
           </emu-alg>
@@ -1827,8 +1831,8 @@
             1. Assert: _op_ is `&amp;`, `^`, or `|`.
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToInt32(_y_).
-            1. Let _lbits_ be the 32-bit two's complement bit string representing the mathematical value of _lnum_.
-            1. Let _rbits_ be the 32-bit two's complement bit string representing the mathematical value of _rnum_.
+            1. Let _lbits_ be the 32-bit two's complement bit string representing ℝ(_lnum_).
+            1. Let _rbits_ be the 32-bit two's complement bit string representing ℝ(_rnum_).
             1. If _op_ is `&amp;`, let _result_ be the result of applying the bitwise AND operation to _lbits_ and _rbits_.
             1. Else if _op_ is `^`, let _result_ be the result of applying the bitwise exclusive OR (XOR) operation to _lbits_ and _rbits_.
             1. Else, _op_ is `|`. Let _result_ be the result of applying the bitwise inclusive OR operation to _lbits_ and _rbits_.
@@ -1865,10 +1869,10 @@
           <p>The abstract operation Number::toString takes argument _x_ (a Number). It converts _x_ to String format. It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ is *NaN*, return the String *"NaN"*.
-            1. If _x_ is *+0* or *-0*, return the String *"0"*.
-            1. If _x_ is less than zero, return the string-concatenation of *"-"* and ! Number::toString(-_x_).
-            1. If _x_ is *+&infin;*, return the String *"Infinity"*.
-            1. [id="step-number-tostring-intermediate-values"] Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10<sub>ℝ</sub>, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
+            1. If _x_ is *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return the String *"0"*.
+            1. If _x_ &lt; *+0*<sub>𝔽</sub>, return the string-concatenation of *"-"* and ! Number::toString(-_x_).
+            1. If _x_ is *+&infin;*<sub>𝔽</sub>, return the String *"Infinity"*.
+            1. [id="step-number-tostring-intermediate-values"] Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, _s_ &times; 10<sup>_n_ - _k_</sup> is ℝ(_x_), and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
             1. If _k_ &le; _n_ &le; 21, return the string-concatenation of:
               * the code units of the _k_ digits of the decimal representation of _s_ (in order, with no leading zeroes)
               * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
@@ -1898,7 +1902,7 @@
             <p>The following observations may be useful as guidelines for implementations, but are not part of the normative requirements of this Standard:</p>
             <ul>
               <li>
-                If x is any Number value other than *-0*, then ToNumber(ToString(x)) is exactly the same Number value as x.
+                If x is any Number value other than *-0*<sub>𝔽</sub>, then ToNumber(ToString(x)) is exactly the same Number value as x.
               </li>
               <li>
                 The least significant digit of s is not always uniquely determined by the requirements listed in step <emu-xref href="#step-number-tostring-intermediate-values"></emu-xref>.
@@ -1908,7 +1912,7 @@
           <emu-note>
             <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step <emu-xref href="#step-number-tostring-intermediate-values"></emu-xref> be used as a guideline:</p>
             <emu-alg replaces-step="step-number-tostring-intermediate-values">
-              1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. If there are multiple possibilities for _s_, choose the value of _s_ for which ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is closest in value to ℝ(_x_). If there are two such possible values of _s_, choose the one that is even. Note that _k_ is the number of digits in the decimal representation of _s_ and that _s_ is not divisible by 10<sub>ℝ</sub>.
+              1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, _s_ &times; 10<sup>_n_ - _k_</sup> is ℝ(_x_), and _k_ is as small as possible. If there are multiple possibilities for _s_, choose the value of _s_ for which _s_ &times; 10<sup>_n_ - _k_</sup> is closest in value to ℝ(_x_). If there are two such possible values of _s_, choose the one that is even. Note that _k_ is the number of digits in the decimal representation of _s_ and that _s_ is not divisible by 10.
             </emu-alg>
           </emu-note>
           <emu-note>
@@ -1926,31 +1930,31 @@
 
       <emu-clause id="sec-ecmascript-language-types-bigint-type">
         <h1>The BigInt Type</h1>
-        <p>The BigInt type represents a mathematical integer value. The value may be any size and is not limited to a particular bit-width. Generally, where not otherwise noted, operations are designed to return exact mathematically-based answers. For binary operations, BigInts act as two's complement binary strings, with negative numbers treated as having bits set infinitely to the left.</p>
+        <p>The BigInt type represents an integer value. The value may be any size and is not limited to a particular bit-width. Generally, where not otherwise noted, operations are designed to return exact mathematically-based answers. For binary operations, BigInts act as two's complement binary strings, with negative numbers treated as having bits set infinitely to the left.</p>
 
-        <p>The BigInt::unit value is *1n*.</p>
+        <p>The BigInt::unit value is *1*<sub>ℤ</sub>.</p>
 
         <emu-clause id="sec-numeric-types-bigint-unaryMinus">
           <h1>BigInt::unaryMinus ( _x_ )</h1>
           <p>The abstract operation BigInt::unaryMinus takes argument _x_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
-            1. If _x_ is *0n*, return *0n*.
-            1. Return the BigInt value that represents the mathematical value of negating _x_.
+            1. If _x_ is *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
+            1. Return the BigInt value that represents the negation of ℝ(_x_).
           </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-bitwiseNOT">
           <h1>BigInt::bitwiseNOT ( _x_ )</h1>
-          <p>The abstract operation BigInt::bitwiseNOT takes argument _x_ (a BigInt). It returns the one's complement of _x_; that is, -_x_ - 1.</p>
+          <p>The abstract operation BigInt::bitwiseNOT takes argument _x_ (a BigInt). It returns the one's complement of _x_; that is, -_x_ - *1*<sub>ℤ</sub>.</p>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-exponentiate">
           <h1>BigInt::exponentiate ( _base_, _exponent_ )</h1>
           <p>The abstract operation BigInt::exponentiate takes arguments _base_ (a BigInt) and _exponent_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
-            1. If _exponent_ &lt; *0n*, throw a *RangeError* exception.
-            1. If _base_ is *0n* and _exponent_ is *0n*, return *1n*.
-            1. Return the BigInt value that represents the mathematical value of _base_ raised to the power _exponent_.
+            1. If _exponent_ &lt; *0*<sub>ℤ</sub>, throw a *RangeError* exception.
+            1. If _base_ is *0*<sub>ℤ</sub> and _exponent_ is *0*<sub>ℤ</sub>, return *1*<sub>ℤ</sub>.
+            1. Return the BigInt value that represents ℝ(_base_) raised to the power ℝ(_exponent_).
           </emu-alg>
         </emu-clause>
 
@@ -1964,9 +1968,9 @@
           <h1>BigInt::divide ( _x_, _y_ )</h1>
           <p>The abstract operation BigInt::divide takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
-            1. If _y_ is *0n*, throw a *RangeError* exception.
-            1. Let _quotient_ be the mathematical value of _x_ divided by _y_.
-            1. Return the BigInt value that represents _quotient_ rounded towards 0 to the next integral value.
+            1. If _y_ is *0*<sub>ℤ</sub>, throw a *RangeError* exception.
+            1. Let _quotient_ be ℝ(_x_) / ℝ(_y_).
+            1. Return the BigInt value that represents _quotient_ rounded towards 0 to the next integer value.
           </emu-alg>
         </emu-clause>
 
@@ -1974,8 +1978,8 @@
           <h1>BigInt::remainder ( _n_, _d_ )</h1>
           <p>The abstract operation BigInt::remainder takes arguments _n_ (a BigInt) and _d_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
-            1. If _d_ is *0n*, throw a *RangeError* exception.
-            1. If _n_ is *0n*, return *0n*.
+            1. If _d_ is *0*<sub>ℤ</sub>, throw a *RangeError* exception.
+            1. If _n_ is *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
             1. Let _r_ be the BigInt defined by the mathematical relation _r_ = _n_ - (_d_ &times; _q_) where _q_ is a BigInt that is negative only if _n_/_d_ is negative and positive only if _n_/_d_ is positive, and whose magnitude is as large as possible without exceeding the magnitude of the true mathematical quotient of _n_ and _d_.
             1. Return _r_.
           </emu-alg>
@@ -1996,9 +2000,9 @@
           <h1>BigInt::leftShift ( _x_, _y_ )</h1>
           <p>The abstract operation BigInt::leftShift takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
-            1. If _y_ &lt; *0n*, then
-              1. Return the BigInt value that represents _x_ &divide; 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.
-            1. Return the BigInt value that represents _x_ &times; 2<sup>_y_</sup>.
+            1. If _y_ &lt; *0*<sub>ℤ</sub>, then
+              1. Return the BigInt value that represents ℝ(_x_) &divide; 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.
+            1. Return the BigInt value that represents ℝ(_x_) &times; 2<sup>_y_</sup>.
           </emu-alg>
           <emu-note>Semantics here should be equivalent to a bitwise shift, treating the BigInt as an infinite length string of binary two's complement digits.</emu-note>
         </emu-clause>
@@ -2021,12 +2025,12 @@
 
         <emu-clause id="sec-numeric-types-bigint-lessThan">
           <h1>BigInt::lessThan ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::lessThan takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns *true* if _x_ is less than _y_ and *false* otherwise.</p>
+          <p>The abstract operation BigInt::lessThan takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns *true* if ℝ(_x_) &lt; ℝ(_y_) and *false* otherwise.</p>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-equal">
           <h1>BigInt::equal ( _x_, _y_ )</h1>
-          <p>The abstract operation BigInt::equal takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns *true* if _x_ and _y_ have the same mathematical integer value and *false* otherwise.</p>
+          <p>The abstract operation BigInt::equal takes arguments _x_ (a BigInt) and _y_ (a BigInt). It returns *true* if ℝ(_x_) = ℝ(_y_) and *false* otherwise.</p>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-sameValue">
@@ -2084,7 +2088,9 @@
           <p>The abstract operation BigIntBitwiseOp takes arguments _op_ (a sequence of Unicode code points), _x_ (a BigInt), and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _op_ is `&amp;`, `^`, or `|`.
-            1. Let _result_ be *0n*.
+            1. Set _x_ to ℝ(_x_).
+            1. Set _y_ to ℝ(_y_).
+            1. Let _result_ be 0.
             1. Let _shift_ be 0.
             1. Repeat, until (_x_ = 0 or _x_ = -1) and (_y_ = 0 or _y_ = -1),
               1. Let _xDigit_ be _x_ modulo 2.
@@ -2105,7 +2111,7 @@
             1. If _tmp_ &ne; 0, then
               1. Set _result_ to _result_ - 2<sup>_shift_</sup>.
               1. NOTE: This extends the sign.
-            1. Return _result_.
+            1. Return the BigInt value for _result_.
           </emu-alg>
         </emu-clause>
 
@@ -2137,7 +2143,7 @@
           <h1>BigInt::toString ( _x_ )</h1>
           <p>The abstract operation BigInt::toString takes argument _x_ (a BigInt). It converts _x_ to String format. It performs the following steps when called:</p>
           <emu-alg>
-            1. If _x_ is less than zero, return the string-concatenation of the String *"-"* and ! BigInt::toString(-_x_).
+            1. If _x_ &lt; *0*<sub>ℤ</sub>, return the string-concatenation of the String *"-"* and ! BigInt::toString(-_x_).
             1. Return the String value consisting of the code units of the digits of the decimal representation of _x_.
           </emu-alg>
         </emu-clause>
@@ -2156,7 +2162,7 @@
         </li>
       </ul>
       <p>Properties are identified using key values. A property key value is either an ECMAScript String value or a Symbol value. All String and Symbol values, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String value.</p>
-      <p>An <dfn id="integer-index">integer index</dfn> is a String-valued property key that is a canonical numeric String (see <emu-xref href="#sec-canonicalnumericindexstring"></emu-xref>) and whose numeric value is either *+0* or a positive integer &le; 2<sup>53</sup> - 1. An <dfn id="array-index">array index</dfn> is an integer index whose numeric value _i_ is in the range <emu-eqn>+0 &le; _i_ &lt; 2<sup>32</sup> - 1</emu-eqn>.</p>
+      <p>An <dfn id="integer-index">integer index</dfn> is a String-valued property key that is a canonical numeric String (see <emu-xref href="#sec-canonicalnumericindexstring"></emu-xref>) and whose numeric value is either *+0*<sub>𝔽</sub> or a positive integral Number &le; 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index">array index</dfn> is an integer index whose numeric value _i_ is in the range <emu-eqn>*+0*<sub>𝔽</sub> &le; _i_ &lt; 𝔽(2<sup>32</sup> - 1)</emu-eqn>.</p>
       <p>Property keys are used to access properties and their values. There are two kinds of access for properties: <em>get</em> and <em>set</em>, corresponding to value retrieval and assignment, respectively. The properties accessible via get and set access includes both <em>own properties</em> that are a direct part of an object and <em>inherited properties</em> which are provided by another associated object via a property inheritance relationship. Inherited properties may be either own or inherited properties of the associated object. Each own property of an object must each have a key value that is distinct from the key values of the other own properties of that object.</p>
       <p>All objects are logically collections of properties, but there are multiple forms of objects that differ in their semantics for accessing and manipulating their properties. Please see <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref> for definitions of the multiple forms of objects.</p>
 
@@ -3654,7 +3660,7 @@
             1. Return *undefined*.
           </emu-alg>
 
-          <p>The *"length"* property of an Await fulfilled function is 1.</p>
+          <p>The *"length"* property of an Await fulfilled function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
 
         <emu-clause id="await-rejected">
@@ -3673,7 +3679,7 @@
             1. Return *undefined*.
           </emu-alg>
 
-          <p>The *"length"* property of an Await rejected function is 1.</p>
+          <p>The *"length"* property of an Await rejected function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -4019,7 +4025,7 @@
 
       <emu-clause id="sec-createsharedbytedatablock" aoid="CreateSharedByteDataBlock">
         <h1>CreateSharedByteDataBlock ( _size_ )</h1>
-        <p>The abstract operation CreateSharedByteDataBlock takes argument _size_ (an integer). It performs the following steps when called:</p>
+        <p>The abstract operation CreateSharedByteDataBlock takes argument _size_ (a non-negative integer). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _size_ &ge; 0.
           1. Let _db_ be a new Shared Data Block value consisting of _size_ bytes. If it is impossible to create such a Shared Data Block, throw a *RangeError* exception.
@@ -4034,10 +4040,9 @@
 
       <emu-clause id="sec-copydatablockbytes" aoid="CopyDataBlockBytes">
         <h1>CopyDataBlockBytes ( _toBlock_, _toIndex_, _fromBlock_, _fromIndex_, _count_ )</h1>
-        <p>The abstract operation CopyDataBlockBytes takes arguments _toBlock_, _toIndex_, _fromBlock_, _fromIndex_, and _count_. It performs the following steps when called:</p>
+        <p>The abstract operation CopyDataBlockBytes takes arguments _toBlock_, _toIndex_ (a non-negative integer), _fromBlock_, _fromIndex_ (a non-negative integer), and _count_ (a non-negative integer). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _fromBlock_ and _toBlock_ are distinct Data Block or Shared Data Block values.
-          1. Assert: _fromIndex_, _toIndex_, and _count_ are integer values &ge; 0.
           1. Let _fromSize_ be the number of bytes in _fromBlock_.
           1. Assert: _fromIndex_ + _count_ &le; _fromSize_.
           1. Let _toSize_ be the number of bytes in _toBlock_.
@@ -4164,7 +4169,7 @@
               Number
             </td>
             <td>
-              If _argument_ is *+0*, *-0*, or *NaN*, return *false*; otherwise return *true*.
+              If _argument_ is *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *NaN*, return *false*; otherwise return *true*.
             </td>
           </tr>
           <tr>
@@ -4188,7 +4193,7 @@
               BigInt
             </td>
             <td>
-              If _argument_ is *0n*, return *false*; otherwise return *true*.
+              If _argument_ is *0*<sub>ℤ</sub>, return *false*; otherwise return *true*.
             </td>
           </tr>
           <tr>
@@ -4206,7 +4211,7 @@
 
     <emu-clause id="sec-tonumeric" aoid="ToNumeric">
       <h1>ToNumeric ( _value_ )</h1>
-      <p>The abstract operation ToNumeric takes argument _value_. It returns _value_ converted to a numeric value of type Number or BigInt. It performs the following steps when called:</p>
+      <p>The abstract operation ToNumeric takes argument _value_. It returns _value_ converted to a Number or a BigInt. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _primValue_ be ? ToPrimitive(_value_, ~number~).
         1. If Type(_primValue_) is BigInt, return _primValue_.
@@ -4241,7 +4246,7 @@
               Null
             </td>
             <td>
-              Return *+0*.
+              Return *+0*<sub>𝔽</sub>.
             </td>
           </tr>
           <tr>
@@ -4249,7 +4254,7 @@
               Boolean
             </td>
             <td>
-              If _argument_ is *true*, return 1. If _argument_ is *false*, return *+0*.
+              If _argument_ is *true*, return *1*<sub>𝔽</sub>. If _argument_ is *false*, return *+0*<sub>𝔽</sub>.
             </td>
           </tr>
           <tr>
@@ -4348,7 +4353,7 @@
               A |StringNumericLiteral| that is decimal may include a `+` or `-` to indicate its sign.
             </li>
             <li>
-              A |StringNumericLiteral| that is empty or contains only white space is converted to *+0*.
+              A |StringNumericLiteral| that is empty or contains only white space is converted to *+0*<sub>𝔽</sub>.
             </li>
             <li>
               `Infinity` and `-Infinity` are recognized as a |StringNumericLiteral| but not as a |NumericLiteral|.
@@ -4364,74 +4369,75 @@
           <p>The conversion of a String to a Number value is similar overall to the determination of the Number value for a numeric literal (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different, so the process for converting a String numeric literal to a value of Number type is given here. This value is determined in two steps: first, a mathematical value (MV) is derived from the String numeric literal; second, this mathematical value is rounded as described below. The MV on any grammar symbol, not provided below, is the MV for that symbol defined in <emu-xref href="#sec-static-semantics-mv"></emu-xref>.</p>
           <ul>
             <li>
-              The MV of <emu-grammar>StringNumericLiteral ::: [empty]</emu-grammar> is 0<sub>ℝ</sub>.
+              The MV of <emu-grammar>StringNumericLiteral ::: [empty]</emu-grammar> is 0.
             </li>
             <li>
-              The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace</emu-grammar> is 0<sub>ℝ</sub>.
+              The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace</emu-grammar> is 0.
             </li>
             <li>
               The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar> is the MV of |StrNumericLiteral|, no matter whether white space is present or not.
             </li>
             <li>
-              The MV of <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar> is the negative of the MV of |StrUnsignedDecimalLiteral|. (Note that if the MV of |StrUnsignedDecimalLiteral| is 0, the negative of this MV is also 0. The rounding rule described below handles the conversion of this signless mathematical zero to a floating-point *+0* or *-0* as appropriate.)
+              The MV of <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar> is the negative of the MV of |StrUnsignedDecimalLiteral|. (Note that if the MV of |StrUnsignedDecimalLiteral| is 0, the negative of this MV is also 0. The rounding rule described below handles the conversion of this signless mathematical zero to a floating-point *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub> as appropriate.)
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sub>ℝ</sub><sup>10000<sub>ℝ</sub></sup> (a value so large that it will round to *+&infin;*).
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sup>10000</sup> (a value so large that it will round to *+&infin;*<sub>𝔽</sub>).
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>), where _n_ is the mathematical value of the number of code points in the second |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>), where _n_ is the number of code points in the second |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>)) times 10<sub>ℝ</sub><sup>_e_</sup>, where _n_ is the mathematical value of the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sup>-_n_</sup>)) times 10<sup>_e_</sup>, where _n_ is the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>, where _n_ is the mathematical value of the number of code points in |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_ -<sub>ℝ</sub> _n_</sup>, where _n_ is the mathematical value of the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_ - _n_</sup>, where _n_ is the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
             </li>
           </ul>
-          <p>Once the exact MV for a String numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0* unless the first non white space code point in the String numeric literal is `-`, in which case the rounded value is *-0*. Otherwise, the rounded value must be the Number value for the MV (in the sense defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal includes a |StrUnsignedDecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit and then incrementing the literal at the 20th digit position. A digit is significant if it is not part of an |ExponentPart| and</p>
+          <p>Once the exact MV for a String numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0*<sub>𝔽</sub> unless the first non white space code point in the String numeric literal is `-`, in which case the rounded value is *-0*<sub>𝔽</sub>. Otherwise, the rounded value must be the Number value for the MV (in the sense defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal includes a |StrUnsignedDecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit and then incrementing the literal at the 20th digit position. A digit is significant if it is not part of an |ExponentPart| and</p>
           <ul>
             <li>
               it is not `0`; or
             </li>
             <li>
-              there is a nonzero digit to its left and there is a nonzero digit, not in the |ExponentPart|, to its right.
+              there is a non-zero digit to its left and there is a non-zero digit, not in the |ExponentPart|, to its right.
             </li>
           </ul>
         </emu-clause>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-tointeger" aoid="ToInteger">
-      <h1>ToInteger ( _argument_ )</h1>
-      <p>The abstract operation ToInteger takes argument _argument_. It converts _argument_ to an integral Number value. It performs the following steps when called:</p>
+    <emu-clause id="sec-tointegerorinfinity" aoid="ToIntegerOrInfinity" oldids="sec-tointeger">
+      <h1>ToIntegerOrInfinity ( _argument_ )</h1>
+      <p>The abstract operation ToIntegerOrInfinity takes argument _argument_. It converts _argument_ to an integer, +&infin;, or -&infin;. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*, or *-0*, return *+0*.
-        1. If _number_ is *+&infin;* or *-&infin;*, return _number_.
-        1. Let _integer_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
-        1. If _integer_ is *-0*, return *+0*.
+        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return 0.
+        1. If _number_ is *+&infin;*<sub>𝔽</sub>, return +&infin;.
+        1. If _number_ is *-&infin;*<sub>𝔽</sub>, return -&infin;.
+        1. Let _integer_ be floor(abs(ℝ(_number_))).
+        1. If _number_ &lt; *+0*<sub>𝔽</sub>, set _integer_ to -_integer_.
         1. Return _integer_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-toint32" aoid="ToInt32">
       <h1>ToInt32 ( _argument_ )</h1>
-      <p>The abstract operation ToInt32 takes argument _argument_. It converts _argument_ to one of 2<sup>32</sup> integer values in the range <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToInt32 takes argument _argument_. It converts _argument_ to one of 2<sup>32</sup> integral Number values in the range 𝔽(<emu-eqn>-2<sup>31</sup></emu-eqn>) through 𝔽(<emu-eqn>2<sup>31</sup> - 1</emu-eqn>), inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
-        1. If _int32bit_ &ge; 2<sup>31</sup>, return _int32bit_ - 2<sup>32</sup>; otherwise return _int32bit_.
+        1. If _int32bit_ &ge; 2<sup>31</sup>, return 𝔽(_int32bit_ - 2<sup>32</sup>); otherwise return 𝔽(_int32bit_).
       </emu-alg>
       <emu-note>
         <p>Given the above definition of ToInt32:</p>
@@ -4440,10 +4446,10 @@
             The ToInt32 abstract operation is idempotent: if applied to a result that it produced, the second application leaves that value unchanged.
           </li>
           <li>
-            ToInt32(ToUint32(_x_)) is equal to ToInt32(_x_) for all values of _x_. (It is to preserve this latter property that *+&infin;* and *-&infin;* are mapped to *+0*.)
+            ToInt32(ToUint32(_x_)) is the same value as ToInt32(_x_) for all values of _x_. (It is to preserve this latter property that *+&infin;*<sub>𝔽</sub> and *-&infin;*<sub>𝔽</sub> are mapped to *+0*<sub>𝔽</sub>.)
           </li>
           <li>
-            ToInt32 maps *-0* to *+0*.
+            ToInt32 maps *-0*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>.
           </li>
         </ul>
       </emu-note>
@@ -4451,13 +4457,13 @@
 
     <emu-clause id="sec-touint32" aoid="ToUint32">
       <h1>ToUint32 ( _argument_ )</h1>
-      <p>The abstract operation ToUint32 takes argument _argument_. It converts _argument_ to one of 2<sup>32</sup> integer values in the range 0 through <emu-eqn>2<sup>32</sup> - 1</emu-eqn>, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToUint32 takes argument _argument_. It converts _argument_ to one of 2<sup>32</sup> integral Number values in the range *+0*<sub>𝔽</sub> through 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>), inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
-        1. [id="step-touint32-return"] Return _int32bit_.
+        1. [id="step-touint32-return"] Return 𝔽(_int32bit_).
       </emu-alg>
       <emu-note>
         <p>Given the above definition of ToUint32:</p>
@@ -4469,10 +4475,10 @@
             The ToUint32 abstract operation is idempotent: if applied to a result that it produced, the second application leaves that value unchanged.
           </li>
           <li>
-            ToUint32(ToInt32(_x_)) is equal to ToUint32(_x_) for all values of _x_. (It is to preserve this latter property that *+&infin;* and *-&infin;* are mapped to *+0*.)
+            ToUint32(ToInt32(_x_)) is the same value as ToUint32(_x_) for all values of _x_. (It is to preserve this latter property that *+&infin;*<sub>𝔽</sub> and *-&infin;*<sub>𝔽</sub> are mapped to *+0*<sub>𝔽</sub>.)
           </li>
           <li>
-            ToUint32 maps *-0* to *+0*.
+            ToUint32 maps *-0*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>.
           </li>
         </ul>
       </emu-note>
@@ -4480,25 +4486,25 @@
 
     <emu-clause id="sec-toint16" aoid="ToInt16">
       <h1>ToInt16 ( _argument_ )</h1>
-      <p>The abstract operation ToInt16 takes argument _argument_. It converts _argument_ to one of 2<sup>16</sup> integer values in the range -32768 through 32767, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToInt16 takes argument _argument_. It converts _argument_ to one of 2<sup>16</sup> integral Number values in the range 𝔽(<emu-eqn>-2<sup>15</sup></emu-eqn>) through 𝔽(<emu-eqn>2<sup>15</sup> - 1</emu-eqn>), inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
-        1. If _int16bit_ &ge; 2<sup>15</sup>, return _int16bit_ - 2<sup>16</sup>; otherwise return _int16bit_.
+        1. If _int16bit_ &ge; 2<sup>15</sup>, return 𝔽(_int16bit_ - 2<sup>16</sup>); otherwise return 𝔽(_int16bit_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-touint16" aoid="ToUint16">
       <h1>ToUint16 ( _argument_ )</h1>
-      <p>The abstract operation ToUint16 takes argument _argument_. It converts _argument_ to one of 2<sup>16</sup> integer values in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToUint16 takes argument _argument_. It converts _argument_ to one of 2<sup>16</sup> integral Number values in the range *+0*<sub>𝔽</sub> through 𝔽(<emu-eqn>2<sup>16</sup> - 1</emu-eqn>), inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. [id="step-touint16-mod"] Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
-        1. Return _int16bit_.
+        1. Return 𝔽(_int16bit_).
       </emu-alg>
       <emu-note>
         <p>Given the above definition of ToUint16:</p>
@@ -4507,7 +4513,7 @@
             The substitution of 2<sup>16</sup> for 2<sup>32</sup> in step <emu-xref href="#step-touint16-mod"></emu-xref> is the only difference between ToUint32 and ToUint16.
           </li>
           <li>
-            ToUint16 maps *-0* to *+0*.
+            ToUint16 maps *-0*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>.
           </li>
         </ul>
       </emu-note>
@@ -4515,44 +4521,44 @@
 
     <emu-clause id="sec-toint8" aoid="ToInt8">
       <h1>ToInt8 ( _argument_ )</h1>
-      <p>The abstract operation ToInt8 takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integer values in the range -128 through 127, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToInt8 takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *-128*<sub>𝔽</sub> through *127*<sub>𝔽</sub>, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
-        1. If _int8bit_ &ge; 2<sup>7</sup>, return _int8bit_ - 2<sup>8</sup>; otherwise return _int8bit_.
+        1. If _int8bit_ &ge; 2<sup>7</sup>, return 𝔽(_int8bit_ - 2<sup>8</sup>); otherwise return 𝔽(_int8bit_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-touint8" aoid="ToUint8">
       <h1>ToUint8 ( _argument_ )</h1>
-      <p>The abstract operation ToUint8 takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integer values in the range 0 through 255, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToUint8 takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *+0*<sub>𝔽</sub> through *255*<sub>𝔽</sub>, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
-        1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. Let _int_ be the mathematical value that is the same sign as _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
-        1. Return _int8bit_.
+        1. Return 𝔽(_int8bit_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-touint8clamp" aoid="ToUint8Clamp">
       <h1>ToUint8Clamp ( _argument_ )</h1>
-      <p>The abstract operation ToUint8Clamp takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integer values in the range 0 through 255, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToUint8Clamp takes argument _argument_. It converts _argument_ to one of 2<sup>8</sup> integral Number values in the range *+0*<sub>𝔽</sub> through *255*<sub>𝔽</sub>, inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, return *+0*.
-        1. If _number_ &le; 0, return *+0*.
-        1. If _number_ &ge; 255, return 255.
-        1. Let _f_ be floor(_number_).
-        1. If _f_ + 0.5 &lt; _number_, return _f_ + 1.
-        1. If _number_ &lt; _f_ + 0.5, return _f_.
-        1. If _f_ is odd, return _f_ + 1.
-        1. Return _f_.
+        1. If _number_ is *NaN*, return *+0*<sub>𝔽</sub>.
+        1. If ℝ(_number_) &le; 0, return *+0*<sub>𝔽</sub>.
+        1. If ℝ(_number_) &ge; 255, return *255*<sub>𝔽</sub>.
+        1. Let _f_ be floor(ℝ(_number_)).
+        1. If _f_ + 0.5 &lt; ℝ(_number_), return 𝔽(_f_ + 1).
+        1. If ℝ(_number_) &lt; _f_ + 0.5, return 𝔽(_f_).
+        1. If _f_ is odd, return 𝔽(_f_ + 1).
+        1. Return 𝔽(_f_).
       </emu-alg>
       <emu-note>
-        <p>Unlike the other ECMAScript integer conversion abstract operation, ToUint8Clamp rounds rather than truncates non-integer values and does not convert *+&infin;* to 0. ToUint8Clamp does &ldquo;round half to even&rdquo; tie-breaking. This differs from `Math.round` which does &ldquo;round half up&rdquo; tie-breaking.</p>
+        <p>Unlike the other ECMAScript integer conversion abstract operation, ToUint8Clamp rounds rather than truncates non-integral values and does not convert *+&infin;*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>. ToUint8Clamp does &ldquo;round half to even&rdquo; tie-breaking. This differs from `Math.round` which does &ldquo;round half up&rdquo; tie-breaking.</p>
       </emu-note>
     </emu-clause>
 
@@ -4650,21 +4656,21 @@
 
     <emu-clause id="sec-tobigint64" aoid="ToBigInt64">
       <h1>ToBigInt64 ( _argument_ )</h1>
-      <p>The abstract operation ToBigInt64 takes argument _argument_. It converts _argument_ to one of 2<sup>64</sup> integer values in the range -2<sup>63</sup> through 2<sup>63</sup>-1, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToBigInt64 takes argument _argument_. It converts _argument_ to one of 2<sup>64</sup> BigInt values in the range ℤ(-2<sup>63</sup>) through ℤ(2<sup>63</sup>-1), inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
-        1. Let _int64bit_ be _n_ modulo 2<sup>64</sup>.
-        1. If _int64bit_ &ge; 2<sup>63</sup>, return _int64bit_ - 2<sup>64</sup>; otherwise return _int64bit_.
+        1. Let _int64bit_ be ℝ(_n_) modulo 2<sup>64</sup>.
+        1. If _int64bit_ &ge; 2<sup>63</sup>, return ℤ(_int64bit_ - 2<sup>64</sup>); otherwise return ℤ(_int64bit_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-tobiguint64" aoid="ToBigUint64">
       <h1>ToBigUint64 ( _argument_ )</h1>
-      <p>The abstract operation ToBigUint64 takes argument _argument_. It converts _argument_ to one of 2<sup>64</sup> integer values in the range 0 through 2<sup>64</sup>-1, inclusive. It performs the following steps when called:</p>
+      <p>The abstract operation ToBigUint64 takes argument _argument_. It converts _argument_ to one of 2<sup>64</sup> BigInt values in the range *0*<sub>ℤ</sub> through the BigInt value for ℤ(2<sup>64</sup>-1), inclusive. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
-        1. Let _int64bit_ be _n_ modulo 2<sup>64</sup>.
-        1. Return _int64bit_.
+        1. Let _int64bit_ be ℝ(_n_) modulo 2<sup>64</sup>.
+        1. Return ℤ(_int64bit_).
       </emu-alg>
     </emu-clause>
 
@@ -4852,11 +4858,11 @@
 
     <emu-clause id="sec-tolength" aoid="ToLength">
       <h1>ToLength ( _argument_ )</h1>
-      <p>The abstract operation ToLength takes argument _argument_. It converts _argument_ to an integer suitable for use as the length of an array-like object. It performs the following steps when called:</p>
+      <p>The abstract operation ToLength takes argument _argument_. It converts _argument_ to an integral Number suitable for use as the length of an array-like object. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _len_ be ? ToInteger(_argument_).
-        1. If _len_ &le; *+0*, return *+0*.
-        1. Return min(_len_, 2<sup>53</sup> - 1).
+        1. Let _len_ be ? ToIntegerOrInfinity(_argument_).
+        1. If _len_ &le; 0, return *+0*<sub>𝔽</sub>.
+        1. Return 𝔽(min(_len_, 2<sup>53</sup> - 1)).
       </emu-alg>
     </emu-clause>
 
@@ -4865,7 +4871,7 @@
       <p>The abstract operation CanonicalNumericIndexString takes argument _argument_. It returns _argument_ converted to a Number value if it is a String representation of a Number that would be produced by ToString, or the string *"-0"*. Otherwise, it returns *undefined*. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_argument_) is String.
-        1. If _argument_ is *"-0"*, return *-0*.
+        1. If _argument_ is *"-0"*, return *-0*<sub>𝔽</sub>.
         1. Let _n_ be ! ToNumber(_argument_).
         1. If SameValue(! ToString(_n_), _argument_) is *false*, return *undefined*.
         1. Return _n_.
@@ -4878,13 +4884,13 @@
       <p>The abstract operation ToIndex takes argument _value_. It returns _value_ argument converted to a non-negative integer if it is a valid integer index value. It performs the following steps when called:</p>
       <emu-alg>
         1. If _value_ is *undefined*, then
-          1. Let _index_ be 0.
+          1. Return 0.
         1. Else,
-          1. Let _integerIndex_ be ? ToInteger(_value_).
-          1. If _integerIndex_ &lt; 0, throw a *RangeError* exception.
+          1. Let _integerIndex_ be 𝔽(? ToIntegerOrInfinity(_value_)).
+          1. If _integerIndex_ &lt; *+0*<sub>𝔽</sub>, throw a *RangeError* exception.
           1. Let _index_ be ! ToLength(_integerIndex_).
           1. If ! SameValue(_integerIndex_, _index_) is *false*, throw a *RangeError* exception.
-        1. Return _index_.
+          1. Return ℝ(_index_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -5018,23 +5024,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isinteger" aoid="IsInteger">
-      <h1>IsInteger ( _argument_ )</h1>
-      <p>The abstract operation IsInteger takes argument _argument_. It determines if _argument_ is a finite integer Number value. It performs the following steps when called:</p>
+    <emu-clause id="sec-isintegralnumber" aoid="IsIntegralNumber" oldids="sec-isinteger">
+      <h1>IsIntegralNumber ( _argument_ )</h1>
+      <p>The abstract operation IsIntegralNumber takes argument _argument_. It determines if _argument_ is a finite integral Number value. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_argument_) is not Number, return *false*.
-        1. If _argument_ is *NaN*, *+&infin;*, or *-&infin;*, return *false*.
-        1. If floor(abs(_argument_)) &ne; abs(_argument_), return *false*.
+        1. If _argument_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
+        1. If floor(abs(ℝ(_argument_))) &ne; abs(ℝ(_argument_)), return *false*.
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-isnonnegativeinteger" aoid="IsNonNegativeInteger">
-      <h1>IsNonNegativeInteger ( _argument_ )</h1>
-      <p>The abstract operation IsNonNegativeInteger takes argument _argument_. It determines if _argument_ is a non-negative integer Number value. It performs the following steps when called:</p>
-      <emu-alg>
-        1. If ! IsInteger(_argument_) is *true* and _argument_ &ge; 0, return *true*.
-        1. Otherwise, return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -5097,7 +5094,7 @@
         1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
-        <p>SameValueZero differs from SameValue only in its treatment of *+0* and *-0*.</p>
+        <p>SameValueZero differs from SameValue only in its treatment of *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>.</p>
       </emu-note>
     </emu-clause>
 
@@ -5133,7 +5130,7 @@
         1. [id="step-arc-string-check"] If Type(_px_) is String and Type(_py_) is String, then
           1. If IsStringPrefix(_py_, _px_) is *true*, return *false*.
           1. If IsStringPrefix(_px_, _py_) is *true*, return *true*.
-          1. Let _k_ be the smallest nonnegative integer such that the code unit at index _k_ within _px_ is different from the code unit at index _k_ within _py_. (There must be such a _k_, for neither String is a prefix of the other.)
+          1. Let _k_ be the smallest non-negative integer such that the code unit at index _k_ within _px_ is different from the code unit at index _k_ within _py_. (There must be such a _k_, for neither String is a prefix of the other.)
           1. Let _m_ be the integer that is the numeric value of the code unit at index _k_ within _px_.
           1. Let _n_ be the integer that is the numeric value of the code unit at index _k_ within _py_.
           1. If _m_ &lt; _n_, return *true*. Otherwise, return *false*.
@@ -5147,14 +5144,14 @@
             1. If _nx_ is *NaN*, return *undefined*.
             1. Return BigInt::lessThan(_nx_, _py_).
           1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
-          1. Let _nx_ be ? ToNumeric(_px_).
-          1. Let _ny_ be ? ToNumeric(_py_).
+          1. Let _nx_ be ! ToNumeric(_px_).
+          1. Let _ny_ be ! ToNumeric(_py_).
           1. If Type(_nx_) is the same as Type(_ny_), return Type(_nx_)::lessThan(_nx_, _ny_).
           1. Assert: Type(_nx_) is BigInt and Type(_ny_) is Number, or Type(_nx_) is Number and Type(_ny_) is BigInt.
           1. If _nx_ or _ny_ is *NaN*, return *undefined*.
-          1. If _nx_ is *-&infin;* or _ny_ is *+&infin;*, return *true*.
-          1. If _nx_ is *+&infin;* or _ny_ is *-&infin;*, return *false*.
-          1. If the mathematical value of _nx_ is less than the mathematical value of _ny_, return *true*; otherwise return *false*.
+          1. If _nx_ is *-&infin;*<sub>𝔽</sub> or _ny_ is *+&infin;*<sub>𝔽</sub>, return *true*.
+          1. If _nx_ is *+&infin;*<sub>𝔽</sub> or _ny_ is *-&infin;*<sub>𝔽</sub>, return *false*.
+          1. If ℝ(_nx_) &lt; ℝ(_ny_), return *true*; otherwise return *false*.
       </emu-alg>
       <emu-note>
         <p>Step <emu-xref href="#step-arc-string-check"></emu-xref> differs from step <emu-xref href="#step-binary-op-string-check"></emu-xref> in the algorithm that handles the addition operator `+` (<emu-xref href="#sec-applystringornumericbinaryoperator"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
@@ -5184,8 +5181,8 @@
         1. If Type(_x_) is either String, Number, BigInt, or Symbol and Type(_y_) is Object, return the result of the comparison _x_ == ? ToPrimitive(_y_).
         1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt, or Symbol, return the result of the comparison ? ToPrimitive(_x_) == _y_.
         1. If Type(_x_) is BigInt and Type(_y_) is Number, or if Type(_x_) is Number and Type(_y_) is BigInt, then
-          1. If _x_ or _y_ are any of *NaN*, *+&infin;*, or *-&infin;*, return *false*.
-          1. If the mathematical value of _x_ is equal to the mathematical value of _y_, return *true*; otherwise return *false*.
+          1. If _x_ or _y_ are any of *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
+          1. If ℝ(_x_) = ℝ(_y_), return *true*; otherwise return *false*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>
@@ -5440,7 +5437,7 @@
         1. Let _array_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each element _e_ of _elements_, do
-          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(_n_), _e_).
+          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_n_)), _e_).
           1. Set _n_ to _n_ + 1.
         1. Return _array_.
       </emu-alg>
@@ -5448,10 +5445,10 @@
 
     <emu-clause id="sec-lengthofarraylike" aoid="LengthOfArrayLike">
       <h1>LengthOfArrayLike ( _obj_ )</h1>
-      <p>The abstract operation LengthOfArrayLike takes argument _obj_. It returns the value of the *"length"* property of an array-like object. It performs the following steps when called:</p>
+      <p>The abstract operation LengthOfArrayLike takes argument _obj_. It returns the value of the *"length"* property of an array-like object (as a non-negative integer). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_obj_) is Object.
-        1. Return ? ToLength(? Get(_obj_, *"length"*)).
+        1. Return ℝ(? ToLength(? Get(_obj_, *"length"*))).
       </emu-alg>
       <p>An <dfn>array-like object</dfn> is any object for which this operation returns an integer rather than an abrupt completion.</p>
       <emu-note>
@@ -5472,7 +5469,7 @@
         1. Let _list_ be a new empty List.
         1. Let _index_ be 0.
         1. Repeat, while _index_ &lt; _len_,
-          1. Let _indexName_ be ! ToString(_index_).
+          1. Let _indexName_ be ! ToString(𝔽(_index_)).
           1. Let _next_ be ? Get(_obj_, _indexName_).
           1. If Type(_next_) is not an element of _elementTypes_, throw a *TypeError* exception.
           1. Append _next_ as the last element of _list_.
@@ -5746,7 +5743,7 @@
           1. Set _O_.[[ListNextIndex]] to _index_ + 1.
           1. Return CreateIterResultObject(_list_[_index_], *false*).
         </emu-alg>
-        <p>The *"length"* property of a ListIteratorNext function is 0.</p>
+        <p>The *"length"* property of a ListIteratorNext function is *+0*<sub>𝔽</sub>.</p>
       </emu-clause>
     </emu-clause>
 
@@ -7623,7 +7620,6 @@
 
       <emu-clause id="sec-host-cleanup-finalization-registry" aoid="HostEnqueueFinalizationRegistryCleanupJob">
         <h1>HostEnqueueFinalizationRegistryCleanupJob ( _finalizationRegistry_ )</h1>
-
         <p>The abstract operation HostEnqueueFinalizationRegistryCleanupJob takes argument _finalizationRegistry_ (a FinalizationRegistry). HostEnqueueFinalizationRegistryCleanupJob is an implementation-defined abstract operation that is expected to call CleanupFinalizationRegistry(_finalizationRegistry_) at some point in the future, if possible. The host's responsibility is to make this call at a time which does not interrupt synchronous ECMAScript code execution.</p>
       </emu-clause>
     </emu-clause>
@@ -8412,12 +8408,10 @@
 
     <emu-clause id="sec-setfunctionlength" aoid="SetFunctionLength">
       <h1>SetFunctionLength ( _F_, _length_ )</h1>
-      <p>The abstract operation SetFunctionLength takes arguments _F_ (a function object) and _length_ (a Number). It adds a *"length"* property to _F_. It performs the following steps when called:</p>
+      <p>The abstract operation SetFunctionLength takes arguments _F_ (a function object) and _length_ (a non-negative integer or +&infin;). It adds a *"length"* property to _F_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _F_ is an extensible object that does not have a *"length"* own property.
-        1. Assert: Type(_length_) is Number.
-        1. Assert: ! IsNonNegativeInteger(_length_) is *true*.
-        1. Return ! DefinePropertyOrThrow(_F_, *"length"*, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Return ! DefinePropertyOrThrow(_F_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
       </emu-alg>
     </emu-clause>
 
@@ -8720,9 +8714,9 @@
 
     <emu-clause id="sec-array-exotic-objects">
       <h1>Array Exotic Objects</h1>
-      <p>An Array object is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array object has a non-configurable *"length"* property whose value is always a nonnegative integer less than 2<sup>32</sup>. The value of the *"length"* property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array object is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the *"length"* property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the *"length"* property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array object and is unaffected by *"length"* or array index properties that may be inherited from its prototypes.</p>
+      <p>An Array object is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array object has a non-configurable *"length"* property whose value is always a non-negative integral Number whose mathematical value is less than 2<sup>32</sup>. The value of the *"length"* property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array object is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the *"length"* property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the *"length"* property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array object and is unaffected by *"length"* or array index properties that may be inherited from its prototypes.</p>
       <emu-note>
-        <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) is equal to _P_ and ToUint32(_P_) is not equal to <emu-eqn>2<sup>32</sup> - 1</emu-eqn>.</p>
+        <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) equals _P_ and ToUint32(_P_) is not the same value as 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>).</p>
       </emu-note>
 
       <p>An object is an <dfn id="array-exotic-object">Array exotic object</dfn> (or simply, an Array object) if its [[DefineOwnProperty]] internal method uses the following implementation, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in ArrayCreate.</p>
@@ -8739,13 +8733,13 @@
             1. Assert: ! IsDataDescriptor(_oldLenDesc_) is *true*.
             1. Assert: _oldLenDesc_.[[Configurable]] is *false*.
             1. Let _oldLen_ be _oldLenDesc_.[[Value]].
-            1. Assert: IsNonNegativeInteger(_oldLen_) is *true*.
+            1. Assert: _oldLen_ is a non-negative integral Number.
             1. Let _index_ be ! ToUint32(_P_).
             1. If _index_ &ge; _oldLen_ and _oldLenDesc_.[[Writable]] is *false*, return *false*.
             1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
             1. If _succeeded_ is *false*, return *false*.
             1. If _index_ &ge; _oldLen_, then
-              1. Set _oldLenDesc_.[[Value]] to _index_ + 1.
+              1. Set _oldLenDesc_.[[Value]] to _index_ + *1*<sub>𝔽</sub>.
               1. Let _succeeded_ be OrdinaryDefineOwnProperty(_A_, *"length"*, _oldLenDesc_).
               1. Assert: _succeeded_ is *true*.
             1. Return *true*.
@@ -8757,24 +8751,20 @@
         <h1>ArrayCreate ( _length_ [ , _proto_ ] )</h1>
         <p>The abstract operation ArrayCreate takes argument _length_ (a non-negative integer) and optional argument _proto_. It is used to specify the creation of new Array exotic objects. It performs the following steps when called:</p>
         <emu-alg>
-          1. Assert: ! IsNonNegativeInteger(_length_) is *true*.
-          1. If _length_ is *-0*, set _length_ to *+0*.
           1. If _length_ &gt; 2<sup>32</sup> - 1, throw a *RangeError* exception.
           1. If _proto_ is not present, set _proto_ to %Array.prototype%.
           1. Let _A_ be ! MakeBasicObject(&laquo; [[Prototype]], [[Extensible]] &raquo;).
           1. Set _A_.[[Prototype]] to _proto_.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
-          1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _A_.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-arrayspeciescreate" aoid="ArraySpeciesCreate">
         <h1>ArraySpeciesCreate ( _originalArray_, _length_ )</h1>
-        <p>The abstract operation ArraySpeciesCreate takes arguments _originalArray_ and _length_. It is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_. It performs the following steps when called:</p>
+        <p>The abstract operation ArraySpeciesCreate takes arguments _originalArray_ and _length_ (a non-negative integer). It is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_. It performs the following steps when called:</p>
         <emu-alg>
-          1. Assert: ! IsNonNegativeInteger(_length_) is *true*.
-          1. If _length_ is *-0*, set _length_ to *+0*.
           1. Let _isArray_ be ? IsArray(_originalArray_).
           1. If _isArray_ is *false*, return ? ArrayCreate(_length_).
           1. Let _C_ be ? Get(_originalArray_, *"constructor"*).
@@ -8788,7 +8778,7 @@
             1. If _C_ is *null*, set _C_ to *undefined*.
           1. If _C_ is *undefined*, return ? ArrayCreate(_length_).
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
-          1. Return ? Construct(_C_, &laquo; _length_ &raquo;).
+          1. Return ? Construct(_C_, &laquo; 𝔽(_length_) &raquo;).
         </emu-alg>
         <emu-note>
           <p>If _originalArray_ was created using the standard built-in Array constructor for a realm that is not the realm of the running execution context, then a new Array is created using the realm of the running execution context. This maintains compatibility with Web browsers that have historically had that behaviour for the `Array.prototype` methods that now are defined using ArraySpeciesCreate.</p>
@@ -8804,7 +8794,7 @@
           1. Let _newLenDesc_ be a copy of _Desc_.
           1. [id="step-arraysetlength-newlen"] Let _newLen_ be ? ToUint32(_Desc_.[[Value]]).
           1. [id="step-arraysetlength-numberlen"] Let _numberLen_ be ? ToNumber(_Desc_.[[Value]]).
-          1. If _newLen_ &ne; _numberLen_, throw a *RangeError* exception.
+          1. If _newLen_ is not the same value as _numberLen_, throw a *RangeError* exception.
           1. Set _newLenDesc_.[[Value]] to _newLen_.
           1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
           1. Assert: ! IsDataDescriptor(_oldLenDesc_) is *true*.
@@ -8823,7 +8813,7 @@
           1. For each own property key _P_ of _A_ that is an array index, whose numeric value is greater than or equal to _newLen_, in descending numeric index order, do
             1. Let _deleteSucceeded_ be ! _A_.[[Delete]](_P_).
             1. If _deleteSucceeded_ is *false*, then
-              1. Set _newLenDesc_.[[Value]] to ! ToUint32(_P_) + 1.
+              1. Set _newLenDesc_.[[Value]] to ! ToUint32(_P_) + *1*<sub>𝔽</sub>.
               1. If _newWritable_ is *false*, set _newLenDesc_.[[Writable]] to *false*.
               1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
               1. Return *false*.
@@ -8878,9 +8868,9 @@
           1. Let _str_ be _O_.[[StringData]].
           1. Assert: Type(_str_) is String.
           1. Let _len_ be the length of _str_.
-          1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
-            1. Add ! ToString(_i_) as the last element of _keys_.
-          1. For each own property key _P_ of _O_ such that _P_ is an array index and ToInteger(_P_) &ge; _len_, in ascending numeric index order, do
+          1. For each non-negative integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
+            1. Add ! ToString(𝔽(_i_)) as the last element of _keys_.
+          1. For each own property key _P_ of _O_ such that _P_ is an array index and ! ToIntegerOrInfinity(_P_) &ge; _len_, in ascending numeric index order, do
             1. Add _P_ as the last element of _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an array index, in ascending chronological order of property creation, do
             1. Add _P_ as the last element of _keys_.
@@ -8892,9 +8882,8 @@
 
       <emu-clause id="sec-stringcreate" aoid="StringCreate">
         <h1>StringCreate ( _value_, _prototype_ )</h1>
-        <p>The abstract operation StringCreate takes arguments _value_ and _prototype_. It is used to specify the creation of new String exotic objects. It performs the following steps when called:</p>
+        <p>The abstract operation StringCreate takes arguments _value_ (a String) and _prototype_. It is used to specify the creation of new String exotic objects. It performs the following steps when called:</p>
         <emu-alg>
-          1. Assert: Type(_value_) is String.
           1. Let _S_ be ! MakeBasicObject(&laquo; [[Prototype]], [[Extensible]], [[StringData]] &raquo;).
           1. Set _S_.[[Prototype]] to _prototype_.
           1. Set _S_.[[StringData]] to _value_.
@@ -8902,7 +8891,7 @@
           1. Set _S_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-string-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _S_.[[OwnPropertyKeys]] as specified in <emu-xref href="#sec-string-exotic-objects-ownpropertykeys"></emu-xref>.
           1. Let _length_ be the number of code unit elements in _value_.
-          1. Perform ! DefinePropertyOrThrow(_S_, *"length"*, PropertyDescriptor { [[Value]]: _length_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ! DefinePropertyOrThrow(_S_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _S_.
         </emu-alg>
       </emu-clause>
@@ -8916,13 +8905,13 @@
           1. If Type(_P_) is not String, return *undefined*.
           1. Let _index_ be ! CanonicalNumericIndexString(_P_).
           1. If _index_ is *undefined*, return *undefined*.
-          1. If IsInteger(_index_) is *false*, return *undefined*.
-          1. If _index_ is *-0*, return *undefined*.
+          1. If IsIntegralNumber(_index_) is *false*, return *undefined*.
+          1. If _index_ is *-0*<sub>𝔽</sub>, return *undefined*.
           1. Let _str_ be _S_.[[StringData]].
           1. Assert: Type(_str_) is String.
           1. Let _len_ be the length of _str_.
-          1. If _index_ &lt; 0 or _len_ &le; _index_, return *undefined*.
-          1. Let _resultStr_ be the String value of length 1, containing one code unit from _str_, specifically the code unit at index _index_.
+          1. If ℝ(_index_) &lt; 0 or _len_ &le; ℝ(_index_), return *undefined*.
+          1. Let _resultStr_ be the String value of length 1, containing one code unit from _str_, specifically the code unit at index ℝ(_index_).
           1. Return the PropertyDescriptor { [[Value]]: _resultStr_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
         </emu-alg>
       </emu-clause>
@@ -9049,11 +9038,11 @@
           1. Let _len_ be the number of elements in _argumentsList_.
           1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
           1. Set _obj_.[[ParameterMap]] to *undefined*.
-          1. Perform DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_len_), [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
             1. Let _val_ be _argumentsList_[_index_].
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(_index_), _val_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(𝔽(_index_)), _val_).
             1. Set _index_ to _index_ + 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
@@ -9081,9 +9070,9 @@
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
             1. Let _val_ be _argumentsList_[_index_].
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(_index_), _val_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(𝔽(_index_)), _val_).
             1. Set _index_ to _index_ + 1.
-          1. Perform ! DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_len_), [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _mappedNames_ be a new empty List.
           1. Let _index_ be _numberOfParameters_ - 1.
           1. Repeat, while _index_ &ge; 0,
@@ -9093,7 +9082,7 @@
               1. If _index_ &lt; _len_, then
                 1. Let _g_ be MakeArgGetter(_name_, _env_).
                 1. Let _p_ be MakeArgSetter(_name_, _env_).
-                1. Perform _map_.[[DefineOwnProperty]](! ToString(_index_), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+                1. Perform _map_.[[DefineOwnProperty]](! ToString(𝔽(_index_)), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
             1. Set _index_ to _index_ - 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Value]]: _func_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
@@ -9241,7 +9230,7 @@
           1. Assert: _O_ is an Integer-Indexed exotic object.
           1. Let _len_ be _O_.[[ArrayLength]].
           1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
-            1. Add ! ToString(_i_) as the last element of _keys_.
+            1. Add ! ToString(𝔽(_i_)) as the last element of _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an integer index, in ascending chronological order of property creation, do
             1. Add _P_ as the last element of _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is Symbol, in ascending chronological order of property creation, do
@@ -9269,30 +9258,28 @@
 
       <emu-clause id="sec-isvalidintegerindex" aoid="IsValidIntegerIndex">
         <h1>IsValidIntegerIndex ( _O_, _index_ )</h1>
-        <p>The abstract operation IsValidIntegerIndex takes arguments _O_ and _index_. It performs the following steps when called:</p>
+        <p>The abstract operation IsValidIntegerIndex takes arguments _O_ and _index_ (a Number). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
-          1. Assert: Type(_index_) is Number.
-          1. If ! IsInteger(_index_) is *false*, return *false*.
-          1. If _index_ is *-0*, return *false*.
-          1. If _index_ &lt; 0 or _index_ &ge; _O_.[[ArrayLength]], return *false*.
+          1. If ! IsIntegralNumber(_index_) is *false*, return *false*.
+          1. If _index_ is *-0*<sub>𝔽</sub>, return *false*.
+          1. If ℝ(_index_) &lt; 0 or ℝ(_index_) &ge; _O_.[[ArrayLength]], return *false*.
           1. Return *true*.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-integerindexedelementget" aoid="IntegerIndexedElementGet">
         <h1>IntegerIndexedElementGet ( _O_, _index_ )</h1>
-        <p>The abstract operation IntegerIndexedElementGet takes arguments _O_ and _index_. It performs the following steps when called:</p>
+        <p>The abstract operation IntegerIndexedElementGet takes arguments _O_ and _index_ (a Number). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
-          1. Assert: Type(_index_) is Number.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. If ! IsValidIntegerIndex(_O_, _index_) is *false*, return *undefined*.
           1. Let _offset_ be _O_.[[ByteOffset]].
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-          1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
+          1. Let _indexedPosition_ be (ℝ(_index_) &times; _elementSize_) + _offset_.
           1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
           1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~Unordered~).
         </emu-alg>
@@ -9300,10 +9287,9 @@
 
       <emu-clause id="sec-integerindexedelementset" aoid="IntegerIndexedElementSet">
         <h1>IntegerIndexedElementSet ( _O_, _index_, _value_ )</h1>
-        <p>The abstract operation IntegerIndexedElementSet takes arguments _O_, _index_, and _value_. It performs the following steps when called:</p>
+        <p>The abstract operation IntegerIndexedElementSet takes arguments _O_, _index_ (a Number), and _value_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
-          1. Assert: Type(_index_) is Number.
           1. If _O_.[[ContentType]] is ~BigInt~, let _numValue_ be ? ToBigInt(_value_).
           1. Otherwise, let _numValue_ be ? ToNumber(_value_).
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
@@ -9312,7 +9298,7 @@
           1. Let _offset_ be _O_.[[ByteOffset]].
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-          1. Let _indexedPosition_ be (_index_ &times; _elementSize_) + _offset_.
+          1. Let _indexedPosition_ be (ℝ(_index_) &times; _elementSize_) + _offset_.
           1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
           1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _numValue_, *true*, ~Unordered~).
           1. Return *true*.
@@ -10207,7 +10193,7 @@
 
     <emu-clause id="sec-codepointtoutf16codeunits" aoid="CodePointToUTF16CodeUnits" oldids="sec-utf16encoding">
       <h1>Static Semantics: CodePointToUTF16CodeUnits ( _cp_ )</h1>
-      <p>The abstract operation CodePointToUTF16CodeUnits takes argument _cp_ (a numeric code point value). It performs the following steps when called:</p>
+      <p>The abstract operation CodePointToUTF16CodeUnits takes argument _cp_ (a Unicode code point). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: 0 &le; _cp_ &le; 0x10FFFF.
         1. If _cp_ &le; 0xFFFF, return _cp_.
@@ -11024,43 +11010,43 @@
             The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.`</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>), where _n_ is the mathematical value of the number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>), where _n_ is the number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>)) &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|, and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>)) &times; 10<sup>_e_</sup>, where _n_ is the number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator| and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
+            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>-_n_</sup>, where _n_ is the number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>_e_ -<sub>ℝ</sub> _n_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|, and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sup>_e_ - _n_</sup>, where _n_ is the number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|, and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalIntegerLiteral :: `0`</emu-grammar> is 0<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalIntegerLiteral :: `0`</emu-grammar> is 0.
           </li>
           <li>
             The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit</emu-grammar> is the MV of |NonZeroDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit NumericLiteralSeparator? DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sub>ℝ</sub><sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
+            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit NumericLiteralSeparator? DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalDigits :: DecimalDigit</emu-grammar> is the MV of |DecimalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub>) plus the MV of |DecimalDigit|.
+            The MV of <emu-grammar>DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10) plus the MV of |DecimalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigits :: DecimalDigits NumericLiteralSeparator DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub>) plus the MV of |DecimalDigit|.
+            The MV of <emu-grammar>DecimalDigits :: DecimalDigits NumericLiteralSeparator DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10) plus the MV of |DecimalDigit|.
           </li>
           <li>
             The MV of <emu-grammar>ExponentPart :: ExponentIndicator SignedInteger</emu-grammar> is the MV of |SignedInteger|.
@@ -11075,52 +11061,52 @@
             The MV of <emu-grammar>SignedInteger :: `-` DecimalDigits</emu-grammar> is the negative of the MV of |DecimalDigits|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `0`</emu-grammar> or of <emu-grammar>HexDigit :: `0`</emu-grammar> or of <emu-grammar>OctalDigit :: `0`</emu-grammar> or of <emu-grammar>BinaryDigit :: `0`</emu-grammar> is 0<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `0`</emu-grammar> or of <emu-grammar>HexDigit :: `0`</emu-grammar> or of <emu-grammar>OctalDigit :: `0`</emu-grammar> or of <emu-grammar>BinaryDigit :: `0`</emu-grammar> is 0.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `1`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `1`</emu-grammar> or of <emu-grammar>HexDigit :: `1`</emu-grammar> or of <emu-grammar>OctalDigit :: `1`</emu-grammar> or of <emu-grammar>BinaryDigit :: `1`</emu-grammar> is 1<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `1`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `1`</emu-grammar> or of <emu-grammar>HexDigit :: `1`</emu-grammar> or of <emu-grammar>OctalDigit :: `1`</emu-grammar> or of <emu-grammar>BinaryDigit :: `1`</emu-grammar> is 1.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `2`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `2`</emu-grammar> or of <emu-grammar>HexDigit :: `2`</emu-grammar> or of <emu-grammar>OctalDigit :: `2`</emu-grammar> is 2<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `2`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `2`</emu-grammar> or of <emu-grammar>HexDigit :: `2`</emu-grammar> or of <emu-grammar>OctalDigit :: `2`</emu-grammar> is 2.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `3`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `3`</emu-grammar> or of <emu-grammar>HexDigit :: `3`</emu-grammar> or of <emu-grammar>OctalDigit :: `3`</emu-grammar> is 3<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `3`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `3`</emu-grammar> or of <emu-grammar>HexDigit :: `3`</emu-grammar> or of <emu-grammar>OctalDigit :: `3`</emu-grammar> is 3.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `4`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `4`</emu-grammar> or of <emu-grammar>HexDigit :: `4`</emu-grammar> or of <emu-grammar>OctalDigit :: `4`</emu-grammar> is 4<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `4`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `4`</emu-grammar> or of <emu-grammar>HexDigit :: `4`</emu-grammar> or of <emu-grammar>OctalDigit :: `4`</emu-grammar> is 4.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `5`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `5`</emu-grammar> or of <emu-grammar>HexDigit :: `5`</emu-grammar> or of <emu-grammar>OctalDigit :: `5`</emu-grammar> is 5<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `5`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `5`</emu-grammar> or of <emu-grammar>HexDigit :: `5`</emu-grammar> or of <emu-grammar>OctalDigit :: `5`</emu-grammar> is 5.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `6`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `6`</emu-grammar> or of <emu-grammar>HexDigit :: `6`</emu-grammar> or of <emu-grammar>OctalDigit :: `6`</emu-grammar> is 6<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `6`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `6`</emu-grammar> or of <emu-grammar>HexDigit :: `6`</emu-grammar> or of <emu-grammar>OctalDigit :: `6`</emu-grammar> is 6.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `7`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `7`</emu-grammar> or of <emu-grammar>HexDigit :: `7`</emu-grammar> or of <emu-grammar>OctalDigit :: `7`</emu-grammar> is 7<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `7`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `7`</emu-grammar> or of <emu-grammar>HexDigit :: `7`</emu-grammar> or of <emu-grammar>OctalDigit :: `7`</emu-grammar> is 7.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `8`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `8`</emu-grammar> or of <emu-grammar>HexDigit :: `8`</emu-grammar> is 8<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `8`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `8`</emu-grammar> or of <emu-grammar>HexDigit :: `8`</emu-grammar> is 8.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalDigit :: `9`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `9`</emu-grammar> or of <emu-grammar>HexDigit :: `9`</emu-grammar> is 9<sub>ℝ</sub>.
+            The MV of <emu-grammar>DecimalDigit :: `9`</emu-grammar> or of <emu-grammar>NonZeroDigit :: `9`</emu-grammar> or of <emu-grammar>HexDigit :: `9`</emu-grammar> is 9.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `a`</emu-grammar> or of <emu-grammar>HexDigit :: `A`</emu-grammar> is 10<sub>ℝ</sub>.
+            The MV of <emu-grammar>HexDigit :: `a`</emu-grammar> or of <emu-grammar>HexDigit :: `A`</emu-grammar> is 10.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `b`</emu-grammar> or of <emu-grammar>HexDigit :: `B`</emu-grammar> is 11<sub>ℝ</sub>.
+            The MV of <emu-grammar>HexDigit :: `b`</emu-grammar> or of <emu-grammar>HexDigit :: `B`</emu-grammar> is 11.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `c`</emu-grammar> or of <emu-grammar>HexDigit :: `C`</emu-grammar> is 12<sub>ℝ</sub>.
+            The MV of <emu-grammar>HexDigit :: `c`</emu-grammar> or of <emu-grammar>HexDigit :: `C`</emu-grammar> is 12.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `d`</emu-grammar> or of <emu-grammar>HexDigit :: `D`</emu-grammar> is 13<sub>ℝ</sub>.
+            The MV of <emu-grammar>HexDigit :: `d`</emu-grammar> or of <emu-grammar>HexDigit :: `D`</emu-grammar> is 13.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `e`</emu-grammar> or of <emu-grammar>HexDigit :: `E`</emu-grammar> is 14<sub>ℝ</sub>.
+            The MV of <emu-grammar>HexDigit :: `e`</emu-grammar> or of <emu-grammar>HexDigit :: `E`</emu-grammar> is 14.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigit :: `f`</emu-grammar> or of <emu-grammar>HexDigit :: `F`</emu-grammar> is 15<sub>ℝ</sub>.
+            The MV of <emu-grammar>HexDigit :: `f`</emu-grammar> or of <emu-grammar>HexDigit :: `F`</emu-grammar> is 15.
           </li>
           <li>
             The MV of <emu-grammar>BinaryIntegerLiteral :: `0b` BinaryDigits</emu-grammar> is the MV of |BinaryDigits|.
@@ -11132,10 +11118,10 @@
             The MV of <emu-grammar>BinaryDigits :: BinaryDigit</emu-grammar> is the MV of |BinaryDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2<sub>ℝ</sub>) plus the MV of |BinaryDigit|.
+            The MV of <emu-grammar>BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2) plus the MV of |BinaryDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>BinaryDigits :: BinaryDigits NumericLiteralSeparator BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2<sub>ℝ</sub>) plus the MV of |BinaryDigit|.
+            The MV of <emu-grammar>BinaryDigits :: BinaryDigits NumericLiteralSeparator BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2) plus the MV of |BinaryDigit|.
           </li>
           <li>
             The MV of <emu-grammar>OctalIntegerLiteral :: `0o` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
@@ -11147,10 +11133,10 @@
             The MV of <emu-grammar>OctalDigits :: OctalDigit</emu-grammar> is the MV of |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8<sub>ℝ</sub>) plus the MV of |OctalDigit|.
+            The MV of <emu-grammar>OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8) plus the MV of |OctalDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>OctalDigits :: OctalDigits NumericLiteralSeparator OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8<sub>ℝ</sub>) plus the MV of |OctalDigit|.
+            The MV of <emu-grammar>OctalDigits :: OctalDigits NumericLiteralSeparator OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8) plus the MV of |OctalDigit|.
           </li>
           <li>
             The MV of <emu-grammar>HexIntegerLiteral :: `0x` HexDigits</emu-grammar> is the MV of |HexDigits|.
@@ -11162,13 +11148,13 @@
             The MV of <emu-grammar>HexDigits :: HexDigit</emu-grammar> is the MV of |HexDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16<sub>ℝ</sub>) plus the MV of |HexDigit|.
+            The MV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16) plus the MV of |HexDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>HexDigits :: HexDigits NumericLiteralSeparator HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16<sub>ℝ</sub>) plus the MV of |HexDigit|.
+            The MV of <emu-grammar>HexDigits :: HexDigits NumericLiteralSeparator HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16) plus the MV of |HexDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is (0x1000<sub>ℝ</sub> times the MV of the first |HexDigit|) plus (0x100<sub>ℝ</sub> times the MV of the second |HexDigit|) plus (0x10<sub>ℝ</sub> times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
+            The MV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is (0x1000 &times; the MV of the first |HexDigit|) plus (0x100 &times; the MV of the second |HexDigit|) plus (0x10 &times; the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
           </li>
         </ul>
       </emu-clause>
@@ -11183,13 +11169,13 @@
         <emu-alg>
           1. Return the Number value that results from rounding the MV of |NonDecimalIntegerLiteral| as described below.
         </emu-alg>
-        <p>Once the exact MV for a numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0<sub>ℝ</sub>, then the rounded value is *+0*; otherwise, the rounded value must be the Number value for the MV (as specified in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal is a |DecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit and then incrementing the literal at the 20th significant digit position. A digit is <em>significant</em> if it is not part of an |ExponentPart| and</p>
+        <p>Once the exact MV for a numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0*<sub>𝔽</sub>; otherwise, the rounded value must be the Number value for the MV (as specified in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal is a |DecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a `0` digit and then incrementing the literal at the 20th significant digit position. A digit is <em>significant</em> if it is not part of an |ExponentPart| and</p>
         <ul>
           <li>
             it is not `0`; or
           </li>
           <li>
-            there is a nonzero digit to its left and there is a nonzero digit, not in the |ExponentPart|, to its right.
+            there is a non-zero digit to its left and there is a non-zero digit, not in the |ExponentPart|, to its right.
           </li>
         </ul>
 
@@ -11199,7 +11185,7 @@
         </emu-alg>
         <emu-grammar>DecimalBigIntegerLiteral :: `0` BigIntLiteralSuffix</emu-grammar>
         <emu-alg>
-          1. Return the BigInt value that represents 0<sub>ℝ</sub>.
+          1. Return *0*<sub>ℤ</sub>.
         </emu-alg>
         <emu-grammar>DecimalBigIntegerLiteral :: NonZeroDigit BigIntLiteralSuffix</emu-grammar>
         <emu-alg>
@@ -11211,9 +11197,9 @@
             NonZeroDigit NumericLiteralSeparator DecimalDigits BigIntLiteralSuffix
         </emu-grammar>
         <emu-alg>
-          1. Let _n_ be the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
-          1. Let _mv_ be (the MV of |NonZeroDigit| &times; 10<sub>ℝ</sub><sup>_n_</sup>) plus the MV of |DecimalDigits|.
-          1. Return the BigInt value that represents _mv_.
+          1. Let _n_ be the number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
+          1. Let _mv_ be (the MV of |NonZeroDigit| &times; 10) plus the MV of |DecimalDigits|.
+          1. Return ℤ(_mv_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -11508,7 +11494,7 @@
             The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit whose value is (16<sub>ℝ</sub> times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
+            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit whose value is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
           </li>
           <li>
             The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit whose value is the MV of |Hex4Digits|.
@@ -12446,7 +12432,7 @@
         <emu-grammar>Elision : `,`</emu-grammar>
         <emu-alg>
           1. Let _len_ be _nextIndex_ + 1.
-          1. Perform ? Set(_array_, *"length"*, _len_, *true*).
+          1. Perform ? Set(_array_, *"length"*, 𝔽(_len_), *true*).
           1. NOTE: The above Set throws if _len_ exceeds 2<sup>32</sup>-1.
           1. Return _len_.
         </emu-alg>
@@ -12461,7 +12447,7 @@
             1. ReturnIfAbrupt(_nextIndex_).
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
-          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(_nextIndex_), _initValue_).
+          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
@@ -12480,7 +12466,7 @@
             1. ReturnIfAbrupt(_nextIndex_).
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
-          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(_nextIndex_), _initValue_).
+          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
@@ -12501,7 +12487,7 @@
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _nextIndex_.
             1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(_nextIndex_), _nextValue_).
+            1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _nextValue_).
             1. Set _nextIndex_ to _nextIndex_ + 1.
         </emu-alg>
         <emu-note>
@@ -13003,7 +12989,7 @@
           1. Let _rawObj_ be ! ArrayCreate(_count_).
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _count_,
-            1. Let _prop_ be ! ToString(_index_).
+            1. Let _prop_ be ! ToString(𝔽(_index_)).
             1. Let _cookedValue_ be _cookedStrings_[_index_].
             1. Perform ! DefinePropertyOrThrow(_template_, _prop_, PropertyDescriptor { [[Value]]: _cookedValue_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }).
             1. Let _rawValue_ be the String value _rawStrings_[_index_].
@@ -14331,7 +14317,7 @@
     <emu-clause id="sec-unary-minus-operator">
       <h1>Unary `-` Operator</h1>
       <emu-note>
-        <p>The unary `-` operator converts its operand to Number type and then negates it. Negating *+0* produces *-0*, and negating *-0* produces *+0*.</p>
+        <p>The unary `-` operator converts its operand to Number type and then negates it. Negating *+0*<sub>𝔽</sub> produces *-0*<sub>𝔽</sub>, and negating *-0*<sub>𝔽</sub> produces *+0*<sub>𝔽</sub>.</p>
       </emu-note>
 
       <emu-clause id="sec-unary-minus-operator-runtime-semantics-evaluation">
@@ -15632,7 +15618,7 @@
               1. Let _nextValue_ be IteratorValue(_next_).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
-              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _nextValue_).
+              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
               1. Set _n_ to _n_ + 1.
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Return ? PutValue(_lref_, _A_).
@@ -16944,7 +16930,7 @@
             1. Let _nextValue_ be IteratorValue(_next_).
             1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_nextValue_).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _nextValue_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
             1. Set _n_ to _n_ + 1.
         </emu-alg>
         <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
@@ -16962,7 +16948,7 @@
             1. Let _nextValue_ be IteratorValue(_next_).
             1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_nextValue_).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _nextValue_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
             1. Set _n_ to _n_ + 1.
         </emu-alg>
       </emu-clause>
@@ -22979,7 +22965,7 @@
                 </td>
                 <td>
                   Auxiliary field used during Link and Evaluate only.
-                  If [[Status]] is ~linking~ or ~evaluating~, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
+                  If [[Status]] is ~linking~ or ~evaluating~, this non-negative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
                 </td>
               </tr>
               <tr>
@@ -23066,7 +23052,7 @@
 
           <emu-clause id="sec-InnerModuleLinking" oldids="sec-innermoduleinstantiation" aoid="InnerModuleLinking">
             <h1>InnerModuleLinking ( _module_, _stack_, _index_ )</h1>
-            <p>The abstract operation InnerModuleLinking takes arguments _module_ (a Cyclic Module Record), _stack_, and _index_. It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together. It performs the following steps when called:</p>
+            <p>The abstract operation InnerModuleLinking takes arguments _module_ (a Cyclic Module Record), _stack_, and _index_ (a non-negative integer). It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together. It performs the following steps when called:</p>
 
             <emu-alg>
               1. If _module_ is not a Cyclic Module Record, then
@@ -23090,8 +23076,8 @@
                     1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? _module_.InitializeEnvironment().
               1. Assert: _module_ occurs exactly once in _stack_.
-              1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
-              1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
+              1. Assert: _module_.[[DFSAncestorIndex]] &le; _module_.[[DFSIndex]].
+              1. If _module_.[[DFSAncestorIndex]] = _module_.[[DFSIndex]], then
                 1. Let _done_ be *false*.
                 1. Repeat, while _done_ is *false*,
                   1. Let _requiredModule_ be the last element in _stack_.
@@ -23131,7 +23117,7 @@
 
           <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
             <h1>InnerModuleEvaluation ( _module_, _stack_, _index_ )</h1>
-            <p>The abstract operation InnerModuleEvaluation takes arguments _module_ (a Module Record), _stack_, and _index_. It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking. It performs the following steps when called:</p>
+            <p>The abstract operation InnerModuleEvaluation takes arguments _module_ (a Module Record), _stack_, and _index_ (a non-negative integer). It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking. It performs the following steps when called:</p>
 
             <emu-alg>
               1. If _module_ is not a Cyclic Module Record, then
@@ -23158,8 +23144,8 @@
                     1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? _module_.ExecuteModule().
               1. Assert: _module_ occurs exactly once in _stack_.
-              1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
-              1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
+              1. Assert: _module_.[[DFSAncestorIndex]] &le; _module_.[[DFSIndex]].
+              1. If _module_.[[DFSAncestorIndex]] = _module_.[[DFSIndex]], then
                 1. Let _done_ be *false*.
                 1. Repeat, while _done_ is *false*,
                   1. Let _requiredModule_ be the last element in _stack_.
@@ -23946,7 +23932,6 @@
       <emu-clause id="sec-hostimportmoduledynamically" aoid="HostImportModuleDynamically">
         <h1>HostImportModuleDynamically ( _referencingScriptOrModule_, _specifier_, _promiseCapability_ )</h1>
         <p>HostImportModuleDynamically is a host-defined abstract operation that performs any necessary setup work in order to make available the module corresponding to the |ModuleSpecifier| String, _specifier_, occurring within the context of the script or module represented by the Script Record or Module Record _referencingScriptOrModule_. (_referencingScriptOrModule_ may also be *null*, if there is no active script or module when the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression occurs.) It then performs FinishDynamicImport to finish the dynamic import process.</p>
-
         <p>The implementation of HostImportModuleDynamically must conform to the following requirements:</p>
 
         <ul>
@@ -23991,7 +23976,6 @@
       <emu-clause id="sec-finishdynamicimport" aoid="FinishDynamicImport">
         <h1>FinishDynamicImport ( _referencingScriptOrModule_, _specifier_, _promiseCapability_, _completion_ )</h1>
         <p>The abstract operation FinishDynamicImport takes arguments _referencingScriptOrModule_, _specifier_, _promiseCapability_ (a PromiseCapability Record), and _completion_. FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically. It performs the following steps when called:</p>
-
         <emu-alg>
           1. If _completion_ is an abrupt completion, then perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
           1. Else,
@@ -24729,7 +24713,7 @@
   <p>Unless otherwise specified every built-in prototype object has the Object prototype object, which is the initial value of the expression `Object.prototype` (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>), as the value of its [[Prototype]] internal slot, except the Object prototype object itself.</p>
   <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function.</p>
   <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>).</p>
-  <p>Every built-in function object, including constructors, has a *"length"* property whose value is a non-negative integer. Unless otherwise specified, this value is equal to the number of required parameters shown in the subclause headings for the function description. Optional parameters and rest parameters are not included in the parameter count.</p>
+  <p>Every built-in function object, including constructors, has a *"length"* property whose value is a non-negative integral Number. Unless otherwise specified, this value is equal to the number of required parameters shown in the subclause headings for the function description. Optional parameters and rest parameters are not included in the parameter count.</p>
   <emu-note>
     <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading &laquo;Array.prototype.map (callbackFn [ , thisArg])&raquo; which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is 1.</p>
   </emu-note>
@@ -24762,7 +24746,7 @@
 
     <emu-clause id="sec-value-properties-of-the-global-object-infinity">
       <h1>Infinity</h1>
-      <p>The value of `Infinity` is *+&infin;* (see <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>). This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      <p>The value of `Infinity` is *+&infin;*<sub>𝔽</sub> (see <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>). This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
     <emu-clause id="sec-value-properties-of-the-global-object-nan">
@@ -24850,7 +24834,6 @@
       <emu-clause id="sec-hostensurecancompilestrings" aoid="HostEnsureCanCompileStrings">
         <h1>HostEnsureCanCompileStrings ( _callerRealm_, _calleeRealm_ )</h1>
         <p>HostEnsureCanCompileStrings is a host-defined abstract operation that allows host environments to block certain ECMAScript functions which allow developers to compile strings into ECMAScript code.</p>
-
         <p>An implementation of HostEnsureCanCompileStrings may complete normally or abruptly. Any abrupt completions will be propagated to its callers. The default implementation of HostEnsureCanCompileStrings is to unconditionally return an empty normal completion.</p>
       </emu-clause>
 
@@ -24950,7 +24933,7 @@
       <p>The `isFinite` function is the <dfn>%isFinite%</dfn> intrinsic object. When the `isFinite` function is called with one argument _number_, the following steps are taken:</p>
       <emu-alg>
         1. Let _num_ be ? ToNumber(_number_).
-        1. If _num_ is *NaN*, *+&infin;*, or *-&infin;*, return *false*.
+        1. If _num_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
         1. Otherwise, return *true*.
       </emu-alg>
     </emu-clause>
@@ -24978,10 +24961,10 @@
         1. If neither _trimmedString_ nor any prefix of _trimmedString_ satisfies the syntax of a |StrDecimalLiteral| (see <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>), return *NaN*.
         1. Let _numberString_ be the longest prefix of _trimmedString_, which might be _trimmedString_ itself, that satisfies the syntax of a |StrDecimalLiteral|.
         1. Let _mathFloat_ be MV of _numberString_.
-        1. If _mathFloat_ = 0<sub>ℝ</sub>, then
-          1. If the first code unit of _trimmedString_ is the code unit 0x002D (HYPHEN-MINUS), return *-0*.
-          1. Return *+0*.
-        1. Return the Number value for _mathFloat_.
+        1. If _mathFloat_ = 0, then
+          1. If the first code unit of _trimmedString_ is the code unit 0x002D (HYPHEN-MINUS), return *-0*<sub>𝔽</sub>.
+          1. Return *+0*<sub>𝔽</sub>.
+        1. Return 𝔽(_mathFloat_).
       </emu-alg>
       <emu-note>
         <p>`parseFloat` may interpret only a leading portion of _string_ as a Number value; it ignores any code units that cannot be interpreted as part of the notation of a decimal literal, and no indication is given that any such code units were ignored.</p>
@@ -24990,7 +24973,7 @@
 
     <emu-clause id="sec-parseint-string-radix">
       <h1>parseInt ( _string_, _radix_ )</h1>
-      <p>The `parseInt` function produces an integer value dictated by interpretation of the contents of the _string_ argument according to the specified _radix_. Leading white space in _string_ is ignored. If _radix_ is *undefined* or 0, it is assumed to be 10 except when the number begins with the code unit pairs `0x` or `0X`, in which case a radix of 16 is assumed. If _radix_ is 16, the number may also optionally begin with the code unit pairs `0x` or `0X`.</p>
+      <p>The `parseInt` function produces an integral Number dictated by interpretation of the contents of the _string_ argument according to the specified _radix_. Leading white space in _string_ is ignored. If _radix_ is *undefined* or 0, it is assumed to be 10 except when the number begins with the code unit pairs `0x` or `0X`, in which case a radix of 16 is assumed. If _radix_ is 16, the number may also optionally begin with the code unit pairs `0x` or `0X`.</p>
       <p>The `parseInt` function is the <dfn>%parseInt%</dfn> intrinsic object. When the `parseInt` function is called, the following steps are taken:</p>
       <emu-alg>
         1. Let _inputString_ be ? ToString(_string_).
@@ -24998,7 +24981,7 @@
         1. Let _sign_ be 1.
         1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002D (HYPHEN-MINUS), set _sign_ to -1.
         1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), remove the first code unit from _S_.
-        1. Let _R_ be ? ToInt32(_radix_).
+        1. Let _R_ be ℝ(? ToInt32(_radix_)).
         1. Let _stripPrefix_ be *true*.
         1. If _R_ &ne; 0, then
           1. If _R_ &lt; 2 or _R_ &gt; 36, return *NaN*.
@@ -25012,12 +24995,11 @@
         1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; otherwise, let _end_ be the length of _S_.
         1. Let _Z_ be the substring of _S_ from 0 to _end_.
         1. If _Z_ is empty, return *NaN*.
-        1. Let _mathInt_ be the mathematical integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b>-<b>Z</b> and <b>a</b>-<b>z</b> for digits with values 10 through 35. (However, if _R_ is 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated value representing the mathematical integer value that is represented by _Z_ in radix-_R_ notation.)
-        1. If _mathInt_ = 0<sub>ℝ</sub>, then
-          1. If _sign_ = -1, return *-0*.
-          1. Return *+0*.
-        1. Let _number_ be the Number value for _mathInt_.
-        1. Return _sign_ &times; _number_.
+        1. Let _mathInt_ be the integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b>-<b>Z</b> and <b>a</b>-<b>z</b> for digits with values 10 through 35. (However, if _R_ is 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated value representing the integer value that is represented by _Z_ in radix-_R_ notation.)
+        1. If _mathInt_ = 0, then
+          1. If _sign_ = -1, return *-0*<sub>𝔽</sub>.
+          1. Return *+0*<sub>𝔽</sub>.
+        1. Return 𝔽(_sign_ &times; _mathInt_).
       </emu-alg>
       <emu-note>
         <p>`parseInt` may interpret only a leading portion of _string_ as an integer value; it ignores any code units that cannot be interpreted as part of the notation of an integer, and no indication is given that any such code units were ignored.</p>
@@ -25084,7 +25066,7 @@
             1. Let _R_ be the empty String.
             1. Let _k_ be 0.
             1. Repeat,
-              1. If _k_ equals _strLen_, return _R_.
+              1. If _k_ = _strLen_, return _R_.
               1. Let _C_ be the code unit at index _k_ within _string_.
               1. If _C_ is in _unescapedSet_, then
                 1. Set _k_ to _k_ + 1.
@@ -25110,13 +25092,13 @@
             1. Let _R_ be the empty String.
             1. Let _k_ be 0.
             1. Repeat,
-              1. If _k_ equals _strLen_, return _R_.
+              1. If _k_ = _strLen_, return _R_.
               1. Let _C_ be the code unit at index _k_ within _string_.
               1. If _C_ is not the code unit 0x0025 (PERCENT SIGN), then
                 1. Let _S_ be the String value containing only the code unit _C_.
               1. Else,
                 1. Let _start_ be _k_.
-                1. If _k_ + 2 is greater than or equal to _strLen_, throw a *URIError* exception.
+                1. If _k_ + 2 &ge; _strLen_, throw a *URIError* exception.
                 1. If the code units at index (_k_ + 1) and (_k_ + 2) within _string_ do not represent hexadecimal digits, throw a *URIError* exception.
                 1. Let _B_ be the 8-bit value represented by the two hexadecimal digits at index (_k_ + 1) and (_k_ + 2).
                 1. Set _k_ to _k_ + 2.
@@ -25129,7 +25111,7 @@
                     1. Let _S_ be the substring of _string_ from _start_ to _k_ + 1.
                 1. Else,
                   1. If _n_ = 1 or _n_ &gt; 4, throw a *URIError* exception.
-                  1. If _k_ + (3 &times; (_n_ - 1)) is greater than or equal to _strLen_, throw a *URIError* exception.
+                  1. If _k_ + (3 &times; (_n_ - 1)) &ge; _strLen_, throw a *URIError* exception.
                   1. Let _Octets_ be a List whose sole element is _B_.
                   1. Let _j_ be 1.
                   1. Repeat, while _j_ &lt; _n_,
@@ -25142,7 +25124,7 @@
                     1. Set _j_ to _j_ + 1.
                   1. Assert: The length of _Octets_ is _n_.
                   1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
-                  1. Let _V_ be the value obtained by applying the UTF-8 transformation to _Octets_, that is, from a List of octets into a 21-bit value.
+                  1. Let _V_ be the code point obtained by applying the UTF-8 transformation to _Octets_, that is, from a List of octets into a 21-bit value.
                   1. Let _S_ be the String value whose code units are the elements in CodePointToUTF16CodeUnits(_V_).
               1. Set _R_ to the string-concatenation of _R_ and _S_.
               1. Set _k_ to _k_ + 1.
@@ -25626,7 +25608,7 @@
           1. If _value_ is *undefined* or *null*, return ! OrdinaryObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
-        <p>The *"length"* property of the `Object` function is 1.</p>
+        <p>The *"length"* property of the `Object` function is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
     </emu-clause>
 
@@ -25656,7 +25638,7 @@
                   1. Perform ? Set(_to_, _nextKey_, _propValue_, *true*).
           1. Return _to_.
         </emu-alg>
-        <p>The *"length"* property of the `assign` function is 2.</p>
+        <p>The *"length"* property of the `assign` function is *2*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-object.create">
@@ -26245,9 +26227,13 @@
           1. If _targetHasLength_ is *true*, then
             1. Let _targetLen_ be ? Get(_Target_, *"length"*).
             1. If Type(_targetLen_) is Number, then
-              1. Set _targetLen_ to ! ToInteger(_targetLen_).
-              1. Let _argCount_ be the number of elements in _args_.
-              1. Set _L_ to max(_targetLen_ - _argCount_, 0).
+              1. If _targetLen_ is *+&infin;*<sub>𝔽</sub>, set _L_ to +&infin;.
+              1. Else if _targetLen_ is *-&infin;*<sub>𝔽</sub>, set _L_ to 0.
+              1. Else,
+                1. Let _targetLenAsInt_ be ! ToIntegerOrInfinity(_targetLen_).
+                1. Assert: _targetLenAsInt_ is finite.
+                1. Let _argCount_ be the number of elements in _args_.
+                1. Set _L_ to max(_targetLenAsInt_ - _argCount_, 0).
           1. Perform ! SetFunctionLength(_F_, _L_).
           1. Let _targetName_ be ? Get(_Target_, *"name"*).
           1. If Type(_targetName_) is not String, set _targetName_ to the empty String.
@@ -26337,7 +26323,7 @@
 
       <emu-clause id="sec-function-instances-length">
         <h1>length</h1>
-        <p>The value of the *"length"* property is an integer that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a function when invoked on a number of arguments other than the number specified by its *"length"* property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The value of the *"length"* property is an integral Number that indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with some other number of arguments. The behaviour of a function when invoked on a number of arguments other than the number specified by its *"length"* property depends on the function. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-function-instances-name">
@@ -27040,10 +27026,10 @@
         <emu-alg>
           1. If _value_ is present, then
             1. Let _prim_ be ? ToNumeric(_value_).
-            1. If Type(_prim_) is BigInt, let _n_ be the Number value for the mathematical value of _prim_.
+            1. If Type(_prim_) is BigInt, let _n_ be 𝔽(ℝ(_prim_)).
             1. Otherwise, let _n_ be _prim_.
           1. Else,
-            1. Let _n_ be *+0*.
+            1. Let _n_ be *+0*<sub>𝔽</sub>.
           1. If NewTarget is *undefined*, return _n_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Number.prototype%"*, &laquo; [[NumberData]] &raquo;).
           1. Set _O_.[[NumberData]] to _n_.
@@ -27062,7 +27048,7 @@
 
       <emu-clause id="sec-number.epsilon">
         <h1>Number.EPSILON</h1>
-        <p>The value of `Number.EPSILON` is the difference between 1 and the smallest value greater than 1 that is representable as a Number value, which is approximately 2.2204460492503130808472633361816 &times; 10<sup>-16</sup>.</p>
+        <p>The value of `Number.EPSILON` is the Number value for the difference between 1 and the smallest value greater than 1 that is representable as a Number value, which is approximately 2.2204460492503130808472633361816 &times; 10<sup>-16</sup>.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -27071,7 +27057,7 @@
         <p>When `Number.isFinite` is called with one argument _number_, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_number_) is not Number, return *false*.
-          1. If _number_ is *NaN*, *+&infin;*, or *-&infin;*, return *false*.
+          1. If _number_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
           1. Otherwise, return *true*.
         </emu-alg>
       </emu-clause>
@@ -27080,7 +27066,7 @@
         <h1>Number.isInteger ( _number_ )</h1>
         <p>When `Number.isInteger` is called with one argument _number_, the following steps are taken:</p>
         <emu-alg>
-          1. Return ! IsInteger(_number_).
+          1. Return ! IsIntegralNumber(_number_).
         </emu-alg>
       </emu-clause>
 
@@ -27101,8 +27087,8 @@
         <h1>Number.isSafeInteger ( _number_ )</h1>
         <p>When `Number.isSafeInteger` is called with one argument _number_, the following steps are taken:</p>
         <emu-alg>
-          1. If ! IsInteger(_number_) is *true*, then
-            1. If abs(_number_) &le; 2<sup>53</sup> - 1, return *true*.
+          1. If ! IsIntegralNumber(_number_) is *true*, then
+            1. If abs(ℝ(_number_)) &le; 2<sup>53</sup> - 1, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -27110,9 +27096,9 @@
       <emu-clause id="sec-number.max_safe_integer">
         <h1>Number.MAX_SAFE_INTEGER</h1>
         <emu-note>
-          <p>The value of `Number.MAX_SAFE_INTEGER` is the largest integer n such that n and n + 1 are both exactly representable as a Number value.</p>
+          <p>The value of `Number.MAX_SAFE_INTEGER` is the largest integral Number n such that ℝ(n) and ℝ(n) + 1 are both exactly representable as a Number value.</p>
         </emu-note>
-        <p>The value of `Number.MAX_SAFE_INTEGER` is 9007199254740991 (2<sup>53</sup> - 1).</p>
+        <p>The value of `Number.MAX_SAFE_INTEGER` is *9007199254740991*<sub>𝔽</sub> (𝔽(2<sup>53</sup> - 1)).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -27125,9 +27111,9 @@
       <emu-clause id="sec-number.min_safe_integer">
         <h1>Number.MIN_SAFE_INTEGER</h1>
         <emu-note>
-          <p>The value of `Number.MIN_SAFE_INTEGER` is the smallest integer n such that n and n - 1 are both exactly representable as a Number value.</p>
+          <p>The value of `Number.MIN_SAFE_INTEGER` is the smallest integral Number n such that ℝ(n) and ℝ(n) - 1 are both exactly representable as a Number value.</p>
         </emu-note>
-        <p>The value of `Number.MIN_SAFE_INTEGER` is -9007199254740991 (-(2<sup>53</sup> - 1)).</p>
+        <p>The value of `Number.MIN_SAFE_INTEGER` is *-9007199254740991*<sub>𝔽</sub> (𝔽(-(2<sup>53</sup> - 1))).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -27146,7 +27132,7 @@
 
       <emu-clause id="sec-number.negative_infinity">
         <h1>Number.NEGATIVE_INFINITY</h1>
-        <p>The value of `Number.NEGATIVE_INFINITY` is *-&infin;*.</p>
+        <p>The value of `Number.NEGATIVE_INFINITY` is *-&infin;*<sub>𝔽</sub>.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -27162,7 +27148,7 @@
 
       <emu-clause id="sec-number.positive_infinity">
         <h1>Number.POSITIVE_INFINITY</h1>
-        <p>The value of `Number.POSITIVE_INFINITY` is *+&infin;*.</p>
+        <p>The value of `Number.POSITIVE_INFINITY` is *+&infin;*<sub>𝔽</sub>.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -27179,7 +27165,7 @@
       <ul>
         <li>is <dfn>%Number.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
-        <li>is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</li>
+        <li>is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*<sub>𝔽</sub>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
@@ -27204,10 +27190,11 @@
         <p>Return a String containing this Number value represented in decimal exponential notation with one digit before the significand's decimal point and _fractionDigits_ digits after the significand's decimal point. If _fractionDigits_ is *undefined*, include as many significand digits as necessary to uniquely specify the Number (just like in ToString except that in this case the Number is always output in exponential notation). Specifically, perform the following steps:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
-          1. Let _f_ be ? ToInteger(_fractionDigits_).
+          1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
           1. If _x_ is not finite, return ! Number::toString(_x_).
           1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
+          1. Set _x_ to ℝ(_x_).
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
             1. Set _s_ to *"-"*.
@@ -27217,9 +27204,9 @@
             1. Let _e_ be 0.
           1. Else,
             1. If _fractionDigits_ is not *undefined*, then
-              1. Let _e_ and _n_ be integers such that 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup> and for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_n_)</sup> - ℝ(_x_) is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is larger.
+              1. Let _e_ and _n_ be integers such that 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup> and for which _n_ &times; 10<sup>_e_ - _n_</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ &times; 10<sup>_e_ - _f_</sup> is larger.
             1. Else,
-              1. [id="step-number-proto-toexponential-intermediate-values"] Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is _x_, and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1<sub>ℝ</sub> digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
+              1. [id="step-number-proto-toexponential-intermediate-values"] Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, _n_ &times; 10<sup>_e_ - _f_</sup> is _x_, and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1 digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
             1. Let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. If _f_ &ne; 0, then
             1. Let _a_ be the first code unit of _m_.
@@ -27241,7 +27228,7 @@
         <emu-note>
           <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step <emu-xref href="#step-number-proto-toexponential-intermediate-values"></emu-xref> be used as a guideline:</p>
           <emu-alg replaces-step="step-number-proto-toexponential-intermediate-values">
-            1. Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is _x_, and _f_ is as small as possible. If there are multiple possibilities for _n_, choose the value of _n_ for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is closest in value to _x_. If there are two such possible values of _n_, choose the one that is even.
+            1. Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, _n_ &times; 10<sup>_e_ - _f_</sup> is _x_, and _f_ is as small as possible. If there are multiple possibilities for _n_, choose the value of _n_ for which _n_ &times; 10<sup>_e_ - _f_</sup> is closest in value to _x_. If there are two such possible values of _n_, choose the one that is even.
           </emu-alg>
         </emu-note>
       </emu-clause>
@@ -27254,18 +27241,20 @@
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
-          1. Let _f_ be ? ToInteger(_fractionDigits_).
+          1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
+          1. If _f_ is not finite, throw a *RangeError* exception.
           1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
           1. If _x_ is not finite, return ! Number::toString(_x_).
+          1. Set _x_ to ℝ(_x_).
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
             1. Set _s_ to *"-"*.
             1. Set _x_ to -_x_.
           1. If _x_ &ge; 10<sup>21</sup>, then
-            1. Let _m_ be ! ToString(_x_).
+            1. Let _m_ be ! ToString(𝔽(_x_)).
           1. Else,
-            1. Let _n_ be an integer for which ℝ(_n_) &divide; 10<sub>ℝ</sub><sup>ℝ(_f_)</sup> - ℝ(_x_) is as close to zero as possible. If there are two such _n_, pick the larger _n_.
+            1. Let _n_ be an integer for which _n_ &divide; 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
             1. If _n_ = 0, let _m_ be the String *"0"*. Otherwise, let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _f_ &ne; 0, then
               1. Let _k_ be the length of _m_.
@@ -27279,7 +27268,7 @@
           1. Return the string-concatenation of _s_ and _m_.
         </emu-alg>
         <emu-note>
-          <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent number values. For example,</p>
+          <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent Number values. For example,</p>
           <p>`(1000000000000000128).toString()` returns *"1000000000000000100"*, while
             <br>
             `(1000000000000000128).toFixed(0)` returns *"1000000000000000128"*.</p>
@@ -27299,9 +27288,10 @@
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. If _precision_ is *undefined*, return ! ToString(_x_).
-          1. Let _p_ be ? ToInteger(_precision_).
+          1. Let _p_ be ? ToIntegerOrInfinity(_precision_).
           1. If _x_ is not finite, return ! Number::toString(_x_).
           1. If _p_ &lt; 1 or _p_ &gt; 100, throw a *RangeError* exception.
+          1. Set _x_ to ℝ(_x_).
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
             1. Set _s_ to the code unit 0x002D (HYPHEN-MINUS).
@@ -27310,7 +27300,7 @@
             1. Let _m_ be the String value consisting of _p_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _e_ be 0.
           1. Else,
-            1. Let _e_ and _n_ be integers such that 10<sup>_p_ - 1</sup> &le; _n_ &lt; 10<sup>_p_</sup> and for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_p_) + 1<sub>ℝ</sub></sup> - ℝ(_x_) is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_p_) + 1<sub>ℝ</sub></sup> is larger.
+            1. Let _e_ and _n_ be integers such that 10<sup>_p_ - 1</sup> &le; _n_ &lt; 10<sup>_p_</sup> and for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> is larger.
             1. Let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _e_ &lt; -6 or _e_ &ge; _p_, then
               1. Assert: _e_ &ne; 0.
@@ -27338,19 +27328,19 @@
       <emu-clause id="sec-number.prototype.tostring">
         <h1>Number.prototype.toString ( [ _radix_ ] )</h1>
         <emu-note>
-          <p>The optional _radix_ should be an integer value in the inclusive range 2 to 36. If _radix_ is *undefined* the Number 10 is used as the value of _radix_.</p>
+          <p>The optional _radix_ should be an integral Number value in the inclusive range *2*<sub>𝔽</sub> to *36*<sub>𝔽</sub>. If _radix_ is *undefined* then *10*<sub>𝔽</sub> is used as the value of _radix_.</p>
         </emu-note>
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
-          1. If _radix_ is *undefined*, let _radixNumber_ be 10.
-          1. Else, let _radixNumber_ be ? ToInteger(_radix_).
-          1. If _radixNumber_ &lt; 2 or _radixNumber_ &gt; 36, throw a *RangeError* exception.
-          1. If _radixNumber_ = 10, return ! ToString(_x_).
-          1. Return the String representation of this Number value using the radix specified by _radixNumber_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-number-tostring"></emu-xref>.
+          1. If _radix_ is *undefined*, let _radixMV_ be 10.
+          1. Else, let _radixMV_ be ? ToIntegerOrInfinity(_radix_).
+          1. If _radixMV_ &lt; 2 or _radixMV_ &gt; 36, throw a *RangeError* exception.
+          1. If _radixMV_ = 10, return ! ToString(_x_).
+          1. Return the String representation of this Number value using the radix specified by _radixMV_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-number-tostring"></emu-xref>.
         </emu-alg>
         <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Number or a Number object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
-        <p>The *"length"* property of the `toString` method is 1.</p>
+        <p>The *"length"* property of the `toString` method is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.prototype.valueof">
@@ -27391,11 +27381,10 @@
 
         <emu-clause id="sec-numbertobigint" aoid="NumberToBigInt">
           <h1>NumberToBigInt ( _number_ )</h1>
-          <p>The abstract operation NumberToBigInt takes argument _number_. It performs the following steps when called:</p>
+          <p>The abstract operation NumberToBigInt takes argument _number_ (a Number). It performs the following steps when called:</p>
           <emu-alg>
-            1. Assert: Type(_number_) is Number.
-            1. If IsInteger(_number_) is *false*, throw a *RangeError* exception.
-            1. Return the BigInt value that represents the mathematical value of _number_.
+            1. If IsIntegralNumber(_number_) is *false*, throw a *RangeError* exception.
+            1. Return the BigInt value that represents ℝ(_number_).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -27412,8 +27401,8 @@
         <emu-alg>
           1. Set _bits_ to ? ToIndex(_bits_).
           1. Set _bigint_ to ? ToBigInt(_bigint_).
-          1. Let _mod_ be the BigInt value that represents _bigint_ modulo 2<sup>_bits_</sup>.
-          1. If _mod_ &ge; 2<sup>_bits_ - 1</sup>, return _mod_ - 2<sup>_bits_</sup>; otherwise, return _mod_.
+          1. Let _mod_ be ℝ(_bigint_) modulo 2<sup>_bits_</sup>.
+          1. If _mod_ &ge; 2<sup>_bits_ - 1</sup>, return ℤ(_mod_ - 2<sup>_bits_</sup>); otherwise, return ℤ(_mod_).
         </emu-alg>
       </emu-clause>
 
@@ -27423,7 +27412,7 @@
         <emu-alg>
           1. Set _bits_ to ? ToIndex(_bits_).
           1. Set _bigint_ to ? ToBigInt(_bigint_).
-          1. Return the BigInt value that represents _bigint_ modulo 2<sup>_bits_</sup>.
+          1. Return the BigInt value that represents ℝ(_bigint_) modulo 2<sup>_bits_</sup>.
         </emu-alg>
       </emu-clause>
 
@@ -27468,16 +27457,16 @@
       <emu-clause id="sec-bigint.prototype.tostring">
         <h1>BigInt.prototype.toString ( [ _radix_ ] )</h1>
         <emu-note>
-          <p>The optional _radix_ should be an integer value in the inclusive range 2 to 36. If _radix_ is *undefined* the Number 10 is used as the value of _radix_.</p>
+          <p>The optional _radix_ should be an integral Number value in the inclusive range *2*<sub>𝔽</sub> to *36*<sub>𝔽</sub>. If _radix_ is *undefined* then *10*<sub>𝔽</sub> is used as the value of _radix_.</p>
         </emu-note>
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _x_ be ? thisBigIntValue(*this* value).
-          1. If _radix_ is *undefined*, let _radixNumber_ be 10.
-          1. Else, let _radixNumber_ be ? ToInteger(_radix_).
-          1. If _radixNumber_ &lt; 2 or _radixNumber_ &gt; 36, throw a *RangeError* exception.
-          1. If _radixNumber_ = 10, return ! ToString(_x_).
-          1. Return the String representation of this Number value using the radix specified by _radixNumber_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-bigint-tostring"></emu-xref>.
+          1. If _radix_ is *undefined*, let _radixMV_ be 10.
+          1. Else, let _radixMV_ be ? ToIntegerOrInfinity(_radix_).
+          1. If _radixMV_ &lt; 2 or _radixMV_ &gt; 36, throw a *RangeError* exception.
+          1. If _radixMV_ = 10, return ! ToString(_x_).
+          1. Return the String representation of this Number value using the radix specified by _radixMV_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-bigint-tostring"></emu-xref>.
         </emu-alg>
         <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a BigInt or a BigInt object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
       </emu-clause>
@@ -27518,25 +27507,25 @@
 
       <emu-clause id="sec-math.e">
         <h1>Math.E</h1>
-        <p>The Number value for _e_<sub>ℝ</sub>, the base of the natural logarithms, which is approximately 2.7182818284590452354.</p>
+        <p>The Number value for _e_, the base of the natural logarithms, which is approximately 2.7182818284590452354.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.ln10">
         <h1>Math.LN10</h1>
-        <p>The Number value for the natural logarithm of 10<sub>ℝ</sub>, which is approximately 2.302585092994046.</p>
+        <p>The Number value for the natural logarithm of 10, which is approximately 2.302585092994046.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.ln2">
         <h1>Math.LN2</h1>
-        <p>The Number value for the natural logarithm of 2<sub>ℝ</sub>, which is approximately 0.6931471805599453.</p>
+        <p>The Number value for the natural logarithm of 2, which is approximately 0.6931471805599453.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.log10e">
         <h1>Math.LOG10E</h1>
-        <p>The Number value for the base-10 logarithm of _e_<sub>ℝ</sub>, the base of the natural logarithms; this value is approximately 0.4342944819032518.</p>
+        <p>The Number value for the base-10 logarithm of _e_, the base of the natural logarithms; this value is approximately 0.4342944819032518.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>The value of `Math.LOG10E` is approximately the reciprocal of the value of `Math.LN10`.</p>
@@ -27545,7 +27534,7 @@
 
       <emu-clause id="sec-math.log2e">
         <h1>Math.LOG2E</h1>
-        <p>The Number value for the base-2 logarithm of _e_<sub>ℝ</sub>, the base of the natural logarithms; this value is approximately 1.4426950408889634.</p>
+        <p>The Number value for the base-2 logarithm of _e_, the base of the natural logarithms; this value is approximately 1.4426950408889634.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>The value of `Math.LOG2E` is approximately the reciprocal of the value of `Math.LN2`.</p>
@@ -27554,13 +27543,13 @@
 
       <emu-clause id="sec-math.pi">
         <h1>Math.PI</h1>
-        <p>The Number value for &pi;<sub>ℝ</sub>, the ratio of the circumference of a circle to its diameter, which is approximately 3.1415926535897932.</p>
+        <p>The Number value for &pi;, the ratio of the circumference of a circle to its diameter, which is approximately 3.1415926535897932.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.sqrt1_2">
         <h1>Math.SQRT1_2</h1>
-        <p>The Number value for the square root of &frac12;<sub>ℝ</sub>, which is approximately 0.7071067811865476.</p>
+        <p>The Number value for the square root of &frac12;, which is approximately 0.7071067811865476.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>The value of `Math.SQRT1_2` is approximately the reciprocal of the value of `Math.SQRT2`.</p>
@@ -27569,7 +27558,7 @@
 
       <emu-clause id="sec-math.sqrt2">
         <h1>Math.SQRT2</h1>
-        <p>The Number value for the square root of 2<sub>ℝ</sub>, which is approximately 1.4142135623730951.</p>
+        <p>The Number value for the square root of 2, which is approximately 1.4142135623730951.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -27594,22 +27583,22 @@
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, return *NaN*.
-          1. If _n_ is *-0*, return *+0*.
-          1. If _n_ is *-&infin;*, return *+&infin;*.
-          1. If _n_ &lt; 0, return -_n_.
+          1. If _n_ is *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. If _n_ is *-&infin;*<sub>𝔽</sub>, return *+&infin;*<sub>𝔽</sub>.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub>, return -_n_.
           1. Return _n_.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-math.acos">
         <h1>Math.acos ( _x_ )</h1>
-        <p>Returns the inverse cosine of _x_. The result is expressed in radians and ranges from *+0* to +&pi;, inclusive.</p>
+        <p>Returns the inverse cosine of _x_. The result is expressed in radians and ranges from *+0*<sub>𝔽</sub> to 𝔽(&pi;), inclusive.</p>
         <p>When the `Math.acos` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ &gt; 1, or _n_ &lt; -1, return *NaN*.
-          1. If _n_ is 1, return *+0*.
-          1. Return an implementation-approximated value representing the result of the inverse cosine of _n_.
+          1. If _n_ is *NaN*, _n_ &gt; *1*<sub>𝔽</sub>, or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
+          1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. Return an implementation-approximated value representing the result of the inverse cosine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27619,22 +27608,22 @@
         <p>When the `Math.acosh` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+&infin;*, return _n_.
-          1. If _n_ is 1, return *+0*.
-          1. If _n_ &lt; 1, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the inverse hyperbolic cosine of _n_.
+          1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. If _n_ &lt; *1*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the inverse hyperbolic cosine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-math.asin">
         <h1>Math.asin ( _x_ )</h1>
-        <p>Returns the inverse sine of _x_. The result is expressed in radians and ranges from -&pi; / 2 to +&pi; / 2, inclusive.</p>
+        <p>Returns the inverse sine of _x_. The result is expressed in radians and ranges from 𝔽(-&pi; / 2) to 𝔽(&pi; / 2), inclusive.</p>
         <p>When the `Math.asin` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, or _n_ is *-0*, return _n_.
-          1. If _n_ &gt; 1 or _n_ &lt; -1, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the inverse sine of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ &gt; *1*<sub>𝔽</sub> or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the inverse sine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27644,21 +27633,21 @@
         <p>When the `Math.asinh` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
-          1. Return an implementation-approximated value representing the result of the inverse hyperbolic sine of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. Return an implementation-approximated value representing the result of the inverse hyperbolic sine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-math.atan">
         <h1>Math.atan ( _x_ )</h1>
-        <p>Returns the inverse tangent of _x_. The result is expressed in radians and ranges from -&pi; / 2 to +&pi; / 2, inclusive.</p>
+        <p>Returns the inverse tangent of _x_. The result is expressed in radians and ranges from 𝔽(-&pi; / 2) to 𝔽(&pi; / 2), inclusive.</p>
         <p>When the `Math.atan` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, or _n_ is *-0*, return _n_.
-          1. If _n_ is *+&infin;*, return an implementation-approximated value representing +&pi; / 2.
-          1. If _n_ is *-&infin;*, return an implementation-approximated value representing -&pi; / 2.
-          1. Return an implementation-approximated value representing the result of the inverse tangent of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *+&infin;*<sub>𝔽</sub>, return an implementation-approximated value representing &pi; / 2.
+          1. If _n_ is *-&infin;*<sub>𝔽</sub>, return an implementation-approximated value representing -&pi; / 2.
+          1. Return an implementation-approximated value representing the result of the inverse tangent of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27668,11 +27657,11 @@
         <p>When the `Math.atanh` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, or _n_ is *-0*, return _n_.
-          1. If _n_ &gt; 1 or _n_ &lt; -1, return *NaN*.
-          1. If _n_ is +1, return *+&infin;*.
-          1. If _n_ is -1, return *-&infin;*.
-          1. Return an implementation-approximated value representing the result of the inverse hyperbolic tangent of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ &gt; *1*<sub>𝔽</sub> or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
+          1. If _n_ is *1*<sub>𝔽</sub>, return *+&infin;*<sub>𝔽</sub>.
+          1. If _n_ is *-1*<sub>𝔽</sub>, return *-&infin;*<sub>𝔽</sub>.
+          1. Return an implementation-approximated value representing the result of the inverse hyperbolic tangent of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27684,31 +27673,31 @@
           1. Let _ny_ be ? ToNumber(_y_).
           1. Let _nx_ be ? ToNumber(_x_).
           1. If _ny_ is *NaN* or _nx_ is *NaN*, return *NaN*.
-          1. If _ny_ is *+&infin;*, then
-            1. If _nx_ is *+&infin;*, return an implementation-approximated value representing +&pi; / 4.
-            1. If _nx_ is *-&infin;*, return an implementation-approximated value representing +3&pi; / 4.
-            1. Return an implementation-approximated value representing +&pi; / 2.
-          1. If _ny_ is *-&infin;*, then
-            1. If _nx_ is *+&infin;*, return an implementation-approximated value representing -&pi; / 4.
-            1. If _nx_ is *-&infin;*, return an implementation-approximated value representing -3&pi; / 4.
+          1. If _ny_ is *+&infin;*<sub>𝔽</sub>, then
+            1. If _nx_ is *+&infin;*<sub>𝔽</sub>, return an implementation-approximated value representing &pi; / 4.
+            1. If _nx_ is *-&infin;*<sub>𝔽</sub>, return an implementation-approximated value representing 3&pi; / 4.
+            1. Return an implementation-approximated value representing &pi; / 2.
+          1. If _ny_ is *-&infin;*<sub>𝔽</sub>, then
+            1. If _nx_ is *+&infin;*<sub>𝔽</sub>, return an implementation-approximated value representing -&pi; / 4.
+            1. If _nx_ is *-&infin;*<sub>𝔽</sub>, return an implementation-approximated value representing -3&pi; / 4.
             1. Return an implementation-approximated value representing -&pi; / 2.
-          1. If _ny_ is *+0*, then
-            1. If _nx_ &gt; 0 or _nx_ is *+0*, return *+0*.
-            1. Return an implementation-approximated value representing +&pi;.
-          1. If _ny_ is *-0*, then
-            1. If _nx_ &gt; 0 or _nx_ is *+0*, return *-0*.
+          1. If _ny_ is *+0*<sub>𝔽</sub>, then
+            1. If _nx_ &gt; *+0*<sub>𝔽</sub> or _nx_ is *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+            1. Return an implementation-approximated value representing &pi;.
+          1. If _ny_ is *-0*<sub>𝔽</sub>, then
+            1. If _nx_ &gt; *+0*<sub>𝔽</sub> or _nx_ is *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
             1. Return an implementation-approximated value representing -&pi;.
-          1. Assert: _ny_ is finite and is neither *+0* nor *-0*.
-          1. If _ny_ &gt; 0, then
-            1. If _nx_ is *+&infin;*, return *+0*.
-            1. If _nx_ is *-&infin;*, return an implementation-approximated value representing +&pi;.
-            1. If _nx_ is *+0* or _nx_ is *-0*, return an implementation-approximated value representing +&pi; / 2.
-          1. If _ny_ &lt; 0, then
-            1. If _nx_ is *+&infin;*, return *-0*.
-            1. If _nx_ is *-&infin;*, return an implementation-approximated value representing -&pi;.
-            1. If _nx_ is *+0* or _nx_ is *-0*, return an implementation-approximated value representing -&pi; / 2.
-          1. Assert: _nx_ is finite and is neither *+0* nor *-0*.
-          1. Return an implementation-approximated value representing the result of the inverse tangent of the quotient _ny_ / _nx_.
+          1. Assert: _ny_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
+          1. If _ny_ &gt; *+0*<sub>𝔽</sub>, then
+            1. If _nx_ is *+&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+            1. If _nx_ is *-&infin;*<sub>𝔽</sub>, return an implementation-approximated value representing &pi;.
+            1. If _nx_ is *+0*<sub>𝔽</sub> or _nx_ is *-0*<sub>𝔽</sub>, return an implementation-approximated value representing &pi; / 2.
+          1. If _ny_ &lt; *+0*<sub>𝔽</sub>, then
+            1. If _nx_ is *+&infin;*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
+            1. If _nx_ is *-&infin;*<sub>𝔽</sub>, return an implementation-approximated value representing -&pi;.
+            1. If _nx_ is *+0*<sub>𝔽</sub> or _nx_ is *-0*<sub>𝔽</sub>, return an implementation-approximated value representing -&pi; / 2.
+          1. Assert: _nx_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
+          1. Return an implementation-approximated value representing the result of the inverse tangent of the quotient ℝ(_ny_) / ℝ(_nx_).
         </emu-alg>
       </emu-clause>
 
@@ -27718,21 +27707,21 @@
         <p>When the `Math.cbrt` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
-          1. Return an implementation-approximated value representing the result of the cube root of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. Return an implementation-approximated value representing the result of the cube root of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-math.ceil">
         <h1>Math.ceil ( _x_ )</h1>
-        <p>Returns the smallest (closest to *-&infin;*) integral Number value that is not less than _x_. If _x_ is already an integral Number, the result is _x_.</p>
+        <p>Returns the smallest (closest to -&infin;) integral Number value that is not less than _x_. If _x_ is already an integral Number, the result is _x_.</p>
         <p>When the `Math.ceil` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
-          1. If _n_ &lt; 0 and _n_ &gt; -1, return *-0*.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub> and _n_ &gt; *-1*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
           1. If _n_ is an integral Number, return _n_.
-          1. Return the smallest (closest to *-&infin;*) integral Number value that is not less than _n_.
+          1. Return the smallest (closest to -&infin;) integral Number value that is not less than _n_.
         </emu-alg>
         <emu-note>
           <p>The value of `Math.ceil(x)` is the same as the value of `-Math.floor(-x)`.</p>
@@ -27744,11 +27733,11 @@
         <p>When the `Math.clz32` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToUint32(_x_).
-          1. Let _p_ be the number of leading zero bits in the 32-bit binary representation of _n_.
-          1. Return _p_.
+          1. Let _p_ be the number of leading zero bits in the unsigned 32-bit binary representation of _n_.
+          1. Return 𝔽(_p_).
         </emu-alg>
         <emu-note>
-          <p>If _n_ is 0, _p_ will be 32. If the most significant bit of the 32-bit binary encoding of _n_ is 1, _p_ will be 0.</p>
+          <p>If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, this method returns *32*<sub>𝔽</sub>. If the most significant bit of the 32-bit binary encoding of _n_ is 1, this method returns *+0*<sub>𝔽</sub>.</p>
         </emu-note>
       </emu-clause>
 
@@ -27758,9 +27747,9 @@
         <p>When the `Math.cos` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, or _n_ is *-0*, return _n_.
-          1. If _n_ is *+&infin;* or _n_ is *-&infin;*, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the cosine of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *+&infin;*<sub>𝔽</sub> or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the cosine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27770,9 +27759,9 @@
         <p>When the `Math.cosh` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
-          1. If _n_ is *+0* or _n_ is *-0*, return 1.
-          1. Return an implementation-approximated value representing the result of the hyperbolic cosine of _n_.
+          1. If _n_ is *NaN*, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. Return an implementation-approximated value representing the result of the hyperbolic cosine of ℝ(_n_).
         </emu-alg>
         <emu-note>
           <p>The value of `Math.cosh(x)` is the same as the value of `(Math.exp(x) + Math.exp(-x)) / 2`.</p>
@@ -27785,35 +27774,35 @@
         <p>When the `Math.exp` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+&infin;*, return _n_.
-          1. If _n_ is *+0* or _n_ is *-0*, return 1.
-          1. If _n_ is *-&infin;*, return *+0*.
-          1. Return an implementation-approximated value representing the result of the exponential function of _n_.
+          1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. If _n_ is *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. Return an implementation-approximated value representing the result of the exponential function of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-math.expm1">
         <h1>Math.expm1 ( _x_ )</h1>
-        <p>Returns the result of subtracting 1 from the exponential function of _x_ (_e_ raised to the power of _x_, where _e_ is the base of the natural logarithms). The result is computed in a way that is accurate even when the value of x is close 0.</p>
+        <p>Returns the result of subtracting 1 from the exponential function of _x_ (_e_ raised to the power of _x_, where _e_ is the base of the natural logarithms). The result is computed in a way that is accurate even when the value of _x_ is close to 0.</p>
         <p>When the `Math.expm1` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, or _n_ is *+&infin;*, return _n_.
-          1. If _n_ is *-&infin;*, return -1.
-          1. Return an implementation-approximated value representing the result of subtracting 1 from the exponential function of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *-&infin;*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
+          1. Return an implementation-approximated value representing the result of subtracting 1 from the exponential function of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-math.floor">
         <h1>Math.floor ( _x_ )</h1>
-        <p>Returns the greatest (closest to *+&infin;*) integral Number value that is not greater than _x_. If _x_ is already an integral Number, the result is _x_.</p>
+        <p>Returns the greatest (closest to +&infin;) integral Number value that is not greater than _x_. If _x_ is already an integral Number, the result is _x_.</p>
         <p>When the `Math.floor` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
-          1. If _n_ &lt; 1 and _n_ &gt; 0, return *+0*.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ &lt; *1*<sub>𝔽</sub> and _n_ &gt; *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ is an integral Number, return _n_.
-          1. Return the greatest (closest to *+&infin;*) integral Number value that is not greater than _n_.
+          1. Return the greatest (closest to +&infin;) integral Number value that is not greater than _n_.
         </emu-alg>
         <emu-note>
           <p>The value of `Math.floor(x)` is the same as the value of `-Math.ceil(-x)`.</p>
@@ -27826,7 +27815,7 @@
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, return *NaN*.
-          1. If _n_ is one of *+0*, *-0*, *+&infin;*, or *-&infin;*, return _n_.
+          1. If _n_ is one of *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return _n_.
           1. Let _n32_ be the result of converting _n_ to a value in IEEE 754-2019 binary32 format using roundTiesToEven mode.
           1. Let _n64_ be the result of converting _n32_ to a value in IEEE 754-2019 binary64 format.
           1. Return the ECMAScript Number value corresponding to _n64_.
@@ -27844,13 +27833,13 @@
             1. Append _n_ to _coerced_.
           1. Let _onlyZero_ be *true*.
           1. For each element _number_ of _coerced_, do
-            1. If _number_ is *NaN* or _number_ is *+&infin;*, return _number_.
-            1. If _number_ is *-&infin;*, return *+&infin;*.
-            1. If _number_ is neither *+0* nor *-0*, set _onlyZero_ to *false*.
-          1. If _onlyZero_ is *true*, return *+0*.
-          1. Return an implementation-approximated value representing the square root of the sum of squares of the elements of _coerced_.
+            1. If _number_ is *NaN* or _number_ is *+&infin;*<sub>𝔽</sub>, return _number_.
+            1. If _number_ is *-&infin;*<sub>𝔽</sub>, return *+&infin;*<sub>𝔽</sub>.
+            1. If _number_ is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>, set _onlyZero_ to *false*.
+          1. If _onlyZero_ is *true*, return *+0*<sub>𝔽</sub>.
+          1. Return an implementation-approximated value representing the square root of the sum of squares of the mathematical values of the elements of _coerced_.
         </emu-alg>
-        <p>The *"length"* property of the `hypot` method is 2.</p>
+        <p>The *"length"* property of the `hypot` method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>Implementations should take care to avoid the loss of precision from overflows and underflows that are prone to occur in naive implementations when this function is called with two or more arguments.</p>
         </emu-note>
@@ -27860,10 +27849,10 @@
         <h1>Math.imul ( _x_, _y_ )</h1>
         <p>When `Math.imul` is called with arguments _x_ and _y_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _a_ be ? ToUint32(_x_).
-          1. Let _b_ be ? ToUint32(_y_).
+          1. Let _a_ be ℝ(? ToUint32(_x_)).
+          1. Let _b_ be ℝ(? ToUint32(_y_)).
           1. Let _product_ be (_a_ &times; _b_) modulo 2<sup>32</sup>.
-          1. If _product_ &ge; 2<sup>31</sup>, return _product_ - 2<sup>32</sup>; otherwise return _product_.
+          1. If _product_ &ge; 2<sup>31</sup>, return 𝔽(_product_ - 2<sup>32</sup>); otherwise return 𝔽(_product_).
         </emu-alg>
       </emu-clause>
 
@@ -27873,11 +27862,11 @@
         <p>When the `Math.log` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+&infin;*, return _n_.
-          1. If _n_ is 1, return *+0*.
-          1. If _n_ is *+0* or _n_ is *-0*, return *-&infin;*.
-          1. If _n_ &lt; 0, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the natural logarithm of _n_.
+          1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *-&infin;*<sub>𝔽</sub>.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the natural logarithm of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27887,10 +27876,10 @@
         <p>When the `Math.log1p` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, or _n_ is *+&infin;*, return _n_.
-          1. If _n_ is -1, return *-&infin;*.
-          1. If _n_ &lt; -1, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the natural logarithm of 1 + _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *-1*<sub>𝔽</sub>, return *-&infin;*<sub>𝔽</sub>.
+          1. If _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the natural logarithm of 1 + ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27900,11 +27889,11 @@
         <p>When the `Math.log10` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+&infin;*, return _n_.
-          1. If _n_ is 1, return *+0*.
-          1. If _n_ is *+0* or _n_ is *-0*, return *-&infin;*.
-          1. If _n_ &lt; 0, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the base 10 logarithm of _n_.
+          1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *-&infin;*<sub>𝔽</sub>.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the base 10 logarithm of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27914,11 +27903,11 @@
         <p>When the `Math.log2` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+&infin;*, return _n_.
-          1. If _n_ is 1, return *+0*.
-          1. If _n_ is *+0* or _n_ is *-0*, return *-&infin;*.
-          1. If _n_ &lt; 0, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the base 2 logarithm of _n_.
+          1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *-&infin;*<sub>𝔽</sub>.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the base 2 logarithm of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -27931,17 +27920,17 @@
           1. For each element _arg_ of _args_, do
             1. Let _n_ be ? ToNumber(_arg_).
             1. Append _n_ to _coerced_.
-          1. Let _highest_ be *-&infin;*.
+          1. Let _highest_ be *-&infin;*<sub>𝔽</sub>.
           1. For each element _number_ of _coerced_, do
             1. If _number_ is *NaN*, return *NaN*.
-            1. If _number_ is *+0* and _highest_ is *-0*, set _highest_ to *+0*.
+            1. If _number_ is *+0*<sub>𝔽</sub> and _highest_ is *-0*<sub>𝔽</sub>, set _highest_ to *+0*<sub>𝔽</sub>.
             1. If _number_ &gt; _highest_, set _highest_ to _number_.
           1. Return _highest_.
         </emu-alg>
         <emu-note>
-          <p>The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0* is considered to be larger than *-0*.</p>
+          <p>The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0*<sub>𝔽</sub> is considered to be larger than *-0*<sub>𝔽</sub>.</p>
         </emu-note>
-        <p>The *"length"* property of the `max` method is 2.</p>
+        <p>The *"length"* property of the `max` method is *2*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.min">
@@ -27953,17 +27942,17 @@
           1. For each element _arg_ of _args_, do
             1. Let _n_ be ? ToNumber(_arg_).
             1. Append _n_ to _coerced_.
-          1. Let _lowest_ be *+&infin;*.
+          1. Let _lowest_ be *+&infin;*<sub>𝔽</sub>.
           1. For each element _number_ of _coerced_, do
             1. If _number_ is *NaN*, return *NaN*.
-            1. If _number_ is *-0* and _lowest_ is *+0*, set _lowest_ to *-0*.
+            1. If _number_ is *-0*<sub>𝔽</sub> and _lowest_ is *+0*<sub>𝔽</sub>, set _lowest_ to *-0*<sub>𝔽</sub>.
             1. If _number_ &lt; _lowest_, set _lowest_ to _number_.
           1. Return _lowest_.
         </emu-alg>
         <emu-note>
-          <p>The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0* is considered to be larger than *-0*.</p>
+          <p>The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0*<sub>𝔽</sub> is considered to be larger than *-0*<sub>𝔽</sub>.</p>
         </emu-note>
-        <p>The *"length"* property of the `min` method is 2.</p>
+        <p>The *"length"* property of the `min` method is *2*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.pow">
@@ -27978,26 +27967,26 @@
 
       <emu-clause id="sec-math.random">
         <h1>Math.random ( )</h1>
-        <p>Returns a Number value with positive sign, greater than or equal to 0 but less than 1, chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an implementation-defined algorithm or strategy. This function takes no arguments.</p>
+        <p>Returns a Number value with positive sign, greater than or equal to *+0*<sub>𝔽</sub> but strictly less than *1*<sub>𝔽</sub>, chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an implementation-defined algorithm or strategy. This function takes no arguments.</p>
         <p>Each `Math.random` function created for distinct realms must produce a distinct sequence of values from successive calls.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.round">
         <h1>Math.round ( _x_ )</h1>
-        <p>Returns the Number value that is closest to _x_ and is an integer. If two integers are equally close to _x_, then the result is the Number value that is closer to *+&infin;*. If _x_ is already an integer, the result is _x_.</p>
+        <p>Returns the Number value that is closest to _x_ and is integral. If two integral Numbers are equally close to _x_, then the result is the Number value that is closer to +&infin;. If _x_ is already integral, the result is _x_.</p>
         <p>When the `Math.round` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, *+&infin;*, *-&infin;*, or an integral Number, return _n_.
-          1. If _n_ &lt; 0.5 and _n_ &gt; 0, return *+0*.
-          1. If _n_ &lt; 0 and _n_ &ge; -0.5, return *-0*.
-          1. Return the integral Number closest to _n_, preferring the Number closer to *+&infin;* in the case of a tie.
+          1. If _n_ is *NaN*, *+&infin;*<sub>𝔽</sub>, *-&infin;*<sub>𝔽</sub>, or an integral Number, return _n_.
+          1. If _n_ &lt; *0.5*<sub>𝔽</sub> and _n_ &gt; *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub> and _n_ &ge; *-0.5*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
+          1. Return the integral Number closest to _n_, preferring the Number closer to +&infin; in the case of a tie.
         </emu-alg>
         <emu-note>
           <p>`Math.round(3.5)` returns 4, but `Math.round(-3.5)` returns -3.</p>
         </emu-note>
         <emu-note>
-          <p>The value of `Math.round(x)` is not always the same as the value of `Math.floor(x + 0.5)`. When `x` is *-0* or is less than 0 but greater than or equal to -0.5, `Math.round(x)` returns *-0*, but `Math.floor(x + 0.5)` returns *+0*. `Math.round(x)` may also differ from the value of `Math.floor(x + 0.5)`because of internal rounding when computing `x + 0.5`.</p>
+          <p>The value of `Math.round(x)` is not always the same as the value of `Math.floor(x + 0.5)`. When `x` is *-0*<sub>𝔽</sub> or is less than *+0*<sub>𝔽</sub> but greater than or equal to *-0.5*<sub>𝔽</sub>, `Math.round(x)` returns *-0*<sub>𝔽</sub>, but `Math.floor(x + 0.5)` returns *+0*<sub>𝔽</sub>. `Math.round(x)` may also differ from the value of `Math.floor(x + 0.5)`because of internal rounding when computing `x + 0.5`.</p>
         </emu-note>
       </emu-clause>
 
@@ -28007,9 +27996,9 @@
         <p>When the `Math.sign` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, or _n_ is *-0*, return _n_.
-          1. If _n_ &lt; 0, return -1.
-          1. Return +1.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
+          1. Return *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
 
@@ -28019,9 +28008,9 @@
         <p>When the `Math.sin` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, or _n_ is *-0*, return _n_.
-          1. If _n_ is *+&infin;* or _n_ is *-&infin;*, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the sine of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *+&infin;*<sub>𝔽</sub> or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the sine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -28031,8 +28020,8 @@
         <p>When the `Math.sinh` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
-          1. Return an implementation-approximated value representing the result of the hyperbolic sine of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. Return an implementation-approximated value representing the result of the hyperbolic sine of ℝ(_n_).
         </emu-alg>
         <emu-note>
           <p>The value of `Math.sinh(x)` is the same as the value of `(Math.exp(x) - Math.exp(-x)) / 2`.</p>
@@ -28045,9 +28034,9 @@
         <p>When the `Math.sqrt` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, or _n_ is *+&infin;*, return _n_.
-          1. If _n_ &lt; 0, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the square root of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the square root of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -28057,9 +28046,9 @@
         <p>When the `Math.tan` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, or _n_ is *-0*, return _n_.
-          1. If _n_ is *+&infin;*, or _n_ is *-&infin;*, return *NaN*.
-          1. Return an implementation-approximated value representing the result of the tangent of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+          1. Return an implementation-approximated value representing the result of the tangent of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -28069,10 +28058,10 @@
         <p>When the `Math.tanh` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, or _n_ is *-0*, return _n_.
-          1. If _n_ is *+&infin;*, return +1.
-          1. If _n_ is *-&infin;*, return -1.
-          1. Return an implementation-approximated value representing the result of the hyperbolic tangent of _n_.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *+&infin;*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. If _n_ is *-&infin;*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
+          1. Return an implementation-approximated value representing the result of the hyperbolic tangent of ℝ(_n_).
         </emu-alg>
         <emu-note>
           <p>The value of `Math.tanh(x)` is the same as the value of `(Math.exp(x) - Math.exp(-x)) / (Math.exp(x) + Math.exp(-x))`.</p>
@@ -28081,14 +28070,14 @@
 
       <emu-clause id="sec-math.trunc">
         <h1>Math.trunc ( _x_ )</h1>
-        <p>Returns the integral part of the number _x_, removing any fractional digits. If _x_ is already an integer, the result is _x_.</p>
+        <p>Returns the integral part of the number _x_, removing any fractional digits. If _x_ is already integral, the result is _x_.</p>
         <p>When the `Math.trunc` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*, _n_ is *-0*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
-          1. If _n_ &lt; 1 and _n_ &gt; 0, return *+0*.
-          1. If _n_ &lt; 0 and _n_ &gt; -1, return *-0*.
-          1. Return the integral Number nearest _n_ in the direction of *+0*.
+          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ &lt; *1*<sub>𝔽</sub> and _n_ &gt; *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+          1. If _n_ &lt; *+0*<sub>𝔽</sub> and _n_ &gt; *-1*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
+          1. Return the integral Number nearest _n_ in the direction of *+0*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -28104,10 +28093,10 @@
       <emu-clause id="sec-time-values-and-time-range">
         <h1>Time Values and Time Range</h1>
         <p>Time measurement in ECMAScript is analogous to time measurement in POSIX, in particular sharing definition in terms of the proleptic Gregorian calendar, an epoch of midnight at the beginning of 1 January 1970 UTC, and an accounting of every day as comprising exactly 86,400 seconds (each of which is 1000 milliseconds long).</p>
-        <p>An ECMAScript <dfn>time value</dfn> is a Number, either a finite integer representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is a multiple of <emu-eqn>24 &times; 60 &times; 60 &times; 1000 = 86,400,000</emu-eqn> (i.e., is equal to 86,400,000 &times; _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _t_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by _t_ &minus; _s_ milliseconds.</p>
+        <p>An ECMAScript <dfn>time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is a multiple of <emu-eqn>24 &times; 60 &times; 60 &times; 1000 = 86,400,000</emu-eqn> (i.e., is equal to 86,400,000 &times; _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _t_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by _t_ &minus; _s_ milliseconds.</p>
         <p>Time values do not account for UTC leap seconds&mdash;there are no time values representing instants within positive leap seconds, and there are time values representing instants removed from the UTC timeline by negative leap seconds. However, the definition of time values nonetheless yields piecewise alignment with UTC, with discontinuities only at leap second boundaries and zero difference outside of leap seconds.</p>
         <p>A Number can exactly represent all integers from -9,007,199,254,740,992 to 9,007,199,254,740,992 (<emu-xref href="#sec-number.min_safe_integer"></emu-xref> and <emu-xref href="#sec-number.max_safe_integer"></emu-xref>). A time value supports a slightly smaller range of -8,640,000,000,000,000 to 8,640,000,000,000,000 milliseconds. This yields a supported time value range of exactly -100,000,000 days to 100,000,000 days relative to midnight at the beginning of 1 January 1970 UTC.</p>
-        <p>The exact moment of midnight at the beginning of 1 January 1970 UTC is represented by the time value *+0*.</p>
+        <p>The exact moment of midnight at the beginning of 1 January 1970 UTC is represented by the time value *+0*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>The 400 year cycle of the proleptic Gregorian calendar contains 97 leap years. This yields an average of 365.2425 days per year, which is 31,556,952,000 milliseconds. Therefore, the maximum range a Number could represent exactly with millisecond precision is approximately -285,426 to 285,426 years relative to 1970. The smaller range supported by a time value as specified in this section is approximately -273,790 to 273,790 years relative to 1970.</p>
         </emu-note>
@@ -28116,91 +28105,91 @@
       <emu-clause id="sec-day-number-and-time-within-day">
         <h1>Day Number and Time within Day</h1>
         <p>A given time value _t_ belongs to day number</p>
-        <emu-eqn id="eqn-Day" aoid="Day">Day(_t_) = floor(_t_ / msPerDay)</emu-eqn>
+        <emu-eqn id="eqn-Day" aoid="Day">Day(_t_) = 𝔽(floor(ℝ(_t_ / msPerDay)))</emu-eqn>
         <p>where the number of milliseconds per day is</p>
-        <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = 86400000</emu-eqn>
+        <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = *86400000*<sub>𝔽</sub></emu-eqn>
         <p>The remainder is called the time within the day:</p>
-        <emu-eqn id="eqn-TimeWithinDay" aoid="TimeWithinDay">TimeWithinDay(_t_) = _t_ modulo msPerDay</emu-eqn>
+        <emu-eqn id="eqn-TimeWithinDay" aoid="TimeWithinDay">TimeWithinDay(_t_) = 𝔽(ℝ(_t_) modulo ℝ(msPerDay))</emu-eqn>
       </emu-clause>
 
       <emu-clause id="sec-year-number">
         <h1>Year Number</h1>
         <p>ECMAScript uses a proleptic Gregorian calendar to map a day number to a year number and to determine the month and date within that year. In this calendar, leap years are precisely those which are (divisible by 4) and ((not divisible by 100) or (divisible by 400)). The number of days in year number _y_ is therefore defined by</p>
         <emu-eqn id="eqn-DaysInYear" aoid="DaysInYear">DaysInYear(_y_)
-          = 365 if (_y_ modulo 4) &ne; 0
-          = 366 if (_y_ modulo 4) = 0 and (_y_ modulo 100) &ne; 0
-          = 365 if (_y_ modulo 100) = 0 and (_y_ modulo 400) &ne; 0
-          = 366 if (_y_ modulo 400) = 0
+          = *365*<sub>𝔽</sub> if (ℝ(_y_) modulo 4) &ne; 0
+          = *366*<sub>𝔽</sub> if (ℝ(_y_) modulo 4) = 0 and (ℝ(_y_) modulo 100) &ne; 0
+          = *365*<sub>𝔽</sub> if (ℝ(_y_) modulo 100) = 0 and (ℝ(_y_) modulo 400) &ne; 0
+          = *366*<sub>𝔽</sub> if (ℝ(_y_) modulo 400) = 0
         </emu-eqn>
         <p>All non-leap years have 365 days with the usual number of days per month and leap years have an extra day in February. The day number of the first day of year _y_ is given by:</p>
-        <emu-eqn id="eqn-DaysFromYear" aoid="DayFromYear">DayFromYear(_y_) = 365 &times; (_y_ - 1970) + floor((_y_ - 1969) / 4) - floor((_y_ - 1901) / 100) + floor((_y_ - 1601) / 400)</emu-eqn>
+        <emu-eqn id="eqn-DaysFromYear" aoid="DayFromYear">DayFromYear(_y_) = 𝔽(365 &times; (ℝ(_y_) - 1970) + floor((ℝ(_y_) - 1969) / 4) - floor((ℝ(_y_) - 1901) / 100) + floor((ℝ(_y_) - 1601) / 400))</emu-eqn>
         <p>The time value of the start of a year is:</p>
         <emu-eqn id="eqn-TimeFromYear" aoid="TimeFromYear">TimeFromYear(_y_) = msPerDay &times; DayFromYear(_y_)</emu-eqn>
         <p>A time value determines a year by:</p>
-        <emu-eqn id="eqn-YearFromTime" aoid="YearFromTime">YearFromTime(_t_) = the largest integer _y_ (closest to positive infinity) such that TimeFromYear(_y_) &le; _t_</emu-eqn>
-        <p>The leap-year function is 1 for a time within a leap year and otherwise is zero:</p>
+        <emu-eqn id="eqn-YearFromTime" aoid="YearFromTime">YearFromTime(_t_) = the largest integral Number _y_ (closest to +&infin;) such that TimeFromYear(_y_) &le; _t_</emu-eqn>
+        <p>The leap-year function is *1*<sub>𝔽</sub> for a time within a leap year and otherwise is *+0*<sub>𝔽</sub>:</p>
         <emu-eqn id="eqn-InLeapYear" aoid="InLeapYear">InLeapYear(_t_)
-          = 0 if DaysInYear(YearFromTime(_t_)) = 365
-          = 1 if DaysInYear(YearFromTime(_t_)) = 366
+          = *+0*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) = *365*<sub>𝔽</sub>
+          = *1*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) = *366*<sub>𝔽</sub>
         </emu-eqn>
       </emu-clause>
 
       <emu-clause id="sec-month-number">
         <h1>Month Number</h1>
-        <p>Months are identified by an integer in the range 0 to 11, inclusive. The mapping MonthFromTime(_t_) from a time value _t_ to a month number is defined by:</p>
+        <p>Months are identified by an integral Number in the range *+0*<sub>𝔽</sub> to *11*<sub>𝔽</sub>, inclusive. The mapping MonthFromTime(_t_) from a time value _t_ to a month number is defined by:</p>
         <emu-eqn id="eqn-MonthFromTime" aoid="MonthFromTime">MonthFromTime(_t_)
-          = 0 if 0 &le; DayWithinYear(_t_) &lt; 31
-          = 1 if 31 &le; DayWithinYear(_t_) &lt; 59 + InLeapYear(_t_)
-          = 2 if 59 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 90 + InLeapYear(_t_)
-          = 3 if 90 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 120 + InLeapYear(_t_)
-          = 4 if 120 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 151 + InLeapYear(_t_)
-          = 5 if 151 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 181 + InLeapYear(_t_)
-          = 6 if 181 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 212 + InLeapYear(_t_)
-          = 7 if 212 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 243 + InLeapYear(_t_)
-          = 8 if 243 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 273 + InLeapYear(_t_)
-          = 9 if 273 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 304 + InLeapYear(_t_)
-          = 10 if 304 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 334 + InLeapYear(_t_)
-          = 11 if 334 + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; 365 + InLeapYear(_t_)
+          = *+0*<sub>𝔽</sub> if *+0*<sub>𝔽</sub> &le; DayWithinYear(_t_) &lt; *31*<sub>𝔽</sub>
+          = *1*<sub>𝔽</sub> if *31*<sub>𝔽</sub> &le; DayWithinYear(_t_) &lt; *59*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *2*<sub>𝔽</sub> if *59*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *90*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *3*<sub>𝔽</sub> if *90*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *120*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *4*<sub>𝔽</sub> if *120*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *151*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *5*<sub>𝔽</sub> if *151*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *181*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *6*<sub>𝔽</sub> if *181*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *212*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *7*<sub>𝔽</sub> if *212*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *243*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *8*<sub>𝔽</sub> if *243*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *273*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *9*<sub>𝔽</sub> if *273*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *304*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *10*<sub>𝔽</sub> if *304*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *334*<sub>𝔽</sub> + InLeapYear(_t_)
+          = *11*<sub>𝔽</sub> if *334*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *365*<sub>𝔽</sub> + InLeapYear(_t_)
         </emu-eqn>
         <p>where</p>
         <emu-eqn id="eqn-DayWithinYear" aoid="DayWithinYear">DayWithinYear(_t_) = Day(_t_) - DayFromYear(YearFromTime(_t_))</emu-eqn>
-        <p>A month value of 0 specifies January; 1 specifies February; 2 specifies March; 3 specifies April; 4 specifies May; 5 specifies June; 6 specifies July; 7 specifies August; 8 specifies September; 9 specifies October; 10 specifies November; and 11 specifies December. Note that <emu-eqn>MonthFromTime(0) = 0</emu-eqn>, corresponding to Thursday, 1 January 1970.</p>
+        <p>A month value of *+0*<sub>𝔽</sub> specifies January; *1*<sub>𝔽</sub> specifies February; *2*<sub>𝔽</sub> specifies March; *3*<sub>𝔽</sub> specifies April; *4*<sub>𝔽</sub> specifies May; *5*<sub>𝔽</sub> specifies June; *6*<sub>𝔽</sub> specifies July; *7*<sub>𝔽</sub> specifies August; *8*<sub>𝔽</sub> specifies September; *9*<sub>𝔽</sub> specifies October; *10*<sub>𝔽</sub> specifies November; and *11*<sub>𝔽</sub> specifies December. Note that <emu-eqn>MonthFromTime(*+0*<sub>𝔽</sub>) = *+0*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</p>
       </emu-clause>
 
       <emu-clause id="sec-date-number">
         <h1>Date Number</h1>
-        <p>A date number is identified by an integer in the range 1 through 31, inclusive. The mapping DateFromTime(_t_) from a time value _t_ to a date number is defined by:</p>
+        <p>A date number is identified by an integral Number in the range *1*<sub>𝔽</sub> through *31*<sub>𝔽</sub>, inclusive. The mapping DateFromTime(_t_) from a time value _t_ to a date number is defined by:</p>
         <emu-eqn aoid="DateFromTime">DateFromTime(_t_)
-          = DayWithinYear(_t_) + 1 if MonthFromTime(_t_) = 0
-          = DayWithinYear(_t_) - 30 if MonthFromTime(_t_) = 1
-          = DayWithinYear(_t_) - 58 - InLeapYear(_t_) if MonthFromTime(_t_) = 2
-          = DayWithinYear(_t_) - 89 - InLeapYear(_t_) if MonthFromTime(_t_) = 3
-          = DayWithinYear(_t_) - 119 - InLeapYear(_t_) if MonthFromTime(_t_) = 4
-          = DayWithinYear(_t_) - 150 - InLeapYear(_t_) if MonthFromTime(_t_) = 5
-          = DayWithinYear(_t_) - 180 - InLeapYear(_t_) if MonthFromTime(_t_) = 6
-          = DayWithinYear(_t_) - 211 - InLeapYear(_t_) if MonthFromTime(_t_) = 7
-          = DayWithinYear(_t_) - 242 - InLeapYear(_t_) if MonthFromTime(_t_) = 8
-          = DayWithinYear(_t_) - 272 - InLeapYear(_t_) if MonthFromTime(_t_) = 9
-          = DayWithinYear(_t_) - 303 - InLeapYear(_t_) if MonthFromTime(_t_) = 10
-          = DayWithinYear(_t_) - 333 - InLeapYear(_t_) if MonthFromTime(_t_) = 11
+          = DayWithinYear(_t_) + *1*<sub>𝔽</sub> if MonthFromTime(_t_) = *+0*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *30*<sub>𝔽</sub> if MonthFromTime(_t_) = *1*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *58*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *2*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *89*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *3*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *119*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *4*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *150*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *5*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *180*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *6*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *211*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *7*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *242*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *8*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *272*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *9*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *303*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *10*<sub>𝔽</sub>
+          = DayWithinYear(_t_) - *333*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *11*<sub>𝔽</sub>
         </emu-eqn>
       </emu-clause>
 
       <emu-clause id="sec-week-day">
         <h1>Week Day</h1>
         <p>The weekday for a particular time value _t_ is defined as</p>
-        <emu-eqn aoid="WeekDay">WeekDay(_t_) = (Day(_t_) + 4) modulo 7</emu-eqn>
-        <p>A weekday value of 0 specifies Sunday; 1 specifies Monday; 2 specifies Tuesday; 3 specifies Wednesday; 4 specifies Thursday; 5 specifies Friday; and 6 specifies Saturday. Note that <emu-eqn>WeekDay(0) = 4</emu-eqn>, corresponding to Thursday, 1 January 1970.</p>
+        <emu-eqn aoid="WeekDay">WeekDay(_t_) = 𝔽(ℝ(Day(_t_) + *4*<sub>𝔽</sub>) modulo 7)</emu-eqn>
+        <p>A weekday value of *+0*<sub>𝔽</sub> specifies Sunday; *1*<sub>𝔽</sub> specifies Monday; *2*<sub>𝔽</sub> specifies Tuesday; *3*<sub>𝔽</sub> specifies Wednesday; *4*<sub>𝔽</sub> specifies Thursday; *5*<sub>𝔽</sub> specifies Friday; and *6*<sub>𝔽</sub> specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = *4*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</p>
       </emu-clause>
 
       <emu-clause id="sec-local-time-zone-adjustment" aoid="LocalTZA">
         <h1>LocalTZA ( _t_, _isUTC_ )</h1>
-        <p>LocalTZA( _t_, _isUTC_ ) is an implementation-defined algorithm that returns the local time zone adjustment, or offset, in milliseconds. The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.</p>
+        <p>LocalTZA( _t_, _isUTC_ ) is an implementation-defined algorithm that returns an integral Number representing the local time zone adjustment, or offset, in milliseconds. The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.</p>
         <p>When _isUTC_ is true, <emu-eqn>LocalTZA( _t_<sub>UTC</sub>, true )</emu-eqn> should return the offset of the local time zone from UTC measured in milliseconds at time represented by time value <emu-eqn>_t_<sub>UTC</sub></emu-eqn>. When the result is added to <emu-eqn>_t_<sub>UTC</sub></emu-eqn>, it should yield the corresponding Number <emu-eqn>_t_<sub>local</sub></emu-eqn>.</p>
         <p>When _isUTC_ is false, <emu-eqn>LocalTZA( _t_<sub>local</sub>, false )</emu-eqn> should return the offset of the local time zone from UTC measured in milliseconds at local time represented by Number <emu-eqn>_t_<sub>local</sub></emu-eqn>. When the result is subtracted from <emu-eqn>_t_<sub>local</sub></emu-eqn>, it should yield the corresponding time value <emu-eqn>_t_<sub>UTC</sub></emu-eqn>.</p>
         <p>Input _t_ is nominally a time value but may be any Number value. This can occur when _isUTC_ is false and _t_<sub>local</sub> represents a time value that is already offset outside of the time value range at the range boundaries. The algorithm must not limit _t_<sub>local</sub> to the time value range, so that such inputs are supported.</p>
         <p>When <emu-eqn>_t_<sub>local</sub></emu-eqn> represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transitions (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), <emu-eqn>_t_<sub>local</sub></emu-eqn> must be interpreted using the time zone offset before the transition.</p>
-        <p>If an implementation does not support a conversion described above or if political rules for time _t_ are not available within the implementation, the result must be 0.</p>
+        <p>If an implementation does not support a conversion described above or if political rules for time _t_ are not available within the implementation, the result must be *+0*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>It is recommended that implementations use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
           <p>1:30 AM on 5 November 2017 in America/New_York is repeated twice (fall backward), but it must be interpreted as 1:30 AM UTC-04 instead of 1:30 AM UTC-05. LocalTZA(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0))), false) is <emu-eqn>-4 &times; msPerHour</emu-eqn>.</p>
@@ -28235,17 +28224,17 @@
       <emu-clause id="sec-hours-minutes-second-and-milliseconds">
         <h1>Hours, Minutes, Second, and Milliseconds</h1>
         <p>The following abstract operations are useful in decomposing time values:</p>
-        <emu-eqn id="eqn-HourFromTime" aoid="HourFromTime">HourFromTime(_t_) = floor(_t_ / msPerHour) modulo HoursPerDay</emu-eqn>
-        <emu-eqn id="eqn-MinFromTime" aoid="MinFromTime">MinFromTime(_t_) = floor(_t_ / msPerMinute) modulo MinutesPerHour</emu-eqn>
-        <emu-eqn id="eqn-SecFromTime" aoid="SecFromTime">SecFromTime(_t_) = floor(_t_ / msPerSecond) modulo SecondsPerMinute</emu-eqn>
-        <emu-eqn id="eqn-msFromTime" aoid="msFromTime">msFromTime(_t_) = _t_ modulo msPerSecond</emu-eqn>
+        <emu-eqn id="eqn-HourFromTime" aoid="HourFromTime">HourFromTime(_t_) = 𝔽(floor(ℝ(_t_ / msPerHour)) modulo HoursPerDay)</emu-eqn>
+        <emu-eqn id="eqn-MinFromTime" aoid="MinFromTime">MinFromTime(_t_) = 𝔽(floor(ℝ(_t_ / msPerMinute)) modulo MinutesPerHour)</emu-eqn>
+        <emu-eqn id="eqn-SecFromTime" aoid="SecFromTime">SecFromTime(_t_) = 𝔽(floor(ℝ(_t_ / msPerSecond)) modulo SecondsPerMinute)</emu-eqn>
+        <emu-eqn id="eqn-msFromTime" aoid="msFromTime">msFromTime(_t_) = 𝔽(ℝ(_t_) modulo msPerSecond)</emu-eqn>
         <p>where</p>
         <emu-eqn id="eqn-HoursPerDay" aoid="HoursPerDay">HoursPerDay = 24</emu-eqn>
         <emu-eqn id="eqn-MinutesPerHour" aoid="MinutesPerHour">MinutesPerHour = 60</emu-eqn>
         <emu-eqn id="eqn-SecondsPerMinute" aoid="SecondsPerMinute">SecondsPerMinute = 60</emu-eqn>
-        <emu-eqn id="eqn-msPerSecond" aoid="msPerSecond">msPerSecond = 1000</emu-eqn>
-        <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = 60000 = msPerSecond &times; SecondsPerMinute</emu-eqn>
-        <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = 3600000 = msPerMinute &times; MinutesPerHour</emu-eqn>
+        <emu-eqn id="eqn-msPerSecond" aoid="msPerSecond">msPerSecond = *1000*<sub>𝔽</sub></emu-eqn>
+        <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = *60000*<sub>𝔽</sub> = msPerSecond &times; 𝔽(SecondsPerMinute)</emu-eqn>
+        <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = *3600000*<sub>𝔽</sub> = msPerMinute &times; 𝔽(MinutesPerHour)</emu-eqn>
       </emu-clause>
 
       <emu-clause id="sec-maketime" aoid="MakeTime">
@@ -28253,10 +28242,10 @@
         <p>The abstract operation MakeTime takes arguments _hour_ (a Number), _min_ (a Number), _sec_ (a Number), and _ms_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
         <emu-alg>
           1. If _hour_ is not finite or _min_ is not finite or _sec_ is not finite or _ms_ is not finite, return *NaN*.
-          1. Let _h_ be ! ToInteger(_hour_).
-          1. Let _m_ be ! ToInteger(_min_).
-          1. Let _s_ be ! ToInteger(_sec_).
-          1. Let _milli_ be ! ToInteger(_ms_).
+          1. Let _h_ be 𝔽(! ToIntegerOrInfinity(_hour_)).
+          1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_min_)).
+          1. Let _s_ be 𝔽(! ToIntegerOrInfinity(_sec_)).
+          1. Let _milli_ be 𝔽(! ToIntegerOrInfinity(_ms_)).
           1. Let _t_ be ((_h_ `*` msPerHour `+` _m_ `*` msPerMinute) `+` _s_ `*` msPerSecond) `+` _milli_, performing the arithmetic according to IEEE 754-2019 rules (that is, as if using the ECMAScript operators `*` and `+`).
           1. Return _t_.
         </emu-alg>
@@ -28267,13 +28256,14 @@
         <p>The abstract operation MakeDay takes arguments _year_ (a Number), _month_ (a Number), and _date_ (a Number). It calculates a number of days. It performs the following steps when called:</p>
         <emu-alg>
           1. If _year_ is not finite or _month_ is not finite or _date_ is not finite, return *NaN*.
-          1. Let _y_ be ! ToInteger(_year_).
-          1. Let _m_ be ! ToInteger(_month_).
-          1. Let _dt_ be ! ToInteger(_date_).
-          1. Let _ym_ be _y_ + floor(_m_ / 12).
-          1. Let _mn_ be _m_ modulo 12.
-          1. Find a value _t_ such that YearFromTime(_t_) is _ym_ and MonthFromTime(_t_) is _mn_ and DateFromTime(_t_) is 1; but if this is not possible (because some argument is out of range), return *NaN*.
-          1. Return Day(_t_) + _dt_ - 1.
+          1. Let _y_ be 𝔽(! ToIntegerOrInfinity(_year_)).
+          1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_month_)).
+          1. Let _dt_ be 𝔽(! ToIntegerOrInfinity(_date_)).
+          1. Let _ym_ be _y_ + 𝔽(floor(ℝ(_m_) / 12)).
+          1. If _ym_ is not finite, return *NaN*.
+          1. Let _mn_ be 𝔽(ℝ(_m_) modulo 12).
+          1. Find a finite time value _t_ such that YearFromTime(_t_) is _ym_ and MonthFromTime(_t_) is _mn_ and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Return Day(_t_) + _dt_ - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
 
@@ -28282,7 +28272,9 @@
         <p>The abstract operation MakeDate takes arguments _day_ (a Number) and _time_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
         <emu-alg>
           1. If _day_ is not finite or _time_ is not finite, return *NaN*.
-          1. Return _day_ &times; msPerDay + _time_.
+          1. Let _tv_ be _day_ &times; msPerDay + _time_.
+          1. If _tv_ is not finite, return *NaN*.
+          1. Return _tv_.
         </emu-alg>
       </emu-clause>
 
@@ -28291,8 +28283,8 @@
         <p>The abstract operation TimeClip takes argument _time_ (a Number). It calculates a number of milliseconds. It performs the following steps when called:</p>
         <emu-alg>
           1. If _time_ is not finite, return *NaN*.
-          1. If abs(_time_) &gt; 8.64 &times; 10<sup>15</sup>, return *NaN*.
-          1. Return ! ToInteger(_time_).
+          1. If abs(ℝ(_time_)) &gt; 8.64 &times; 10<sup>15</sup>, return *NaN*.
+          1. Return 𝔽(! ToIntegerOrInfinity(_time_)).
         </emu-alg>
       </emu-clause>
 
@@ -28487,20 +28479,20 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ &ge; 2.
           1. If NewTarget is *undefined*, then
-            1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
+            1. Let _now_ be the time value (UTC) identifying the current time.
             1. Return ToDateString(_now_).
           1. Else,
             1. Let _y_ be ? ToNumber(_year_).
             1. Let _m_ be ? ToNumber(_month_).
-            1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 1.
-            1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be 0.
-            1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be 0.
-            1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be 0.
-            1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be 0.
+            1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be *1*<sub>𝔽</sub>.
+            1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be *+0*<sub>𝔽</sub>.
+            1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be *+0*<sub>𝔽</sub>.
+            1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be *+0*<sub>𝔽</sub>.
+            1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be *+0*<sub>𝔽</sub>.
             1. If _y_ is *NaN*, let _yr_ be *NaN*.
             1. Else,
-              1. Let _yi_ be ! ToInteger(_y_).
-              1. If 0 &le; _yi_ &le; 99, let _yr_ be 1900 + _yi_; otherwise, let _yr_ be _y_.
+              1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
+              1. If 0 &le; _yi_ &le; 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
             1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
             1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
             1. Set _O_.[[DateValue]] to TimeClip(UTC(_finalDate_)).
@@ -28516,11 +28508,11 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ = 1.
           1. If NewTarget is *undefined*, then
-            1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
+            1. Let _now_ be the time value (UTC) identifying the current time.
             1. Return ToDateString(_now_).
           1. Else,
             1. If Type(_value_) is Object and _value_ has a [[DateValue]] internal slot, then
-              1. Let _tv_ be thisTimeValue(_value_).
+              1. Let _tv_ be ! thisTimeValue(_value_).
             1. Else,
               1. Let _v_ be ? ToPrimitive(_value_).
               1. If Type(_v_) is String, then
@@ -28542,7 +28534,7 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of arguments passed to this function call.
           1. Assert: _numberOfArgs_ = 0.
           1. If NewTarget is *undefined*, then
-            1. Let _now_ be the Number that is the time value (UTC) identifying the current time.
+            1. Let _now_ be the time value (UTC) identifying the current time.
             1. Return ToDateString(_now_).
           1. Else,
             1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
@@ -28562,7 +28554,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.now">
         <h1>Date.now ( )</h1>
-        <p>The `now` function returns a Number value that is the time value designating the UTC date and time of the occurrence of the call to `now`.</p>
+        <p>The `now` function returns the time value designating the UTC date and time of the occurrence of the call to `now`.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.parse">
@@ -28594,19 +28586,19 @@ THH:mm:ss.sss
         <p>When the `UTC` function is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 0.
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 1.
-          1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be 0.
-          1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be 0.
-          1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be 0.
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be 0.
+          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be *+0*<sub>𝔽</sub>.
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be *1*<sub>𝔽</sub>.
+          1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be *+0*<sub>𝔽</sub>.
+          1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be *+0*<sub>𝔽</sub>.
+          1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be *+0*<sub>𝔽</sub>.
+          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be *+0*<sub>𝔽</sub>.
           1. If _y_ is *NaN*, let _yr_ be *NaN*.
           1. Else,
-            1. Let _yi_ be ! ToInteger(_y_).
-            1. If 0 &le; _yi_ &le; 99, let _yr_ be 1900 + _yi_; otherwise, let _yr_ be _y_.
+            1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
+            1. If 0 &le; _yi_ &le; 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
           1. Return TimeClip(MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_))).
         </emu-alg>
-        <p>The *"length"* property of the `UTC` function is 7.</p>
+        <p>The *"length"* property of the `UTC` function is *7*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>The `UTC` function differs from the Date constructor in two ways: it returns a time value as a Number, rather than creating a Date object, and it interprets the arguments in UTC rather than as local time.</p>
         </emu-note>
@@ -28832,7 +28824,7 @@ THH:mm:ss.sss
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
-          1. If _t_ is *NaN*, set _t_ to *+0*; otherwise, set _t_ to LocalTime(_t_).
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
           1. Let _y_ be ? ToNumber(_year_).
           1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
@@ -28841,7 +28833,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setFullYear` method is 3.</p>
+        <p>The *"length"* property of the `setFullYear` method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getDate()`.</p>
         </emu-note>
@@ -28861,7 +28853,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setHours` method is 4.</p>
+        <p>The *"length"* property of the `setHours` method is *4*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -28893,7 +28885,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setMinutes` method is 3.</p>
+        <p>The *"length"* property of the `setMinutes` method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, this behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -28911,7 +28903,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setMonth` method is 2.</p>
+        <p>The *"length"* property of the `setMonth` method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getDate()`.</p>
         </emu-note>
@@ -28929,7 +28921,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setSeconds` method is 2.</p>
+        <p>The *"length"* property of the `setSeconds` method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -28965,7 +28957,7 @@ THH:mm:ss.sss
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
-          1. If _t_ is *NaN*, set _t_ to *+0*.
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>.
           1. Let _y_ be ? ToNumber(_year_).
           1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
@@ -28974,7 +28966,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCFullYear` method is 3.</p>
+        <p>The *"length"* property of the `setUTCFullYear` method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getUTCMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getUTCDate()`.</p>
         </emu-note>
@@ -28994,7 +28986,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCHours` method is 4.</p>
+        <p>The *"length"* property of the `setUTCHours` method is *4*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getUTCMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -29030,7 +29022,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCMinutes` method is 3.</p>
+        <p>The *"length"* property of the `setUTCMinutes` method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it function behaves as if _ms_ was present with the value return by `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -29050,7 +29042,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCMonth` method is 2.</p>
+        <p>The *"length"* property of the `setUTCMonth` method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getUTCDate()`.</p>
         </emu-note>
@@ -29070,7 +29062,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCSeconds` method is 2.</p>
+        <p>The *"length"* property of the `setUTCSeconds` method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -29140,7 +29132,7 @@ THH:mm:ss.sss
           1. Return ToDateString(_tv_).
         </emu-alg>
         <emu-note>
-          <p>For any Date object `d` whose milliseconds amount is zero, the result of `Date.parse(d.toString())` is equal to `d.valueOf()`. See <emu-xref href="#sec-date.parse"></emu-xref>.</p>
+          <p>For any Date object `d` such that `d.[[DateValue]]` is evenly divisible by 1000, the result of `Date.parse(d.toString())` = `d.valueOf()`. See <emu-xref href="#sec-date.parse"></emu-xref>.</p>
         </emu-note>
         <emu-note>
           <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Date object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
@@ -29152,9 +29144,9 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
-            1. Let _hour_ be the String representation of HourFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-            1. Let _minute_ be the String representation of MinFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-            1. Let _second_ be the String representation of SecFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+            1. Let _hour_ be the String representation of HourFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
+            1. Let _minute_ be the String representation of MinFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
+            1. Let _second_ be the String representation of SecFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
             1. Return the string-concatenation of _hour_, *":"*, _minute_, *":"*, _second_, the code unit 0x0020 (SPACE), and *"GMT"*.
           </emu-alg>
         </emu-clause>
@@ -29167,11 +29159,11 @@ THH:mm:ss.sss
             1. Assert: _tv_ is not *NaN*.
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
-            1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+            1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
             1. Let _yv_ be YearFromTime(_tv_).
-            1. If _yv_ &ge; 0, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
-            1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
-            1. Let _paddedYear_ be ! StringPad(_year_, 4, *"0"*, ~start~).
+            1. If _yv_ &ge; *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
+            1. Let _year_ be the String representation of abs(ℝ(_yv_)), formatted as a decimal number.
+            1. Let _paddedYear_ be ! StringPad(_year_, *4*<sub>𝔽</sub>, *"0"*, ~start~).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
@@ -29187,7 +29179,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  0
+                  *+0*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Sun"*
@@ -29195,7 +29187,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  1
+                  *1*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Mon"*
@@ -29203,7 +29195,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  2
+                  *2*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Tue"*
@@ -29211,7 +29203,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  3
+                  *3*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Wed"*
@@ -29219,7 +29211,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  4
+                  *4*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Thu"*
@@ -29227,7 +29219,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  5
+                  *5*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Fri"*
@@ -29235,7 +29227,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  6
+                  *6*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Sat"*
@@ -29257,7 +29249,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  0
+                  *+0*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Jan"*
@@ -29265,7 +29257,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  1
+                  *1*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Feb"*
@@ -29273,7 +29265,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  2
+                  *2*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Mar"*
@@ -29281,7 +29273,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  3
+                  *3*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Apr"*
@@ -29289,7 +29281,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  4
+                  *4*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"May"*
@@ -29297,7 +29289,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  5
+                  *5*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Jun"*
@@ -29305,7 +29297,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  6
+                  *6*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Jul"*
@@ -29313,7 +29305,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  7
+                  *7*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Aug"*
@@ -29321,7 +29313,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  8
+                  *8*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Sep"*
@@ -29329,7 +29321,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  9
+                  *9*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Oct"*
@@ -29337,7 +29329,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  10
+                  *10*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Nov"*
@@ -29345,7 +29337,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  11
+                  *11*<sub>𝔽</sub>
                 </td>
                 <td>
                   *"Dec"*
@@ -29363,9 +29355,14 @@ THH:mm:ss.sss
             1. Assert: Type(_tv_) is Number.
             1. Assert: _tv_ is not *NaN*.
             1. Let _offset_ be LocalTZA(_tv_, *true*).
-            1. If _offset_ &ge; 0, let _offsetSign_ be *"+"*; otherwise, let _offsetSign_ be *"-"*.
-            1. Let _offsetMin_ be the String representation of MinFromTime(abs(_offset_)), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-            1. Let _offsetHour_ be the String representation of HourFromTime(abs(_offset_)), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+            1. If _offset_ &ge; *+0*<sub>𝔽</sub>, then
+              1. Let _offsetSign_ be *"+"*.
+              1. Let _absOffset_ be _offset_.
+            1. Else,
+              1. Let _offsetSign_ be *"-"*.
+              1. Let _absOffset_ be -_offset_.
+            1. Let _offsetMin_ be the String representation of MinFromTime(_absOffset_), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
+            1. Let _offsetHour_ be the String representation of HourFromTime(_absOffset_), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
             1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>
@@ -29404,11 +29401,11 @@ THH:mm:ss.sss
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
-          1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+          1. Let _day_ be the String representation of DateFromTime(_tv_), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
           1. Let _yv_ be YearFromTime(_tv_).
-          1. If _yv_ &ge; 0, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
-          1. Let _year_ be the String representation of abs(_yv_), formatted as a decimal number.
-          1. Let _paddedYear_ be ! StringPad(_year_, 4, *"0"*, ~start~).
+          1. If _yv_ &ge; *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
+          1. Let _year_ be the String representation of abs(ℝ(_yv_)), formatted as a decimal number.
+          1. Let _paddedYear_ be ! StringPad(_year_, *4*<sub>𝔽</sub>, *"0"*, ~start~).
           1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
@@ -29493,11 +29490,11 @@ THH:mm:ss.sss
           1. Let _length_ be the number of elements in _codeUnits_.
           1. Let _elements_ be a new empty List.
           1. For each element _next_ of _codeUnits_, do
-            1. Let _nextCU_ be ? ToUint16(_next_).
+            1. Let _nextCU_ be ℝ(? ToUint16(_next_)).
             1. Append _nextCU_ to the end of _elements_.
           1. Return the String value whose code units are the elements in the List _elements_. If _codeUnits_ is empty, the empty String is returned.
         </emu-alg>
-        <p>The *"length"* property of the `fromCharCode` function is 1.</p>
+        <p>The *"length"* property of the `fromCharCode` function is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-string.fromcodepoint">
@@ -29507,12 +29504,12 @@ THH:mm:ss.sss
           1. Let _elements_ be a new empty List.
           1. For each element _next_ of _codePoints_, do
             1. Let _nextCP_ be ? ToNumber(_next_).
-            1. If ! IsInteger(_nextCP_) is *false*, throw a *RangeError* exception.
-            1. If _nextCP_ &lt; 0 or _nextCP_ &gt; 0x10FFFF, throw a *RangeError* exception.
-            1. Append the elements of ! CodePointToUTF16CodeUnits(_nextCP_) to the end of _elements_.
+            1. If ! IsIntegralNumber(_nextCP_) is *false*, throw a *RangeError* exception.
+            1. If ℝ(_nextCP_) &lt; 0 or ℝ(_nextCP_) &gt; 0x10FFFF, throw a *RangeError* exception.
+            1. Append the elements of ! CodePointToUTF16CodeUnits(ℝ(_nextCP_)) to the end of _elements_.
           1. Return the String value whose code units are the elements in the List _elements_. If _codePoints_ is empty, the empty String is returned.
         </emu-alg>
-        <p>The *"length"* property of the `fromCodePoint` function is 1.</p>
+        <p>The *"length"* property of the `fromCodePoint` function is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype">
@@ -29533,7 +29530,7 @@ THH:mm:ss.sss
           1. Let _stringElements_ be a new empty List.
           1. Let _nextIndex_ be 0.
           1. Repeat,
-            1. Let _nextKey_ be ! ToString(_nextIndex_).
+            1. Let _nextKey_ be ! ToString(𝔽(_nextIndex_)).
             1. Let _nextSeg_ be ? ToString(? Get(_raw_, _nextKey_)).
             1. Append the code unit elements of _nextSeg_ to the end of _stringElements_.
             1. If _nextIndex_ + 1 = _literalSegments_, then
@@ -29575,13 +29572,13 @@ THH:mm:ss.sss
         <h1>String.prototype.charAt ( _pos_ )</h1>
         <emu-note>
           <p>Returns a single element String containing the code unit at index _pos_ within the String value resulting from converting this object to a String. If there is no element at that index, the result is the empty String. The result is a String value, not a String object.</p>
-          <p>If `pos` is a value of Number type that is an integer, then the result of `x.charAt(pos)` is equal to the result of `x.substring(pos, pos + 1)`.</p>
+          <p>If `pos` is an integral Number, then the result of `x.charAt(pos)` is equivalent to the result of `x.substring(pos, pos + 1)`.</p>
         </emu-note>
         <p>When the `charAt` method is called with one argument _pos_, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _position_ be ? ToInteger(_pos_).
+          1. Let _position_ be ? ToIntegerOrInfinity(_pos_).
           1. Let _size_ be the length of _S_.
           1. If _position_ &lt; 0 or _position_ &ge; _size_, return the empty String.
           1. Return the String value of length 1, containing one code unit from _S_, namely the code unit at index _position_.
@@ -29594,16 +29591,16 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.charcodeat">
         <h1>String.prototype.charCodeAt ( _pos_ )</h1>
         <emu-note>
-          <p>Returns a Number (a nonnegative integer less than 2<sup>16</sup>) that is the numeric value of the code unit at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *NaN*.</p>
+          <p>Returns a Number (a non-negative integral Number less than 2<sup>16</sup>) that is the numeric value of the code unit at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *NaN*.</p>
         </emu-note>
         <p>When the `charCodeAt` method is called with one argument _pos_, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _position_ be ? ToInteger(_pos_).
+          1. Let _position_ be ? ToIntegerOrInfinity(_pos_).
           1. Let _size_ be the length of _S_.
           1. If _position_ &lt; 0 or _position_ &ge; _size_, return *NaN*.
-          1. Return a value of Number type, whose value is the numeric value of the code unit at index _position_ within the String _S_.
+          1. Return the Number value for the numeric value of the code unit at index _position_ within the String _S_.
         </emu-alg>
         <emu-note>
           <p>The `charCodeAt` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -29613,17 +29610,17 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.codepointat">
         <h1>String.prototype.codePointAt ( _pos_ )</h1>
         <emu-note>
-          <p>Returns a nonnegative integer Number less than or equal to 0x10FFFF that is the code point value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> does not begin at _pos_, the result is the code unit at _pos_.</p>
+          <p>Returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the code point value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> does not begin at _pos_, the result is the code unit at _pos_.</p>
         </emu-note>
         <p>When the `codePointAt` method is called with one argument _pos_, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _position_ be ? ToInteger(_pos_).
+          1. Let _position_ be ? ToIntegerOrInfinity(_pos_).
           1. Let _size_ be the length of _S_.
           1. If _position_ &lt; 0 or _position_ &ge; _size_, return *undefined*.
           1. Let _cp_ be ! CodePointAt(_S_, _position_).
-          1. Return _cp_.[[CodePoint]].
+          1. Return 𝔽(_cp_.[[CodePoint]]).
         </emu-alg>
         <emu-note>
           <p>The `codePointAt` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -29645,7 +29642,7 @@ THH:mm:ss.sss
             1. Set _R_ to the string-concatenation of _R_ and _nextString_.
           1. Return _R_.
         </emu-alg>
-        <p>The *"length"* property of the `concat` method is 1.</p>
+        <p>The *"length"* property of the `concat` method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>The `concat` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -29666,8 +29663,8 @@ THH:mm:ss.sss
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _len_ be the length of _S_.
-          1. If _endPosition_ is *undefined*, let _pos_ be _len_; else let _pos_ be ? ToInteger(_endPosition_).
-          1. Let _end_ be min(max(_pos_, 0), _len_).
+          1. If _endPosition_ is *undefined*, let _pos_ be _len_; else let _pos_ be ? ToIntegerOrInfinity(_endPosition_).
+          1. Let _end_ be the result of clamping _pos_ between 0 and _len_.
           1. Let _searchLength_ be the length of _searchStr_.
           1. If _searchLength_ = 0, return *true*.
           1. Let _start_ be _end_ - _searchLength_.
@@ -29695,10 +29692,10 @@ THH:mm:ss.sss
           1. Let _isRegExp_ be ? IsRegExp(_searchString_).
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
-          1. Let _pos_ be ? ToInteger(_position_).
+          1. Let _pos_ be ? ToIntegerOrInfinity(_position_).
           1. Assert: If _position_ is *undefined*, then _pos_ is 0.
           1. Let _len_ be the length of _S_.
-          1. Let _start_ be min(max(_pos_, 0), _len_).
+          1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
           1. Let _index_ be ! StringIndexOf(_S_, _searchStr_, _start_).
           1. If _index_ is not -1, return *true*.
           1. Return *false*.
@@ -29717,18 +29714,18 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.indexof">
         <h1>String.prototype.indexOf ( _searchString_ [ , _position_ ] )</h1>
         <emu-note>
-          <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, at one or more indices that are greater than or equal to _position_, then the smallest such index is returned; otherwise, -1 is returned. If _position_ is *undefined*, 0 is assumed, so as to search all of the String.</p>
+          <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, at one or more indices that are greater than or equal to _position_, then the smallest such index is returned; otherwise, *-1*<sub>𝔽</sub> is returned. If _position_ is *undefined*, *+0*<sub>𝔽</sub> is assumed, so as to search all of the String.</p>
         </emu-note>
         <p>The `indexOf` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _searchStr_ be ? ToString(_searchString_).
-          1. Let _pos_ be ? ToInteger(_position_).
+          1. Let _pos_ be ? ToIntegerOrInfinity(_position_).
           1. Assert: If _position_ is *undefined*, then _pos_ is 0.
           1. Let _len_ be the length of _S_.
-          1. Let _start_ be min(max(_pos_, 0), _len_).
-          1. Return ! StringIndexOf(_S_, _searchStr_, _start_).
+          1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
+          1. Return 𝔽(! StringIndexOf(_S_, _searchStr_, _start_)).
         </emu-alg>
         <emu-note>
           <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -29738,7 +29735,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.lastindexof">
         <h1>String.prototype.lastIndexOf ( _searchString_ [ , _position_ ] )</h1>
         <emu-note>
-          <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String at one or more indices that are smaller than or equal to _position_, then the greatest such index is returned; otherwise, -1 is returned. If _position_ is *undefined*, the length of the String value is assumed, so as to search all of the String.</p>
+          <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String at one or more indices that are smaller than or equal to _position_, then the greatest such index is returned; otherwise, *-1*<sub>𝔽</sub> is returned. If _position_ is *undefined*, the length of the String value is assumed, so as to search all of the String.</p>
         </emu-note>
         <p>The `lastIndexOf` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
         <emu-alg>
@@ -29747,11 +29744,12 @@ THH:mm:ss.sss
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _numPos_ be ? ToNumber(_position_).
           1. Assert: If _position_ is *undefined*, then _numPos_ is *NaN*.
-          1. If _numPos_ is *NaN*, let _pos_ be *+&infin;*; otherwise, let _pos_ be ! ToInteger(_numPos_).
+          1. If _numPos_ is *NaN*, let _pos_ be +&infin;; otherwise, let _pos_ be ! ToIntegerOrInfinity(_numPos_).
           1. Let _len_ be the length of _S_.
-          1. Let _start_ be min(max(_pos_, 0), _len_).
+          1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
           1. Let _searchLen_ be the length of _searchStr_.
-          1. Return the largest possible nonnegative integer _k_ not larger than _start_ such that _k_ + _searchLen_ is not greater than _len_, and for all nonnegative integers _j_ less than _searchLen_, the code unit at index _k_ + _j_ within _S_ is the same as the code unit at index _j_ within _searchStr_; but if there is no such integer _k_, return the value -1.
+          1. Let _k_ be the largest possible non-negative integer not larger than _start_ such that _k_ + _searchLen_ &le; _len_, and for all non-negative integers _j_ such that _j_ &lt; _searchLen_, the code unit at index _k_ + _j_ within _S_ is the same as the code unit at index _j_ within _searchStr_; but if there is no such integer, let _k_ be -1.
+          1. Return 𝔽(_k_).
         </emu-alg>
         <emu-note>
           <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -29864,9 +29862,9 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: _placement_ is ~start~ or ~end~.
             1. Let _S_ be ? ToString(_O_).
-            1. Let _intMaxLength_ be ? ToLength(_maxLength_).
+            1. Let _intMaxLength_ be ℝ(? ToLength(_maxLength_)).
             1. Let _stringLength_ be the length of _S_.
-            1. If _intMaxLength_ is not greater than _stringLength_, return _S_.
+            1. If _intMaxLength_ &le; _stringLength_, return _S_.
             1. If _fillString_ is *undefined*, let _filler_ be the String value consisting solely of the code unit 0x0020 (SPACE).
             1. Else, let _filler_ be ? ToString(_fillString_).
             1. If _filler_ is the empty String, return _S_.
@@ -29890,9 +29888,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _n_ be ? ToInteger(_count_).
-          1. If _n_ &lt; 0, throw a *RangeError* exception.
-          1. If _n_ is *+&infin;*, throw a *RangeError* exception.
+          1. Let _n_ be ? ToIntegerOrInfinity(_count_).
+          1. If _n_ &lt; 0 or _n_ is +&infin;, throw a *RangeError* exception.
           1. If _n_ is 0, return the empty String.
           1. Return the String value that is made from _n_ copies of _S_ appended together.
         </emu-alg>
@@ -29923,7 +29920,7 @@ THH:mm:ss.sss
           1. If _position_ is -1, return _string_.
           1. Let _preserved_ be the substring of _string_ from 0 to _position_.
           1. If _functionalReplace_ is *true*, then
-            1. Let _replacement_ be ? ToString(? Call(_replaceValue_, *undefined*, &laquo; _searchString_, _position_, _string_ &raquo;)).
+            1. Let _replacement_ be ? ToString(? Call(_replaceValue_, *undefined*, &laquo; _searchString_, 𝔽(_position_), _string_ &raquo;)).
           1. Else,
             1. Assert: Type(_replaceValue_) is String.
             1. Let _captures_ be a new empty List.
@@ -29936,13 +29933,12 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-getsubstitution" aoid="GetSubstitution">
           <h1>GetSubstitution ( _matched_, _str_, _position_, _captures_, _namedCaptures_, _replacement_ )</h1>
-          <p>The abstract operation GetSubstitution takes arguments _matched_, _str_, _position_, _captures_, _namedCaptures_, and _replacement_. It performs the following steps when called:</p>
+          <p>The abstract operation GetSubstitution takes arguments _matched_, _str_, _position_ (a non-negative integer), _captures_, _namedCaptures_, and _replacement_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_matched_) is String.
             1. Let _matchLength_ be the number of code units in _matched_.
             1. Assert: Type(_str_) is String.
             1. Let _stringLength_ be the number of code units in _str_.
-            1. Assert: ! IsNonNegativeInteger(_position_) is *true*.
             1. Assert: _position_ &le; _stringLength_.
             1. Assert: _captures_ is a possibly empty List of Strings.
             1. Assert: Type(_replacement_) is String.
@@ -30110,16 +30106,16 @@ THH:mm:ss.sss
             1. Set _position_ to ! StringIndexOf(_string_, _searchString_, _position_ + _advanceBy_).
           1. Let _endOfLastMatch_ be 0.
           1. Let _result_ be the empty String.
-          1. For each element _position_ of _matchPositions_, do
-            1. Let _preserved_ be the substring of _string_ from _endOfLastMatch_ to _position_.
+          1. For each element _p_ of _matchPositions_, do
+            1. Let _preserved_ be the substring of _string_ from _endOfLastMatch_ to _p_.
             1. If _functionalReplace_ is *true*, then
-              1. Let _replacement_ be ? ToString(? Call(_replaceValue_, *undefined*, &laquo; _searchString_, _position_, _string_ &raquo;)).
+              1. Let _replacement_ be ? ToString(? Call(_replaceValue_, *undefined*, &laquo; _searchString_, 𝔽(_p_), _string_ &raquo;)).
             1. Else,
               1. Assert: Type(_replaceValue_) is String.
               1. Let _captures_ be a new empty List.
-              1. Let _replacement_ be ! GetSubstitution(_searchString_, _string_, _position_, _captures_, *undefined*, _replaceValue_).
+              1. Let _replacement_ be ! GetSubstitution(_searchString_, _string_, _p_, _captures_, *undefined*, _replaceValue_).
             1. Set _result_ to the string-concatenation of _result_, _preserved_, and _replacement_.
-            1. Set _endOfLastMatch_ to _position_ + _searchLength_.
+            1. Set _endOfLastMatch_ to _p_ + _searchLength_.
           1. If _endOfLastMatch_ &lt; the length of _string_, then
             1. Set _result_ to the string-concatenation of _result_ and the substring of _string_ from _endOfLastMatch_.
           1. Return _result_.
@@ -30151,10 +30147,14 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the length of _S_.
-          1. Let _intStart_ be ? ToInteger(_start_).
-          1. If _end_ is *undefined*, let _intEnd_ be _len_; else let _intEnd_ be ? ToInteger(_end_).
-          1. If _intStart_ &lt; 0, let _from_ be max(_len_ + _intStart_, 0); otherwise let _from_ be min(_intStart_, _len_).
-          1. If _intEnd_ &lt; 0, let _to_ be max(_len_ + _intEnd_, 0); otherwise let _to_ be min(_intEnd_, _len_).
+          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _intStart_ is -&infin;, let _from_ be 0.
+          1. Else if _intStart_ &lt; 0, let _from_ be max(_len_ + _intStart_, 0).
+          1. Else, let _from_ be min(_intStart_, _len_).
+          1. If _end_ is *undefined*, let _intEnd_ be _len_; else let _intEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _intEnd_ is -&infin;, let _to_ be 0.
+          1. Else if _intEnd_ &lt; 0, let _to_ be max(_len_ + _intEnd_, 0).
+          1. Else, let _to_ be min(_intEnd_, _len_).
           1. If _from_ &ge; _to_, return the empty String.
           1. Return the substring of _S_ from _from_ to _to_.
         </emu-alg>
@@ -30176,7 +30176,7 @@ THH:mm:ss.sss
           1. Let _S_ be ? ToString(_O_).
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _lengthA_ be 0.
-          1. If _limit_ is *undefined*, let _lim_ be 2<sup>32</sup> - 1; else let _lim_ be ? ToUint32(_limit_).
+          1. If _limit_ is *undefined*, let _lim_ be 2<sup>32</sup> - 1; else let _lim_ be ℝ(? ToUint32(_limit_)).
           1. Let _R_ be ? ToString(_separator_).
           1. If _lim_ = 0, return _A_.
           1. If _separator_ is *undefined*, then
@@ -30191,19 +30191,19 @@ THH:mm:ss.sss
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &ne; _s_,
             1. Let _e_ be SplitMatch(_S_, _q_, _R_).
-            1. If _e_ is *false*, set _q_ to _q_ + 1.
+            1. If _e_ is ~not-matched~, set _q_ to _q_ + 1.
             1. Else,
-              1. Assert: _e_ is an integer index &le; _s_.
+              1. Assert: _e_ is a non-negative integer &le; _s_.
               1. If _e_ = _p_, set _q_ to _q_ + 1.
               1. Else,
                 1. Let _T_ be the substring of _S_ from _p_ to _q_.
-                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
+                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _T_).
                 1. Set _lengthA_ to _lengthA_ + 1.
                 1. If _lengthA_ = _lim_, return _A_.
                 1. Set _p_ to _e_.
                 1. Set _q_ to _p_.
           1. Let _T_ be the substring of _S_ from _p_ to _s_.
-          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _T_).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -30217,13 +30217,13 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-splitmatch" aoid="SplitMatch">
           <h1>SplitMatch ( _S_, _q_, _R_ )</h1>
-          <p>The abstract operation SplitMatch takes arguments _S_ (a String), _q_ (an integer), and _R_ (a String). It returns either *false* or the end index of a match. It performs the following steps when called:</p>
+          <p>The abstract operation SplitMatch takes arguments _S_ (a String), _q_ (a non-negative integer), and _R_ (a String). It returns either ~not-matched~ or the end index of a match. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_R_) is String.
             1. Let _r_ be the number of code units in _R_.
             1. Let _s_ be the number of code units in _S_.
-            1. If _q_ + _r_ &gt; _s_, return *false*.
-            1. If there exists an integer _i_ between 0 (inclusive) and _r_ (exclusive) such that the code unit at index _q_ + _i_ within _S_ is different from the code unit at index _i_ within _R_, return *false*.
+            1. If _q_ + _r_ &gt; _s_, return ~not-matched~.
+            1. If there exists an integer _i_ between 0 (inclusive) and _r_ (exclusive) such that the code unit at index _q_ + _i_ within _S_ is different from the code unit at index _i_ within _R_, return ~not-matched~.
             1. Return _q_ + _r_.
           </emu-alg>
         </emu-clause>
@@ -30239,8 +30239,8 @@ THH:mm:ss.sss
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _len_ be the length of _S_.
-          1. If _position_ is *undefined*, let _pos_ be 0; else let _pos_ be ? ToInteger(_position_).
-          1. Let _start_ be min(max(_pos_, 0), _len_).
+          1. If _position_ is *undefined*, let _pos_ be 0; else let _pos_ be ? ToIntegerOrInfinity(_position_).
+          1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
           1. Let _searchLength_ be the length of _searchStr_.
           1. If _searchLength_ = 0, return *true*.
           1. Let _end_ be _start_ + _searchLength_.
@@ -30269,10 +30269,10 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the length of _S_.
-          1. Let _intStart_ be ? ToInteger(_start_).
-          1. If _end_ is *undefined*, let _intEnd_ be _len_; else let _intEnd_ be ? ToInteger(_end_).
-          1. Let _finalStart_ be min(max(_intStart_, 0), _len_).
-          1. Let _finalEnd_ be min(max(_intEnd_, 0), _len_).
+          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _end_ is *undefined*, let _intEnd_ be _len_; else let _intEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. Let _finalStart_ be the result of clamping _intStart_ between 0 and _len_.
+          1. Let _finalEnd_ be the result of clamping _intEnd_ between 0 and _len_.
           1. Let _from_ be min(_finalStart_, _finalEnd_).
           1. Let _to_ be max(_finalStart_, _finalEnd_).
           1. Return the substring of _S_ from _from_ to _to_.
@@ -30828,12 +30828,12 @@ THH:mm:ss.sss
         <h1>Static Semantics: CapturingGroupNumber</h1>
         <emu-grammar>DecimalEscape :: NonZeroDigit</emu-grammar>
         <emu-alg>
-          1. Return the Number value for the MV of |NonZeroDigit|.
+          1. Return the MV of |NonZeroDigit|.
         </emu-alg>
         <emu-grammar>DecimalEscape :: NonZeroDigit DecimalDigits</emu-grammar>
         <emu-alg>
-          1. Let _n_ be the mathematical integer number of code points in |DecimalDigits|.
-          1. Return the Number value for (the MV of |NonZeroDigit| &times;<sub>ℝ</sub> 10<sub>ℝ</sub><sup>_n_</sup> plus the MV of |DecimalDigits|).
+          1. Let _n_ be the number of code points in |DecimalDigits|.
+          1. Return (the MV of |NonZeroDigit| &times; 10<sup>_n_</sup> plus the MV of |DecimalDigits|).
         </emu-alg>
         <p>The definitions of &ldquo;the MV of |NonZeroDigit|&rdquo; and &ldquo;the MV of |DecimalDigits|&rdquo; are in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
       </emu-clause>
@@ -31025,11 +31025,11 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar>
         <emu-alg>
-          1. Return the Number value for the MV of |Hex4Digits|.
+          1. Return the MV of |Hex4Digits|.
         </emu-alg>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar>
         <emu-alg>
-          1. Return the Number value for the MV of |CodePoint|.
+          1. Return the MV of |CodePoint|.
         </emu-alg>
         <emu-grammar>
           HexLeadSurrogate :: Hex4Digits
@@ -31039,7 +31039,7 @@ THH:mm:ss.sss
           HexNonSurrogate :: Hex4Digits
         </emu-grammar>
         <emu-alg>
-          1. Return the Number value for the MV of |HexDigits|.
+          1. Return the MV of |HexDigits|.
         </emu-alg>
         <emu-grammar>CharacterEscape :: IdentityEscape</emu-grammar>
         <emu-alg>
@@ -31140,10 +31140,10 @@ THH:mm:ss.sss
         <h1>Pattern</h1>
         <p>The production <emu-grammar>Pattern :: Disjunction</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Evaluate |Disjunction| with +1 as its _direction_ argument to obtain a Matcher _m_.
+          1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
           1. Return a new Abstract Closure with parameters (_str_, _index_) that captures _m_ and performs the following steps when called:
             1. Assert: Type(_str_) is String.
-            1. Assert: ! IsNonNegativeInteger(_index_) is *true* and _index_ &le; the length of _str_.
+            1. Assert: _index_ is a non-negative integer which is &le; the length of _str_.
             1. If _Unicode_ is *true*, let _Input_ be ! StringToCodePoints(_str_). Otherwise, let _Input_ be a List whose elements are the code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
             1. Let _InputLength_ be the number of characters contained in _Input_. This alias will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.
             1. Let _listIndex_ be the index into _Input_ of the character that was obtained from element _index_ of _str_.
@@ -31205,7 +31205,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Evaluate |Alternative| with argument _direction_ to obtain a Matcher _m1_.
           1. Evaluate |Term| with argument _direction_ to obtain a Matcher _m2_.
-          1. If _direction_ is equal to +1, then
+          1. If _direction_ = 1, then
             1. Return a new Matcher with parameters (_x_, _c_) that captures _m1_ and _m2_ and performs the following steps when called:
               1. Assert: _x_ is a State.
               1. Assert: _c_ is a Continuation.
@@ -31214,7 +31214,7 @@ THH:mm:ss.sss
                 1. Return _m2_(_y_, _c_).
               1. Return _m1_(_x_, _d_).
           1. Else,
-            1. Assert: _direction_ is equal to -1.
+            1. Assert: _direction_ is -1.
             1. Return a new Matcher with parameters (_x_, _c_) that captures _m1_ and _m2_ and performs the following steps when called:
               1. Assert: _x_ is a State.
               1. Assert: _c_ is a Continuation.
@@ -31224,7 +31224,7 @@ THH:mm:ss.sss
               1. Return _m2_(_x_, _d_).
         </emu-alg>
         <emu-note>
-          <p>Consecutive |Term|s try to simultaneously match consecutive portions of _Input_. When _direction_ is equal to +1, if the left |Alternative|, the right |Term|, and the sequel of the regular expression all have choice points, all choices in the sequel are tried before moving on to the next choice in the right |Term|, and all choices in the right |Term| are tried before moving on to the next choice in the left |Alternative|. When _direction_ is equal to -1, the evaluation order of |Alternative| and |Term| are reversed.</p>
+          <p>Consecutive |Term|s try to simultaneously match consecutive portions of _Input_. When _direction_ = 1, if the left |Alternative|, the right |Term|, and the sequel of the regular expression all have choice points, all choices in the sequel are tried before moving on to the next choice in the right |Term|, and all choices in the right |Term| are tried before moving on to the next choice in the left |Alternative|. When _direction_ = -1, the evaluation order of |Alternative| and |Term| are reversed.</p>
         </emu-note>
       </emu-clause>
 
@@ -31245,8 +31245,8 @@ THH:mm:ss.sss
         <p>The production <emu-grammar>Term :: Atom Quantifier</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Evaluate |Atom| with argument _direction_ to obtain a Matcher _m_.
-          1. Evaluate |Quantifier| to obtain the three results: an integer _min_, an integer (or &infin;) _max_, and Boolean _greedy_.
-          1. Assert: If _max_ is finite, then _max_ is not less than _min_.
+          1. Evaluate |Quantifier| to obtain the three results: a non-negative integer _min_, a non-negative integer (or +&infin;) _max_, and Boolean _greedy_.
+          1. Assert: _min_ &le; _max_.
           1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of this |Term|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing this |Term|.
           1. Let _parenCount_ be the number of left-capturing parentheses in |Atom|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes enclosed by |Atom|.
           1. Return a new Matcher with parameters (_x_, _c_) that captures _m_, _min_, _max_, _greedy_, _parenIndex_, and _parenCount_ and performs the following steps when called:
@@ -31257,20 +31257,20 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" aoid="RepeatMatcher">
           <h1>RepeatMatcher ( _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_ )</h1>
-          <p>The abstract operation RepeatMatcher takes arguments _m_ (a Matcher), _min_ (an integer), _max_ (an integer or &infin;), _greedy_ (a Boolean), _x_ (a State), _c_ (a Continuation), _parenIndex_ (an integer), and _parenCount_ (an integer). It performs the following steps when called:</p>
+          <p>The abstract operation RepeatMatcher takes arguments _m_ (a Matcher), _min_ (a non-negative integer), _max_ (a non-negative integer or +&infin;), _greedy_ (a Boolean), _x_ (a State), _c_ (a Continuation), _parenIndex_ (a non-negative integer), and _parenCount_ (a non-negative integer). It performs the following steps when called:</p>
           <emu-alg>
-            1. If _max_ is zero, return _c_(_x_).
+            1. If _max_ = 0, return _c_(_x_).
             1. Let _d_ be a new Continuation with parameters (_y_) that captures _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, and _parenCount_ and performs the following steps when called:
               1. Assert: _y_ is a State.
-              1. [id="step-repeatmatcher-done"] If _min_ is zero and _y_'s _endIndex_ is equal to _x_'s _endIndex_, return ~failure~.
-              1. If _min_ is zero, let _min2_ be zero; otherwise let _min2_ be _min_ - 1.
-              1. If _max_ is &infin;, let _max2_ be &infin;; otherwise let _max2_ be _max_ - 1.
+              1. [id="step-repeatmatcher-done"] If _min_ = 0 and _y_'s _endIndex_ = _x_'s _endIndex_, return ~failure~.
+              1. If _min_ = 0, let _min2_ be 0; otherwise let _min2_ be _min_ - 1.
+              1. If _max_ is +&infin;, let _max2_ be +&infin;; otherwise let _max2_ be _max_ - 1.
               1. Return ! RepeatMatcher(_m_, _min2_, _max2_, _greedy_, _y_, _c_, _parenIndex_, _parenCount_).
             1. Let _cap_ be a copy of _x_'s _captures_ List.
             1. [id="step-repeatmatcher-clear-captures"] For each integer _k_ that satisfies _parenIndex_ &lt; _k_ and _k_ &le; _parenIndex_ + _parenCount_, set _cap_[_k_] to *undefined*.
             1. Let _e_ be _x_'s _endIndex_.
             1. Let _xr_ be the State (_e_, _cap_).
-            1. If _min_ is not zero, return _m_(_xr_, _d_).
+            1. If _min_ &ne; 0, return _m_(_xr_, _d_).
             1. If _greedy_ is *false*, then
               1. Let _z_ be _c_(_x_).
               1. If _z_ is not ~failure~, return _z_.
@@ -31330,7 +31330,7 @@ THH:mm:ss.sss
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
             1. Let _e_ be _x_'s _endIndex_.
-            1. If _e_ is zero, or if _Multiline_ is *true* and the character _Input_[_e_ - 1] is one of |LineTerminator|, then
+            1. If _e_ = 0, or if _Multiline_ is *true* and the character _Input_[_e_ - 1] is one of |LineTerminator|, then
               1. Return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
@@ -31343,7 +31343,7 @@ THH:mm:ss.sss
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
             1. Let _e_ be _x_'s _endIndex_.
-            1. If _e_ is equal to _InputLength_, or if _Multiline_ is *true* and the character _Input_[_e_] is one of |LineTerminator|, then
+            1. If _e_ = _InputLength_, or if _Multiline_ is *true* and the character _Input_[_e_] is one of |LineTerminator|, then
               1. Return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
@@ -31371,7 +31371,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The production <emu-grammar>Assertion :: `(` `?` `=` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Evaluate |Disjunction| with +1 as its _direction_ argument to obtain a Matcher _m_.
+          1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
           1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
@@ -31388,7 +31388,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The production <emu-grammar>Assertion :: `(` `?` `!` Disjunction `)`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Evaluate |Disjunction| with +1 as its _direction_ argument to obtain a Matcher _m_.
+          1. Evaluate |Disjunction| with 1 as its _direction_ argument to obtain a Matcher _m_.
           1. Return a new Matcher with parameters (_x_, _c_) that captures _m_ and performs the following steps when called:
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
@@ -31434,7 +31434,7 @@ THH:mm:ss.sss
           <h1>IsWordChar ( _e_ )</h1>
           <p>The abstract operation IsWordChar takes argument _e_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
-            1. If _e_ is -1 or _e_ is _InputLength_, return *false*.
+            1. If _e_ = -1 or _e_ is _InputLength_, return *false*.
             1. Let _c_ be the character _Input_[_e_].
             1. If _c_ is in _WordCharacters_, return *true*.
             1. Return *false*.
@@ -31445,21 +31445,21 @@ THH:mm:ss.sss
         <h1>Quantifier</h1>
         <p>The production <emu-grammar>Quantifier :: QuantifierPrefix</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Evaluate |QuantifierPrefix| to obtain the two results: an integer _min_ and an integer (or &infin;) _max_.
+          1. Evaluate |QuantifierPrefix| to obtain the two results: an integer _min_ and an integer (or +&infin;) _max_.
           1. Return the three results _min_, _max_, and *true*.
         </emu-alg>
         <p>The production <emu-grammar>Quantifier :: QuantifierPrefix `?`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Evaluate |QuantifierPrefix| to obtain the two results: an integer _min_ and an integer (or &infin;) _max_.
+          1. Evaluate |QuantifierPrefix| to obtain the two results: an integer _min_ and an integer (or +&infin;) _max_.
           1. Return the three results _min_, _max_, and *false*.
         </emu-alg>
         <p>The production <emu-grammar>QuantifierPrefix :: `*`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the two results 0 and &infin;.
+          1. Return the two results 0 and +&infin;.
         </emu-alg>
         <p>The production <emu-grammar>QuantifierPrefix :: `+`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Return the two results 1 and &infin;.
+          1. Return the two results 1 and +&infin;.
         </emu-alg>
         <p>The production <emu-grammar>QuantifierPrefix :: `?`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
@@ -31473,7 +31473,7 @@ THH:mm:ss.sss
         <p>The production <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
           1. Let _i_ be the MV of |DecimalDigits|.
-          1. Return the two results _i_ and &infin;.
+          1. Return the two results _i_ and +&infin;.
         </emu-alg>
         <p>The production <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar> evaluates as follows:</p>
         <emu-alg>
@@ -31520,11 +31520,11 @@ THH:mm:ss.sss
               1. Let _cap_ be a copy of _y_'s _captures_ List.
               1. Let _xe_ be _x_'s _endIndex_.
               1. Let _ye_ be _y_'s _endIndex_.
-              1. If _direction_ is equal to +1, then
+              1. If _direction_ = 1, then
                 1. Assert: _xe_ &le; _ye_.
                 1. Let _s_ be a List whose elements are the characters of _Input_ at indices _xe_ (inclusive) through _ye_ (exclusive).
               1. Else,
-                1. Assert: _direction_ is equal to -1.
+                1. Assert: _direction_ is -1.
                 1. Assert: _ye_ &le; _xe_.
                 1. Let _s_ be a List whose elements are the characters of _Input_ at indices _ye_ (inclusive) through _xe_ (exclusive).
               1. Set _cap_[_parenIndex_ + 1] to _s_.
@@ -31539,7 +31539,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" aoid="CharacterSetMatcher">
           <h1>CharacterSetMatcher ( _A_, _invert_, _direction_ )</h1>
-          <p>The abstract operation CharacterSetMatcher takes arguments _A_ (a CharSet), _invert_ (a Boolean), and _direction_ (an integer). It performs the following steps when called:</p>
+          <p>The abstract operation CharacterSetMatcher takes arguments _A_ (a CharSet), _invert_ (a Boolean), and _direction_ (1 or -1). It performs the following steps when called:</p>
           <emu-alg>
             1. Return a new Matcher with parameters (_x_, _c_) that captures _A_, _invert_, and _direction_ and performs the following steps when called:
               1. Assert: _x_ is a State.
@@ -31577,7 +31577,7 @@ THH:mm:ss.sss
             1. Return _cu_.
           </emu-alg>
           <emu-note>
-            <p>Parentheses of the form `(` |Disjunction| `)` serve both to group the components of the |Disjunction| pattern together and to save the result of the match. The result can be used either in a backreference (`\\` followed by a nonzero decimal number), referenced in a replace String, or returned as part of an array from the regular expression matching Abstract Closure. To inhibit the capturing behaviour of parentheses, use the form `(?:` |Disjunction| `)` instead.</p>
+            <p>Parentheses of the form `(` |Disjunction| `)` serve both to group the components of the |Disjunction| pattern together and to save the result of the match. The result can be used either in a backreference (`\\` followed by a non-zero decimal number), referenced in a replace String, or returned as part of an array from the regular expression matching Abstract Closure. To inhibit the capturing behaviour of parentheses, use the form `(?:` |Disjunction| `)` instead.</p>
           </emu-note>
           <emu-note>
             <p>The form `(?=` |Disjunction| `)` specifies a zero-width positive lookahead. In order for it to succeed, the pattern inside |Disjunction| must match at the current position, but the current position is not advanced before matching the sequel. If |Disjunction| can match at the current position in several ways, only the first one is tried. Unlike other regular expression operators, there is no backtracking into a `(?=` form (this unusual behaviour is inherited from Perl). This only matters when the |Disjunction| contains capturing parentheses and the sequel of the pattern contains backreferences to those captures.</p>
@@ -31662,7 +31662,7 @@ THH:mm:ss.sss
           1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
         <emu-note>
-          <p>An escape sequence of the form `\\` followed by a nonzero decimal number _n_ matches the result of the _n_<sup>th</sup> set of capturing parentheses (<emu-xref href="#sec-notation"></emu-xref>). It is an error if the regular expression has fewer than _n_ capturing parentheses. If the regular expression has _n_ or more capturing parentheses but the _n_<sup>th</sup> one is *undefined* because it has not captured anything, then the backreference always succeeds.</p>
+          <p>An escape sequence of the form `\\` followed by a non-zero decimal number _n_ matches the result of the _n_<sup>th</sup> set of capturing parentheses (<emu-xref href="#sec-notation"></emu-xref>). It is an error if the regular expression has fewer than _n_ capturing parentheses. If the regular expression has _n_ or more capturing parentheses but the _n_<sup>th</sup> one is *undefined* because it has not captured anything, then the backreference always succeeds.</p>
         </emu-note>
         <p>The production <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar> evaluates as follows:</p>
         <emu-alg>
@@ -31674,7 +31674,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-backreference-matcher" aoid="BackreferenceMatcher">
           <h1>BackreferenceMatcher ( _n_, _direction_ )</h1>
-          <p>The abstract operation BackreferenceMatcher takes arguments _n_ (an integer) and _direction_ (an integer). It performs the following steps when called:</p>
+          <p>The abstract operation BackreferenceMatcher takes arguments _n_ (a positive integer) and _direction_ (1 or -1). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _n_ &ge; 1.
             1. Return a new Matcher with parameters (_x_, _c_) that captures _n_ and _direction_ and performs the following steps when called:
@@ -31999,7 +31999,7 @@ THH:mm:ss.sss
             1. Set _obj_.[[OriginalSource]] to _P_.
             1. Set _obj_.[[OriginalFlags]] to _F_.
             1. Set _obj_.[[RegExpMatcher]] to the Abstract Closure that evaluates _parseResult_ by applying the semantics provided in <emu-xref href="#sec-pattern-semantics"></emu-xref> using _patternCharacters_ as the pattern's List of |SourceCharacter| values and _F_ as the flag parameters.
-            1. Perform ? Set(_obj_, *"lastIndex"*, 0, *true*).
+            1. Perform ? Set(_obj_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
             1. Return _obj_.
           </emu-alg>
         </emu-clause>
@@ -32120,7 +32120,7 @@ THH:mm:ss.sss
             1. Assert: _R_ is an initialized RegExp instance.
             1. Assert: Type(_S_) is String.
             1. Let _length_ be the number of code units in _S_.
-            1. Let _lastIndex_ be ? ToLength(? Get(_R_, *"lastIndex"*)).
+            1. Let _lastIndex_ be ℝ(? ToLength(? Get(_R_, *"lastIndex"*))).
             1. Let _flags_ be _R_.[[OriginalFlags]].
             1. If _flags_ contains *"g"*, let _global_ be *true*; else let _global_ be *false*.
             1. If _flags_ contains *"y"*, let _sticky_ be *true*; else let _sticky_ be *false*.
@@ -32131,12 +32131,12 @@ THH:mm:ss.sss
             1. Repeat, while _matchSucceeded_ is *false*,
               1. If _lastIndex_ &gt; _length_, then
                 1. If _global_ is *true* or _sticky_ is *true*, then
-                  1. Perform ? Set(_R_, *"lastIndex"*, 0, *true*).
+                  1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
                 1. Return *null*.
               1. Let _r_ be _matcher_(_S_, _lastIndex_).
               1. If _r_ is ~failure~, then
                 1. If _sticky_ is *true*, then
-                  1. Perform ? Set(_R_, *"lastIndex"*, 0, *true*).
+                  1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
                   1. Return *null*.
                 1. Set _lastIndex_ to AdvanceStringIndex(_S_, _lastIndex_, _fullUnicode_).
               1. Else,
@@ -32147,12 +32147,12 @@ THH:mm:ss.sss
               1. _e_ is an index into the _Input_ character list, derived from _S_, matched by _matcher_. Let _eUTF_ be the smallest index into _S_ that corresponds to the character at element _e_ of _Input_. If _e_ is greater than or equal to the number of elements in _Input_, then _eUTF_ is the number of code units in _S_.
               1. Set _e_ to _eUTF_.
             1. If _global_ is *true* or _sticky_ is *true*, then
-              1. Perform ? Set(_R_, *"lastIndex"*, _e_, *true*).
+              1. Perform ? Set(_R_, *"lastIndex"*, 𝔽(_e_), *true*).
             1. Let _n_ be the number of elements in _r_'s _captures_ List. (This is the same value as <emu-xref href="#sec-notation"></emu-xref>'s _NcapturingParens_.)
             1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
             1. Let _A_ be ! ArrayCreate(_n_ + 1).
-            1. Assert: The value of _A_'s *"length"* property is _n_ + 1.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"index"*, _lastIndex_).
+            1. Assert: The mathematical value of _A_'s *"length"* property is _n_ + 1.
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"index"*, 𝔽(_lastIndex_)).
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"input"*, _S_).
             1. Let _matchedSubstr_ be the substring of _S_ from _lastIndex_ to _e_.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _matchedSubstr_).
@@ -32171,7 +32171,7 @@ THH:mm:ss.sss
                 1. Assert: _fullUnicode_ is *false*.
                 1. Assert: _captureI_ is a List of code units.
                 1. Let _capturedValue_ be the String value consisting of the code units of _captureI_.
-              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_i_), _capturedValue_).
+              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _capturedValue_).
               1. If the _i_<sup>th</sup> capture of _R_ was defined with a |GroupName|, then
                 1. Let _s_ be the StringValue of the corresponding |RegExpIdentifierName|.
                 1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
@@ -32181,11 +32181,9 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-advancestringindex" aoid="AdvanceStringIndex">
           <h1>AdvanceStringIndex ( _S_, _index_, _unicode_ )</h1>
-          <p>The abstract operation AdvanceStringIndex takes arguments _S_, _index_, and _unicode_. It performs the following steps when called:</p>
+          <p>The abstract operation AdvanceStringIndex takes arguments _S_ (a String), _index_ (a non-negative integer), and _unicode_ (a Boolean). It performs the following steps when called:</p>
           <emu-alg>
-            1. Assert: Type(_S_) is String.
-            1. Assert: 0 &le; _index_ &le; 2<sup>53</sup> - 1 and ! IsInteger(_index_) is *true*.
-            1. Assert: Type(_unicode_) is Boolean.
+            1. Assert: _index_ &le; 2<sup>53</sup> - 1.
             1. If _unicode_ is *false*, return _index_ + 1.
             1. Let _length_ be the number of code units in _S_.
             1. If _index_ + 1 &ge; _length_, return _index_ + 1.
@@ -32276,7 +32274,7 @@ THH:mm:ss.sss
           1. Else,
             1. Assert: _global_ is *true*.
             1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, *"unicode"*)).
-            1. Perform ? Set(_rx_, *"lastIndex"*, 0, *true*).
+            1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
             1. Let _A_ be ! ArrayCreate(0).
             1. Let _n_ be 0.
             1. Repeat,
@@ -32286,11 +32284,11 @@ THH:mm:ss.sss
                 1. Return _A_.
               1. Else,
                 1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
-                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _matchStr_).
+                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _matchStr_).
                 1. If _matchStr_ is the empty String, then
-                  1. Let _thisIndex_ be ? ToLength(? Get(_rx_, *"lastIndex"*)).
+                  1. Let _thisIndex_ be ℝ(? ToLength(? Get(_rx_, *"lastIndex"*))).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Perform ? Set(_rx_, *"lastIndex"*, _nextIndex_, *true*).
+                  1. Perform ? Set(_rx_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
                 1. Set _n_ to _n_ + 1.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"[Symbol.match]"*.</p>
@@ -32349,7 +32347,7 @@ THH:mm:ss.sss
           1. Let _global_ be ! ToBoolean(? Get(_rx_, *"global"*)).
           1. If _global_ is *true*, then
             1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, *"unicode"*)).
-            1. Perform ? Set(_rx_, *"lastIndex"*, 0, *true*).
+            1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
           1. Let _results_ be a new empty List.
           1. Let _done_ be *false*.
           1. Repeat, while _done_ is *false*,
@@ -32361,9 +32359,9 @@ THH:mm:ss.sss
               1. Else,
                 1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
                 1. If _matchStr_ is the empty String, then
-                  1. Let _thisIndex_ be ? ToLength(? Get(_rx_, *"lastIndex"*)).
+                  1. Let _thisIndex_ be ℝ(? ToLength(? Get(_rx_, *"lastIndex"*))).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Perform ? Set(_rx_, *"lastIndex"*, _nextIndex_, *true*).
+                  1. Perform ? Set(_rx_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
           1. Let _accumulatedResult_ be the empty String.
           1. Let _nextSourcePosition_ be 0.
           1. For each element _result_ of _results_, do
@@ -32371,12 +32369,12 @@ THH:mm:ss.sss
             1. Let _nCaptures_ be max(_resultLength_ - 1, 0).
             1. Let _matched_ be ? ToString(? Get(_result_, *"0"*)).
             1. Let _matchLength_ be the number of code units in _matched_.
-            1. Let _position_ be ? ToInteger(? Get(_result_, *"index"*)).
-            1. Set _position_ to max(min(_position_, _lengthS_), 0).
+            1. Let _position_ be ? ToIntegerOrInfinity(? Get(_result_, *"index"*)).
+            1. Set _position_ to the result of clamping _position_ between 0 and _lengthS_.
             1. Let _n_ be 1.
             1. Let _captures_ be a new empty List.
             1. Repeat, while _n_ &le; _nCaptures_,
-              1. Let _capN_ be ? Get(_result_, ! ToString(_n_)).
+              1. Let _capN_ be ? Get(_result_, ! ToString(𝔽(_n_))).
               1. If _capN_ is not *undefined*, then
                 1. Set _capN_ to ? ToString(_capN_).
               1. Append _capN_ as the last element of _captures_.
@@ -32385,7 +32383,7 @@ THH:mm:ss.sss
             1. If _functionalReplace_ is *true*, then
               1. Let _replacerArgs_ be &laquo; _matched_ &raquo;.
               1. Append in List order the elements of _captures_ to the end of the List _replacerArgs_.
-              1. Append _position_ and _S_ to _replacerArgs_.
+              1. Append 𝔽(_position_) and _S_ to _replacerArgs_.
               1. If _namedCaptures_ is not *undefined*, then
                 1. Append _namedCaptures_ as the last element of _replacerArgs_.
               1. Let _replValue_ be ? Call(_replaceValue_, *undefined*, _replacerArgs_).
@@ -32412,8 +32410,8 @@ THH:mm:ss.sss
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
           1. Let _previousLastIndex_ be ? Get(_rx_, *"lastIndex"*).
-          1. If SameValue(_previousLastIndex_, 0) is *false*, then
-            1. Perform ? Set(_rx_, *"lastIndex"*, 0, *true*).
+          1. If SameValue(_previousLastIndex_, *+0*<sub>𝔽</sub>) is *false*, then
+            1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
           1. Let _result_ be ? RegExpExec(_rx_, _S_).
           1. Let _currentLastIndex_ be ? Get(_rx_, *"lastIndex"*).
           1. If SameValue(_currentLastIndex_, _previousLastIndex_) is *false*, then
@@ -32469,10 +32467,10 @@ THH:mm:ss.sss
           1. Let _splitter_ be ? Construct(_C_, &laquo; _rx_, _newFlags_ &raquo;).
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _lengthA_ be 0.
-          1. If _limit_ is *undefined*, let _lim_ be 2<sup>32</sup> - 1; else let _lim_ be ? ToUint32(_limit_).
-          1. If _lim_ = 0, return _A_.
+          1. If _limit_ is *undefined*, let _lim_ be 2<sup>32</sup> - 1; else let _lim_ be ℝ(? ToUint32(_limit_)).
+          1. If _lim_ is 0, return _A_.
           1. Let _size_ be the length of _S_.
-          1. If _size_ = 0, then
+          1. If _size_ is 0, then
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is not *null*, return _A_.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
@@ -32480,16 +32478,16 @@ THH:mm:ss.sss
           1. Let _p_ be 0.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &lt; _size_,
-            1. Perform ? Set(_splitter_, *"lastIndex"*, _q_, *true*).
+            1. Perform ? Set(_splitter_, *"lastIndex"*, 𝔽(_q_), *true*).
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is *null*, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
             1. Else,
-              1. Let _e_ be ? ToLength(? Get(_splitter_, *"lastIndex"*)).
+              1. Let _e_ be ℝ(? ToLength(? Get(_splitter_, *"lastIndex"*))).
               1. Set _e_ to min(_e_, _size_).
               1. If _e_ = _p_, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
               1. Else,
                 1. Let _T_ be the substring of _S_ from _p_ to _q_.
-                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
+                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _T_).
                 1. Set _lengthA_ to _lengthA_ + 1.
                 1. If _lengthA_ = _lim_, return _A_.
                 1. Set _p_ to _e_.
@@ -32497,14 +32495,14 @@ THH:mm:ss.sss
                 1. Set _numberOfCaptures_ to max(_numberOfCaptures_ - 1, 0).
                 1. Let _i_ be 1.
                 1. Repeat, while _i_ &le; _numberOfCaptures_,
-                  1. Let _nextCapture_ be ? Get(_z_, ! ToString(_i_)).
-                  1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _nextCapture_).
+                  1. Let _nextCapture_ be ? Get(_z_, ! ToString(𝔽(_i_))).
+                  1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _nextCapture_).
                   1. Set _i_ to _i_ + 1.
                   1. Set _lengthA_ to _lengthA_ + 1.
                   1. If _lengthA_ = _lim_, return _A_.
                 1. Set _q_ to _p_.
           1. Let _T_ be the substring of _S_ from _p_ to _size_.
-          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(_lengthA_), _T_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _T_).
           1. Return _A_.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"[Symbol.split]"*.</p>
@@ -32581,7 +32579,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-lastindex">
         <h1>lastIndex</h1>
-        <p>The value of the *"lastIndex"* property specifies the String index at which to start the next match. It is coerced to an integer when used (see <emu-xref href="#sec-regexpbuiltinexec"></emu-xref>). This property shall have the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <p>The value of the *"lastIndex"* property specifies the String index at which to start the next match. It is coerced to an integral Number when used (see <emu-xref href="#sec-regexpbuiltinexec"></emu-xref>). This property shall have the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
@@ -32635,9 +32633,9 @@ THH:mm:ss.sss
               1. If _global_ is *true*, then
                 1. Let _matchStr_ be ? ToString(? Get(_match_, *"0"*)).
                 1. If _matchStr_ is the empty String, then
-                  1. Let _thisIndex_ be ? ToLength(? Get(_R_, *"lastIndex"*)).
-                  1. Let _nextIndex_ be ! AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Perform ? Set(_R_, *"lastIndex"*, _nextIndex_, *true*).
+                  1. Let _thisIndex_ be ℝ(? ToLength(? Get(_R_, *"lastIndex"*))).
+                  1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
+                  1. Perform ? Set(_R_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
                 1. Return ! CreateIterResultObject(_match_, *false*).
               1. Else,
                 1. Set _O_.[[Done]] to *true*.
@@ -32733,10 +32731,10 @@ THH:mm:ss.sss
           1. Let _array_ be ! ArrayCreate(0, _proto_).
           1. If Type(_len_) is not Number, then
             1. Perform ! CreateDataPropertyOrThrow(_array_, *"0"*, _len_).
-            1. Let _intLen_ be 1.
+            1. Let _intLen_ be *1*<sub>𝔽</sub>.
           1. Else,
-            1. Let _intLen_ be ToUint32(_len_).
-            1. If _intLen_ &ne; _len_, throw a *RangeError* exception.
+            1. Let _intLen_ be ! ToUint32(_len_).
+            1. If _intLen_ is not the same value as _len_, throw a *RangeError* exception.
           1. Perform ! Set(_array_, *"length"*, _intLen_, *true*).
           1. Return _array_.
         </emu-alg>
@@ -32754,11 +32752,11 @@ THH:mm:ss.sss
           1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _numberOfArgs_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _itemK_ be _items_[_k_].
             1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
             1. Set _k_ to _k_ + 1.
-          1. Assert: The value of _array_'s *"length"* property is _numberOfArgs_.
+          1. Assert: The mathematical value of _array_'s *"length"* property is _numberOfArgs_.
           1. Return _array_.
         </emu-alg>
       </emu-clause>
@@ -32793,14 +32791,14 @@ THH:mm:ss.sss
               1. If _k_ &ge; 2<sup>53</sup> - 1, then
                 1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
                 1. Return ? IteratorClose(_iteratorRecord_, _error_).
-              1. Let _Pk_ be ! ToString(_k_).
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Let _next_ be ? IteratorStep(_iteratorRecord_).
               1. If _next_ is *false*, then
-                1. Perform ? Set(_A_, *"length"*, _k_, *true*).
+                1. Perform ? Set(_A_, *"length"*, 𝔽(_k_), *true*).
                 1. Return _A_.
               1. Let _nextValue_ be ? IteratorValue(_next_).
               1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be Call(_mapfn_, _thisArg_, &laquo; _nextValue_, _k_ &raquo;).
+                1. Let _mappedValue_ be Call(_mapfn_, _thisArg_, &laquo; _nextValue_, 𝔽(_k_) &raquo;).
                 1. If _mappedValue_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _mappedValue_).
                 1. Set _mappedValue_ to _mappedValue_.[[Value]].
               1. Else, let _mappedValue_ be _nextValue_.
@@ -32811,19 +32809,19 @@ THH:mm:ss.sss
           1. Let _arrayLike_ be ! ToObject(_items_).
           1. Let _len_ be ? LengthOfArrayLike(_arrayLike_).
           1. If IsConstructor(_C_) is *true*, then
-            1. Let _A_ be ? Construct(_C_, &laquo; _len_ &raquo;).
+            1. Let _A_ be ? Construct(_C_, &laquo; 𝔽(_len_) &raquo;).
           1. Else,
             1. Let _A_ be ? ArrayCreate(_len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. If _mapping_ is *true*, then
-              1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, _k_ &raquo;).
+              1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_) &raquo;).
             1. Else, let _mappedValue_ be _kValue_.
             1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_A_, *"length"*, _len_, *true*).
+          1. Perform ? Set(_A_, *"length"*, 𝔽(_len_), *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -32844,18 +32842,19 @@ THH:mm:ss.sss
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _items_.
+          1. Let _lenNumber_ be 𝔽(_len_).
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *true*, then
-            1. Let _A_ be ? Construct(_C_, &laquo; _len_ &raquo;).
+            1. Let _A_ be ? Construct(_C_, &laquo; _lenNumber_ &raquo;).
           1. Else,
             1. Let _A_ be ? ArrayCreate(_len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _kValue_ be _items_[_k_].
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _kValue_).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_A_, *"length"*, _len_, *true*).
+          1. Perform ? Set(_A_, *"length"*, _lenNumber_, *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -32911,22 +32910,22 @@ THH:mm:ss.sss
               1. Let _len_ be ? LengthOfArrayLike(_E_).
               1. If _n_ + _len_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
               1. Repeat, while _k_ &lt; _len_,
-                1. Let _P_ be ! ToString(_k_).
+                1. Let _P_ be ! ToString(𝔽(_k_)).
                 1. Let _exists_ be ? HasProperty(_E_, _P_).
                 1. If _exists_ is *true*, then
                   1. Let _subElement_ be ? Get(_E_, _P_).
-                  1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _subElement_).
+                  1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _subElement_).
                 1. Set _n_ to _n_ + 1.
                 1. Set _k_ to _k_ + 1.
             1. Else,
               1. NOTE: _E_ is added as a single item rather than spread.
               1. If _n_ &ge; 2<sup>53</sup> - 1, throw a *TypeError* exception.
-              1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _E_).
+              1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _E_).
               1. Set _n_ to _n_ + 1.
-          1. [id="step-array-proto-concat-set-length"] Perform ? Set(_A_, *"length"*, _n_, *true*).
+          1. [id="step-array-proto-concat-set-length"] Perform ? Set(_A_, *"length"*, 𝔽(_n_), *true*).
           1. Return _A_.
         </emu-alg>
-        <p>The *"length"* property of the `concat` method is 1.</p>
+        <p>The *"length"* property of the `concat` method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>The explicit setting of the *"length"* property in step <emu-xref href="#step-array-proto-concat-set-length"></emu-xref> is necessary to ensure that its value is correct in situations where the trailing elements of the result Array are not present.</p>
         </emu-note>
@@ -32961,12 +32960,18 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeTarget_ be ? ToInteger(_target_).
-          1. If _relativeTarget_ &lt; 0, let _to_ be max((_len_ + _relativeTarget_), 0); else let _to_ be min(_relativeTarget_, _len_).
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _from_ be max((_len_ + _relativeStart_), 0); else let _from_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
+          1. If _relativeTarget_ is -&infin;, let _to_ be 0.
+          1. Else if _relativeTarget_ &lt; 0, let _to_ be max(_len_ + _relativeTarget_, 0).
+          1. Else, let _to_ be min(_relativeTarget_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _from_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _from_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _from_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _final_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
+          1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be min(_final_ - _from_, _len_ - _to_).
           1. If _from_ &lt; _to_ and _to_ &lt; _from_ + _count_, then
             1. Let _direction_ be -1.
@@ -32975,8 +32980,8 @@ THH:mm:ss.sss
           1. Else,
             1. Let _direction_ be 1.
           1. Repeat, while _count_ &gt; 0,
-            1. Let _fromKey_ be ! ToString(_from_).
-            1. Let _toKey_ be ! ToString(_to_).
+            1. Let _fromKey_ be ! ToString(𝔽(_from_)).
+            1. Let _toKey_ be ! ToString(𝔽(_to_)).
             1. Let _fromPresent_ be ? HasProperty(_O_, _fromKey_).
             1. If _fromPresent_ is *true*, then
               1. Let _fromVal_ be ? Get(_O_, _fromKey_).
@@ -33019,11 +33024,11 @@ THH:mm:ss.sss
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
               1. If _testResult_ is *false*, return *false*.
             1. Set _k_ to _k_ + 1.
           1. Return *true*.
@@ -33043,12 +33048,16 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _k_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _k_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _final_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
+          1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Repeat, while _k_ &lt; _final_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Perform ? Set(_O_, _Pk_, _value_, *true*).
             1. Set _k_ to _k_ + 1.
           1. Return _O_.
@@ -33076,13 +33085,13 @@ THH:mm:ss.sss
           1. Let _k_ be 0.
           1. Let _to_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
               1. If _selected_ is *true*, then
-                1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_to_), _kValue_).
+                1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_to_)), _kValue_).
                 1. Set _to_ to _to_ + 1.
             1. Set _k_ to _k_ + 1.
           1. Return _A_.
@@ -33109,9 +33118,9 @@ THH:mm:ss.sss
           1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _testResult_ is *true*, return _kValue_.
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
@@ -33137,9 +33146,9 @@ THH:mm:ss.sss
           1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _testResult_ is *true*, return _k_.
             1. Set _k_ to _k_ + 1.
           1. Return -1.
@@ -33157,7 +33166,8 @@ THH:mm:ss.sss
           1. Let _sourceLen_ be ? LengthOfArrayLike(_O_).
           1. Let _depthNum_ be 1.
           1. If _depth_ is not *undefined*, then
-            1. Set _depthNum_ to ? ToInteger(_depth_).
+            1. Set _depthNum_ to ? ToIntegerOrInfinity(_depth_).
+            1. If _depthNum_ &lt; 0, set _depthNum_ to 0.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, _depthNum_).
           1. Return _A_.
@@ -33165,17 +33175,14 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-flattenintoarray" aoid="FlattenIntoArray">
           <h1>FlattenIntoArray ( _target_, _source_, _sourceLen_, _start_, _depth_ [ , _mapperFunction_, _thisArg_ ] )</h1>
-          <p>The abstract operation FlattenIntoArray takes arguments _target_, _source_, _sourceLen_, _start_, and _depth_ and optional arguments _mapperFunction_ and _thisArg_. It performs the following steps when called:</p>
+          <p>The abstract operation FlattenIntoArray takes arguments _target_, _source_, _sourceLen_ (a non-negative integer), _start_ (a non-negative integer), and _depth_ (a non-negative integer or +&infin;) and optional arguments _mapperFunction_ and _thisArg_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_target_) is Object.
             1. Assert: Type(_source_) is Object.
-            1. Assert: ! IsNonNegativeInteger(_sourceLen_) is *true*.
-            1. Assert: ! IsNonNegativeInteger(_start_) is *true*.
-            1. Assert: ! IsInteger(_depth_) is *true*, or _depth_ is either *+&infin;* or *-&infin;*.
-            1. Assert: If _mapperFunction_ is present, then ! IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is *1*.
+            1. Assert: If _mapperFunction_ is present, then ! IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is 1.
             1. Let _targetIndex_ be _start_.
-            1. Let _sourceIndex_ be 0.
-            1. Repeat, while _sourceIndex_ &lt; _sourceLen_,
+            1. Let _sourceIndex_ be *+0*<sub>𝔽</sub>.
+            1. Repeat, while ℝ(_sourceIndex_) &lt; _sourceLen_,
               1. Let _P_ be ! ToString(_sourceIndex_).
               1. Let _exists_ be ? HasProperty(_source_, _P_).
               1. If _exists_ is *true*, then
@@ -33186,13 +33193,15 @@ THH:mm:ss.sss
                 1. If _depth_ &gt; 0, then
                   1. Set _shouldFlatten_ to ? IsArray(_element_).
                 1. If _shouldFlatten_ is *true*, then
+                  1. If _depth_ is +&infin;, let _newDepth_ be +&infin;.
+                  1. Else, let _newDepth_ be _depth_ - 1.
                   1. Let _elementLen_ be ? LengthOfArrayLike(_element_).
-                  1. Set _targetIndex_ to ? FlattenIntoArray(_target_, _element_, _elementLen_, _targetIndex_, _depth_ - 1).
+                  1. Set _targetIndex_ to ? FlattenIntoArray(_target_, _element_, _elementLen_, _targetIndex_, _newDepth_).
                 1. Else,
                   1. If _targetIndex_ &ge; 2<sup>53</sup> - 1, throw a *TypeError* exception.
-                  1. Perform ? CreateDataPropertyOrThrow(_target_, ! ToString(_targetIndex_), _element_).
+                  1. Perform ? CreateDataPropertyOrThrow(_target_, ! ToString(𝔽(_targetIndex_)), _element_).
                   1. Set _targetIndex_ to _targetIndex_ + 1.
-              1. Set _sourceIndex_ to _sourceIndex_ + 1.
+              1. Set _sourceIndex_ to _sourceIndex_ + *1*<sub>𝔽</sub>.
             1. Return _targetIndex_.
           </emu-alg>
         </emu-clause>
@@ -33227,11 +33236,11 @@ THH:mm:ss.sss
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;).
+              1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;).
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
         </emu-alg>
@@ -33246,7 +33255,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>`includes` compares _searchElement_ to the elements of the array, in ascending order, using the SameValueZero algorithm, and if found at any position, returns *true*; otherwise, *false* is returned.</p>
 
-          <p>The optional second argument _fromIndex_ defaults to 0 (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *false* is returned, i.e. the array will not be searched. If it is negative, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than 0, the whole array will be searched.</p>
+          <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *false* is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
         <p>When the `includes` method is called, the following steps are taken:</p>
 
@@ -33254,15 +33263,17 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If _len_ is 0, return *false*.
-          1. Let _n_ be ? ToInteger(_fromIndex_).
+          1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
+          1. If _n_ is +&infin;, return *false*.
+          1. Else if _n_ is -&infin;, set _n_ to 0.
           1. If _n_ &ge; 0, then
             1. Let _k_ be _n_.
           1. Else,
             1. Let _k_ be _len_ + _n_.
             1. If _k_ &lt; 0, set _k_ to 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _elementK_ be the result of ? Get(_O_, ! ToString(_k_)).
+            1. Let _elementK_ be the result of ? Get(_O_, ! ToString(𝔽(_k_))).
             1. If SameValueZero(_searchElement_, _elementK_) is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -33280,30 +33291,31 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.indexof">
         <h1>Array.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
-          <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the smallest such index; otherwise, -1 is returned.</p>
-          <p>The optional second argument _fromIndex_ defaults to 0 (i.e. the whole array is searched). If it is greater than or equal to the length of the array, -1 is returned, i.e. the array will not be searched. If it is negative, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than 0, the whole array will be searched.</p>
+          <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the smallest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
+          <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *-1*<sub>𝔽</sub> is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
         <p>When the `indexOf` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _len_ is 0, return -1.
-          1. Let _n_ be ? ToInteger(_fromIndex_).
+          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
-          1. If _n_ &ge; _len_, return -1.
+          1. If _n_ is +&infin;, return *-1*<sub>𝔽</sub>.
+          1. Else if _n_ is -&infin;, set _n_ to 0.
           1. If _n_ &ge; 0, then
             1. Let _k_ be _n_.
           1. Else,
             1. Let _k_ be _len_ + _n_.
             1. If _k_ &lt; 0, set _k_ to 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(_k_)).
+            1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
-              1. Let _elementK_ be ? Get(_O_, ! ToString(_k_)).
+              1. Let _elementK_ be ? Get(_O_, ! ToString(𝔽(_k_))).
               1. Let _same_ be the result of performing Strict Equality Comparison _searchElement_ === _elementK_.
-              1. If _same_ is *true*, return _k_.
+              1. If _same_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
-          1. Return -1.
+          1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
           <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -33325,7 +33337,7 @@ THH:mm:ss.sss
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. If _k_ &gt; 0, set _R_ to the string-concatenation of _R_ and _sep_.
-            1. Let _element_ be ? Get(_O_, ! ToString(_k_)).
+            1. Let _element_ be ? Get(_O_, ! ToString(𝔽(_k_))).
             1. If _element_ is *undefined* or *null*, let _next_ be the empty String; otherwise, let _next_ be ? ToString(_element_).
             1. Set _R_ to the string-concatenation of _R_ and _next_.
             1. Set _k_ to _k_ + 1.
@@ -33348,27 +33360,28 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.lastindexof">
         <h1>Array.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
-          <p>`lastIndexOf` compares _searchElement_ to the elements of the array in descending order using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the largest such index; otherwise, -1 is returned.</p>
-          <p>The optional second argument _fromIndex_ defaults to the array's length minus one (i.e. the whole array is searched). If it is greater than or equal to the length of the array, the whole array will be searched. If it is negative, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than 0, -1 is returned.</p>
+          <p>`lastIndexOf` compares _searchElement_ to the elements of the array in descending order using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the largest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
+          <p>The optional second argument _fromIndex_ defaults to the array's length minus one (i.e. the whole array is searched). If it is greater than or equal to the length of the array, the whole array will be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, *-1*<sub>𝔽</sub> is returned.</p>
         </emu-note>
         <p>When the `lastIndexOf` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _len_ is 0, return -1.
-          1. If _fromIndex_ is present, let _n_ be ? ToInteger(_fromIndex_); else let _n_ be _len_ - 1.
+          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. If _fromIndex_ is present, let _n_ be ? ToIntegerOrInfinity(_fromIndex_); else let _n_ be _len_ - 1.
+          1. If _n_ is -&infin;, return *-1*<sub>𝔽</sub>.
           1. If _n_ &ge; 0, then
             1. Let _k_ be min(_n_, _len_ - 1).
           1. Else,
             1. Let _k_ be _len_ + _n_.
           1. Repeat, while _k_ &ge; 0,
-            1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(_k_)).
+            1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
-              1. Let _elementK_ be ? Get(_O_, ! ToString(_k_)).
+              1. Let _elementK_ be ? Get(_O_, ! ToString(𝔽(_k_))).
               1. Let _same_ be the result of performing Strict Equality Comparison _searchElement_ === _elementK_.
-              1. If _same_ is *true*, return _k_.
+              1. If _same_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ - 1.
-          1. Return -1.
+          1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
           <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -33392,11 +33405,11 @@ THH:mm:ss.sss
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;).
+              1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;).
               1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
             1. Set _k_ to _k_ + 1.
           1. Return _A_.
@@ -33415,12 +33428,12 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _len_ is zero, then
-            1. Perform ? Set(_O_, *"length"*, 0, *true*).
+          1. If _len_ = 0, then
+            1. Perform ? Set(_O_, *"length"*, *+0*<sub>𝔽</sub>, *true*).
             1. Return *undefined*.
           1. Else,
             1. Assert: _len_ &gt; 0.
-            1. Let _newLen_ be _len_ - 1.
+            1. Let _newLen_ be 𝔽(_len_ - 1).
             1. Let _index_ be ! ToString(_newLen_).
             1. Let _element_ be ? Get(_O_, _index_).
             1. Perform ? DeletePropertyOrThrow(_O_, _index_).
@@ -33444,12 +33457,12 @@ THH:mm:ss.sss
           1. Let _argCount_ be the number of elements in _items_.
           1. If _len_ + _argCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
           1. For each element _E_ of _items_, do
-            1. Perform ? Set(_O_, ! ToString(_len_), _E_, *true*).
+            1. Perform ? Set(_O_, ! ToString(𝔽(_len_)), _E_, *true*).
             1. Set _len_ to _len_ + 1.
-          1. Perform ? Set(_O_, *"length"*, _len_, *true*).
-          1. Return _len_.
+          1. Perform ? Set(_O_, *"length"*, 𝔽(_len_), *true*).
+          1. Return 𝔽(_len_).
         </emu-alg>
-        <p>The *"length"* property of the `push` method is 1.</p>
+        <p>The *"length"* property of the `push` method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>The `push` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -33468,7 +33481,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _len_ is 0 and _initialValue_ is not present, throw a *TypeError* exception.
+          1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
           1. If _initialValue_ is present, then
@@ -33476,18 +33489,18 @@ THH:mm:ss.sss
           1. Else,
             1. Let _kPresent_ be *false*.
             1. Repeat, while _kPresent_ is *false* and _k_ &lt; _len_,
-              1. Let _Pk_ be ! ToString(_k_).
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Set _kPresent_ to ? HasProperty(_O_, _Pk_).
               1. If _kPresent_ is *true*, then
                 1. Set _accumulator_ to ? Get(_O_, _Pk_).
               1. Set _k_ to _k_ + 1.
             1. If _kPresent_ is *false*, throw a *TypeError* exception.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, &laquo; _accumulator_, _kValue_, _k_, _O_ &raquo;).
+              1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, &laquo; _accumulator_, _kValue_, 𝔽(_k_), _O_ &raquo;).
             1. Set _k_ to _k_ + 1.
           1. Return _accumulator_.
         </emu-alg>
@@ -33517,18 +33530,18 @@ THH:mm:ss.sss
           1. Else,
             1. Let _kPresent_ be *false*.
             1. Repeat, while _kPresent_ is *false* and _k_ &ge; 0,
-              1. Let _Pk_ be ! ToString(_k_).
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Set _kPresent_ to ? HasProperty(_O_, _Pk_).
               1. If _kPresent_ is *true*, then
                 1. Set _accumulator_ to ? Get(_O_, _Pk_).
               1. Set _k_ to _k_ - 1.
             1. If _kPresent_ is *false*, throw a *TypeError* exception.
           1. Repeat, while _k_ &ge; 0,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, &laquo; _accumulator_, _kValue_, _k_, _O_ &raquo;).
+              1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, &laquo; _accumulator_, _kValue_, 𝔽(_k_), _O_ &raquo;).
             1. Set _k_ to _k_ - 1.
           1. Return _accumulator_.
         </emu-alg>
@@ -33550,8 +33563,8 @@ THH:mm:ss.sss
           1. Let _lower_ be 0.
           1. Repeat, while _lower_ &ne; _middle_,
             1. Let _upper_ be _len_ - _lower_ - 1.
-            1. Let _upperP_ be ! ToString(_upper_).
-            1. Let _lowerP_ be ! ToString(_lower_).
+            1. Let _upperP_ be ! ToString(𝔽(_upper_)).
+            1. Let _lowerP_ be ! ToString(𝔽(_lower_)).
             1. Let _lowerExists_ be ? HasProperty(_O_, _lowerP_).
             1. If _lowerExists_ is *true*, then
               1. Let _lowerValue_ be ? Get(_O_, _lowerP_).
@@ -33587,14 +33600,14 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _len_ is zero, then
-            1. Perform ? Set(_O_, *"length"*, 0, *true*).
+          1. If _len_ = 0, then
+            1. Perform ? Set(_O_, *"length"*, *+0*<sub>𝔽</sub>, *true*).
             1. Return *undefined*.
           1. Let _first_ be ? Get(_O_, *"0"*).
           1. Let _k_ be 1.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _from_ be ! ToString(_k_).
-            1. Let _to_ be ! ToString(_k_ - 1).
+            1. Let _from_ be ! ToString(𝔽(_k_)).
+            1. Let _to_ be ! ToString(𝔽(_k_ - 1)).
             1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
             1. If _fromPresent_ is *true*, then
               1. Let _fromVal_ be ? Get(_O_, _from_).
@@ -33603,8 +33616,8 @@ THH:mm:ss.sss
               1. Assert: _fromPresent_ is *false*.
               1. Perform ? DeletePropertyOrThrow(_O_, _to_).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? DeletePropertyOrThrow(_O_, ! ToString(_len_ - 1)).
-          1. Perform ? Set(_O_, *"length"*, _len_ - 1, *true*).
+          1. Perform ? DeletePropertyOrThrow(_O_, ! ToString(𝔽(_len_ - 1))).
+          1. Perform ? Set(_O_, *"length"*, 𝔽(_len_ - 1), *true*).
           1. Return _first_.
         </emu-alg>
         <emu-note>
@@ -33621,22 +33634,26 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _k_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _k_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _final_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
+          1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be max(_final_ - _k_, 0).
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _count_).
           1. Let _n_ be 0.
           1. Repeat, while _k_ &lt; _final_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _kValue_).
+              1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _kValue_).
             1. Set _k_ to _k_ + 1.
             1. Set _n_ to _n_ + 1.
-          1. [id="step-array-proto-slice-set-length"] Perform ? Set(_A_, *"length"*, _n_, *true*).
+          1. [id="step-array-proto-slice-set-length"] Perform ? Set(_A_, *"length"*, 𝔽(_n_), *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -33663,11 +33680,11 @@ THH:mm:ss.sss
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
               1. If _testResult_ is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -33689,7 +33706,8 @@ THH:mm:ss.sss
         <p>Within this specification of the `sort` method, an object, _obj_, is said to be <em>sparse</em> if the following algorithm returns *true*:</p>
         <emu-alg>
           1. For each integer _i_ in the range 0 &le; _i_ &lt; _len_, do
-            1. Let _elem_ be _obj_.[[GetOwnProperty]](! ToString(_i_)).
+            1. Let _prop_ be ! ToString(𝔽(_i_)).
+            1. Let _elem_ be _obj_.[[GetOwnProperty]](_prop_).
             1. If _elem_ is *undefined*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -33704,7 +33722,7 @@ THH:mm:ss.sss
             0 &le; _j_ &lt; _len_
           </li>
           <li>
-            HasProperty(_proto_, ToString(_j_)) is *true*.
+            HasProperty(_proto_, ToString(𝔽(_j_))) is *true*.
           </li>
         </ul>
         <p>The sort order is also implementation-defined if _obj_ is sparse and any of the following conditions are true:</p>
@@ -33713,7 +33731,7 @@ THH:mm:ss.sss
             IsExtensible(_obj_) is *false*.
           </li>
           <li>
-            Any integer index property of _obj_ whose name is a nonnegative integer less than _len_ is a data property whose [[Configurable]] attribute is *false*.
+            Any integer index property of _obj_ whose name is a non-negative integer less than _len_ is a data property whose [[Configurable]] attribute is *false*.
           </li>
         </ul>
         <p>The sort order is also implementation-defined if any of the following conditions are true:</p>
@@ -33722,7 +33740,7 @@ THH:mm:ss.sss
             If _obj_ is an exotic object (including Proxy exotic objects) whose behaviour for [[Get]], [[Set]], [[Delete]], and [[GetOwnProperty]] is not the ordinary object implementation of these internal methods.
           </li>
           <li>
-            If any index property of _obj_ whose name is a nonnegative integer less than _len_ is an accessor property or is a data property whose [[Writable]] attribute is *false*.
+            If any index property of _obj_ whose name is a non-negative integer less than _len_ is an accessor property or is a data property whose [[Writable]] attribute is *false*.
           </li>
           <li>
             If _comparefn_ is *undefined* and the application of ToString to any value passed as an argument to SortCompare modifies _obj_ or any object on _obj_'s prototype chain.
@@ -33734,9 +33752,9 @@ THH:mm:ss.sss
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Perform an implementation-defined sequence of calls to the Get, <emu-xref href="#sec-set-o-p-v-throw">Set</emu-xref>, DeletePropertyOrThrow, and HasOwnProperty abstract operation with _obj_ as the first argument, and to SortCompare (described below), such that:
-            * The property key argument for each call to Get, <emu-xref href="#sec-set-o-p-v-throw">Set</emu-xref>, HasOwnProperty, or DeletePropertyOrThrow is the string representation of a nonnegative integer less than _len_.
+            * The property key argument for each call to Get, <emu-xref href="#sec-set-o-p-v-throw">Set</emu-xref>, HasOwnProperty, or DeletePropertyOrThrow is the string representation of a non-negative integer less than _len_.
             * The `Throw` argument for every call to <emu-xref href="#sec-set-o-p-v-throw">Set</emu-xref> is *true*.
-            * The arguments for calls to SortCompare are values returned by a previous call to the Get abstract operation, unless the properties accessed by those previous calls did not exist according to HasOwnProperty. If both prospective arguments to SortCompare correspond to non-existent properties, use *+0* instead of calling SortCompare. If only the first prospective argument is non-existent use +1. If only the second prospective argument is non-existent use -1.
+            * The arguments for calls to SortCompare are values returned by a previous call to the Get abstract operation, unless the properties accessed by those previous calls did not exist according to HasOwnProperty. If both prospective arguments to SortCompare correspond to non-existent properties, use *+0*<sub>𝔽</sub> instead of calling SortCompare. If only the first prospective argument is non-existent, use *1*<sub>𝔽</sub>. If only the second prospective argument is non-existent, use *-1*<sub>𝔽</sub>.
             * If _obj_ is not sparse then DeletePropertyOrThrow must not be called.
             * If an abrupt completion is returned from any of these operations, it is immediately returned as the value of this function.
           1. Return _obj_.
@@ -33744,10 +33762,10 @@ THH:mm:ss.sss
         <p>Unless the sort order is specified above to be implementation-defined, the returned object must have the following two characteristics:</p>
         <ul>
           <li>
-            There must be some mathematical permutation &pi; of the nonnegative integers less than _len_, such that for every nonnegative integer _j_ less than _len_, if property <emu-eqn>old[_j_]</emu-eqn> existed, then <emu-eqn>new[&pi;(_j_)]</emu-eqn> is exactly the same value as <emu-eqn>old[_j_]</emu-eqn>. But if property <emu-eqn>old[_j_]</emu-eqn> did not exist, then <emu-eqn>new[&pi;(_j_)]</emu-eqn> does not exist.
+            There must be some mathematical permutation &pi; of the non-negative integers less than _len_, such that for every non-negative integer _j_ less than _len_, if property <emu-eqn>old[_j_]</emu-eqn> existed, then <emu-eqn>new[&pi;(_j_)]</emu-eqn> is exactly the same value as <emu-eqn>old[_j_]</emu-eqn>. But if property <emu-eqn>old[_j_]</emu-eqn> did not exist, then <emu-eqn>new[&pi;(_j_)]</emu-eqn> does not exist.
           </li>
           <li>
-            Then for all nonnegative integers _j_ and _k_, each less than _len_, if <emu-eqn>SortCompare(old[_j_], old[_k_]) &lt; 0</emu-eqn> (see SortCompare below), then <emu-eqn>new[&pi;(_j_)] &lt; new[&pi;(_k_)]</emu-eqn>.
+            Then for all non-negative integers _j_ and _k_, each less than _len_, if <emu-eqn>SortCompare(old[_j_], old[_k_]) &lt; 0</emu-eqn> (see SortCompare below), then <emu-eqn>new[&pi;(_j_)] &lt; new[&pi;(_k_)]</emu-eqn>.
           </li>
         </ul>
         <p>Here the notation <emu-eqn>old[_j_]</emu-eqn> is used to refer to the hypothetical result of calling <emu-eqn>Get(_obj_, _j_)</emu-eqn> before this function is executed, and the notation <emu-eqn>new[_j_]</emu-eqn> to refer to the hypothetical result of calling <emu-eqn>Get(_obj_, _j_)</emu-eqn> after this function has been executed.</p>
@@ -33786,20 +33804,20 @@ THH:mm:ss.sss
           <h1>SortCompare ( _x_, _y_ )</h1>
           <p>The abstract operation SortCompare takes arguments _x_ and _y_. It also has access to the _comparefn_ argument passed to the current invocation of the `sort` method. It performs the following steps when called:</p>
           <emu-alg>
-            1. If _x_ and _y_ are both *undefined*, return *+0*.
-            1. If _x_ is *undefined*, return 1.
-            1. If _y_ is *undefined*, return -1.
+            1. If _x_ and _y_ are both *undefined*, return *+0*<sub>𝔽</sub>.
+            1. If _x_ is *undefined*, return *1*<sub>𝔽</sub>.
+            1. If _y_ is *undefined*, return *-1*<sub>𝔽</sub>.
             1. If _comparefn_ is not *undefined*, then
               1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
-              1. If _v_ is *NaN*, return *+0*.
+              1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
               1. Return _v_.
             1. [id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).
             1. [id="step-sortcompare-tostring-y"] Let _yString_ be ? ToString(_y_).
             1. Let _xSmaller_ be the result of performing Abstract Relational Comparison _xString_ &lt; _yString_.
-            1. If _xSmaller_ is *true*, return -1.
+            1. If _xSmaller_ is *true*, return *-1*<sub>𝔽</sub>.
             1. Let _ySmaller_ be the result of performing Abstract Relational Comparison _yString_ &lt; _xString_.
-            1. If _ySmaller_ is *true*, return 1.
-            1. Return *+0*.
+            1. If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.
+            1. Return *+0*<sub>𝔽</sub>.
           </emu-alg>
           <emu-note>
             <p>Because non-existent property values always compare greater than *undefined* property values, and *undefined* always compares greater than any other value, *undefined* property values always sort to the end of the result, followed by non-existent property values.</p>
@@ -33819,8 +33837,10 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _actualStart_ be max((_len_ + _relativeStart_), 0); else let _actualStart_ be min(_relativeStart_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _actualStart_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _actualStart_ be min(_relativeStart_, _len_).
           1. If _start_ is not present, then
             1. Let _insertCount_ be 0.
             1. Let _actualDeleteCount_ be 0.
@@ -33829,25 +33849,25 @@ THH:mm:ss.sss
             1. Let _actualDeleteCount_ be _len_ - _actualStart_.
           1. Else,
             1. Let _insertCount_ be the number of elements in _items_.
-            1. Let _dc_ be ? ToInteger(_deleteCount_).
-            1. Let _actualDeleteCount_ be min(max(_dc_, 0), _len_ - _actualStart_).
+            1. Let _dc_ be ? ToIntegerOrInfinity(_deleteCount_).
+            1. Let _actualDeleteCount_ be the result of clamping _dc_ between 0 and _len_ - _actualStart_.
           1. If _len_ + _insertCount_ - _actualDeleteCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _actualDeleteCount_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _actualDeleteCount_,
-            1. Let _from_ be ! ToString(_actualStart_ + _k_).
+            1. Let _from_ be ! ToString(𝔽(_actualStart_ + _k_)).
             1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
             1. If _fromPresent_ is *true*, then
               1. Let _fromValue_ be ? Get(_O_, _from_).
-              1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_k_), _fromValue_).
+              1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_k_)), _fromValue_).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_A_, *"length"*, _actualDeleteCount_, *true*).
+          1. Perform ? Set(_A_, *"length"*, 𝔽(_actualDeleteCount_), *true*).
           1. Let _itemCount_ be the number of elements in _items_.
           1. If _itemCount_ &lt; _actualDeleteCount_, then
             1. Set _k_ to _actualStart_.
             1. Repeat, while _k_ &lt; (_len_ - _actualDeleteCount_),
-              1. Let _from_ be ! ToString(_k_ + _actualDeleteCount_).
-              1. Let _to_ be ! ToString(_k_ + _itemCount_).
+              1. Let _from_ be ! ToString(𝔽(_k_ + _actualDeleteCount_)).
+              1. Let _to_ be ! ToString(𝔽(_k_ + _itemCount_)).
               1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
               1. If _fromPresent_ is *true*, then
                 1. Let _fromValue_ be ? Get(_O_, _from_).
@@ -33858,13 +33878,13 @@ THH:mm:ss.sss
               1. Set _k_ to _k_ + 1.
             1. Set _k_ to _len_.
             1. Repeat, while _k_ &gt; (_len_ - _actualDeleteCount_ + _itemCount_),
-              1. Perform ? DeletePropertyOrThrow(_O_, ! ToString(_k_ - 1)).
+              1. Perform ? DeletePropertyOrThrow(_O_, ! ToString(𝔽(_k_ - 1))).
               1. Set _k_ to _k_ - 1.
           1. Else if _itemCount_ &gt; _actualDeleteCount_, then
             1. Set _k_ to (_len_ - _actualDeleteCount_).
             1. Repeat, while _k_ &gt; _actualStart_,
-              1. Let _from_ be ! ToString(_k_ + _actualDeleteCount_ - 1).
-              1. Let _to_ be ! ToString(_k_ + _itemCount_ - 1).
+              1. Let _from_ be ! ToString(𝔽(_k_ + _actualDeleteCount_ - 1)).
+              1. Let _to_ be ! ToString(𝔽(_k_ + _itemCount_ - 1)).
               1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
               1. If _fromPresent_ is *true*, then
                 1. Let _fromValue_ be ? Get(_O_, _from_).
@@ -33875,9 +33895,9 @@ THH:mm:ss.sss
               1. Set _k_ to _k_ - 1.
           1. Set _k_ to _actualStart_.
           1. For each element _E_ of _items_, do
-            1. Perform ? Set(_O_, ! ToString(_k_), _E_, *true*).
+            1. Perform ? Set(_O_, ! ToString(𝔽(_k_)), _E_, *true*).
             1. Set _k_ to _k_ + 1.
-          1. [id="step-array-proto-splice-set-length"] Perform ? Set(_O_, *"length"*, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
+          1. [id="step-array-proto-splice-set-length"] Perform ? Set(_O_, *"length"*, 𝔽(_len_ - _actualDeleteCount_ + _itemCount_), *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
@@ -33905,7 +33925,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. If _k_ &gt; 0, then
               1. Set _R_ to the string-concatenation of _R_ and _separator_.
-            1. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
+            1. Let _nextElement_ be ? Get(_array_, ! ToString(𝔽(_k_))).
             1. If _nextElement_ is not *undefined* or *null*, then
               1. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*)).
               1. Set _R_ to the string-concatenation of _R_ and _S_.
@@ -33948,8 +33968,8 @@ THH:mm:ss.sss
             1. If _len_ + _argCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
             1. Let _k_ be _len_.
             1. Repeat, while _k_ &gt; 0,
-              1. Let _from_ be ! ToString(_k_ - 1).
-              1. Let _to_ be ! ToString(_k_ + _argCount_ - 1).
+              1. Let _from_ be ! ToString(𝔽(_k_ - 1)).
+              1. Let _to_ be ! ToString(𝔽(_k_ + _argCount_ - 1)).
               1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
               1. If _fromPresent_ is *true*, then
                 1. Let _fromValue_ be ? Get(_O_, _from_).
@@ -33958,14 +33978,14 @@ THH:mm:ss.sss
                 1. Assert: _fromPresent_ is *false*.
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Set _k_ to _k_ - 1.
-            1. Let _j_ be 0.
+            1. Let _j_ be *+0*<sub>𝔽</sub>.
             1. For each element _E_ of _items_, do
               1. Perform ? Set(_O_, ! ToString(_j_), _E_, *true*).
-              1. Set _j_ to _j_ + 1.
-          1. Perform ? Set(_O_, *"length"*, _len_ + _argCount_, *true*).
-          1. Return _len_ + _argCount_.
+              1. Set _j_ to _j_ + *1*<sub>𝔽</sub>.
+          1. Perform ? Set(_O_, *"length"*, 𝔽(_len_ + _argCount_), *true*).
+          1. Return 𝔽(_len_ + _argCount_).
         </emu-alg>
-        <p>The *"length"* property of the `unshift` method is 1.</p>
+        <p>The *"length"* property of the `unshift` method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>The `unshift` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -34071,13 +34091,13 @@ THH:mm:ss.sss
               1. Set _O_.[[IteratedArrayLike]] to *undefined*.
               1. Return CreateIterResultObject(*undefined*, *true*).
             1. Set _O_.[[ArrayLikeNextIndex]] to _index_ + 1.
-            1. If _itemKind_ is ~key~, return CreateIterResultObject(_index_, *false*).
-            1. Let _elementKey_ be ! ToString(_index_).
+            1. If _itemKind_ is ~key~, return CreateIterResultObject(𝔽(_index_), *false*).
+            1. Let _elementKey_ be ! ToString(𝔽(_index_)).
             1. Let _elementValue_ be ? Get(_a_, _elementKey_).
             1. If _itemKind_ is ~value~, let _result_ be _elementValue_.
             1. Else,
               1. Assert: _itemKind_ is ~key+value~.
-              1. Let _result_ be ! CreateArrayFromList(&laquo; _index_, _elementValue_ &raquo;).
+              1. Let _result_ be ! CreateArrayFromList(&laquo; 𝔽(_index_), _elementValue_ &raquo;).
             1. Return CreateIterResultObject(_result_, *false*).
           </emu-alg>
         </emu-clause>
@@ -34386,7 +34406,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Throw a *TypeError* exception.
         </emu-alg>
-        <p>The *"length"* property of the %TypedArray% constructor function is 0.</p>
+        <p>The *"length"* property of the %TypedArray% constructor function is *+0*<sub>𝔽</sub>.</p>
       </emu-clause>
     </emu-clause>
 
@@ -34413,13 +34433,13 @@ THH:mm:ss.sss
           1. If _usingIterator_ is not *undefined*, then
             1. Let _values_ be ? IterableToList(_source_, _usingIterator_).
             1. Let _len_ be the number of elements in _values_.
-            1. Let _targetObj_ be ? TypedArrayCreate(_C_, &laquo; _len_ &raquo;).
+            1. Let _targetObj_ be ? TypedArrayCreate(_C_, &laquo; 𝔽(_len_) &raquo;).
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _len_,
-              1. Let _Pk_ be ! ToString(_k_).
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
               1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, _k_ &raquo;).
+                1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_) &raquo;).
               1. Else, let _mappedValue_ be _kValue_.
               1. Perform ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
               1. Set _k_ to _k_ + 1.
@@ -34428,13 +34448,13 @@ THH:mm:ss.sss
           1. NOTE: _source_ is not an Iterable so assume it is already an array-like object.
           1. Let _arrayLike_ be ! ToObject(_source_).
           1. Let _len_ be ? LengthOfArrayLike(_arrayLike_).
-          1. Let _targetObj_ be ? TypedArrayCreate(_C_, &laquo; _len_ &raquo;).
+          1. Let _targetObj_ be ? TypedArrayCreate(_C_, &laquo; 𝔽(_len_) &raquo;).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. If _mapping_ is *true*, then
-              1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, _k_ &raquo;).
+              1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_) &raquo;).
             1. Else, let _mappedValue_ be _kValue_.
             1. Perform ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
             1. Set _k_ to _k_ + 1.
@@ -34449,11 +34469,11 @@ THH:mm:ss.sss
           1. Let _len_ be the number of elements in _items_.
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
-          1. Let _newObj_ be ? TypedArrayCreate(_C_, &laquo; _len_ &raquo;).
+          1. Let _newObj_ be ? TypedArrayCreate(_C_, &laquo; 𝔽(_len_) &raquo;).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _kValue_ be _items_[_k_].
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Perform ? Set(_newObj_, _Pk_, _kValue_, *true*).
             1. Set _k_ to _k_ + 1.
           1. Return _newObj_.
@@ -34509,9 +34529,9 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
-          1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
+          1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
           1. Let _size_ be _O_.[[ByteLength]].
-          1. Return _size_.
+          1. Return 𝔽(_size_).
         </emu-alg>
       </emu-clause>
 
@@ -34523,9 +34543,9 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
-          1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
+          1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
           1. Let _offset_ be _O_.[[ByteOffset]].
-          1. Return _offset_.
+          1. Return 𝔽(_offset_).
         </emu-alg>
       </emu-clause>
 
@@ -34542,12 +34562,18 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. Let _relativeTarget_ be ? ToInteger(_target_).
-          1. If _relativeTarget_ &lt; 0, let _to_ be max((_len_ + _relativeTarget_), 0); else let _to_ be min(_relativeTarget_, _len_).
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _from_ be max((_len_ + _relativeStart_), 0); else let _from_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
+          1. If _relativeTarget_ is -&infin;, let _to_ be 0.
+          1. Else if _relativeTarget_ &lt; 0, let _to_ be max(_len_ + _relativeTarget_, 0).
+          1. Else, let _to_ be min(_relativeTarget_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _from_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _from_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _from_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _final_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
+          1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be min(_final_ - _from_, _len_ - _to_).
           1. If _count_ &gt; 0, then
             1. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
@@ -34613,13 +34639,17 @@ THH:mm:ss.sss
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If _O_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
           1. Otherwise, set _value_ to ? ToNumber(_value_).
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _k_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _k_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _final_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
+          1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
           1. Repeat, while _k_ &lt; _final_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Perform ! Set(_O_, _Pk_, _value_, *true*).
             1. Set _k_ to _k_ + 1.
           1. Return _O_.
@@ -34639,17 +34669,17 @@ THH:mm:ss.sss
           1. Let _k_ be 0.
           1. Let _captured_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;)).
+            1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _selected_ is *true*, then
               1. Append _kValue_ to the end of _kept_.
               1. Set _captured_ to _captured_ + 1.
             1. Set _k_ to _k_ + 1.
-          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _captured_ &raquo;).
+          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_captured_) &raquo;).
           1. Let _n_ be 0.
           1. For each element _e_ of _kept_, do
-            1. Perform ! Set(_A_, ! ToString(_n_), _e_, *true*).
+            1. Perform ! Set(_A_, ! ToString(𝔽(_n_)), _e_, *true*).
             1. Set _n_ to _n_ + 1.
           1. Return _A_.
         </emu-alg>
@@ -34716,9 +34746,9 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
           1. Assert: _O_ has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
-          1. If IsDetachedBuffer(_buffer_) is *true*, return 0.
+          1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
           1. Let _length_ be _O_.[[ArrayLength]].
-          1. Return _length_.
+          1. Return 𝔽(_length_).
         </emu-alg>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
@@ -34732,12 +34762,12 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _len_ &raquo;).
+          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_len_) &raquo;).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, _k_, _O_ &raquo;).
+            1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;).
             1. Perform ? Set(_A_, _Pk_, _mappedValue_, *true*).
             1. Set _k_ to _k_ + 1.
           1. Return _A_.
@@ -34776,7 +34806,7 @@ THH:mm:ss.sss
             1. Let _target_ be the *this* value.
             1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
             1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
-            1. Let _targetOffset_ be ? ToInteger(_offset_).
+            1. Let _targetOffset_ be ? ToIntegerOrInfinity(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
@@ -34787,12 +34817,13 @@ THH:mm:ss.sss
             1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _src_ be ? ToObject(_array_).
             1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
+            1. If _targetOffset_ is +&infin;, throw a *RangeError* exception.
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
             1. Let _targetByteIndex_ be _targetOffset_ &times; _targetElementSize_ + _targetByteOffset_.
             1. Let _k_ be 0.
             1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ &times; _srcLength_.
             1. Repeat, while _targetByteIndex_ &lt; _limit_,
-              1. Let _Pk_ be ! ToString(_k_).
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Let _value_ be ? Get(_src_, _Pk_).
               1. If _target_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
               1. Otherwise, set _value_ to ? ToNumber(_value_).
@@ -34812,7 +34843,7 @@ THH:mm:ss.sss
             1. Let _target_ be the *this* value.
             1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
             1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
-            1. Let _targetOffset_ be ? ToInteger(_offset_).
+            1. Let _targetOffset_ be ? ToIntegerOrInfinity(_offset_).
             1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
@@ -34828,8 +34859,9 @@ THH:mm:ss.sss
             1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
             1. Let _srcLength_ be _typedArray_.[[ArrayLength]].
             1. Let _srcByteOffset_ be _typedArray_.[[ByteOffset]].
+            1. If _targetOffset_ is +&infin;, throw a *RangeError* exception.
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
-            1. If _target_.[[ContentType]] is not equal to _typedArray_.[[ContentType]], throw a *TypeError* exception.
+            1. If _target_.[[ContentType]] &ne; _typedArray_.[[ContentType]], throw a *TypeError* exception.
             1. If both IsSharedArrayBuffer(_srcBuffer_) and IsSharedArrayBuffer(_targetBuffer_) are *true*, then
               1. If _srcBuffer_.[[ArrayBufferData]] and _targetBuffer_.[[ArrayBufferData]] are the same Shared Data Block values, let _same_ be *true*; else let _same_ be *false*.
             1. Else, let _same_ be SameValue(_srcBuffer_, _targetBuffer_).
@@ -34866,12 +34898,16 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _k_ be max((_len_ + _relativeStart_), 0); else let _k_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _k_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _k_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _final_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
+          1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be max(_final_ - _k_, 0).
-          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; _count_ &raquo;).
+          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_count_) &raquo;).
           1. Let _srcName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
           1. Let _targetName_ be the String value of _A_.[[TypedArrayName]].
@@ -34879,9 +34915,9 @@ THH:mm:ss.sss
           1. If _srcType_ is different from _targetType_, then
             1. Let _n_ be 0.
             1. Repeat, while _k_ &lt; _final_,
-              1. Let _Pk_ be ! ToString(_k_).
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Perform ! Set(_A_, ! ToString(_n_), _kValue_, *true*).
+              1. Perform ! Set(_A_, ! ToString(𝔽(_n_)), _kValue_, *true*).
               1. Set _k_ to _k_ + 1.
               1. Set _n_ to _n_ + 1.
           1. Else if _count_ &gt; 0, then
@@ -34929,16 +34965,16 @@ THH:mm:ss.sss
           1. If _comparefn_ is not *undefined*, then
             1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-            1. If _v_ is *NaN*, return *+0*.
+            1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
             1. Return _v_.
-          1. If _x_ and _y_ are both *NaN*, return *+0*.
-          1. If _x_ is *NaN*, return 1.
-          1. If _y_ is *NaN*, return -1.
-          1. If _x_ &lt; _y_, return -1.
-          1. If _x_ &gt; _y_, return 1.
-          1. If _x_ is *-0* and _y_ is *+0*, return -1.
-          1. If _x_ is *+0* and _y_ is *-0*, return 1.
-          1. Return *+0*.
+          1. If _x_ and _y_ are both *NaN*, return *+0*<sub>𝔽</sub>.
+          1. If _x_ is *NaN*, return *1*<sub>𝔽</sub>.
+          1. If _y_ is *NaN*, return *-1*<sub>𝔽</sub>.
+          1. If _x_ &lt; _y_, return *-1*<sub>𝔽</sub>.
+          1. If _x_ &gt; _y_, return *1*<sub>𝔽</sub>.
+          1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
+          1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. Return *+0*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
           <p>Because *NaN* always compares greater than any other value, *NaN* property values always sort to the end of the result when _comparefn_ is not provided.</p>
@@ -34954,16 +34990,20 @@ THH:mm:ss.sss
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Let _srcLength_ be _O_.[[ArrayLength]].
-          1. Let _relativeBegin_ be ? ToInteger(_begin_).
-          1. If _relativeBegin_ &lt; 0, let _beginIndex_ be max((_srcLength_ + _relativeBegin_), 0); else let _beginIndex_ be min(_relativeBegin_, _srcLength_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _srcLength_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _endIndex_ be max((_srcLength_ + _relativeEnd_), 0); else let _endIndex_ be min(_relativeEnd_, _srcLength_).
+          1. Let _relativeBegin_ be ? ToIntegerOrInfinity(_begin_).
+          1. If _relativeBegin_ is -&infin;, let _beginIndex_ be 0.
+          1. Else if _relativeBegin_ &lt; 0, let _beginIndex_ be max(_srcLength_ + _relativeBegin_, 0).
+          1. Else, let _beginIndex_ be min(_relativeBegin_, _srcLength_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _srcLength_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _endIndex_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_srcLength_ + _relativeEnd_, 0).
+          1. Else, let _endIndex_ be min(_relativeEnd_, _srcLength_).
           1. Let _newLength_ be max(_endIndex_ - _beginIndex_, 0).
           1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
           1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
           1. Let _beginByteOffset_ be _srcByteOffset_ + _beginIndex_ &times; _elementSize_.
-          1. Let _argumentsList_ be &laquo; _buffer_, _beginByteOffset_, _newLength_ &raquo;.
+          1. Let _argumentsList_ be &laquo; _buffer_, 𝔽(_beginByteOffset_), 𝔽(_newLength_) &raquo;.
           1. Return ? TypedArraySpeciesCreate(_O_, _argumentsList_).
         </emu-alg>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
@@ -35049,7 +35089,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
           <h1>AllocateTypedArray ( _constructorName_, _newTarget_, _defaultProto_ [ , _length_ ] )</h1>
-          <p>The abstract operation AllocateTypedArray takes arguments _constructorName_ (a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>), _newTarget_, and _defaultProto_ and optional argument _length_. It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypedArray_ overloads. It performs the following steps when called:</p>
+          <p>The abstract operation AllocateTypedArray takes arguments _constructorName_ (a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>), _newTarget_, and _defaultProto_ and optional argument _length_ (a non-negative integer). It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypedArray_ overloads. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
             1. Let _obj_ be ! IntegerIndexedObjectCreate(_proto_).
@@ -35069,11 +35109,10 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-allocatetypedarraybuffer" aoid="AllocateTypedArrayBuffer">
           <h1>AllocateTypedArrayBuffer ( _O_, _length_ )</h1>
-          <p>The abstract operation AllocateTypedArrayBuffer takes arguments _O_ (a TypedArray object) and _length_. It allocates and associates an ArrayBuffer with _O_. It performs the following steps when called:</p>
+          <p>The abstract operation AllocateTypedArrayBuffer takes arguments _O_ (a TypedArray object) and _length_ (a non-negative integer). It allocates and associates an ArrayBuffer with _O_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
             1. Assert: _O_.[[ViewedArrayBuffer]] is *undefined*.
-            1. Assert: ! IsNonNegativeInteger(_length_) is *true*.
             1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
             1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
             1. Let _byteLength_ be _elementSize_ &times; _length_.
@@ -35116,7 +35155,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
             1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-            1. If _srcArray_.[[ContentType]] is not equal to _O_.[[ContentType]], throw a *TypeError* exception.
+            1. If _srcArray_.[[ContentType]] &ne; _O_.[[ContentType]], throw a *TypeError* exception.
             1. Let _srcByteIndex_ be _srcByteOffset_.
             1. Let _targetByteIndex_ be 0.
             1. Let _count_ be _elementLength_.
@@ -35150,7 +35189,7 @@ THH:mm:ss.sss
             1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _len_,
-              1. Let _Pk_ be ! ToString(_k_).
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
               1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
               1. Set _k_ to _k_ + 1.
@@ -35162,7 +35201,7 @@ THH:mm:ss.sss
           1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(_k_).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
             1. Set _k_ to _k_ + 1.
@@ -35208,7 +35247,7 @@ THH:mm:ss.sss
           1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
           1. Perform ? ValidateTypedArray(_newTypedArray_).
           1. If _argumentList_ is a List of a single Number, then
-            1. If _newTypedArray_.[[ArrayLength]] &lt; _argumentList_[0], throw a *TypeError* exception.
+            1. If _newTypedArray_.[[ArrayLength]] &lt; ℝ(_argumentList_[0]), throw a *TypeError* exception.
           1. Return _newTypedArray_.
         </emu-alg>
       </emu-clause>
@@ -35222,7 +35261,7 @@ THH:mm:ss.sss
           1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
           1. Let _result_ be ? TypedArrayCreate(_constructor_, _argumentList_).
           1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
-          1. If _result_.[[ContentType]] is not equal to _exemplar_.[[ContentType]], throw a *TypeError* exception.
+          1. If _result_.[[ContentType]] &ne; _exemplar_.[[ContentType]], throw a *TypeError* exception.
           1. Return _result_.
         </emu-alg>
       </emu-clause>
@@ -35494,7 +35533,7 @@ THH:mm:ss.sss
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Value]] to _value_.
               1. Return _M_.
-          1. If _key_ is *-0*, set _key_ to *+0*.
+          1. If _key_ is *-0*<sub>𝔽</sub>, set _key_ to *+0*<sub>𝔽</sub>.
           1. Let _p_ be the Record { [[Key]]: _key_, [[Value]]: _value_ }.
           1. Append _p_ as the last element of _entries_.
           1. Return _M_.
@@ -35582,7 +35621,7 @@ THH:mm:ss.sss
             1. Let _entries_ be the List that is _m_.[[MapData]].
             1. Let _numEntries_ be the number of elements of _entries_.
             1. NOTE: _numEntries_ must be redetermined each time this method is evaluated.
-            1. Repeat, while _index_ is less than _numEntries_,
+            1. Repeat, while _index_ &lt; _numEntries_,
               1. Let _e_ be the Record { [[Key]], [[Value]] } that is the value of _entries_[_index_].
               1. Set _index_ to _index_ + 1.
               1. Set _O_.[[MapNextIndex]] to _index_.
@@ -35734,7 +35773,7 @@ THH:mm:ss.sss
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Return _S_.
-          1. If _value_ is *-0*, set _value_ to *+0*.
+          1. If _value_ is *-0*<sub>𝔽</sub>, set _value_ to *+0*<sub>𝔽</sub>.
           1. Append _value_ as the last element of _entries_.
           1. Return _S_.
         </emu-alg>
@@ -35916,7 +35955,7 @@ THH:mm:ss.sss
             1. Let _entries_ be the List that is _s_.[[SetData]].
             1. Let _numEntries_ be the number of elements of _entries_.
             1. NOTE: _numEntries_ must be redetermined each time this method is evaluated.
-            1. Repeat, while _index_ is less than _numEntries_,
+            1. Repeat, while _index_ &lt; _numEntries_,
               1. Let _e_ be _entries_[_index_].
               1. Set _index_ to _index_ + 1.
               1. Set _O_.[[SetNextIndex]] to _index_.
@@ -36292,10 +36331,9 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-allocatearraybuffer" aoid="AllocateArrayBuffer">
         <h1>AllocateArrayBuffer ( _constructor_, _byteLength_ )</h1>
-        <p>The abstract operation AllocateArrayBuffer takes arguments _constructor_ and _byteLength_. It is used to create an ArrayBuffer object. It performs the following steps when called:</p>
+        <p>The abstract operation AllocateArrayBuffer takes arguments _constructor_ and _byteLength_ (a non-negative integer). It is used to create an ArrayBuffer object. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%ArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] &raquo;).
-          1. Assert: ! IsNonNegativeInteger(_byteLength_) is *true*.
           1. Let _block_ be ? CreateByteDataBlock(_byteLength_).
           1. Set _obj_.[[ArrayBufferData]] to _block_.
           1. Set _obj_.[[ArrayBufferByteLength]] to _byteLength_.
@@ -36332,7 +36370,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-clonearraybuffer" aoid="CloneArrayBuffer">
         <h1>CloneArrayBuffer ( _srcBuffer_, _srcByteOffset_, _srcLength_, _cloneConstructor_ )</h1>
-        <p>The abstract operation CloneArrayBuffer takes arguments _srcBuffer_ (an ArrayBuffer object), _srcByteOffset_ (an integer), _srcLength_ (an integer), and _cloneConstructor_ (a constructor). It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. It performs the following steps when called:</p>
+        <p>The abstract operation CloneArrayBuffer takes arguments _srcBuffer_ (an ArrayBuffer object), _srcByteOffset_ (a non-negative integer), _srcLength_ (a non-negative integer), and _cloneConstructor_ (a constructor). It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_srcBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
           1. Assert: IsConstructor(_cloneConstructor_) is *true*.
@@ -36407,11 +36445,10 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-getvaluefrombuffer" aoid="GetValueFromBuffer">
         <h1>GetValueFromBuffer ( _arrayBuffer_, _byteIndex_, _type_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation GetValueFromBuffer takes arguments _arrayBuffer_ (an ArrayBuffer or SharedArrayBuffer), _byteIndex_ (an integer), _type_ (a TypedArray element type), _isTypedArray_ (a Boolean), and _order_ (either ~SeqCst~ or ~Unordered~) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
+        <p>The abstract operation GetValueFromBuffer takes arguments _arrayBuffer_ (an ArrayBuffer or SharedArrayBuffer), _byteIndex_ (a non-negative integer), _type_ (a TypedArray element type), _isTypedArray_ (a Boolean), and _order_ (either ~SeqCst~ or ~Unordered~) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: ! IsNonNegativeInteger(_byteIndex_) is *true*.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
@@ -36441,8 +36478,8 @@ THH:mm:ss.sss
           1. Else,
             1. Let _n_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
             1. Let _convOp_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
-            1. Let _intValue_ be _convOp_(_value_) treated as a mathematical value, whether the result is a BigInt or Number.
-            1. If _intValue_ &ge; 0<sub>ℝ</sub>, then
+            1. Let _intValue_ be ℝ(_convOp_(_value_)).
+            1. If _intValue_ &ge; 0, then
               1. Let _rawBytes_ be a List whose elements are the _n_-byte binary encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
             1. Else,
               1. Let _rawBytes_ be a List whose elements are the _n_-byte binary two's complement encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
@@ -36452,11 +36489,10 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-setvalueinbuffer" aoid="SetValueInBuffer">
         <h1>SetValueInBuffer ( _arrayBuffer_, _byteIndex_, _type_, _value_, _isTypedArray_, _order_ [ , _isLittleEndian_ ] )</h1>
-        <p>The abstract operation SetValueInBuffer takes arguments _arrayBuffer_ (an ArrayBuffer or SharedArrayBuffer), _byteIndex_ (an integer), _type_ (a TypedArray element type), _value_ (a Number or a BigInt), _isTypedArray_ (a Boolean), and _order_ (one of ~SeqCst~, ~Unordered~, or ~Init~) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
+        <p>The abstract operation SetValueInBuffer takes arguments _arrayBuffer_ (an ArrayBuffer or SharedArrayBuffer), _byteIndex_ (a non-negative integer), _type_ (a TypedArray element type), _value_ (a Number or a BigInt), _isTypedArray_ (a Boolean), and _order_ (one of ~SeqCst~, ~Unordered~, or ~Init~) and optional argument _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: ! IsNonNegativeInteger(_byteIndex_) is *true*.
           1. Assert: Type(_value_) is BigInt if ! IsBigIntElementType(_type_) is *true*; otherwise, Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
@@ -36478,7 +36514,6 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: ! IsNonNegativeInteger(_byteIndex_) is *true*.
           1. Assert: Type(_value_) is BigInt if ! IsBigIntElementType(_type_) is *true*; otherwise, Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
@@ -36579,7 +36614,7 @@ THH:mm:ss.sss
           1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _length_ be _O_.[[ArrayBufferByteLength]].
-          1. Return _length_.
+          1. Return 𝔽(_length_).
         </emu-alg>
       </emu-clause>
 
@@ -36597,13 +36632,17 @@ THH:mm:ss.sss
           1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _first_ be max((_len_ + _relativeStart_), 0); else let _first_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _first_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _first_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _first_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _final_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
+          1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
           1. Let _ctor_ be ? SpeciesConstructor(_O_, %ArrayBuffer%).
-          1. Let _new_ be ? Construct(_ctor_, &laquo; _newLen_ &raquo;).
+          1. Let _new_ be ? Construct(_ctor_, &laquo; 𝔽(_newLen_) &raquo;).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
@@ -36641,10 +36680,9 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-allocatesharedarraybuffer" aoid="AllocateSharedArrayBuffer">
         <h1>AllocateSharedArrayBuffer ( _constructor_, _byteLength_ )</h1>
-        <p>The abstract operation AllocateSharedArrayBuffer takes arguments _constructor_ and _byteLength_. It is used to create a SharedArrayBuffer object. It performs the following steps when called:</p>
+        <p>The abstract operation AllocateSharedArrayBuffer takes arguments _constructor_ and _byteLength_ (a non-negative integer). It is used to create a SharedArrayBuffer object. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%SharedArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
-          1. Assert: ! IsNonNegativeInteger(_byteLength_) is *true*.
           1. Let _block_ be ? CreateSharedByteDataBlock(_byteLength_).
           1. Set _obj_.[[ArrayBufferData]] to _block_.
           1. Set _obj_.[[ArrayBufferByteLength]] to _byteLength_.
@@ -36736,7 +36774,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
           1. Let _length_ be _O_.[[ArrayBufferByteLength]].
-          1. Return _length_.
+          1. Return 𝔽(_length_).
         </emu-alg>
       </emu-clause>
 
@@ -36753,13 +36791,17 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
-          1. Let _relativeStart_ be ? ToInteger(_start_).
-          1. If _relativeStart_ &lt; 0, let _first_ be max((_len_ + _relativeStart_), 0); else let _first_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToInteger(_end_).
-          1. If _relativeEnd_ &lt; 0, let _final_ be max((_len_ + _relativeEnd_), 0); else let _final_ be min(_relativeEnd_, _len_).
+          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _relativeStart_ is -&infin;, let _first_ be 0.
+          1. Else if _relativeStart_ &lt; 0, let _first_ be max(_len_ + _relativeStart_, 0).
+          1. Else, let _first_ be min(_relativeStart_, _len_).
+          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
+          1. If _relativeEnd_ is -&infin;, let _final_ be 0.
+          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
+          1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
           1. Let _ctor_ be ? SpeciesConstructor(_O_, %SharedArrayBuffer%).
-          1. Let _new_ be ? Construct(_ctor_, &laquo; _newLen_ &raquo;).
+          1. Let _new_ be ? Construct(_ctor_, &laquo; 𝔽(_newLen_) &raquo;).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *false*, throw a *TypeError* exception.
           1. If _new_.[[ArrayBufferData]] and _O_.[[ArrayBufferData]] are the same Shared Data Block values, throw a *TypeError* exception.
@@ -36918,7 +36960,7 @@ THH:mm:ss.sss
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _size_ be _O_.[[ByteLength]].
-          1. Return _size_.
+          1. Return 𝔽(_size_).
         </emu-alg>
       </emu-clause>
 
@@ -36932,7 +36974,7 @@ THH:mm:ss.sss
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _offset_ be _O_.[[ByteOffset]].
-          1. Return _offset_.
+          1. Return 𝔽(_offset_).
         </emu-alg>
       </emu-clause>
 
@@ -37271,7 +37313,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-removewaiters" aoid="RemoveWaiters">
         <h1>RemoveWaiters ( _WL_, _c_ )</h1>
-        <p>The abstract operation RemoveWaiters takes arguments _WL_ (a WaiterList) and _c_ (a non-negative integer). It performs the following steps when called:</p>
+        <p>The abstract operation RemoveWaiters takes arguments _WL_ (a WaiterList) and _c_ (a non-negative integer or +&infin;). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Let _L_ be a new empty List.
@@ -37280,17 +37322,17 @@ THH:mm:ss.sss
             1. Let _W_ be the first waiter in _S_.
             1. Add _W_ to the end of _L_.
             1. Remove _W_ from _S_.
-            1. Set _c_ to _c_ - 1.
+            1. If _c_ is finite, set _c_ to _c_ - 1.
           1. Return _L_.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-suspendagent" aoid="SuspendAgent" oldids="sec-suspend">
         <h1>SuspendAgent ( _WL_, _W_, _timeout_ )</h1>
-        <p>The abstract operation SuspendAgent takes arguments _WL_ (a WaiterList), _W_ (an agent signifier), and _timeout_ (a Number). It performs the following steps when called:</p>
+        <p>The abstract operation SuspendAgent takes arguments _WL_ (a WaiterList), _W_ (an agent signifier), and _timeout_ (a non-negative integer). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
-          1. Assert: _W_ is equal to AgentSignifier().
+          1. Assert: _W_ is equivalent to AgentSignifier().
           1. Assert: _W_ is on the list of waiters in _WL_.
           1. Assert: AgentCanSuspend() is *true*.
           1. Perform LeaveCriticalSection(_WL_) and suspend _W_ for up to _timeout_ milliseconds, performing the combined operation in such a way that a notification that arrives after the critical section is exited but before the suspension takes effect is not lost. _W_ can notify either because the timeout expired or because it was notified explicitly by another agent calling NotifyWaiter(_WL_, _W_), and not for any other reasons at all.
@@ -37320,9 +37362,9 @@ THH:mm:ss.sss
           1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
           1. If _typedArray_.[[ContentType]] is ~BigInt~, let _v_ be ? ToBigInt(_value_).
-          1. Otherwise, let _v_ be ? ToInteger(_value_).
+          1. Otherwise, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToInteger on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
+          1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
           1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
           1. Return GetModifySetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, _op_).
         </emu-alg>
@@ -37355,7 +37397,7 @@ THH:mm:ss.sss
           1. Let _i_ be 0.
           1. For each element _xByte_ of _xBytes_, do
             1. Let _yByte_ be _yBytes_[_i_].
-            1. If _xByte_ is not equal to _yByte_, return *false*.
+            1. If _xByte_ &ne; _yByte_, return *false*.
             1. Set _i_ to _i_ + 1.
           1. Return *true*.
         </emu-alg>
@@ -37401,10 +37443,10 @@ THH:mm:ss.sss
           1. Let _expected_ be ? ToBigInt(_expectedValue_).
           1. Let _replacement_ be ? ToBigInt(_replacementValue_).
         1. Else,
-          1. Let _expected_ be ? ToInteger(_expectedValue_).
-          1. Let _replacement_ be ? ToInteger(_replacementValue_).
+          1. Let _expected_ be 𝔽(? ToIntegerOrInfinity(_expectedValue_)).
+          1. Let _replacement_ be 𝔽(? ToIntegerOrInfinity(_replacementValue_)).
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToInteger on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
+        1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
@@ -37429,12 +37471,12 @@ THH:mm:ss.sss
       <h1>Atomics.isLockFree ( _size_ )</h1>
       <p>The following steps are taken:</p>
       <emu-alg>
-        1. Let _n_ be ? ToInteger(_size_).
+        1. Let _n_ be ? ToIntegerOrInfinity(_size_).
         1. Let _AR_ be the Agent Record of the surrounding agent.
-        1. If _n_ equals 1, return _AR_.[[IsLockFree1]].
-        1. If _n_ equals 2, return _AR_.[[IsLockFree2]].
-        1. If _n_ equals 4, return *true*.
-        1. If _n_ equals 8, return _AR_.[[IsLockFree8]].
+        1. If _n_ = 1, return _AR_.[[IsLockFree1]].
+        1. If _n_ = 2, return _AR_.[[IsLockFree2]].
+        1. If _n_ = 4, return *true*.
+        1. If _n_ = 8, return _AR_.[[IsLockFree8]].
         1. Return *false*.
       </emu-alg>
       <emu-note>
@@ -37475,9 +37517,9 @@ THH:mm:ss.sss
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
         1. If _arrayTypeName_ is *"BigUint64Array"* or *"BigInt64Array"*, let _v_ be ? ToBigInt(_value_).
-        1. Otherwise, let _v_ be ? ToInteger(_value_).
+        1. Otherwise, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToInteger on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
+        1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
         1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, *true*, ~SeqCst~).
         1. Return _v_.
@@ -37513,7 +37555,7 @@ THH:mm:ss.sss
         1. If _arrayTypeName_ is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
         1. Otherwise, let _v_ be ? ToInt32(_value_).
         1. Let _q_ be ? ToNumber(_timeout_).
-        1. If _q_ is *NaN*, let _t_ be *+&infin;*; else let _t_ be max(_q_, 0).
+        1. If _q_ is *NaN* or *+&infin;*<sub>𝔽</sub>, let _t_ be +&infin;; else if _q_ is *-&infin;*<sub>𝔽</sub>, let _t_ be 0; else let _t_ be max(ℝ(_q_), 0).
         1. Let _B_ be AgentCanSuspend().
         1. If _B_ is *false*, throw a *TypeError* exception.
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
@@ -37521,7 +37563,7 @@ THH:mm:ss.sss
         1. Perform EnterCriticalSection(_WL_).
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
         1. Let _w_ be ! GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
-        1. If _v_ is not equal to _w_, then
+        1. If _v_ &ne; _w_, then
           1. Perform LeaveCriticalSection(_WL_).
           1. Return the String *"not-equal"*.
         1. Let _W_ be AgentSignifier().
@@ -37543,13 +37585,13 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-        1. If _count_ is *undefined*, let _c_ be *+&infin;*.
+        1. If _count_ is *undefined*, let _c_ be +&infin;.
         1. Else,
-          1. Let _intCount_ be ? ToInteger(_count_).
+          1. Let _intCount_ be ? ToIntegerOrInfinity(_count_).
           1. Let _c_ be max(_intCount_, 0).
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. If IsSharedArrayBuffer(_buffer_) is *false*, return 0.
+        1. If IsSharedArrayBuffer(_buffer_) is *false*, return *+0*<sub>𝔽</sub>.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Let _n_ be 0.
         1. Perform EnterCriticalSection(_WL_).
@@ -37560,7 +37602,7 @@ THH:mm:ss.sss
           1. Perform NotifyWaiter(_WL_, _W_).
           1. Set _n_ to _n_ + 1.
         1. Perform LeaveCriticalSection(_WL_).
-        1. Return _n_.
+        1. Return 𝔽(_n_).
       </emu-alg>
     </emu-clause>
 
@@ -37614,7 +37656,7 @@ THH:mm:ss.sss
         1. Else,
           1. Return _unfiltered_.
       </emu-alg>
-      <p>The *"length"* property of the `parse` function is 2.</p>
+      <p>The *"length"* property of the `parse` function is *2*<sub>𝔽</sub>.</p>
       <emu-note>
         <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by step <emu-xref href="#step-json-parse-parse"></emu-xref> above. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that that parsing and evaluation returns a value of an appropriate type.</p>
       </emu-note>
@@ -37633,11 +37675,12 @@ THH:mm:ss.sss
               1. Let _I_ be 0.
               1. Let _len_ be ? LengthOfArrayLike(_val_).
               1. Repeat, while _I_ &lt; _len_,
-                1. Let _newElement_ be ? InternalizeJSONProperty(_val_, ! ToString(_I_), _reviver_).
+                1. Let _prop_ be ! ToString(𝔽(_I_)).
+                1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _prop_, _reviver_).
                 1. If _newElement_ is *undefined*, then
-                  1. Perform ? _val_.[[Delete]](! ToString(_I_)).
+                  1. Perform ? _val_.[[Delete]](_prop_).
                 1. Else,
-                  1. Perform ? CreateDataProperty(_val_, ! ToString(_I_), _newElement_).
+                  1. Perform ? CreateDataProperty(_val_, _prop_, _newElement_).
                 1. Set _I_ to _I_ + 1.
             1. Else,
               1. Let _keys_ be ? EnumerableOwnPropertyNames(_val_, ~key~).
@@ -37674,7 +37717,8 @@ THH:mm:ss.sss
               1. Let _len_ be ? LengthOfArrayLike(_replacer_).
               1. Let _k_ be 0.
               1. Repeat, while _k_ &lt; _len_,
-                1. Let _v_ be ? Get(_replacer_, ! ToString(_k_)).
+                1. Let _prop_ be ! ToString(𝔽(_k_)).
+                1. Let _v_ be ? Get(_replacer_, _prop_).
                 1. Let _item_ be *undefined*.
                 1. If Type(_v_) is String, set _item_ to _v_.
                 1. Else if Type(_v_) is Number, set _item_ to ! ToString(_v_).
@@ -37689,8 +37733,9 @@ THH:mm:ss.sss
           1. Else if _space_ has a [[StringData]] internal slot, then
             1. Set _space_ to ? ToString(_space_).
         1. If Type(_space_) is Number, then
-          1. Set _space_ to min(10, ! ToInteger(_space_)).
-          1. If _space_ &lt; 1, let _gap_ be the empty String; otherwise let _gap_ be the String value containing _space_ occurrences of the code unit 0x0020 (SPACE).
+          1. Let _spaceMV_ be ! ToIntegerOrInfinity(_space_).
+          1. Set _spaceMV_ to min(10, _spaceMV_).
+          1. If _spaceMV_ &lt; 1, let _gap_ be the empty String; otherwise let _gap_ be the String value containing _spaceMV_ occurrences of the code unit 0x0020 (SPACE).
         1. Else if Type(_space_) is String, then
           1. If the length of _space_ is 10 or less, let _gap_ be _space_; otherwise let _gap_ be the substring of _space_ from 0 to 10.
         1. Else,
@@ -37700,7 +37745,7 @@ THH:mm:ss.sss
         1. Let _state_ be the Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
         1. Return ? SerializeJSONProperty(_state_, the empty String, _wrapper_).
       </emu-alg>
-      <p>The *"length"* property of the `stringify` function is 3.</p>
+      <p>The *"length"* property of the `stringify` function is *3*<sub>𝔽</sub>.</p>
       <emu-note>
         <p>JSON structures are allowed to be nested to any depth, but they must be acyclic. If _value_ is or contains a cyclic structure, then the stringify function must throw a *TypeError* exception. This is an example of a value that cannot be stringified:</p>
         <pre><code class="javascript">
@@ -37950,7 +37995,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_value_).
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
-            1. Let _strP_ be ? SerializeJSONProperty(_state_, ! ToString(_index_), _value_).
+            1. Let _strP_ be ? SerializeJSONProperty(_state_, ! ToString(𝔽(_index_)), _value_).
             1. If _strP_ is *undefined*, then
               1. Append *"null"* to _partial_.
             1. Else,
@@ -38888,7 +38933,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-length">
         <h1>length</h1>
-        <p>The value of the *"length"* property is an integer that indicates the typical number of arguments expected by the AsyncGeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of an AsyncGeneratorFunction when invoked on a number of arguments other than the number specified by its *"length"* property depends on the function.</p>
+        <p>The value of the *"length"* property is an integral Number that indicates the typical number of arguments expected by the AsyncGeneratorFunction. However, the language permits the function to be invoked with some other number of arguments. The behaviour of an AsyncGeneratorFunction when invoked on a number of arguments other than the number specified by its *"length"* property depends on the function.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -39346,7 +39391,7 @@ THH:mm:ss.sss
             1. Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
           </emu-alg>
 
-          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor fulfilled function is 1.</p>
+          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor fulfilled function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
 
         <emu-clause id="async-generator-resume-next-return-processor-rejected">
@@ -39360,7 +39405,7 @@ THH:mm:ss.sss
             1. Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
           </emu-alg>
 
-          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor rejected function is 1.</p>
+          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor rejected function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39586,7 +39631,7 @@ THH:mm:ss.sss
             1. Set _alreadyResolved_.[[Value]] to *true*.
             1. Return RejectPromise(_promise_, _reason_).
           </emu-alg>
-          <p>The *"length"* property of a promise reject function is 1.</p>
+          <p>The *"length"* property of a promise reject function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
 
         <emu-clause id="sec-promise-resolve-functions">
@@ -39616,7 +39661,7 @@ THH:mm:ss.sss
             1. Perform HostEnqueuePromiseJob(_job_.[[Job]], _job_.[[Realm]]).
             1. Return *undefined*.
           </emu-alg>
-          <p>The *"length"* property of a promise resolve function is 1.</p>
+          <p>The *"length"* property of a promise resolve function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39668,7 +39713,7 @@ THH:mm:ss.sss
             1. Set _promiseCapability_.[[Reject]] to _reject_.
             1. Return *undefined*.
           </emu-alg>
-          <p>The *"length"* property of a GetCapabilitiesExecutor function is 2.</p>
+          <p>The *"length"* property of a GetCapabilitiesExecutor function is *2*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -39711,7 +39756,6 @@ THH:mm:ss.sss
       <emu-clause id="sec-host-promise-rejection-tracker" aoid="HostPromiseRejectionTracker">
         <h1>HostPromiseRejectionTracker ( _promise_, _operation_ )</h1>
         <p>HostPromiseRejectionTracker is a host-defined abstract operation that allows host environments to track promise rejections.</p>
-
         <p>An implementation of HostPromiseRejectionTracker must complete normally in all cases. The default implementation of HostPromiseRejectionTracker is to unconditionally return an empty normal completion.</p>
 
         <emu-note>
@@ -39925,7 +39969,7 @@ THH:mm:ss.sss
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The *"length"* property of a `Promise.all` resolve element function is 1.</p>
+          <p>The *"length"* property of a `Promise.all` resolve element function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -40018,7 +40062,7 @@ THH:mm:ss.sss
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The *"length"* property of a `Promise.allSettled` resolve element function is 1.</p>
+          <p>The *"length"* property of a `Promise.allSettled` resolve element function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
 
         <emu-clause id="sec-promise.allsettled-reject-element-functions">
@@ -40044,7 +40088,7 @@ THH:mm:ss.sss
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The *"length"* property of a `Promise.allSettled` reject element function is 1.</p>
+          <p>The *"length"* property of a `Promise.allSettled` reject element function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -40128,7 +40172,7 @@ THH:mm:ss.sss
               1. Return ? Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _error_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
-          <p>The *"length"* property of a `Promise.any` reject element function is 1.</p>
+          <p>The *"length"* property of a `Promise.any` reject element function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -40299,7 +40343,7 @@ THH:mm:ss.sss
             1. Let _valueThunk_ be equivalent to a function that returns _value_.
             1. Return ? Invoke(_promise_, *"then"*, &laquo; _valueThunk_ &raquo;).
           </emu-alg>
-          <p>The *"length"* property of a Then Finally function is *1*.</p>
+          <p>The *"length"* property of a Then Finally function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
 
         <emu-clause id="sec-catchfinallyfunctions">
@@ -40317,7 +40361,7 @@ THH:mm:ss.sss
             1. Let _thrower_ be equivalent to a function that throws _reason_.
             1. Return ? Invoke(_promise_, *"then"*, &laquo; _thrower_ &raquo;).
           </emu-alg>
-          <p>The *"length"* property of a Catch Finally function is *1*.</p>
+          <p>The *"length"* property of a Catch Finally function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -40786,7 +40830,7 @@ THH:mm:ss.sss
             1. Set _p_.[[ProxyHandler]] to *null*.
             1. Return *undefined*.
           </emu-alg>
-          <p>The *"length"* property of a Proxy revocation function is 0.</p>
+          <p>The *"length"* property of a Proxy revocation function is *+0*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
     </emu-clause>
@@ -40846,12 +40890,12 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[ByteIndex]]</td>
-            <td>A nonnegative integer</td>
+            <td>A non-negative integer</td>
             <td>The byte address of the read in [[Block]].</td>
           </tr>
           <tr>
             <td>[[ElementSize]]</td>
-            <td>A nonnegative integer</td>
+            <td>A non-negative integer</td>
             <td>The size of the read.</td>
           </tr>
         </tbody>
@@ -40883,12 +40927,12 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[ByteIndex]]</td>
-            <td>A nonnegative integer</td>
+            <td>A non-negative integer</td>
             <td>The byte address of the write in [[Block]].</td>
           </tr>
           <tr>
             <td>[[ElementSize]]</td>
-            <td>A nonnegative integer</td>
+            <td>A non-negative integer</td>
             <td>The size of the write.</td>
           </tr>
           <tr>
@@ -40925,12 +40969,12 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[ByteIndex]]</td>
-            <td>A nonnegative integer</td>
+            <td>A non-negative integer</td>
             <td>The byte address of the read-modify-write in [[Block]].</td>
           </tr>
           <tr>
             <td>[[ElementSize]]</td>
-            <td>A nonnegative integer</td>
+            <td>A non-negative integer</td>
             <td>The size of the read-modify-write.</td>
           </tr>
           <tr>
@@ -41262,9 +41306,9 @@ THH:mm:ss.sss
           1. Let _readValue_ be ValueOfReadEvent(_execution_, _R_).
           1. Let _chosenLen_ be the number of elements of _chosenValue_.
           1. Let _readLen_ be the number of elements of _readValue_.
-          1. If _chosenLen_ is not equal to _readLen_, then
+          1. If _chosenLen_ &ne; _readLen_, then
             1. Return *false*.
-          1. If _chosenValue_[_i_] is not equal to _readValue_[_i_] for any integer value _i_ in the range 0 through _chosenLen_, exclusive, then
+          1. If _chosenValue_[_i_] &ne; _readValue_[_i_] for any integer value _i_ in the range 0 through _chosenLen_, exclusive, then
             1. Return *false*.
         1. Return *true*.
       </emu-alg>
@@ -42410,7 +42454,7 @@ THH:mm:ss.sss
               1. If _hexEscape_ can be interpreted as an expansion of |HexDigits[~Sep]|, then
                 1. Let _hexIntegerLiteral_ be the string-concatenation of *"0x"* and _hexEscape_.
                 1. Let _n_ be ! ToNumber(_hexIntegerLiteral_).
-                1. Set _c_ to the code unit whose value is _n_.
+                1. Set _c_ to the code unit whose value is ℝ(_n_).
                 1. Set _k_ to _k_ + _skip_.
             1. Set _R_ to the string-concatenation of _R_ and _c_.
             1. Set _k_ to _k_ + 1.
@@ -42518,10 +42562,11 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _size_ be the length of _S_.
-          1. Let _intStart_ be ? ToInteger(_start_).
-          1. If _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
-          1. If _length_ is *undefined*, let _intLength_ be _size_; otherwise let _intLength_ be ? ToInteger(_length_).
-          1. If _intLength_ &le; 0, return the empty String.
+          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
+          1. If _intStart_ is -&infin;, set _intStart_ to 0.
+          1. Else if _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
+          1. If _length_ is *undefined*, let _intLength_ be _size_; otherwise let _intLength_ be ? ToIntegerOrInfinity(_length_).
+          1. If _intStart_ is +&infin;, _intLength_ &le; 0, or _intLength_ is +&infin;, return the empty String.
           1. Let _intEnd_ be min(_intStart_ + _intLength_, _size_).
           1. If _intStart_ &ge; _intEnd_, return the empty String.
           1. Return the substring of _S_ from _intStart_ to _intEnd_.
@@ -42702,7 +42747,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return YearFromTime(LocalTime(_t_)) - 1900.
+          1. Return YearFromTime(LocalTime(_t_)) - *1900*<sub>𝔽</sub>.
         </emu-alg>
       </emu-annex>
 
@@ -42714,13 +42759,13 @@ THH:mm:ss.sss
         <p>When the `setYear` method is called with one argument _year_, the following steps are taken:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
-          1. If _t_ is *NaN*, set _t_ to *+0*; otherwise, set _t_ to LocalTime(_t_).
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
           1. Let _y_ be ? ToNumber(_year_).
           1. If _y_ is *NaN*, then
             1. Set the [[DateValue]] internal slot of this Date object to *NaN*.
             1. Return *NaN*.
-          1. Let _yi_ be ! ToInteger(_y_).
-          1. If 0 &le; _yi_ &le; 99, let _yyyy_ be _yi_ + 1900.
+          1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
+          1. If 0 &le; _yi_ &le; 99, let _yyyy_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_).
           1. Else, let _yyyy_ be _y_.
           1. Let _d_ be MakeDay(_yyyy_, MonthFromTime(_t_), DateFromTime(_t_)).
           1. Let _date_ be UTC(MakeDate(_d_, TimeWithinDay(_t_))).
@@ -42732,7 +42777,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-date.prototype.togmtstring">
         <h1>Date.prototype.toGMTString ( )</h1>
         <emu-note>
-          <p>The property *"toUTCString"* is preferred. The *"toGMTString"* property is provided principally for compatibility with old code. It is recommended that the *"toUTCString"* property be used in new ECMAScript code.</p>
+          <p>The `toUTCString` method is preferred. The `toGMTString` method is provided principally for compatibility with old code.</p>
         </emu-note>
         <p>The function object that is the initial value of `Date.prototype.toGMTString` is the same function object that is the initial value of `Date.prototype.toUTCString`.</p>
       </emu-annex>
@@ -43289,13 +43334,13 @@ THH:mm:ss.sss
   <h1>Corrections and Clarifications in ECMAScript 2015 with Possible Compatibility Impact</h1>
   <p><emu-xref href="#sec-candeclareglobalvar"></emu-xref>-<emu-xref href="#sec-createglobalfunctionbinding"></emu-xref> Edition 5 and 5.1 used a property existence test to determine whether a global object property corresponding to a new global declaration already existed. ECMAScript 2015 uses an own property existence test. This corresponds to what has been most commonly implemented by web browsers.</p>
   <p><emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>: The 5<sup>th</sup> Edition moved the capture of the current array length prior to the integer conversion of the array index or new length value. However, the captured length value could become invalid if the conversion process has the side-effect of changing the array length. ECMAScript 2015 specifies that the current array length must be captured after the possible occurrence of such side-effects.</p>
-  <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0* or *-0* as the representation of a 0 time value. ECMAScript 2015 specifies that *+0* always returned. This means that for ECMAScript 2015 the time value of a Date object is never observably *-0* and methods that return time values never return *-0*.</p>
+  <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub> as the representation of a 0 time value. ECMAScript 2015 specifies that *+0*<sub>𝔽</sub> always returned. This means that for ECMAScript 2015 the time value of a Date object is never observably *-0*<sub>𝔽</sub> and methods that return time values never return *-0*<sub>𝔽</sub>.</p>
   <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a UTC offset representation is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as *"z"*.</p>
   <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the *"source"* property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `/`.</p>
   <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by one only if the pattern matched the empty String.</p>
-  <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>, <emu-xref href="#sec-sortcompare"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0* was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-defined. In practice, implementations call ToNumber.</p>
+  <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>, <emu-xref href="#sec-sortcompare"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0*<sub>𝔽</sub> was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-defined. In practice, implementations call ToNumber.</p>
 </emu-annex>
 
 <emu-annex id="sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->

As reported on #1964, the fact that we are using Number as default representation of numeric literals and operations creates uncounted bugs throughout the spec. This PR is proposing to rollback the default value to mathematical value. Since the major intention of PR #1135 was to avoid implicit conversions between numeric versions, we are keeping this change but it necessary to properly cast those numeric types when they are manipulated, since mixing different numeric types is not allowed.

The goals we want to achieve here are:

1. Resolve bugs on current version of spec like #1960 or #1229.
1. Mathematical values should never be leaked and are internal concept of ECMA262 specification. If this happens, it should be considered as editorial error.
1. Avoid the maximum of explicit conversions between Number, BigInt and Mathematical values.

Cc. @littledan @waldemarhorwat @ljharb @syg @michaelficarra @bakkot 

PS. It's still a WIP PR, but I think we have enough changes to discuss some changes made before I keep moving forward. 