### PR TITLE
Editorial: Add <dfn>s for native error constructors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26927,31 +26927,37 @@
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-evalerror">
         <h1>EvalError</h1>
+        <p>The EvalError constructor is the intrinsic object <dfn>%EvalError%</dfn>.</p>
         <p>This exception is not currently used within this specification. This object remains for compatibility with previous editions of this specification.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-rangeerror">
         <h1>RangeError</h1>
+        <p>The RangeError constructor is the intrinsic object <dfn>%RangeError%</dfn>.</p>
         <p>Indicates a value that is not in the set or range of allowable values.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-referenceerror">
         <h1>ReferenceError</h1>
+        <p>The ReferenceError constructor is the intrinsic object <dfn>%ReferenceError%</dfn>.</p>
         <p>Indicate that an invalid reference value has been detected.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-syntaxerror">
         <h1>SyntaxError</h1>
+        <p>The SyntaxError constructor is the intrinsic object <dfn>%SyntaxError%</dfn>.</p>
         <p>Indicates that a parsing error has occurred.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-typeerror">
         <h1>TypeError</h1>
+        <p>The TypeError constructor is the intrinsic object <dfn>%TypeError%</dfn>.</p>
         <p>TypeError is used to indicate an unsuccessful operation when none of the other _NativeError_ objects are an appropriate indication of the failure cause.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-urierror">
         <h1>URIError</h1>
+        <p>The URIError constructor is the intrinsic object <dfn>%URIError%</dfn>.</p>
         <p>Indicates that one of the global URI handling functions was used in a way that is incompatible with its definition.</p>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
This makes auto‑linking work.

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2026) ([#sec-well-known-intrinsic-objects](https://ci.tc39.es/preview/tc39/ecma262/pull/2026#sec-well-known-intrinsic-objects))