### PR TITLE
Editorial: Add <dfn> for %BigInt.prototype%

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27422,6 +27422,7 @@
 
       <emu-clause id="sec-bigint.prototype">
         <h1>BigInt.prototype</h1>
+        <p>The initial value of `BigInt.prototype` is %BigInt.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -27430,6 +27431,7 @@
       <h1>Properties of the BigInt Prototype Object</h1>
       <p>The BigInt prototype object:</p>
       <ul>
+        <li>is the intrinsic object <dfn>%BigInt.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a BigInt object; it does not have a [[BigIntData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Object.prototype%.</li>


### PR DESCRIPTION
This also makes the definition of [`BigInt.prototype`](https://tc39.es/ecma262/#sec-bigint.prototype) consistent with other `prototype` properties.

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2024) ([#sec-bigint.prototype](https://ci.tc39.es/preview/tc39/ecma262/pull/2024#sec-bigint.prototype))