### PR TITLE
Editorial: Intrinsic %ArrayIterator% doesn’t exist

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2800,7 +2800,7 @@
               <td>
               </td>
               <td>
-                The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"></emu-xref>); i.e., %ArrayIterator.prototype%
+                The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"></emu-xref>)
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
This was incorrectly added by @ljharb in <https://github.com/tc39/ecma262/pull/1376>.

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2036) ([#sec-well-known-intrinsic-objects](https://ci.tc39.es/preview/tc39/ecma262/pull/2036#sec-well-known-intrinsic-objects))