### PR TITLE
Editorial: Add specific id for string-concatenation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1015,7 +1015,7 @@
       <emu-note>
         <p>The rationale behind this design was to keep the implementation of Strings as simple and high-performing as possible. If ECMAScript source text is in Normalized Form C, string literals are guaranteed to also be normalized, as long as they do not contain any Unicode escape sequences.</p>
       </emu-note>
-      <p>In this specification, the phrase "the <dfn>string-concatenation</dfn> of _A_, _B_, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
+      <p>In this specification, the phrase "the <dfn id="string-concatenation">string-concatenation</dfn> of _A_, _B_, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
 
       <emu-clause id="sec-stringindexof" aoid="StringIndexOf">
         <h1>Runtime Semantics: StringIndexOf ( _string_, _searchValue_, _fromIndex_ )</h1>


### PR DESCRIPTION
Fixes suboptimal linking. Compare the latest draft to the preview build of this PR.
* Draft: string-concatenation links (e.g., from https://tc39.es/ecma262/#sec-utf16encode) point at #sec-ecmascript-language-types-string-type (6.1.4 The String Type).
* This PR: string-concatenation links (e.g., from https://ci.tc39.es/preview/tc39/ecma262/sha/e80669a328d044fed714e6975844ce1bdc4b2e9f/#sec-utf16encode) point at #string-concatenation (the specific definition of "string-concatenation").