### PR TITLE
Editorial: deduplicate some work in atomics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37609,20 +37609,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-atomicload" aoid="AtomicLoad">
-        <h1>AtomicLoad ( _typedArray_, _index_ )</h1>
-        <p>The abstract operation AtomicLoad takes arguments _typedArray_ and _index_. It atomically loads a value and returns the loaded value. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
-          1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ValidateAtomicAccess on the preceding line can have arbitrary side effects, which could cause the buffer to become detached.
-          1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-          1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-bytelistbitwiseop" aoid="ByteListBitwiseOp">
         <h1>ByteListBitwiseOp ( _op_, _xBytes_, _yBytes_ )</h1>
         <p>The abstract operation ByteListBitwiseOp takes arguments _op_ (a sequence of Unicode code points), _xBytes_ (a List of byte values), and _yBytes_ (a List of byte values). The operation atomically performs a bitwise operation on all byte values of the arguments and returns a List of byte values. It performs the following steps when called:</p>
@@ -37738,11 +37724,17 @@ THH:mm:ss.sss
         <p>Regardless of the value of `Atomics.isLockFree`, all atomic operations are guaranteed to be atomic. For example, they will never have a visible operation take place in the middle of the operation (e.g., "tearing").</p>
       </emu-note>
     </emu-clause>
-    <emu-clause id="sec-atomics.load">
+    <emu-clause id="sec-atomics.load" oldids="sec-atomicload">
       <h1>Atomics.load ( _typedArray_, _index_ )</h1>
       <p>The following steps are taken:</p>
       <emu-alg>
-        1. Return ? AtomicLoad(_typedArray_, _index_).
+        1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+        1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ValidateAtomicAccess on the preceding line can have arbitrary side effects, which could cause the buffer to become detached.
+        1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
+        1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+        1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
       </emu-alg>
     </emu-clause>
 
@@ -37808,7 +37800,8 @@ THH:mm:ss.sss
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Perform EnterCriticalSection(_WL_).
-        1. Let _w_ be ! AtomicLoad(_typedArray_, ! ToIndex(_index_)).
+        1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+        1. Let _w_ be ! GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
         1. If _v_ is not equal to _w_, then
           1. Perform LeaveCriticalSection(_WL_).
           1. Return the String *"not-equal"*.

--- a/spec.html
+++ b/spec.html
@@ -37474,7 +37474,10 @@ THH:mm:ss.sss
           1. Let _accessIndex_ be ? ToIndex(_requestIndex_).
           1. Assert: _accessIndex_ &ge; 0.
           1. If _accessIndex_ &ge; _length_, throw a *RangeError* exception.
-          1. Return _accessIndex_.
+          1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
+          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+          1. Let _offset_ be _typedArray_.[[ByteOffset]].
+          1. Return (_accessIndex_ &times; _elementSize_) + _offset_.
         </emu-alg>
       </emu-clause>
 
@@ -37595,16 +37598,13 @@ THH:mm:ss.sss
         <p>The abstract operation AtomicReadModifyWrite takes arguments _typedArray_, _index_, _value_, and _op_ (a read-modify-write modification function). _op_ takes two List of byte values arguments and returns a List of byte values. This operation atomically loads a value, combines it with another value, and stores the result of the combination. It returns the loaded value. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
-          1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+          1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
           1. If _typedArray_.[[ContentType]] is ~BigInt~, let _v_ be ? ToBigInt(_value_).
           1. Otherwise, let _v_ be ? ToInteger(_value_).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToInteger on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
-          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
           1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-          1. Let _offset_ be _typedArray_.[[ByteOffset]].
-          1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
           1. Return GetModifySetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, _op_).
         </emu-alg>
       </emu-clause>
@@ -37614,14 +37614,11 @@ THH:mm:ss.sss
         <p>The abstract operation AtomicLoad takes arguments _typedArray_ and _index_. It atomically loads a value and returns the loaded value. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
-          1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+          1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ValidateAtomicAccess on the preceding line can have arbitrary side effects, which could cause the buffer to become detached.
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
           1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-          1. Let _offset_ be _typedArray_.[[ByteOffset]].
-          1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
           1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
         </emu-alg>
       </emu-clause>
@@ -37693,7 +37690,7 @@ THH:mm:ss.sss
       <p>The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
         1. If _typedArray_.[[ContentType]] is ~BigInt~, then
           1. Let _expected_ be ? ToBigInt(_expectedValue_).
@@ -37706,9 +37703,6 @@ THH:mm:ss.sss
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
-        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Let _compareExchange_ be a new read-modify-write modification function with parameters (_oldBytes_, _newBytes_) that captures _expectedBytes_ and performs the following steps atomically when called:
           1. If ByteListEqual(_oldBytes_, _expectedBytes_) is *true*, return _newBytes_.
           1. Return _oldBytes_.
@@ -37767,16 +37761,13 @@ THH:mm:ss.sss
       <p>The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
         1. If _arrayTypeName_ is *"BigUint64Array"* or *"BigInt64Array"*, let _v_ be ? ToBigInt(_value_).
         1. Otherwise, let _v_ be ? ToInteger(_value_).
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
         1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToInteger on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
-        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, *true*, ~SeqCst~).
         1. Return _v_.
       </emu-alg>
@@ -37806,7 +37797,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
         1. If IsSharedArrayBuffer(_buffer_) is *false*, throw a *TypeError* exception.
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
         1. If _arrayTypeName_ is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
         1. Otherwise, let _v_ be ? ToInt32(_value_).
@@ -37815,12 +37806,9 @@ THH:mm:ss.sss
         1. Let _B_ be AgentCanSuspend().
         1. If _B_ is *false*, throw a *TypeError* exception.
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
-        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Perform EnterCriticalSection(_WL_).
-        1. Let _w_ be ! AtomicLoad(_typedArray_, _i_).
+        1. Let _w_ be ! AtomicLoad(_typedArray_, ! ToIndex(_index_)).
         1. If _v_ is not equal to _w_, then
           1. Perform LeaveCriticalSection(_WL_).
           1. Return the String *"not-equal"*.
@@ -37842,16 +37830,13 @@ THH:mm:ss.sss
       <p>`Atomics.notify` notifies some agents that are sleeping in the wait queue. The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
-        1. Let _i_ be ? ValidateAtomicAccess(_typedArray_, _index_).
+        1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. If _count_ is *undefined*, let _c_ be *+&infin;*.
         1. Else,
           1. Let _intCount_ be ? ToInteger(_count_).
           1. Let _c_ be max(_intCount_, 0).
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
-        1. Let _offset_ be _typedArray_.[[ByteOffset]].
         1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-        1. Let _indexedPosition_ be (_i_ &times; _elementSize_) + _offset_.
         1. If IsSharedArrayBuffer(_buffer_) is *false*, return 0.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Let _n_ be 0.


### PR DESCRIPTION
Replaces https://github.com/tc39/ecma262/pull/835. This includes two of the three commits in that PR; the third, https://github.com/tc39/ecma262/pull/835/commits/8e56f87a235130a319a8adcc4b99bd4acc336aef, I am not inclined to take.

I'm neutral on the second commit, but included it for completeness.

(I opened a separate PR rather than just updating #835 because I wanted to drop https://github.com/tc39/ecma262/pull/835/commits/8e56f87a235130a319a8adcc4b99bd4acc336aef but didn't want to force-push it away.)

cc @anba @syg @lars-t-hansen