### PR TITLE
Editorial: fix inconsistent phrase "the empty String value"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32884,7 +32884,7 @@ THH:mm:ss.sss
                   1. Let _thisIndex_ be ? ToLength(? Get(_rx_, *"lastIndex"*)).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
                   1. Perform ? Set(_rx_, *"lastIndex"*, _nextIndex_, *true*).
-          1. Let _accumulatedResult_ be the empty String value.
+          1. Let _accumulatedResult_ be the empty String.
           1. Let _nextSourcePosition_ be 0.
           1. For each _result_ in _results_, do
             1. Let _nCaptures_ be ? LengthOfArrayLike(_result_).


### PR DESCRIPTION
This was the only occurrence.