### PR TITLE
Editorial: Have SV, TV, TRV, and CodePointToUTF16CodeUnits return a String rather than a sequence of code units

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30628,13 +30628,13 @@ THH:mm:ss.sss
       <p>Each `\\u` |HexTrailSurrogate| for which the choice of associated `u` |HexLeadSurrogate| is ambiguous shall be associated with the nearest possible `u` |HexLeadSurrogate| that would otherwise have no corresponding `\\u` |HexTrailSurrogate|.</p>
       <emu-grammar type="definition">
         HexLeadSurrogate ::
-          Hex4Digits [> but only if the SV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
+          Hex4Digits [> but only if the MV of |Hex4Digits| is in the inclusive range 0xD800 to 0xDBFF]
 
         HexTrailSurrogate ::
-          Hex4Digits [> but only if the SV of |Hex4Digits| is in the inclusive range 0xDC00 to 0xDFFF]
+          Hex4Digits [> but only if the MV of |Hex4Digits| is in the inclusive range 0xDC00 to 0xDFFF]
 
         HexNonSurrogate ::
-          Hex4Digits [> but only if the SV of |Hex4Digits| is not in the inclusive range 0xD800 to 0xDFFF]
+          Hex4Digits [> but only if the MV of |Hex4Digits| is not in the inclusive range 0xD800 to 0xDFFF]
 
         IdentityEscape[U] ::
           [+U] SyntaxCharacter

--- a/spec.html
+++ b/spec.html
@@ -10215,9 +10215,9 @@
       <p>ECMAScript differs from the Java programming language in the behaviour of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a string literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a string literal&mdash;one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the String value of a string literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a string literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the string literal.</p>
     </emu-note>
 
-    <emu-clause id="sec-codepointtoutf16codeunits" aoid="CodePointToUTF16CodeUnits" oldids="sec-utf16encoding">
-      <h1>Static Semantics: CodePointToUTF16CodeUnits ( _cp_ )</h1>
-      <p>The abstract operation CodePointToUTF16CodeUnits takes argument _cp_ (a Unicode code point). It performs the following steps when called:</p>
+    <emu-clause id="sec-utf16encodecodepoint" aoid="UTF16EncodeCodePoint" oldids="sec-utf16encoding,sec-codepointtoutf16codeunits">
+      <h1>Static Semantics: UTF16EncodeCodePoint ( _cp_ )</h1>
+      <p>The abstract operation UTF16EncodeCodePoint takes argument _cp_ (a Unicode code point). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: 0 &le; _cp_ &le; 0x10FFFF.
         1. If _cp_ &le; 0xFFFF, return the String value consisting of _cp_.
@@ -10233,7 +10233,7 @@
       <emu-alg>
         1. Let _result_ be the empty String.
         1. For each code point _cp_ of _text_, do
-          1. Set _result_ to the string-concatenation of _result_ and ! CodePointToUTF16CodeUnits(_cp_).
+          1. Set _result_ to the string-concatenation of _result_ and ! UTF16EncodeCodePoint(_cp_).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -10785,13 +10785,13 @@
         <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is none of *"$"*, or *"_"*, or ! CodePointToUTF16CodeUnits(_cp_) for some Unicode code point _cp_ matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is none of *"$"*, or *"_"*, or ! UTF16EncodeCodePoint(_cp_) for some Unicode code point _cp_ matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is none of *"$"*, *"_"*, ! CodePointToUTF16CodeUnits(&lt;ZWNJ&gt;), ! CodePointToUTF16CodeUnits(&lt;ZWJ&gt;), or ! CodePointToUTF16CodeUnits(_cp_) for some Unicode code point _cp_ that would be matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is none of *"$"*, *"_"*, ! UTF16EncodeCodePoint(&lt;ZWNJ&gt;), ! UTF16EncodeCodePoint(&lt;ZWJ&gt;), or ! UTF16EncodeCodePoint(_cp_) for some Unicode code point _cp_ that would be matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
       </emu-clause>
@@ -11239,7 +11239,7 @@
     <emu-clause id="sec-literals-string-literals">
       <h1>String Literals</h1>
       <emu-note>
-        <p>A string literal is zero or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-codepointtoutf16codeunits"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
+        <p>A string literal is zero or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encodecodepoint"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -11339,7 +11339,7 @@
             The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is the string-concatenation of the SV of |SingleStringCharacter| and the SV of |SingleStringCharacters|.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>DoubleStringCharacter :: &lt;LS&gt;</emu-grammar> is the String value consisting of the code unit 0x2028 (LINE SEPARATOR).
@@ -11351,7 +11351,7 @@
             The SV of <emu-grammar>DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty String.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>SingleStringCharacter :: &lt;LS&gt;</emu-grammar> is the String value consisting of the code unit 0x2028 (LINE SEPARATOR).
@@ -11517,7 +11517,7 @@
         </emu-table>
         <ul>
           <li>
-            The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the String value consisting of the code unit whose value is the MV of |HexEscapeSequence|.
@@ -11526,7 +11526,7 @@
             The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the String value consisting of the code unit whose value is the MV of |Hex4Digits|.
           </li>
           <li>
-            The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the MV of |CodePoint|.
+            The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar> is the result of performing UTF16EncodeCodePoint on the MV of |CodePoint|.
           </li>
         </ul>
       </emu-clause>
@@ -11704,7 +11704,7 @@
             The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is *undefined* if either the TV of |TemplateCharacter| is *undefined* or the TV of |TemplateCharacters| is *undefined*. Otherwise, it is the string-concatenation of the TV of |TemplateCharacter| and the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
+            The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
           </li>
           <li>
             The TV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the String value consisting of the code unit 0x0024 (DOLLAR SIGN).
@@ -11725,7 +11725,7 @@
             The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is the string-concatenation of the TRV of |TemplateCharacter| and the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
+            The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
           </li>
           <li>
             The TRV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the String value consisting of the code unit 0x0024 (DOLLAR SIGN).
@@ -11770,13 +11770,13 @@
             The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` CodePoint [lookahead &lt;! HexDigit] [lookahead != `}`]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the code unit 0x007B (LEFT CURLY BRACKET), and the TRV of |CodePoint|.
           </li>
           <li>
-            The TRV of <emu-grammar>DecimalDigit :: one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the single code point matched by this production.
+            The TRV of <emu-grammar>DecimalDigit :: one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`</emu-grammar> is the result of performing UTF16EncodeCodePoint on the single code point matched by this production.
           </li>
           <li>
             The TRV of <emu-grammar>CharacterEscapeSequence :: NonEscapeCharacter</emu-grammar> is the SV of |NonEscapeCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar>SingleEscapeCharacter :: one of `'` `"` `\` `b` `f` `n` `r` `t` `v`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the single code point matched by this production.
+            The TRV of <emu-grammar>SingleEscapeCharacter :: one of `'` `"` `\` `b` `f` `n` `r` `t` `v`</emu-grammar> is the result of performing UTF16EncodeCodePoint on the single code point matched by this production.
           </li>
           <li>
             The TRV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the string-concatenation of the code unit 0x0078 (LATIN SMALL LETTER X), the TRV of the first |HexDigit|, and the TRV of the second |HexDigit|.
@@ -11794,7 +11794,7 @@
             The TRV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is the string-concatenation of the TRV of |HexDigits| and the TRV of |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>HexDigit :: one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the single code point matched by this production.
+            The TRV of <emu-grammar>HexDigit :: one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`</emu-grammar> is the result of performing UTF16EncodeCodePoint on the single code point matched by this production.
           </li>
           <li>
             The TRV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS) and the TRV of |LineTerminatorSequence|.
@@ -25131,7 +25131,7 @@
                   1. Assert: The length of _Octets_ is _n_.
                   1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
                   1. Let _V_ be the code point obtained by applying the UTF-8 transformation to _Octets_, that is, from a List of octets into a 21-bit value.
-                  1. Let _S_ be CodePointToUTF16CodeUnits(_V_).
+                  1. Let _S_ be UTF16EncodeCodePoint(_V_).
               1. Set _R_ to the string-concatenation of _R_ and _S_.
               1. Set _k_ to _k_ + 1.
           </emu-alg>
@@ -29483,7 +29483,7 @@ THH:mm:ss.sss
             1. Let _nextCP_ be ? ToNumber(_next_).
             1. If ! IsIntegralNumber(_nextCP_) is *false*, throw a *RangeError* exception.
             1. If ℝ(_nextCP_) &lt; 0 or ℝ(_nextCP_) &gt; 0x10FFFF, throw a *RangeError* exception.
-            1. Set _result_ to the string-concatenation of _result_ and ! CodePointToUTF16CodeUnits(ℝ(_nextCP_)).
+            1. Set _result_ to the string-concatenation of _result_ and ! UTF16EncodeCodePoint(ℝ(_nextCP_)).
           1. Assert: If _codePoints_ is empty, then _result_ is the empty String.
           1. Return _result_.
         </emu-alg>
@@ -37820,7 +37820,7 @@ THH:mm:ss.sss
               1. Let _unit_ be the code unit whose numeric value is that of _C_.
               1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_unit_).
             1. Else,
-              1. Set _product_ to the string-concatenation of _product_ and ! CodePointToUTF16CodeUnits(_C_).
+              1. Set _product_ to the string-concatenation of _product_ and ! UTF16EncodeCodePoint(_C_).
           1. Set _product_ to the string-concatenation of _product_ and the code unit 0x0022 (QUOTATION MARK).
           1. Return _product_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -41991,16 +41991,16 @@ THH:mm:ss.sss
         <h1>Static Semantics</h1>
         <ul>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: OctalDigit</emu-grammar> is the code unit whose value is the MV of |OctalDigit|.
+            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the code unit whose value is the MV of |LegacyOctalEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of |ZeroToThree|) plus the MV of |OctalDigit|.
+            The MV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is (8 times the MV of |ZeroToThree|) plus the MV of |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: FourToSeven OctalDigit</emu-grammar> is the code unit whose value is (8 times the MV of |FourToSeven|) plus the MV of |OctalDigit|.
+            The MV of <emu-grammar>LegacyOctalEscapeSequence :: FourToSeven OctalDigit</emu-grammar> is (8 times the MV of |FourToSeven|) plus the MV of |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is the code unit whose value is (64 (that is, 8<sup>2</sup>) times the MV of |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
+            The MV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is (64 (that is, 8<sup>2</sup>) times the MV of |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
           </li>
           <li>
             The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `8`</emu-grammar> is the code unit 0x0038 (DIGIT EIGHT).
@@ -42240,8 +42240,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar>
         <emu-alg>
-          1. Evaluate the SV of |LegacyOctalEscapeSequence| (see <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>) to obtain a code unit _cu_.
-          1. Return the numeric value of _cu_.
+          1. Return the MV of |LegacyOctalEscapeSequence| (see <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>).
         </emu-alg>
       </emu-annex>
 

--- a/spec.html
+++ b/spec.html
@@ -10220,9 +10220,9 @@
       <p>The abstract operation UTF16EncodeCodePoint takes argument _cp_ (a Unicode code point). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: 0 &le; _cp_ &le; 0x10FFFF.
-        1. If _cp_ &le; 0xFFFF, return the String value consisting of _cp_.
-        1. Let _cu1_ be floor((_cp_ - 0x10000) / 0x400) + 0xD800.
-        1. Let _cu2_ be ((_cp_ - 0x10000) modulo 0x400) + 0xDC00.
+        1. If _cp_ &le; 0xFFFF, return the String value consisting of the code unit whose value is _cp_.
+        1. Let _cu1_ be the code unit whose value is floor((_cp_ - 0x10000) / 0x400) + 0xD800.
+        1. Let _cu2_ be the code unit whose value is ((_cp_ - 0x10000) modulo 0x400) + 0xDC00.
         1. Return the string-concatenation of _cu1_ and _cu2_.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -11336,13 +11336,7 @@
             The SV of <emu-grammar>StringLiteral :: `'` `'`</emu-grammar> is the empty code unit sequence.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacters :: DoubleStringCharacter</emu-grammar> is a sequence of up to two code units that is the SV of |DoubleStringCharacter|.
-          </li>
-          <li>
             The SV of <emu-grammar>DoubleStringCharacters :: DoubleStringCharacter DoubleStringCharacters</emu-grammar> is a sequence of up to two code units that is the SV of |DoubleStringCharacter| followed by the code units of the SV of |DoubleStringCharacters|.
-          </li>
-          <li>
-            The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter</emu-grammar> is a sequence of up to two code units that is the SV of |SingleStringCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is a sequence of up to two code units that is the SV of |SingleStringCharacter| followed by the code units of the SV of |SingleStringCharacters|.

--- a/spec.html
+++ b/spec.html
@@ -11188,9 +11188,6 @@
           <li>
             The MV of <emu-grammar>HexDigits :: HexDigits NumericLiteralSeparator HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16) plus the MV of |HexDigit|.
           </li>
-          <li>
-            The MV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is (0x1000 &times; the MV of the first |HexDigit|) plus (0x100 &times; the MV of the second |HexDigit|) plus (0x10 &times; the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
-          </li>
         </ul>
       </emu-clause>
 
@@ -11523,13 +11520,25 @@
             The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit whose value is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
+            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit whose value is the MV of |HexEscapeSequence|.
           </li>
           <li>
             The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit whose value is the MV of |Hex4Digits|.
           </li>
           <li>
             The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the MV of |CodePoint|.
+          </li>
+        </ul>
+      </emu-clause>
+
+      <emu-clause id="sec-string-literals-static-semantics-mv">
+        <h1>Static Semantics: MV</h1>
+        <ul>
+          <li>
+            The MV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is (16 times the MV of the first |HexDigit|) plus the MV of the second |HexDigit|.
+          </li>
+          <li>
+            The MV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is (0x1000 &times; the MV of the first |HexDigit|) plus (0x100 &times; the MV of the second |HexDigit|) plus (0x10 &times; the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
           </li>
         </ul>
       </emu-clause>
@@ -30999,7 +31008,7 @@ THH:mm:ss.sss
         </emu-note>
         <emu-grammar>CharacterEscape :: HexEscapeSequence</emu-grammar>
         <emu-alg>
-          1. Return the numeric value of the code unit that is the SV of |HexEscapeSequence|.
+          1. Return the MV of |HexEscapeSequence|.
         </emu-alg>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u` HexLeadSurrogate `\u` HexTrailSurrogate</emu-grammar>
         <emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -10220,10 +10220,10 @@
       <p>The abstract operation CodePointToUTF16CodeUnits takes argument _cp_ (a Unicode code point). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: 0 &le; _cp_ &le; 0x10FFFF.
-        1. If _cp_ &le; 0xFFFF, return _cp_.
+        1. If _cp_ &le; 0xFFFF, return the String value consisting of _cp_.
         1. Let _cu1_ be floor((_cp_ - 0x10000) / 0x400) + 0xD800.
         1. Let _cu2_ be ((_cp_ - 0x10000) modulo 0x400) + 0xDC00.
-        1. Return the code unit sequence consisting of _cu1_ followed by _cu2_.
+        1. Return the string-concatenation of _cu1_ and _cu2_.
       </emu-alg>
     </emu-clause>
 
@@ -11318,55 +11318,55 @@
             `'` SingleStringCharacters? `'`
         </emu-grammar>
         <emu-alg>
-          1. Return the String value whose code units are the SV of this |StringLiteral|.
+          1. Return the SV of this |StringLiteral|.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-sv">
         <h1>Static Semantics: SV</h1>
-        <p>A string literal stands for a value of the String type. The String value (SV) of the literal is described in terms of code unit values contributed by the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value (MV), as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
+        <p>A string literal stands for a value of the String type. The String value (SV) of the literal is described in terms of String values contributed by the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value (MV), as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
         <ul>
           <li>
-            The SV of <emu-grammar>StringLiteral :: `"` `"`</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar>StringLiteral :: `"` `"`</emu-grammar> is the empty String.
           </li>
           <li>
-            The SV of <emu-grammar>StringLiteral :: `'` `'`</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar>StringLiteral :: `'` `'`</emu-grammar> is the empty String.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacters :: DoubleStringCharacter DoubleStringCharacters</emu-grammar> is a sequence of up to two code units that is the SV of |DoubleStringCharacter| followed by the code units of the SV of |DoubleStringCharacters|.
+            The SV of <emu-grammar>DoubleStringCharacters :: DoubleStringCharacter DoubleStringCharacters</emu-grammar> is the string-concatenation of the SV of |DoubleStringCharacter| and the SV of |DoubleStringCharacters|.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is a sequence of up to two code units that is the SV of |SingleStringCharacter| followed by the code units of the SV of |SingleStringCharacters|.
+            The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is the string-concatenation of the SV of |SingleStringCharacter| and the SV of |SingleStringCharacters|.
           </li>
           <li>
             The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: &lt;LS&gt;</emu-grammar> is the code unit 0x2028 (LINE SEPARATOR).
+            The SV of <emu-grammar>DoubleStringCharacter :: &lt;LS&gt;</emu-grammar> is the String value consisting of the code unit 0x2028 (LINE SEPARATOR).
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: &lt;PS&gt;</emu-grammar> is the code unit 0x2029 (PARAGRAPH SEPARATOR).
+            The SV of <emu-grammar>DoubleStringCharacter :: &lt;PS&gt;</emu-grammar> is the String value consisting of the code unit 0x2029 (PARAGRAPH SEPARATOR).
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar>DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty String.
           </li>
           <li>
             The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: &lt;LS&gt;</emu-grammar> is the code unit 0x2028 (LINE SEPARATOR).
+            The SV of <emu-grammar>SingleStringCharacter :: &lt;LS&gt;</emu-grammar> is the String value consisting of the code unit 0x2028 (LINE SEPARATOR).
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: &lt;PS&gt;</emu-grammar> is the code unit 0x2029 (PARAGRAPH SEPARATOR).
+            The SV of <emu-grammar>SingleStringCharacter :: &lt;PS&gt;</emu-grammar> is the String value consisting of the code unit 0x2029 (PARAGRAPH SEPARATOR).
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: LineContinuation</emu-grammar> is the empty code unit sequence.
+            The SV of <emu-grammar>SingleStringCharacter :: LineContinuation</emu-grammar> is the empty String.
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit 0x0000 (NULL).
+            The SV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the String value consisting of the code unit 0x0000 (NULL).
           </li>
           <li>
-            The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-string-single-character-escape-sequences"></emu-xref>.
+            The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the String value consisting of the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-string-single-character-escape-sequences"></emu-xref>.
           </li>
         </ul>
         <emu-table id="table-string-single-character-escape-sequences" caption="String Single Character Escape Sequences" oldids="table-34">
@@ -11520,10 +11520,10 @@
             The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the code unit whose value is the MV of |HexEscapeSequence|.
+            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the String value consisting of the code unit whose value is the MV of |HexEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the code unit whose value is the MV of |Hex4Digits|.
+            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the String value consisting of the code unit whose value is the MV of |Hex4Digits|.
           </li>
           <li>
             The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the MV of |CodePoint|.
@@ -11686,28 +11686,28 @@
 
       <emu-clause id="sec-static-semantics-tv-and-trv">
         <h1>Static Semantics: TV and TRV</h1>
-        <p>A template literal component is interpreted as a sequence of Unicode code points. The Template Value (TV) of a literal component is described in terms of code unit values (SV, <emu-xref href="#sec-literals-string-literals"></emu-xref>) contributed by the various parts of the template literal component. As part of this process, some Unicode code points within the template component are interpreted as having a mathematical value (MV, <emu-xref href="#sec-literals-numeric-literals"></emu-xref>). In determining a TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence. The Template Raw Value (TRV) is similar to a Template Value with the difference that in TRVs escape sequences are interpreted literally.</p>
+        <p>A template literal component is interpreted as a sequence of Unicode code points. The Template Value (TV) of a literal component is described in terms of String values (SV, <emu-xref href="#sec-literals-string-literals"></emu-xref>) contributed by the various parts of the template literal component. As part of this process, some Unicode code points within the template component are interpreted as having a mathematical value (MV, <emu-xref href="#sec-literals-numeric-literals"></emu-xref>). In determining a TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence. The Template Raw Value (TRV) is similar to a Template Value with the difference that in TRVs escape sequences are interpreted literally.</p>
         <ul>
           <li>
-            The TV and TRV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty String.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateHead :: ``` `${`</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar>TemplateHead :: ``` `${`</emu-grammar> is the empty String.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateMiddle :: `}` `${`</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar>TemplateMiddle :: `}` `${`</emu-grammar> is the empty String.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateTail :: `}` ```</emu-grammar> is the empty code unit sequence.
+            The TV and TRV of <emu-grammar>TemplateTail :: `}` ```</emu-grammar> is the empty String.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is *undefined* if either the TV of |TemplateCharacter| is *undefined* or the TV of |TemplateCharacters| is *undefined*. Otherwise, it is a sequence consisting of the code units of the TV of |TemplateCharacter| followed by the code units of the TV of |TemplateCharacters|.
+            The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is *undefined* if either the TV of |TemplateCharacter| is *undefined* or the TV of |TemplateCharacters| is *undefined*. Otherwise, it is the string-concatenation of the TV of |TemplateCharacter| and the TV of |TemplateCharacters|.
           </li>
           <li>
             The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the code unit 0x0024 (DOLLAR SIGN).
+            The TV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the String value consisting of the code unit 0x0024 (DOLLAR SIGN).
           </li>
           <li>
             The TV of <emu-grammar>TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the SV of |EscapeSequence|.
@@ -11719,55 +11719,55 @@
             The TV of <emu-grammar>TemplateCharacter :: LineTerminatorSequence</emu-grammar> is the TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the empty code unit sequence.
+            The TV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the empty String.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is a sequence consisting of the code units of the TRV of |TemplateCharacter| followed by the code units of the TRV of |TemplateCharacters|.
+            The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is the string-concatenation of the TRV of |TemplateCharacter| and the TRV of |TemplateCharacters|.
           </li>
           <li>
             The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the code point value of |SourceCharacter|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the code unit 0x0024 (DOLLAR SIGN).
+            The TRV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the String value consisting of the code unit 0x0024 (DOLLAR SIGN).
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the sequence consisting of the code unit 0x005C (REVERSE SOLIDUS) followed by the code units of TRV of |EscapeSequence|.
+            The TRV of <emu-grammar>TemplateCharacter :: `\` EscapeSequence</emu-grammar> is the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS) and the TRV of |EscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: `\` NotEscapeSequence</emu-grammar> is the sequence consisting of the code unit 0x005C (REVERSE SOLIDUS) followed by the code units of TRV of |NotEscapeSequence|.
+            The TRV of <emu-grammar>TemplateCharacter :: `\` NotEscapeSequence</emu-grammar> is the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS) and the TRV of |NotEscapeSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit 0x0030 (DIGIT ZERO).
+            The TRV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the String value consisting of the code unit 0x0030 (DIGIT ZERO).
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `0` DecimalDigit</emu-grammar> is the sequence consisting of the code unit 0x0030 (DIGIT ZERO) followed by the code units of the TRV of |DecimalDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `0` DecimalDigit</emu-grammar> is the string-concatenation of the code unit 0x0030 (DIGIT ZERO) and the TRV of |DecimalDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `x` [lookahead &lt;! HexDigit]</emu-grammar> is the code unit 0x0078 (LATIN SMALL LETTER X).
+            The TRV of <emu-grammar>NotEscapeSequence :: `x` [lookahead &lt;! HexDigit]</emu-grammar> is the String value consisting of the code unit 0x0078 (LATIN SMALL LETTER X).
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `x` HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the sequence consisting of the code unit 0x0078 (LATIN SMALL LETTER X) followed by the code units of the TRV of |HexDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `x` HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0078 (LATIN SMALL LETTER X) and the TRV of |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` [lookahead &lt;! HexDigit] [lookahead != `{`]</emu-grammar> is the code unit 0x0075 (LATIN SMALL LETTER U).
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` [lookahead &lt;! HexDigit] [lookahead != `{`]</emu-grammar> is the String value consisting of the code unit 0x0075 (LATIN SMALL LETTER U).
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code units of the TRV of |HexDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U) and the TRV of |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code units of the TRV of the first |HexDigit| followed by the code units of the TRV of the second |HexDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the TRV of the first |HexDigit|, and the TRV of the second |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit HexDigit HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code units of the TRV of the first |HexDigit| followed by the code units of the TRV of the second |HexDigit| followed by the code units of the TRV of the third |HexDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit HexDigit HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the TRV of the first |HexDigit|, the TRV of the second |HexDigit|, and the TRV of the third |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` [lookahead &lt;! HexDigit]</emu-grammar> is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code unit 0x007B (LEFT CURLY BRACKET).
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U) and the code unit 0x007B (LEFT CURLY BRACKET).
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` NotCodePoint [lookahead &lt;! HexDigit]</emu-grammar> is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code unit 0x007B (LEFT CURLY BRACKET) followed by the code units of the TRV of |NotCodePoint|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` NotCodePoint [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the code unit 0x007B (LEFT CURLY BRACKET), and the TRV of |NotCodePoint|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` CodePoint [lookahead &lt;! HexDigit] [lookahead != `}`]</emu-grammar> is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code unit 0x007B (LEFT CURLY BRACKET) followed by the code units of the TRV of |CodePoint|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` CodePoint [lookahead &lt;! HexDigit] [lookahead != `}`]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the code unit 0x007B (LEFT CURLY BRACKET), and the TRV of |CodePoint|.
           </li>
           <li>
             The TRV of <emu-grammar>DecimalDigit :: one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the single code point matched by this production.
@@ -11779,40 +11779,40 @@
             The TRV of <emu-grammar>SingleEscapeCharacter :: one of `'` `"` `\` `b` `f` `n` `r` `t` `v`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the single code point matched by this production.
           </li>
           <li>
-            The TRV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the sequence consisting of the code unit 0x0078 (LATIN SMALL LETTER X) followed by TRV of the first |HexDigit| followed by the TRV of the second |HexDigit|.
+            The TRV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the string-concatenation of the code unit 0x0078 (LATIN SMALL LETTER X), the TRV of the first |HexDigit|, and the TRV of the second |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by TRV of |Hex4Digits|.
+            The TRV of <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U) and the TRV of |Hex4Digits|.
           </li>
           <li>
-            The TRV of <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar> is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code unit 0x007B (LEFT CURLY BRACKET) followed by TRV of |CodePoint| followed by the code unit 0x007D (RIGHT CURLY BRACKET).
+            The TRV of <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the code unit 0x007B (LEFT CURLY BRACKET), the TRV of |CodePoint|, and the code unit 0x007D (RIGHT CURLY BRACKET).
           </li>
           <li>
-            The TRV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the sequence consisting of the TRV of the first |HexDigit| followed by the TRV of the second |HexDigit| followed by the TRV of the third |HexDigit| followed by the TRV of the fourth |HexDigit|.
+            The TRV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the string-concatenation of the TRV of the first |HexDigit|, the TRV of the second |HexDigit|, the TRV of the third |HexDigit|, and the TRV of the fourth |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is the sequence consisting of TRV of |HexDigits| followed by TRV of |HexDigit|.
+            The TRV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is the string-concatenation of the TRV of |HexDigits| and the TRV of |HexDigit|.
           </li>
           <li>
             The TRV of <emu-grammar>HexDigit :: one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`</emu-grammar> is the result of performing CodePointToUTF16CodeUnits on the single code point matched by this production.
           </li>
           <li>
-            The TRV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the sequence consisting of the code unit 0x005C (REVERSE SOLIDUS) followed by the code units of TRV of |LineTerminatorSequence|.
+            The TRV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS) and the TRV of |LineTerminatorSequence|.
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;LF&gt;</emu-grammar> is the code unit 0x000A (LINE FEED).
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;LF&gt;</emu-grammar> is the String value consisting of the code unit 0x000A (LINE FEED).
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt;</emu-grammar> is the code unit 0x000A (LINE FEED).
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt;</emu-grammar> is the String value consisting of the code unit 0x000A (LINE FEED).
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;LS&gt;</emu-grammar> is the code unit 0x2028 (LINE SEPARATOR).
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;LS&gt;</emu-grammar> is the String value consisting of the code unit 0x2028 (LINE SEPARATOR).
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;PS&gt;</emu-grammar> is the code unit 0x2029 (PARAGRAPH SEPARATOR).
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;PS&gt;</emu-grammar> is the String value consisting of the code unit 0x2029 (PARAGRAPH SEPARATOR).
           </li>
           <li>
-            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt; &lt;LF&gt;</emu-grammar> is the sequence consisting of the code unit 0x000A (LINE FEED).
+            The TRV of <emu-grammar>LineTerminatorSequence :: &lt;CR&gt; &lt;LF&gt;</emu-grammar> is the String value consisting of the code unit 0x000A (LINE FEED).
           </li>
         </ul>
         <emu-note>
@@ -12696,7 +12696,7 @@
         </emu-alg>
         <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
-          1. Return the String value whose code units are the SV of |StringLiteral|.
+          1. Return the SV of |StringLiteral|.
         </emu-alg>
         <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
@@ -12747,7 +12747,7 @@
         </emu-alg>
         <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
-          1. Return the String value whose code units are the SV of |StringLiteral|.
+          1. Return the SV of |StringLiteral|.
         </emu-alg>
         <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
         <emu-alg>
@@ -13080,7 +13080,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
-          1. Return the String value whose code units are the elements of the TV of |NoSubstitutionTemplate| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
+          1. Return the TV of |NoSubstitutionTemplate| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
         </emu-alg>
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
@@ -13097,8 +13097,7 @@
         </emu-note>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
-          1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Return the String value consisting of the code units of _tail_.
+          1. Return the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
@@ -13113,7 +13112,7 @@
           1. Let _subRef_ be the result of evaluating |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _middle_ be ? ToString(_sub_).
-          1. Return the sequence of code units consisting of the code units of _head_ followed by the elements of _middle_.
+          1. Return the string-concatenation of _head_ and _middle_.
         </emu-alg>
         <emu-note>
           <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
@@ -13126,7 +13125,7 @@
           1. Let _subRef_ be the result of evaluating |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _last_ be ? ToString(_sub_).
-          1. Return the sequence of code units consisting of the elements of _rest_ followed by the code units of _middle_ followed by the elements of _last_.
+          1. Return the string-concatenation of _rest_, _middle_, and _last_.
         </emu-alg>
         <emu-note>
           <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
@@ -25132,7 +25131,7 @@
                   1. Assert: The length of _Octets_ is _n_.
                   1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
                   1. Let _V_ be the code point obtained by applying the UTF-8 transformation to _Octets_, that is, from a List of octets into a 21-bit value.
-                  1. Let _S_ be the String value whose code units are the elements in CodePointToUTF16CodeUnits(_V_).
+                  1. Let _S_ be CodePointToUTF16CodeUnits(_V_).
               1. Set _R_ to the string-concatenation of _R_ and _S_.
               1. Set _k_ to _k_ + 1.
           </emu-alg>
@@ -29479,13 +29478,14 @@ THH:mm:ss.sss
         <h1>String.fromCodePoint ( ..._codePoints_ )</h1>
         <p>The `String.fromCodePoint` function may be called with any number of arguments which form the rest parameter _codePoints_. The following steps are taken:</p>
         <emu-alg>
-          1. Let _elements_ be a new empty List.
+          1. Let _result_ be the empty String.
           1. For each element _next_ of _codePoints_, do
             1. Let _nextCP_ be ? ToNumber(_next_).
             1. If ! IsIntegralNumber(_nextCP_) is *false*, throw a *RangeError* exception.
             1. If ℝ(_nextCP_) &lt; 0 or ℝ(_nextCP_) &gt; 0x10FFFF, throw a *RangeError* exception.
-            1. Append the elements of ! CodePointToUTF16CodeUnits(ℝ(_nextCP_)) to the end of _elements_.
-          1. Return the String value whose code units are the elements in the List _elements_. If _codePoints_ is empty, the empty String is returned.
+            1. Set _result_ to the string-concatenation of _result_ and ! CodePointToUTF16CodeUnits(ℝ(_nextCP_)).
+          1. Assert: If _codePoints_ is empty, then _result_ is the empty String.
+          1. Return _result_.
         </emu-alg>
         <p>The *"length"* property of the `fromCodePoint` function is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
@@ -42000,7 +42000,7 @@ THH:mm:ss.sss
         <h1>Static Semantics</h1>
         <ul>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the code unit whose value is the MV of |LegacyOctalEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the String value consisting of the code unit whose value is the MV of |LegacyOctalEscapeSequence|.
           </li>
           <li>
             The MV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit</emu-grammar> is (8 times the MV of |ZeroToThree|) plus the MV of |OctalDigit|.
@@ -42012,10 +42012,10 @@ THH:mm:ss.sss
             The MV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is (64 (that is, 8<sup>2</sup>) times the MV of |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
           </li>
           <li>
-            The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `8`</emu-grammar> is the code unit 0x0038 (DIGIT EIGHT).
+            The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `8`</emu-grammar> is the String value consisting of the code unit 0x0038 (DIGIT EIGHT).
           </li>
           <li>
-            The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `9`</emu-grammar> is the code unit 0x0039 (DIGIT NINE).
+            The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `9`</emu-grammar> is the String value consisting of the code unit 0x0039 (DIGIT NINE).
           </li>
           <li>
             The MV of <emu-grammar>ZeroToThree :: `0`</emu-grammar> is 0.


### PR DESCRIPTION
(See issue #828.)

The first 4 commits are independent refactorings that would be useful even if the main point of the PR is rejected. They're here because they reduce the number of cases that the final commit has to deal with.