### PR TITLE
Editorial: Add <dfn>s for TypedArray subclass constructors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34667,7 +34667,7 @@ THH:mm:ss.sss
           <td>
             Int8Array
             <br>
-            %Int8Array%
+            <dfn>%Int8Array%</dfn>
           </td>
           <td>
             ~Int8~
@@ -34686,7 +34686,7 @@ THH:mm:ss.sss
           <td>
             Uint8Array
             <br>
-            %Uint8Array%
+            <dfn>%Uint8Array%</dfn>
           </td>
           <td>
             ~Uint8~
@@ -34705,7 +34705,7 @@ THH:mm:ss.sss
           <td>
             Uint8ClampedArray
             <br>
-            %Uint8ClampedArray%
+            <dfn>%Uint8ClampedArray%</dfn>
           </td>
           <td>
             ~Uint8C~
@@ -34724,7 +34724,7 @@ THH:mm:ss.sss
           <td>
             Int16Array
             <br>
-            %Int16Array%
+            <dfn>%Int16Array%</dfn>
           </td>
           <td>
             ~Int16~
@@ -34743,7 +34743,7 @@ THH:mm:ss.sss
           <td>
             Uint16Array
             <br>
-            %Uint16Array%
+            <dfn>%Uint16Array%</dfn>
           </td>
           <td>
             ~Uint16~
@@ -34762,7 +34762,7 @@ THH:mm:ss.sss
           <td>
             Int32Array
             <br>
-            %Int32Array%
+            <dfn>%Int32Array%</dfn>
           </td>
           <td>
             ~Int32~
@@ -34781,7 +34781,7 @@ THH:mm:ss.sss
           <td>
             Uint32Array
             <br>
-            %Uint32Array%
+            <dfn>%Uint32Array%</dfn>
           </td>
           <td>
             ~Uint32~
@@ -34800,7 +34800,7 @@ THH:mm:ss.sss
           <td>
             BigInt64Array
             <br>
-            %BigInt64Array%
+            <dfn>%BigInt64Array%</dfn>
           </td>
           <td>
             ~BigInt64~
@@ -34819,7 +34819,7 @@ THH:mm:ss.sss
           <td>
             BigUint64Array
             <br>
-            %BigUint64Array%
+            <dfn>%BigUint64Array%</dfn>
           </td>
           <td>
             ~BigUint64~
@@ -34838,7 +34838,7 @@ THH:mm:ss.sss
           <td>
             Float32Array
             <br>
-            %Float32Array%
+            <dfn>%Float32Array%</dfn>
           </td>
           <td>
             ~Float32~
@@ -34856,7 +34856,7 @@ THH:mm:ss.sss
           <td>
             Float64Array
             <br>
-            %Float64Array%
+            <dfn>%Float64Array%</dfn>
           </td>
           <td>
             ~Float64~


### PR DESCRIPTION
This makes auto‑linking work.

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2025) ([#sec-well-known-intrinsic-objects](https://ci.tc39.es/preview/tc39/ecma262/pull/2025#sec-well-known-intrinsic-objects))