### PR TITLE
Meta: bump ecmarkup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -186,9 +186,9 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
     },
     "acorn": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -525,9 +525,9 @@
       }
     },
     "ecmarkup": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-3.23.0.tgz",
-      "integrity": "sha512-QF+Z8JL9tUzruT/d7JTW3ztwwdhZaPHHlzXGOtQzBaoniu7xzwROdsOrsWvGkYJAy6TnKbQynMKHz6vApoS1WQ==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-3.24.0.tgz",
+      "integrity": "sha512-NELdYb+OaR5jEppyl3Dcu6cUmBZC6G1Hg3CWsDmU760GDkfXmgZu9s8RzXaTZjFh/fckyyCWm83vdhiAAgNmFQ==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
@@ -696,9 +696,9 @@
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -713,9 +713,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
+      "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ=="
     },
     "espree": {
       "version": "6.2.1",
@@ -1005,9 +1005,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.2.0.tgz",
+      "integrity": "sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^3.23.0"
+    "ecmarkup": "^3.24.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -763,9 +763,9 @@
       <p>Syntax-directed operations are invoked with a parse node and, optionally, other parameters by using the conventions on steps 1, 3, and 4 in the following algorithm:</p>
       <emu-alg>
         1. Let _status_ be SyntaxDirectedOperation of |SomeNonTerminal|.
-        2. Let _someParseNode_ be the parse of some source text.
-        2. Perform SyntaxDirectedOperation of _someParseNode_.
-        2. Perform SyntaxDirectedOperation of _someParseNode_ passing *"value"* as the argument.
+        1. Let _someParseNode_ be the parse of some source text.
+        1. Perform SyntaxDirectedOperation of _someParseNode_.
+        1. Perform SyntaxDirectedOperation of _someParseNode_ passing *"value"* as the argument.
       </emu-alg>
       <p>Unless explicitly specified otherwise, all chain productions have an implicit definition for every operation that might be applied to that production's left-hand side nonterminal. The implicit definition simply reapplies the same operation with the same parameters, if any, to the chain production's sole right-hand side nonterminal and then returns the result. For example, assume that some algorithm has a step of the form: &ldquo;Return the result of evaluating |Block|&rdquo; and that there is a production:</p>
       <emu-grammar type="example">
@@ -21468,7 +21468,7 @@
       </emu-grammar>
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
-        2. Return |AsyncFunctionBody| Contains |SuperCall|.
+        1. Return |AsyncFunctionBody| Contains |SuperCall|.
       </emu-alg>
     </emu-clause>
 
@@ -21733,9 +21733,9 @@
       </emu-grammar>
       <emu-alg>
         1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
-        2. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
-        3. If _head_ Contains _symbol_ is *true*, return *true*.
-        4. Return |AsyncConciseBody| Contains _symbol_.
+        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. If _head_ Contains _symbol_ is *true*, return *true*.
+        1. Return |AsyncConciseBody| Contains _symbol_.
       </emu-alg>
       <emu-note>Normally, Contains does not look inside most function forms. However, Contains is used to detect `new.target`, `this`, and `super` usage within an AsyncArrowFunction.</emu-note>
     </emu-clause>
@@ -40637,8 +40637,8 @@ THH:mm:ss.sss
 
         <emu-alg>
           1. Let _C_ be the active function object.
-          2. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          3. Return CreateDynamicFunction(_C_, NewTarget, ~async~, _args_).
+          1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
+          1. Return CreateDynamicFunction(_C_, NewTarget, ~async~, _args_).
         </emu-alg>
 
         <emu-note>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</emu-note>


### PR DESCRIPTION
Two commits: one to bump ecmarkdown, one to make it pass linting by changing some stray non-`1.` step numbers to `1.`.