### PR TITLE
add searchfox link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ the ECMAScript® Language Specification.
 This source is processed to obtain a human-readable version,
 which you can view [here](https://tc39.es/ecma262/).
 
+If you want to explore how the specification was written, you can also view the source with its history in [searchfox](https://searchfox.org/ecma262/source/spec.html).
+
 ## Current Proposals
 
 Proposals follow [the TC39 process](https://tc39.es/process-document/) and are tracked in the [proposals repository](https://github.com/tc39/proposals).


### PR DESCRIPTION
I realized that the historical view of the spec might not be accessible for most people, so this PR adds a link to the readme. Related to #1999 