### PR TITLE
Normative: add NumericLiteralSeparator

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4912,7 +4912,6 @@
             `+` StrDecimalDigits
             `-` StrDecimalDigits
 
-
           StrBinaryLiteral :::
             `0b` StrBinaryDigits
             `0B` StrBinaryDigits
@@ -4920,7 +4919,6 @@
           StrBinaryDigits :::
             BinaryDigit
             StrBinaryDigits BinaryDigit
-
 
           StrOctalLiteral :::
             `0o` StrOctalDigits
@@ -5022,8 +5020,6 @@
             <li>
               The MV of <emu-grammar>StrSignedInteger ::: `-` StrDecimalDigits</emu-grammar> is the negative of the MV of |StrDecimalDigits|.
             </li>
-
-
             <li>
               The MV of <emu-grammar>StrBinaryLiteral ::: `0b` StrBinaryDigits</emu-grammar> is the MV of |StrBinaryDigits|.
             </li>
@@ -11604,7 +11600,6 @@
           NonZeroDigit
           NonZeroDigit NumericLiteralSeparator? DecimalDigits
 
-
         DecimalDigits ::
           DecimalDigit
           DecimalDigits NumericLiteralSeparator? DecimalDigit
@@ -11633,7 +11628,6 @@
         BinaryDigits ::
           BinaryDigit
           BinaryDigits NumericLiteralSeparator? BinaryDigit
-
 
         BinaryDigit :: one of
           `0` `1`

--- a/spec.html
+++ b/spec.html
@@ -11579,8 +11579,8 @@
 
         DecimalBigIntegerLiteral ::
           `0` BigIntLiteralSuffix
-          NonZeroDigit
-          NonZeroDigit NumericLiteralSeparator? DecimalDigits BigIntLiteralSuffix
+          NonZeroDigit DecimalDigits? BigIntLiteralSuffix
+          NonZeroDigit NumericLiteralSeparator DecimalDigits BigIntLiteralSuffix
 
         NonDecimalIntegerLiteral ::
           BinaryIntegerLiteral
@@ -11861,7 +11861,11 @@
         <emu-alg>
           1. Return the BigInt value that represents the MV of |NonZeroDigit|.
         </emu-alg>
-        <emu-grammar>DecimalBigIntegerLiteral :: NonZeroDigit DecimalDigits BigIntLiteralSuffix</emu-grammar>
+        <emu-grammar>
+          DecimalBigIntegerLiteral ::
+            NonZeroDigit DecimalDigits BigIntLiteralSuffix
+            NonZeroDigit NumericLiteralSeparator DecimalDigits BigIntLiteralSuffix
+        </emu-grammar>
         <emu-alg>
           1. Let _n_ be the mathematical integer number of code points in |DecimalDigits|.
           1. Let _mv_ be (the MV of |NonZeroDigit| &times; 10<sub>ℝ</sub><sup>_n_</sup>) plus the MV of |DecimalDigits|.
@@ -43121,6 +43125,7 @@ THH:mm:ss.sss
 
         DecimalIntegerLiteral ::
           `0`
+          NonZeroDigit
           NonZeroDigit NumericLiteralSeparator? DecimalDigits
           NonOctalDecimalIntegerLiteral
 

--- a/spec.html
+++ b/spec.html
@@ -4885,7 +4885,9 @@
 
           StrNumericLiteral :::
             StrDecimalLiteral
-            NonDecimalIntegerLiteral
+            StrBinaryLiteral
+            StrOctalLiteral
+            StrHexLiteral
 
           StrDecimalLiteral :::
             StrUnsignedDecimalLiteral
@@ -4894,9 +4896,48 @@
 
           StrUnsignedDecimalLiteral :::
             `Infinity`
-            DecimalDigits `.` DecimalDigits? ExponentPart?
-            `.` DecimalDigits ExponentPart?
-            DecimalDigits ExponentPart?
+            StrDecimalDigits `.` StrDecimalDigits? StrExponentPart?
+            `.` StrDecimalDigits StrExponentPart?
+            StrDecimalDigits StrExponentPart?
+
+          StrDecimalDigits :::
+            DecimalDigit
+            StrDecimalDigits DecimalDigit
+
+          StrExponentPart :::
+            ExponentIndicator StrSignedInteger
+
+          StrSignedInteger :::
+            StrDecimalDigits
+            `+` StrDecimalDigits
+            `-` StrDecimalDigits
+
+
+          StrBinaryLiteral :::
+            `0b` StrBinaryDigits
+            `0B` StrBinaryDigits
+
+          StrBinaryDigits :::
+            BinaryDigit
+            StrBinaryDigits BinaryDigit
+
+
+          StrOctalLiteral :::
+            `0o` StrOctalDigits
+            `0O` StrOctalDigits
+
+          StrOctalDigits :::
+            OctalDigit
+            StrOctalDigits OctalDigit
+
+          StrHexLiteral :::
+            `0x` StrHexDigits
+            `0X` StrHexDigits
+
+          StrHexDigits :::
+            HexDigit
+            StrHexDigits HexDigit
+
         </emu-grammar>
         <p>All grammar symbols not explicitly defined above have the definitions used in the Lexical Grammar for numeric literals (<emu-xref href="#sec-literals-numeric-literals"></emu-xref>)</p>
         <emu-note>
@@ -4937,28 +4978,87 @@
               The MV of <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar> is the MV of |StrNumericLiteral|, no matter whether white space is present or not.
             </li>
             <li>
+              The MV of <emu-grammar>StrNumericLiteral :: StrBinaryLiteral</emu-grammar> is the MV of |StrBinaryLiteral|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrNumericLiteral :: StrOctalLiteral</emu-grammar> is the MV of |StrOctalLiteral|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrNumericLiteral :: StrHexLiteral</emu-grammar> is the MV of |StrHexLiteral|.
+            </li>
+            <li>
               The MV of <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar> is the negative of the MV of |StrUnsignedDecimalLiteral|. (Note that if the MV of |StrUnsignedDecimalLiteral| is 0, the negative of this MV is also 0. The rounding rule described below handles the conversion of this signless mathematical zero to a floating-point *+0* or *-0* as appropriate.)
             </li>
             <li>
               The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar> is 10<sub>ℝ</sub><sup>10000<sub>ℝ</sub></sup> (a value so large that it will round to *+&infin;*).
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits</emu-grammar> is the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>), where _n_ is the mathematical value of the number of code points in the second |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: StrDecimalDigits `.` StrDecimalDigits</emu-grammar> is the MV of the first |StrDecimalDigits| plus (the MV of the second |StrDecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>), where _n_ is the mathematical value of the number of code points in the second |StrDecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: StrDecimalDigits `.` StrExponentPart</emu-grammar> is the MV of |StrDecimalDigits| times 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |StrExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of the first |DecimalDigits| plus (the MV of the second |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>)) times 10<sub>ℝ</sub><sup>_e_</sup>, where _n_ is the mathematical value of the number of code points in the second |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: StrDecimalDigits `.` StrDecimalDigits StrExponentPart</emu-grammar> is (the MV of the first |StrDecimalDigits| plus (the MV of the second |StrDecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>)) times 10<sub>ℝ</sub><sup>_e_</sup>, where _n_ is the mathematical value of the number of code points in the second |StrDecimalDigits| and _e_ is the MV of |StrExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>, where _n_ is the mathematical value of the number of code points in |DecimalDigits|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` StrDecimalDigits</emu-grammar> is the MV of |StrDecimalDigits| times 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>, where _n_ is the mathematical value of the number of code points in |StrDecimalDigits|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_ -<sub>ℝ</sub> _n_</sup>, where _n_ is the mathematical value of the number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: `.` StrDecimalDigits StrExponentPart</emu-grammar> is the MV of |StrDecimalDigits| times 10<sub>ℝ</sub><sup>_e_ -<sub>ℝ</sub> _n_</sup>, where _n_ is the mathematical value of the number of code points in |StrDecimalDigits| and _e_ is the MV of |StrExponentPart|.
             </li>
             <li>
-              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| times 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
+              The MV of <emu-grammar>StrUnsignedDecimalLiteral ::: StrDecimalDigits StrExponentPart</emu-grammar> is the MV of |StrDecimalDigits| times 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |StrExponentPart|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrExponentPart ::: ExponentIndicator StrSignedInteger</emu-grammar> is the MV of |StrSignedInteger|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrSignedInteger ::: StrDecimalDigits</emu-grammar> is the MV of |StrDecimalDigits|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrSignedInteger ::: `+` StrDecimalDigits</emu-grammar> is the MV of |StrDecimalDigits|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrSignedInteger ::: `-` StrDecimalDigits</emu-grammar> is the negative of the MV of |StrDecimalDigits|.
+            </li>
+
+
+            <li>
+              The MV of <emu-grammar>StrBinaryLiteral ::: `0b` StrBinaryDigits</emu-grammar> is the MV of |StrBinaryDigits|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrBinaryLiteral ::: `0B` StrBinaryDigits</emu-grammar> is the MV of |StrBinaryDigits|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrBinaryDigits ::: BinaryDigit</emu-grammar> is the MV of |BinaryDigit|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrBinaryDigits ::: StrBinaryDigits BinaryDigit</emu-grammar> is (the MV of |StrBinaryDigits| &times; 2) plus the MV of |BinaryDigit|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrOctalLiteral ::: `0o` StrOctalDigits</emu-grammar> is the MV of |StrOctalDigits|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrOctalLiteral ::: `0O` StrOctalDigits</emu-grammar> is the MV of |StrOctalDigits|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrOctalDigits ::: OctalDigit</emu-grammar> is the MV of |OctalDigit|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrOctalDigits ::: StrOctalDigits OctalDigit </emu-grammar> is (the MV of |StrOctalDigits| &times; 8) plus the MV of |OctalDigit|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrHexLiteral ::: `0x` StrHexDigits</emu-grammar> is the MV of |StrHexDigits|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrHexLiteral ::: `0X` StrHexDigits</emu-grammar> is the MV of |StrHexDigits|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrHexDigits ::: HexDigit</emu-grammar> is the MV of |HexDigit|.
+            </li>
+            <li>
+              The MV of <emu-grammar>StrHexDigits ::: StrHexDigits HexDigit</emu-grammar> is (the MV of |StrHexDigits| &times; 16) plus the MV of |HexDigit|.
             </li>
           </ul>
           <p>Once the exact MV for a String numeric literal has been determined, it is then rounded to a value of the Number type. If the MV is 0, then the rounded value is *+0* unless the first non white space code point in the String numeric literal is `-`, in which case the rounded value is *-0*. Otherwise, the rounded value must be the Number value for the MV (in the sense defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>), unless the literal includes a |StrUnsignedDecimalLiteral| and the literal has more than 20 significant digits, in which case the Number value may be either the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit or the Number value for the MV of a literal produced by replacing each significant digit after the 20th with a 0 digit and then incrementing the literal at the 20th digit position. A digit is significant if it is not part of an |ExponentPart| and</p>
@@ -11472,6 +11572,9 @@
       <h1>Numeric Literals</h1>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
+        NumericLiteralSeparator ::
+          `_`
+
         NumericLiteral ::
           DecimalLiteral
           DecimalBigIntegerLiteral
@@ -11480,7 +11583,8 @@
 
         DecimalBigIntegerLiteral ::
           `0` BigIntLiteralSuffix
-          NonZeroDigit DecimalDigits? BigIntLiteralSuffix
+          NonZeroDigit
+          NonZeroDigit NumericLiteralSeparator? DecimalDigits BigIntLiteralSuffix
 
         NonDecimalIntegerLiteral ::
           BinaryIntegerLiteral
@@ -11497,11 +11601,13 @@
 
         DecimalIntegerLiteral ::
           `0`
-          NonZeroDigit DecimalDigits?
+          NonZeroDigit
+          NonZeroDigit NumericLiteralSeparator? DecimalDigits
+
 
         DecimalDigits ::
           DecimalDigit
-          DecimalDigits DecimalDigit
+          DecimalDigits NumericLiteralSeparator? DecimalDigit
 
         DecimalDigit :: one of
           `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
@@ -11526,7 +11632,8 @@
 
         BinaryDigits ::
           BinaryDigit
-          BinaryDigits BinaryDigit
+          BinaryDigits NumericLiteralSeparator? BinaryDigit
+
 
         BinaryDigit :: one of
           `0` `1`
@@ -11537,7 +11644,7 @@
 
         OctalDigits ::
           OctalDigit
-          OctalDigits OctalDigit
+          OctalDigits NumericLiteralSeparator? OctalDigit
 
         OctalDigit :: one of
           `0` `1` `2` `3` `4` `5` `6` `7`
@@ -11548,7 +11655,7 @@
 
         HexDigits ::
           HexDigit
-          HexDigits HexDigit
+          HexDigits NumericLiteralSeparator? HexDigit
 
         HexDigit :: one of
           `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`
@@ -11563,6 +11670,9 @@
         <h1>Static Semantics: MV</h1>
         <p>A numeric literal stands for a value of the Number type or the BigInt type.</p>
         <ul>
+          <li>
+            <emu-grammar>NumericLiteralSeparator :: `_`</emu-grammar> has no MV.
+          </li>
           <li>
             The MV of <emu-grammar>NumericLiteral :: DecimalLiteral</emu-grammar> is the MV of |DecimalLiteral|.
           </li>
@@ -11579,19 +11689,19 @@
             The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.`</emu-grammar> is the MV of |DecimalIntegerLiteral|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>), where _n_ is the mathematical value of the number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits</emu-grammar> is the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>), where _n_ is the mathematical value of the number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` ExponentPart</emu-grammar> is the MV of |DecimalIntegerLiteral| &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>)) &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral `.` DecimalDigits ExponentPart</emu-grammar> is (the MV of |DecimalIntegerLiteral| plus (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>)) &times; 10<sub>ℝ</sub><sup>_e_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|, and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits</emu-grammar> is the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>-<sub>ℝ</sub>_n_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>_e_ -<sub>ℝ</sub> _n_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits| and _e_ is the MV of |ExponentPart|.
+            The MV of <emu-grammar>DecimalLiteral :: `.` DecimalDigits ExponentPart</emu-grammar> is the MV of |DecimalDigits| &times; 10<sub>ℝ</sub><sup>_e_ -<sub>ℝ</sub> _n_</sup>, where _n_ is the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|, and _e_ is the MV of |ExponentPart|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalLiteral :: DecimalIntegerLiteral</emu-grammar> is the MV of |DecimalIntegerLiteral|.
@@ -11606,13 +11716,16 @@
             The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit</emu-grammar> is the MV of |NonZeroDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sub>ℝ</sub><sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the mathematical integer number of code points in |DecimalDigits|.
+            The MV of <emu-grammar>DecimalIntegerLiteral :: NonZeroDigit DecimalDigits</emu-grammar> is (the MV of |NonZeroDigit| &times; 10<sub>ℝ</sub><sup>_n_</sup>) plus the MV of |DecimalDigits|, where _n_ is the mathematical integer number of code points in |DecimalDigits|, excluding all occurrences of |NumericLiteralSeparator|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalDigits :: DecimalDigit</emu-grammar> is the MV of |DecimalDigit|.
           </li>
           <li>
             The MV of <emu-grammar>DecimalDigits :: DecimalDigits DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub>) plus the MV of |DecimalDigit|.
+          </li>
+          <li>
+            The MV of <emu-grammar>DecimalDigits :: DecimalDigits NumericLiteralSeparator DecimalDigit</emu-grammar> is (the MV of |DecimalDigits| &times; 10<sub>ℝ</sub>) plus the MV of |DecimalDigit|.
           </li>
           <li>
             The MV of <emu-grammar>ExponentPart :: ExponentIndicator SignedInteger</emu-grammar> is the MV of |SignedInteger|.
@@ -11684,7 +11797,7 @@
             The MV of <emu-grammar>BinaryDigits :: BinaryDigit</emu-grammar> is the MV of |BinaryDigit|.
           </li>
           <li>
-            The MV of <emu-grammar>BinaryDigits :: BinaryDigits BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2<sub>ℝ</sub>) plus the MV of |BinaryDigit|.
+            The MV of <emu-grammar>BinaryDigits :: BinaryDigits NumericLiteralSeparator BinaryDigit</emu-grammar> is (the MV of |BinaryDigits| &times; 2<sub>ℝ</sub>) plus the MV of |BinaryDigit|.
           </li>
           <li>
             The MV of <emu-grammar>OctalIntegerLiteral :: `0o` OctalDigits</emu-grammar> is the MV of |OctalDigits|.
@@ -11699,6 +11812,9 @@
             The MV of <emu-grammar>OctalDigits :: OctalDigits OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8<sub>ℝ</sub>) plus the MV of |OctalDigit|.
           </li>
           <li>
+            The MV of <emu-grammar>OctalDigits :: OctalDigits NumericLiteralSeparator OctalDigit</emu-grammar> is (the MV of |OctalDigits| &times; 8<sub>ℝ</sub>) plus the MV of |OctalDigit|.
+          </li>
+          <li>
             The MV of <emu-grammar>HexIntegerLiteral :: `0x` HexDigits</emu-grammar> is the MV of |HexDigits|.
           </li>
           <li>
@@ -11709,6 +11825,9 @@
           </li>
           <li>
             The MV of <emu-grammar>HexDigits :: HexDigits HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16<sub>ℝ</sub>) plus the MV of |HexDigit|.
+          </li>
+          <li>
+            The MV of <emu-grammar>HexDigits :: HexDigits NumericLiteralSeparator HexDigit</emu-grammar> is (the MV of |HexDigits| &times; 16<sub>ℝ</sub>) plus the MV of |HexDigit|.
           </li>
           <li>
             The MV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is (0x1000<sub>ℝ</sub> times the MV of the first |HexDigit|) plus (0x100<sub>ℝ</sub> times the MV of the second |HexDigit|) plus (0x10<sub>ℝ</sub> times the MV of the third |HexDigit|) plus the MV of the fourth |HexDigit|.
@@ -12192,7 +12311,11 @@
           HexDigits [> but only if MV of |HexDigits| &gt; 0x10FFFF]
 
         CodePoint ::
-          HexDigits [> but only if MV of |HexDigits| &le; 0x10FFFF]
+          CodePointDigits [> but only if MV of |HexDigits| &le; 0x10FFFF]
+
+        CodePointDigits ::
+          HexDigit
+          CodePointDigits HexDigit
       </emu-grammar>
       <p>A conforming implementation must not use the extended definition of |EscapeSequence| described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref> when parsing a |TemplateCharacter|.</p>
       <emu-note>
@@ -43004,7 +43127,7 @@ THH:mm:ss.sss
 
         DecimalIntegerLiteral ::
           `0`
-          NonZeroDigit DecimalDigits?
+          NonZeroDigit NumericLiteralSeparator? DecimalDigits
           NonOctalDecimalIntegerLiteral
 
         NonOctalDecimalIntegerLiteral ::


### PR DESCRIPTION
There is nothing surprising here, it's the same spec that's been in the proposal for almost two years and is now in many engines. https://github.com/tc39/proposal-numeric-separator