### PR TITLE
Editorial: Add auto‑linking for dotted intrinsics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9728,7 +9728,7 @@
       <p>An object is an <dfn id="immutable-prototype-exotic-object">immutable prototype exotic object</dfn> if its [[SetPrototypeOf]] internal method uses the following implementation. (Its other essential internal methods may use any implementation, depending on the specific immutable prototype exotic object in question.)</p>
 
       <emu-note>
-        <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %ObjectPrototype% and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>
+        <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %Object.prototype% and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>
       </emu-note>
 
       <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v">
@@ -26031,6 +26031,7 @@
       <p>The Object prototype object:</p>
       <ul>
         <li>is <dfn>%ObjectPrototype%</dfn>.</li>
+        <li>is <dfn>%Object.prototype%</dfn>.</li>
         <li>has an [[Extensible]] internal slot whose value is *true*.</li>
         <li>has the internal methods defined for ordinary objects, except for the [[SetPrototypeOf]] method, which is as defined in <emu-xref href="#sec-immutable-prototype-exotic-objects-setprototypeof-v"></emu-xref>. (Thus, it is an immutable prototype exotic object.)</li>
         <li>has a [[Prototype]] internal slot whose value is *null*.</li>
@@ -26511,6 +26512,7 @@
       <p>The Boolean prototype object:</p>
       <ul>
         <li>is <dfn>%BooleanPrototype%</dfn>.</li>
+        <li>is <dfn>%Boolean.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -26745,6 +26747,7 @@
       <p>The Symbol prototype object:</p>
       <ul>
         <li>is <dfn>%SymbolPrototype%</dfn>.</li>
+        <li>is <dfn>%Symbol.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a Symbol instance and does not have a [[SymbolData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -26876,6 +26879,7 @@
       <p>The Error prototype object:</p>
       <ul>
         <li>is <dfn>%ErrorPrototype%</dfn>.</li>
+        <li>is <dfn>%Error.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -27198,6 +27202,7 @@
       <p>The Number prototype object:</p>
       <ul>
         <li>is <dfn>%NumberPrototype%</dfn>.</li>
+        <li>is <dfn>%Number.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -28922,6 +28927,7 @@ THH:mm:ss.sss
       <p>The Date prototype object:</p>
       <ul>
         <li>is <dfn>%DatePrototype%</dfn>.</li>
+        <li>is <dfn>%Date.prototype%</dfn>.</li>
         <li>is itself an ordinary object.</li>
         <li>is not a Date instance and does not have a [[DateValue]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -29869,6 +29875,7 @@ THH:mm:ss.sss
       <p>The String prototype object:</p>
       <ul>
         <li>is <dfn>%StringPrototype%</dfn>.</li>
+        <li>is <dfn>%String.prototype%</dfn>.</li>
         <li>is a String exotic object and has the internal methods specified for such objects.</li>
         <li>has a [[StringData]] internal slot whose value is the empty String.</li>
         <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
@@ -32630,6 +32637,7 @@ THH:mm:ss.sss
       <p>The RegExp prototype object:</p>
       <ul>
         <li>is <dfn>%RegExpPrototype%</dfn>.</li>
+        <li>is <dfn>%RegExp.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a RegExp instance and does not have a [[RegExpMatcher]] internal slot or any of the other internal slots of RegExp instance objects.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -33453,6 +33461,7 @@ THH:mm:ss.sss
       <p>The Array prototype object:</p>
       <ul>
         <li>is <dfn>%ArrayPrototype%</dfn>.</li>
+        <li>is <dfn>%Array.prototype%</dfn>.</li>
         <li>is an Array exotic object and has the internal methods specified for such objects.</li>
         <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -35968,6 +35977,7 @@ THH:mm:ss.sss
       <p>The Map prototype object:</p>
       <ul>
         <li>is <dfn>%MapPrototype%</dfn>.</li>
+        <li>is <dfn>%Map.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[MapData]] internal slot.</li>
@@ -36293,7 +36303,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype">
         <h1>Set.prototype</h1>
-        <p>The initial value of `Set.prototype` is the intrinsic %SetPrototype% object.</p>
+        <p>The initial value of `Set.prototype` is %Set.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -36315,6 +36325,7 @@ THH:mm:ss.sss
       <p>The Set prototype object:</p>
       <ul>
         <li>is <dfn>%SetPrototype%</dfn>.</li>
+        <li>is <dfn>%Set.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[SetData]] internal slot.</li>
@@ -36637,6 +36648,7 @@ THH:mm:ss.sss
       <p>The WeakMap prototype object:</p>
       <ul>
         <li>is <dfn>%WeakMapPrototype%</dfn>.</li>
+        <li>is <dfn>%WeakMap.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[WeakMapData]] internal slot.</li>
@@ -36777,7 +36789,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakset.prototype">
         <h1>WeakSet.prototype</h1>
-        <p>The initial value of `WeakSet.prototype` is the intrinsic %WeakSetPrototype% object.</p>
+        <p>The initial value of `WeakSet.prototype` is %WeakSet.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -36787,6 +36799,7 @@ THH:mm:ss.sss
       <p>The WeakSet prototype object:</p>
       <ul>
         <li>is <dfn>%WeakSetPrototype%</dfn>.</li>
+        <li>is <dfn>%WeakSet.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[WeakSetData]] internal slot.</li>
@@ -37155,6 +37168,7 @@ THH:mm:ss.sss
       <p>The ArrayBuffer prototype object:</p>
       <ul>
         <li>is <dfn>%ArrayBufferPrototype%</dfn>.</li>
+        <li>is <dfn>%ArrayBuffer.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
@@ -37311,6 +37325,7 @@ THH:mm:ss.sss
       <p>The SharedArrayBuffer prototype object:</p>
       <ul>
         <li>is <dfn>%SharedArrayBufferPrototype%</dfn>.</li>
+        <li>is <dfn>%SharedArrayBuffer.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
@@ -37479,6 +37494,7 @@ THH:mm:ss.sss
       <p>The DataView prototype object:</p>
       <ul>
         <li>is <dfn>%DataViewPrototype%</dfn>.</li>
+        <li>is <dfn>%DataView.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</li>
@@ -40503,6 +40519,7 @@ THH:mm:ss.sss
       <p>The Promise prototype object:</p>
       <ul>
         <li>is <dfn>%PromisePrototype%</dfn>.</li>
+        <li>is <dfn>%Promise.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</li>


### PR DESCRIPTION
This was already done for [%Function.prototype%] in <https://github.com/tc39/ecma262/commit/f1b22ef430455201eae1d932a272d4a8d1969886> (<https://github.com/tc39/ecma262/pull/1376>).

[%Function.prototype%]: https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object

## Depends on:
- [x] <https://github.com/tc39/ecma262/pull/2059> (merged)

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2041) ([#sec-well-known-intrinsic-objects](https://ci.tc39.es/preview/tc39/ecma262/pull/2041#sec-well-known-intrinsic-objects))