### PR TITLE
Editorial: Extract operation ParseText

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37620,7 +37620,7 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. [id="step-json-parse-validate"] Parse ! StringToCodePoints(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
         1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
-        1. [id="step-json-parse-parse"] Let _completion_ be the result of parsing and evaluating ! StringToCodePoints(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
+        1. Let _completion_ be the result of parsing and evaluating ! StringToCodePoints(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then
@@ -37633,7 +37633,7 @@ THH:mm:ss.sss
       </emu-alg>
       <p>The *"length"* property of the `parse` function is *2*<sub>𝔽</sub>.</p>
       <emu-note>
-        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by step <emu-xref href="#step-json-parse-parse"></emu-xref> above. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that that parsing and evaluation returns a value of an appropriate type.</p>
+        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that that parsing and evaluation returns a value of an appropriate type.</p>
       </emu-note>
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">

--- a/spec.html
+++ b/spec.html
@@ -10269,6 +10269,22 @@
         1. Return _codePoints_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-parsetext" aoid="ParseText">
+      <h1>Static Semantics: ParseText ( _sourceText_, _goalSymbol_ )</h1>
+      <p>The abstract operation ParseText takes arguments _sourceText_ (a sequence of Unicode code points) and _goalSymbol_ (a nonterminal in one of the ECMAScript grammars). It performs the following steps when called:</p>
+      <emu-alg>
+        1. Attempt to parse _sourceText_ using _goalSymbol_ as the goal symbol, and analyse the parse result for any early error conditions. Parsing and early error detection may be interleaved in an implementation-defined manner.
+        1. If the parse succeeded and no early errors were found, return the Parse Node (an instance of _goalSymbol_) at the root of the parse tree resulting from the parse.
+        1. Otherwise, return a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-defined, but at least one must be present.
+      </emu-alg>
+      <emu-note>
+        <p>Consider a text that has an early error at a particular point, and also a syntax error at a later point. An implementation that does a parse pass followed by an early errors pass might report the syntax error and not proceed to the early errors pass. An implementation that interleaves the two activities might report the early error and not proceed to find the syntax error. A third implementation might report both errors. All of these behaviours are conformant.</p>
+      </emu-note>
+      <emu-note>
+        <p>See also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>.</p>
+      </emu-note>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-types-of-source-code">
@@ -21141,13 +21157,13 @@
         1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
         1. If _constructor_ is ~empty~, then
           1. If |ClassHeritage_opt| is present, then
-            1. Set _constructor_ to the result of parsing the source text
+            1. Let _constructorText_ be the source text
               <pre><code class="javascript">constructor(...args) { super(...args); }</code></pre>
-              using the syntactic grammar with the goal symbol |MethodDefinition[~Yield, ~Await]|.
           1. Else,
-            1. Set _constructor_ to the result of parsing the source text
+            1. Let _constructorText_ be the source text
               <pre><code class="javascript">constructor() {}</code></pre>
-              using the syntactic grammar with the goal symbol |MethodDefinition[~Yield, ~Await]|.
+          1. Set _constructor_ to ParseText(_constructorText_, |MethodDefinition[~Yield, ~Await]|).
+          1. Assert: _constructor_ is a Parse Node.
         1. Set the running execution context's LexicalEnvironment to _classScope_.
         1. Let _constructorInfo_ be ! DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_.
         1. Let _F_ be _constructorInfo_.[[Closure]].
@@ -22340,7 +22356,7 @@
 
       <emu-alg>
         1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
-        1. Parse _sourceText_ using |Script| as the goal symbol and analyse the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation-defined manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-defined, but at least one must be present.
+        1. Let _body_ be ParseText(_sourceText_, |Script|).
         1. If _body_ is a List of errors, return _body_.
         1. Return Script Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[ECMAScriptCode]]: _body_, [[HostDefined]]: _hostDefined_ }.
       </emu-alg>
@@ -23699,7 +23715,7 @@
           <p>The abstract operation ParseModule takes arguments _sourceText_ (ECMAScript source text), _realm_, and _hostDefined_. It creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
-            1. Parse _sourceText_ using |Module| as the goal symbol and analyse the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation-defined manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-defined, but at least one must be present.
+            1. Let _body_ be ParseText(_sourceText_, |Module|).
             1. If _body_ is a List of errors, return _body_.
             1. Let _requestedModules_ be the ModuleRequests of _body_.
             1. Let _importEntries_ be ImportEntries of _body_.
@@ -24785,7 +24801,8 @@
               1. Set _inMethod_ to _thisEnvRec_.HasSuperBinding().
               1. If _F_.[[ConstructorKind]] is ~derived~, set _inDerivedConstructor_ to *true*.
           1. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
-            1. Let _script_ be the ECMAScript code that is the result of parsing ! StringToCodePoints(_x_), for the goal symbol |Script|. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* exception (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>).
+            1. Let _script_ be ParseText(! StringToCodePoints(_x_), |Script|).
+            1. If _script_ is a List of errors, throw a *SyntaxError* exception.
             1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
             1. Let _body_ be the |ScriptBody| of _script_.
             1. If _inFunction_ is *false*, and _body_ Contains |NewTarget|, throw a *SyntaxError* exception.
@@ -26099,10 +26116,12 @@
             1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
             1. Let _sourceText_ be ! StringToCodePoints(_sourceString_).
             1. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
-              1. Let _parameters_ be the result of parsing ! StringToCodePoints(_P_), using _parameterGoal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
-              1. Let _body_ be the result of parsing ! StringToCodePoints(_bodyString_), using _goal_ as the goal symbol. Throw a *SyntaxError* exception if the parse fails.
+              1. Let _parameters_ be ParseText(! StringToCodePoints(_P_), _parameterGoal_).
+              1. If _parameters_ is a List of errors, throw a *SyntaxError* exception.
+              1. Let _body_ be ParseText(! StringToCodePoints(_bodyString_), _goal_).
+              1. If _body_ is a List of errors, throw a *SyntaxError* exception.
               1. Let _strict_ be ContainsUseStrict of _body_.
-              1. If any static semantics errors are detected for _parameters_ or _body_, throw a *SyntaxError* exception. If _strict_ is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+              1. If _strict_ is *true*, apply the early error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> to _parameters_.
               1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
               1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.
               1. If _body_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
@@ -31993,11 +32012,12 @@ THH:mm:ss.sss
           <p>The abstract operation ParsePattern takes arguments _patternText_ (a sequence of Unicode code points) and _u_ (a Boolean). It performs the following steps when called:</p>
           <emu-alg>
             1. If _u_ is *true*, then
-              1. Parse _patternText_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[+U, +N]|.
+              1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+U, +N]|).
             1. Else,
-              1. Parse _patternText_ using the grammars in <emu-xref href="#sec-patterns"></emu-xref>. The goal symbol for the parse is |Pattern[~U, ~N]|. If the result of parsing contains a |GroupName|, reparse with the goal symbol |Pattern[~U, +N]| and use this result instead.
-            1. If _patternText_ did not conform to the grammar, or any elements of _patternText_ were not matched by the parse, or any Early Error conditions exist, return a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors.
-            1. Otherwise, return the Parse Node resulting from the parse.
+              1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~U, ~N]|).
+              1. If _parseResult_ is a Parse Node and _parseResult_ contains a |GroupName|, then
+                1. Set _parseResult_ to ParseText(_patternText_, |Pattern[~U, +N]|).
+            1. Return _parseResult_.
           </emu-alg>
         </emu-clause>
 
@@ -37620,7 +37640,9 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. [id="step-json-parse-validate"] Parse ! StringToCodePoints(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
         1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
-        1. Let _completion_ be the result of parsing and evaluating ! StringToCodePoints(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
+        1. Let _script_ be ParseText(! StringToCodePoints(_scriptString_), |Script|).
+        1. Assert: _script_ is a Parse Node.
+        1. Let _completion_ be the result of evaluating _script_. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then


### PR DESCRIPTION
(This is the PR foreshadowed [here](https://github.com/tc39/ecma262/pull/1866#discussion_r423416235). Attn @michaelficarra)

<s>It's only a draft pull request so far, because:
(a) Some of the prose is first draft.
(b) I haven't used ParseText in IsValidRegularExpressionLiteral and RegExpInitialize yet, because that would just raise merge conflicts when #1866 is merged. Simpler to just wait.</s>