### PR TITLE
Editorial: Misc fixes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38149,7 +38149,7 @@ THH:mm:ss.sss
       <p>This function is the <dfn>%JSONParse%</dfn> intrinsic object.</p>
       <p>The *"length"* property of the `parse` function is 2.</p>
       <emu-note>
-        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by Step 4 above. Step 2 verifies that _jsonString_ conforms to that subset, and step 6 verifies that that parsing and evaluation returns a value of an appropriate type.</p>
+        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by step 4 above. Step 2 verifies that _jsonString_ conforms to that subset, and step 6 verifies that that parsing and evaluation returns a value of an appropriate type.</p>
       </emu-note>
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">

--- a/spec.html
+++ b/spec.html
@@ -40740,7 +40740,7 @@ THH:mm:ss.sss
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
-          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, the step 4.g above.
+          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, step 4.g above.
           1. Return.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -4292,7 +4292,7 @@
             1. Return ? _base_.SetMutableBinding(GetReferencedName(_V_), _W_, IsStrictReference(_V_)) (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
-          <p>The object that may be created in step 6.a.ii is not accessible outside of the above algorithm and the ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that object.</p>
+          <p>The object that may be created in step 6.a.ii is not accessible outside of the above abstract operation and the ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that object.</p>
         </emu-note>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -38149,7 +38149,7 @@ THH:mm:ss.sss
       <p>This function is the <dfn>%JSONParse%</dfn> intrinsic object.</p>
       <p>The *"length"* property of the `parse` function is 2.</p>
       <emu-note>
-        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by step 4 above. Step 2 verifies that _jsonString_ conforms to that subset, and step 6 verifies that that parsing and evaluation returns a value of an appropriate type.</p>
+        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by step 4 above. Step 2 verifies that _jsonString_ conforms to that subset, and step 6 asserts that that parsing and evaluation returns a value of an appropriate type.</p>
       </emu-note>
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">


### PR DESCRIPTION
First commit: [`GetValue`](https://tc39.es/ecma262/#sec-getvalue) and [`PutValue`](https://tc39.es/ecma262/#sec-putvalue) both have a step which creates a spec-fictional object, and a note which says it is spec-fictional, but `GetValue`'s note says "The object [...] is not accessible outside of the above **abstract operation**" and `PutValue`'s note says "The object [...] is not accessible outside of the above **algorithm**" (emphasis added). They should match. I went with "abstract operation" for both.

Second commit: there was exactly one place where "Step N" was capitalized as if it were a proper noun, in contrast to dozens where it was not (including one in the subsequent sentence); this fixes that.

Third commit: [`JSON.parse`](https://tc39.es/ecma262/#sec-json.parse) has an assertion about the type of the data returned (prior to invoking the reviver), but the assertion was described as "verifying" the type. Assertions are not normative, so that doesn't make sense.

Fourth commit: everywhere we refer to a step we say "step N", except in one place we said "the step N". Now it's actually everywhere.