### PR TITLE
Editorial: use step labels rather than numbers to refer to steps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -517,21 +517,21 @@
       }
     },
     "ecmarkdown": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.0.2.tgz",
-      "integrity": "sha512-SYMAz8dwLVHz4ggUypzcohIzqL1DNRrvWhPNU8vk4/QcAChlIyWyBZuxg/YTskdMnT3sRUADr61kV9MOjfeRfA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.1.2.tgz",
+      "integrity": "sha512-3mV+/g9p5dw1BTlIRJk5jnQY59CHOsKyhy/RWfcYEB721vcm6A2J9F6YYCbcCG6ZQF+nEUCgszUzMVhcYeP1ig==",
       "requires": {
         "escape-html": "^1.0.1"
       }
     },
     "ecmarkup": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-3.24.0.tgz",
-      "integrity": "sha512-NELdYb+OaR5jEppyl3Dcu6cUmBZC6G1Hg3CWsDmU760GDkfXmgZu9s8RzXaTZjFh/fckyyCWm83vdhiAAgNmFQ==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-3.25.1.tgz",
+      "integrity": "sha512-l06+H4ossZLM9yJ1jEXVnjo88tnTSg7Dxi4qq5kkKTHbsb+BCKc6lTuN1AxzX1noWqtgmjqaBopIF4EF31zR4Q==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
-        "ecmarkdown": "^5.0.2",
+        "ecmarkdown": "^5.1.2",
         "eslint": "^6.8.0",
         "grammarkdown": "^2.2.0",
         "highlight.js": "^9.17.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^3.24.0"
+    "ecmarkup": "^3.25.1"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -760,12 +760,12 @@
       <h1>Syntax-Directed Operations</h1>
       <p>A <dfn>syntax-directed operation</dfn> is a named operation whose definition consists of algorithms, each of which is associated with one or more productions from one of the ECMAScript grammars. A production that has multiple alternative definitions will typically have a distinct algorithm for each alternative. When an algorithm is associated with a grammar production, it may reference the terminal and nonterminal symbols of the production alternative as if they were parameters of the algorithm. When used in this manner, nonterminal symbols refer to the actual alternative definition that is matched when parsing the source text. The <dfn>source text matched by</dfn> a grammar production is the portion of the source text that starts at the beginning of the first terminal that participated in the match and ends at the end of the last terminal that participated in the match.</p>
       <p>When an algorithm is associated with a production alternative, the alternative is typically shown without any &ldquo;[ ]&rdquo; grammar annotations. Such annotations should only affect the syntactic recognition of the alternative and have no effect on the associated semantics for the alternative.</p>
-      <p>Syntax-directed operations are invoked with a parse node and, optionally, other parameters by using the conventions on steps 1, 3, and 4 in the following algorithm:</p>
+      <p>Syntax-directed operations are invoked with a parse node and, optionally, other parameters by using the conventions on steps <emu-xref href="#step-sdo-invocation-example-1"></emu-xref>, <emu-xref href="#step-sdo-invocation-example-2"></emu-xref>, and <emu-xref href="#step-sdo-invocation-example-3"></emu-xref> in the following algorithm:</p>
       <emu-alg>
-        1. Let _status_ be SyntaxDirectedOperation of |SomeNonTerminal|.
+        1. [id="step-sdo-invocation-example-1"] Let _status_ be SyntaxDirectedOperation of |SomeNonTerminal|.
         1. Let _someParseNode_ be the parse of some source text.
-        1. Perform SyntaxDirectedOperation of _someParseNode_.
-        1. Perform SyntaxDirectedOperation of _someParseNode_ passing *"value"* as the argument.
+        1. [id="step-sdo-invocation-example-2"] Perform SyntaxDirectedOperation of _someParseNode_.
+        1. [id="step-sdo-invocation-example-3"] Perform SyntaxDirectedOperation of _someParseNode_ passing *"value"* as the argument.
       </emu-alg>
       <p>Unless explicitly specified otherwise, all chain productions have an implicit definition for every operation that might be applied to that production's left-hand side nonterminal. The implicit definition simply reapplies the same operation with the same parameters, if any, to the chain production's sole right-hand side nonterminal and then returns the result. For example, assume that some algorithm has a step of the form: &ldquo;Return the result of evaluating |Block|&rdquo; and that there is a production:</p>
       <emu-grammar type="example">
@@ -1808,7 +1808,7 @@
             1. If _x_ is *+0* or *-0*, return the String *"0"*.
             1. If _x_ is less than zero, return the string-concatenation of *"-"* and ! Number::toString(-_x_).
             1. If _x_ is *+&infin;*, return the String *"Infinity"*.
-            1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10<sub>ℝ</sub>, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
+            1. [id="step-number-tostring-intermediate-values"] Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10<sub>ℝ</sub>, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
             1. If _k_ &le; _n_ &le; 21, return the string-concatenation of:
               * the code units of the _k_ digits of the decimal representation of _s_ (in order, with no leading zeroes)
               * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
@@ -1841,14 +1841,14 @@
                 If x is any Number value other than *-0*, then ToNumber(ToString(x)) is exactly the same Number value as x.
               </li>
               <li>
-                The least significant digit of s is not always uniquely determined by the requirements listed in step 5.
+                The least significant digit of s is not always uniquely determined by the requirements listed in step <emu-xref href="#step-number-tostring-intermediate-values"></emu-xref>.
               </li>
             </ul>
           </emu-note>
           <emu-note>
-            <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 5 be used as a guideline:</p>
-            <emu-alg>
-              5. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. If there are multiple possibilities for _s_, choose the value of _s_ for which ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is closest in value to ℝ(_x_). If there are two such possible values of _s_, choose the one that is even. Note that _k_ is the number of digits in the decimal representation of _s_ and that _s_ is not divisible by 10<sub>ℝ</sub>.
+            <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step <emu-xref href="#step-number-tostring-intermediate-values"></emu-xref> be used as a guideline:</p>
+            <emu-alg replaces-step="step-number-tostring-intermediate-values">
+              1. Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, the Number value for ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is _x_, and _k_ is as small as possible. If there are multiple possibilities for _s_, choose the value of _s_ for which ℝ(_s_) &times; 10<sub>ℝ</sub><sup>ℝ(_n_) - ℝ(_k_)</sup> is closest in value to ℝ(_x_). If there are two such possible values of _s_, choose the one that is even. Note that _k_ is the number of digits in the decimal representation of _s_ and that _s_ is not divisible by 10<sub>ℝ</sub>.
             </emu-alg>
           </emu-note>
           <emu-note>
@@ -4256,14 +4256,14 @@
           1. If IsPropertyReference(_V_) is *true*, then
             1. If HasPrimitiveBase(_V_) is *true*, then
               1. Assert: In this case, _base_ will never be *undefined* or *null*.
-              1. Set _base_ to ! ToObject(_base_).
+              1. [id="step-getvalue-toobject"] Set _base_ to ! ToObject(_base_).
             1. Return ? _base_.[[Get]](GetReferencedName(_V_), GetThisValue(_V_)).
           1. Else,
             1. Assert: _base_ is an Environment Record.
             1. Return ? _base_.GetBindingValue(GetReferencedName(_V_), IsStrictReference(_V_)) (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
-          <p>The object that may be created in step 5.a.ii is not accessible outside of the above abstract operation and the ordinary object [[Get]] internal method. An implementation might choose to avoid the actual creation of the object.</p>
+          <p>The object that may be created in step <emu-xref href="#step-getvalue-toobject"></emu-xref> is not accessible outside of the above abstract operation and the ordinary object [[Get]] internal method. An implementation might choose to avoid the actual creation of the object.</p>
         </emu-note>
       </emu-clause>
 
@@ -4283,7 +4283,7 @@
           1. Else if IsPropertyReference(_V_) is *true*, then
             1. If HasPrimitiveBase(_V_) is *true*, then
               1. Assert: In this case, _base_ will never be *undefined* or *null*.
-              1. Set _base_ to ! ToObject(_base_).
+              1. [id="step-putvalue-toobject"] Set _base_ to ! ToObject(_base_).
             1. Let _succeeded_ be ? _base_.[[Set]](GetReferencedName(_V_), _W_, GetThisValue(_V_)).
             1. If _succeeded_ is *false* and IsStrictReference(_V_) is *true*, throw a *TypeError* exception.
             1. Return.
@@ -4292,7 +4292,7 @@
             1. Return ? _base_.SetMutableBinding(GetReferencedName(_V_), _W_, IsStrictReference(_V_)) (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
-          <p>The object that may be created in step 6.a.ii is not accessible outside of the above abstract operation and the ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that object.</p>
+          <p>The object that may be created in step <emu-xref href="#step-putvalue-toobject"></emu-xref> is not accessible outside of the above abstract operation and the ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that object.</p>
         </emu-note>
       </emu-clause>
 
@@ -4918,13 +4918,13 @@
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
         1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
-        1. Return _int32bit_.
+        1. [id="step-touint32-return"] Return _int32bit_.
       </emu-alg>
       <emu-note>
         <p>Given the above definition of ToUint32:</p>
         <ul>
           <li>
-            Step 5 is the only difference between ToUint32 and ToInt32.
+            Step <emu-xref href="#step-touint32-return"></emu-xref> is the only difference between ToUint32 and ToInt32.
           </li>
           <li>
             The ToUint32 abstract operation is idempotent: if applied to a result that it produced, the second application leaves that value unchanged.
@@ -4958,14 +4958,14 @@
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, *-0*, *+&infin;*, or *-&infin;*, return *+0*.
         1. Let _int_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
-        1. Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
+        1. [id="step-touint16-mod"] Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
         1. Return _int16bit_.
       </emu-alg>
       <emu-note>
         <p>Given the above definition of ToUint16:</p>
         <ul>
           <li>
-            The substitution of 2<sup>16</sup> for 2<sup>32</sup> in step 4 is the only difference between ToUint32 and ToUint16.
+            The substitution of 2<sup>16</sup> for 2<sup>32</sup> in step <emu-xref href="#step-touint16-mod"></emu-xref> is the only difference between ToUint32 and ToUint16.
           </li>
           <li>
             ToUint16 maps *-0* to *+0*.
@@ -5591,7 +5591,7 @@
           1. NOTE: The order of evaluation needs to be reversed to preserve left to right evaluation.
           1. Let _py_ be ? ToPrimitive(_y_, hint Number).
           1. Let _px_ be ? ToPrimitive(_x_, hint Number).
-        1. If Type(_px_) is String and Type(_py_) is String, then
+        1. [id="step-arc-string-check"] If Type(_px_) is String and Type(_py_) is String, then
           1. If IsStringPrefix(_py_, _px_) is *true*, return *false*.
           1. If IsStringPrefix(_px_, _py_) is *true*, return *true*.
           1. Let _k_ be the smallest nonnegative integer such that the code unit at index _k_ within _px_ is different from the code unit at index _k_ within _py_. (There must be such a _k_, for neither String is a prefix of the other.)
@@ -5618,7 +5618,7 @@
           1. If the mathematical value of _nx_ is less than the mathematical value of _ny_, return *true*; otherwise return *false*.
       </emu-alg>
       <emu-note>
-        <p>Step 3 differs from step 1.c in the algorithm that handles the addition operator `+` (<emu-xref href="#sec-applystringornumericbinaryoperator"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
+        <p>Step <emu-xref href="#step-arc-string-check"></emu-xref> differs from step <emu-xref href="#step-binary-op-string-check"></emu-xref> in the algorithm that handles the addition operator `+` (<emu-xref href="#sec-applystringornumericbinaryoperator"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
       </emu-note>
       <emu-note>
         <p>The comparison of Strings uses a simple lexicographic ordering on sequences of code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or string equality and collating order defined in the Unicode specification. Therefore String values that are canonically equal according to the Unicode standard could test as unequal. In effect this algorithm assumes that both Strings are already in normalized form. Also, note that for strings containing supplementary characters, lexicographic ordering on sequences of UTF-16 code unit values differs from that on sequences of code point values.</p>
@@ -5632,7 +5632,7 @@
         1. If Type(_x_) is the same as Type(_y_), then
           1. Return the result of performing Strict Equality Comparison _x_ === _y_.
         1. If _x_ is *null* and _y_ is *undefined*, return *true*.
-        1. If _x_ is *undefined* and _y_ is *null*, return *true*.
+        1. [id="step-abstract-equality-comparison-web-compat-insertion-point"] If _x_ is *undefined* and _y_ is *null*, return *true*.
         1. If Type(_x_) is Number and Type(_y_) is String, return the result of the comparison _x_ == ! ToNumber(_y_).
         1. If Type(_x_) is String and Type(_y_) is Number, return the result of the comparison ! ToNumber(_x_) == _y_.
         1. If Type(_x_) is BigInt and Type(_y_) is String, then
@@ -6024,10 +6024,10 @@
           1. If _obj_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
           1. Let _proxyTarget_ be _obj_.[[ProxyTarget]].
           1. Return ? GetFunctionRealm(_proxyTarget_).
-        1. Return the current Realm Record.
+        1. [id="step-getfunctionrealm-default-return"] Return the current Realm Record.
       </emu-alg>
       <emu-note>
-        <p>Step 5 will only be reached if _obj_ is a non-standard function exotic object that does not have a [[Realm]] internal slot.</p>
+        <p>Step <emu-xref href="#step-getfunctionrealm-default-return"></emu-xref> will only be reached if _obj_ is a non-standard function exotic object that does not have a [[Realm]] internal slot.</p>
       </emu-note>
     </emu-clause>
 
@@ -6400,7 +6400,7 @@
           <p>The concrete Environment Record method SetMutableBinding for declarative Environment Records attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. A binding for _N_ normally already exists, but in rare cases it may not. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*.</p>
           <emu-alg>
             1. Let _envRec_ be the declarative Environment Record for which the method was invoked.
-            1. If _envRec_ does not have a binding for _N_, then
+            1. [id="step-setmutablebinding-missing-binding"] If _envRec_ does not have a binding for _N_, then
               1. If _S_ is *true*, throw a *ReferenceError* exception.
               1. Perform _envRec_.CreateMutableBinding(_N_, *true*).
               1. Perform _envRec_.InitializeBinding(_N_, _V_).
@@ -6414,7 +6414,7 @@
             1. Return NormalCompletion(~empty~).
           </emu-alg>
           <emu-note>
-            <p>An example of ECMAScript code that results in a missing binding at step 2 is:</p>
+            <p>An example of ECMAScript code that results in a missing binding at step <emu-xref href="#step-setmutablebinding-missing-binding"></emu-xref> is:</p>
             <pre><code class="javascript">function f() { eval("var x; x = (delete x, 0);"); }</code></pre>
           </emu-note>
         </emu-clause>
@@ -7120,15 +7120,15 @@
             1. Else,
               1. Let _desc_ be the PropertyDescriptor { [[Value]]: _V_ }.
             1. Perform ? DefinePropertyOrThrow(_globalObject_, _N_, _desc_).
-            1. <emu-not-ref>Record</emu-not-ref> that the binding for _N_ in _ObjRec_ has been initialized.
-            1. Perform ? Set(_globalObject_, _N_, _V_, *false*).
+            1. [id="step-createglobalfunctionbinding-record-initialized"] <emu-not-ref>Record</emu-not-ref> that the binding for _N_ in _ObjRec_ has been initialized.
+            1. [id="step-createglobalfunctionbinding-set"] Perform ? Set(_globalObject_, _N_, _V_, *false*).
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
             1. If _varDeclaredNames_ does not contain _N_, then
               1. Append _N_ to _varDeclaredNames_.
             1. Return NormalCompletion(~empty~).
           </emu-alg>
           <emu-note>
-            <p>Global function declarations are always represented as own properties of the global object. If possible, an existing own property is reconfigured to have a standard set of attribute values. Steps 8-9 are equivalent to what calling the InitializeBinding concrete method would do and if _globalObject_ is a Proxy will produce the same sequence of Proxy trap calls.</p>
+            <p>Global function declarations are always represented as own properties of the global object. If possible, an existing own property is reconfigured to have a standard set of attribute values. Steps <emu-xref href="#step-createglobalfunctionbinding-record-initialized"></emu-xref>-<emu-xref href="#step-createglobalfunctionbinding-set"></emu-xref> are equivalent to what calling the InitializeBinding concrete method would do and if _globalObject_ is a Proxy will produce the same sequence of Proxy trap calls.</p>
           </emu-note>
         </emu-clause>
       </emu-clause>
@@ -7590,7 +7590,7 @@
       <p>The abstract operation GetThisEnvironment takes no arguments. It finds the Environment Record that currently supplies the binding of the keyword `this`. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _env_ be the running execution context's LexicalEnvironment.
-        1. Repeat,
+        1. [id="step-getthisenvironment-loop"] Repeat,
           1. Let _exists_ be _env_.HasThisBinding().
           1. If _exists_ is *true*, return _env_.
           1. Let _outer_ be _env_.[[OuterEnv]].
@@ -7598,7 +7598,7 @@
           1. Set _env_ to _outer_.
       </emu-alg>
       <emu-note>
-        <p>The loop in step 2 will always terminate because the list of environments always ends with the global environment which has a `this` binding.</p>
+        <p>The loop in step <emu-xref href="#step-getthisenvironment-loop"></emu-xref> will always terminate because the list of environments always ends with the global environment which has a `this` binding.</p>
       </emu-note>
     </emu-clause>
 
@@ -7896,7 +7896,7 @@
           1. If _extensible_ is *false*, return *false*.
           1. Let _p_ be _V_.
           1. Let _done_ be *false*.
-          1. Repeat, while _done_ is *false*,
+          1. [id="step-ordinarysetprototypeof-loop"] Repeat, while _done_ is *false*,
             1. If _p_ is *null*, set _done_ to *true*.
             1. Else if SameValue(_p_, _O_) is *true*, return *false*.
             1. Else,
@@ -7906,7 +7906,7 @@
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>The loop in step 8 guarantees that there will be no circularities in any prototype chain that only includes objects that use the ordinary object definitions for [[GetPrototypeOf]] and [[SetPrototypeOf]].</p>
+          <p>The loop in step <emu-xref href="#step-ordinarysetprototypeof-loop"></emu-xref> guarantees that there will be no circularities in any prototype chain that only includes objects that use the ordinary object definitions for [[GetPrototypeOf]] and [[SetPrototypeOf]].</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -8400,13 +8400,13 @@
         1. Assert: _calleeContext_ is now the running execution context.
         1. Perform OrdinaryCallBindThis(_F_, _calleeContext_, _thisArgument_).
         1. Let _result_ be OrdinaryCallEvaluateBody(_F_, _argumentsList_).
-        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. [id="step-call-pop-context-stack"] Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. If _result_.[[Type]] is ~return~, return NormalCompletion(_result_.[[Value]]).
         1. ReturnIfAbrupt(_result_).
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack in step 8 it must not be destroyed if it is suspended and retained for later resumption by an accessible generator object.</p>
+        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is suspended and retained for later resumption by an accessible generator object.</p>
       </emu-note>
 
       <emu-clause id="sec-prepareforordinarycall" aoid="PrepareForOrdinaryCall">
@@ -8704,7 +8704,7 @@
                 1. Let _initialValue_ be ! _env_.GetBindingValue(_n_, *false*).
               1. Call _varEnv_.InitializeBinding(_n_, _initialValue_).
               1. NOTE: A var with the same name as a formal parameter initially has the same value as the corresponding initialized parameter.
-        1. NOTE: Annex <emu-xref href="#sec-web-compat-functiondeclarationinstantiation"></emu-xref> adds additional steps at this point.
+        1. [id="step-functiondeclarationinstantiation-web-compat-insertion-point"] NOTE: Annex <emu-xref href="#sec-web-compat-functiondeclarationinstantiation"></emu-xref> adds additional steps at this point.
         1. If _strict_ is *false*, then
           1. Let _lexEnv_ be NewDeclarativeEnvironment(_varEnv_).
           1. NOTE: Non-strict functions use a separate Environment Record for top-level lexical declarations so that a direct eval can determine whether any var scoped declarations introduced by the eval code conflict with pre-existing top-level lexically scoped declarations. This is not needed for strict functions because a strict direct eval always places all declarations into a new Environment Record.
@@ -8756,7 +8756,7 @@
         1. Set the ScriptOrModule of _calleeContext_ to _F_.[[ScriptOrModule]].
         1. Perform any necessary implementation-defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
-        1. Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
+        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. Return _result_.
       </emu-alg>
@@ -8767,9 +8767,9 @@
 
     <emu-clause id="sec-built-in-function-objects-construct-argumentslist-newtarget">
       <h1>[[Construct]] ( _argumentsList_, _newTarget_ )</h1>
-      <p>The [[Construct]] internal method for built-in function object _F_ is called with parameters _argumentsList_ and _newTarget_. The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step 10 is replaced by:</p>
-      <emu-alg>
-        10. Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. The *this* value is uninitialized, _argumentsList_ provides the named parameters, and _newTarget_ provides the NewTarget value.
+      <p>The [[Construct]] internal method for built-in function object _F_ is called with parameters _argumentsList_ and _newTarget_. The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step <emu-xref href="#step-call-builtin-function-result"></emu-xref> is replaced by:</p>
+      <emu-alg replaces-step="step-call-builtin-function-result">
+        1. Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. The *this* value is uninitialized, _argumentsList_ provides the named parameters, and _newTarget_ provides the NewTarget value.
       </emu-alg>
     </emu-clause>
 
@@ -8983,8 +8983,8 @@
           1. If _Desc_.[[Value]] is absent, then
             1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _Desc_).
           1. Let _newLenDesc_ be a copy of _Desc_.
-          1. Let _newLen_ be ? ToUint32(_Desc_.[[Value]]).
-          1. Let _numberLen_ be ? ToNumber(_Desc_.[[Value]]).
+          1. [id="step-arraysetlength-newlen"] Let _newLen_ be ? ToUint32(_Desc_.[[Value]]).
+          1. [id="step-arraysetlength-numberlen"] Let _numberLen_ be ? ToNumber(_Desc_.[[Value]]).
           1. If _newLen_ &ne; _numberLen_, throw a *RangeError* exception.
           1. Set _newLenDesc_.[[Value]] to _newLen_.
           1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
@@ -9014,7 +9014,7 @@
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>In steps 3 and 4, if _Desc_.[[Value]] is an object then its `valueOf` method is called twice. This is legacy behaviour that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
+          <p>In steps <emu-xref href="#step-arraysetlength-newlen"></emu-xref> and <emu-xref href="#step-arraysetlength-numberlen"></emu-xref>, if _Desc_.[[Value]] is an object then its `valueOf` method is called twice. This is legacy behaviour that was specified with this effect starting with the 2<sup>nd</sup> Edition of this specification.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -13755,12 +13755,12 @@
               1. Let _evalArg_ be the first element of _argList_.
               1. If the source code matching this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
               1. Let _evalRealm_ be the current Realm Record.
-              1. Return ? PerformEval(_evalArg_, _evalRealm_, _strictCaller_, *true*).
+              1. [id="step-callexpression-evaluation-direct-eval"] Return ? PerformEval(_evalArg_, _evalRealm_, _strictCaller_, *true*).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_func_, _ref_, _arguments_, _tailCall_).
         </emu-alg>
-        <p>A |CallExpression| evaluation that executes step 6.a.vi is a <dfn>direct eval</dfn>.</p>
+        <p>A |CallExpression| evaluation that executes step <emu-xref href="#step-callexpression-evaluation-direct-eval"></emu-xref> is a <dfn>direct eval</dfn>.</p>
         <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |CallExpression|.
@@ -14891,11 +14891,11 @@
         1. Let _instOfHandler_ be ? GetMethod(_target_, @@hasInstance).
         1. If _instOfHandler_ is not *undefined*, then
           1. Return ! ToBoolean(? Call(_instOfHandler_, _target_, &laquo; _V_ &raquo;)).
-        1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
-        1. Return ? OrdinaryHasInstance(_target_, _V_).
+        1. [id="step-instanceof-check-function"] If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+        1. [id="step-instanceof-fallback"] Return ? OrdinaryHasInstance(_target_, _V_).
       </emu-alg>
       <emu-note>
-        <p>Steps 4 and 5 provide compatibility with previous editions of ECMAScript that did not use a @@hasInstance method to define the `instanceof` operator semantics. If an object does not define or inherit @@hasInstance it uses the default `instanceof` semantics.</p>
+        <p>Steps <emu-xref href="#step-instanceof-check-function"></emu-xref> and <emu-xref href="#step-instanceof-fallback"></emu-xref> provide compatibility with previous editions of ECMAScript that did not use a @@hasInstance method to define the `instanceof` operator semantics. If an object does not define or inherit @@hasInstance it uses the default `instanceof` semantics.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -15316,7 +15316,7 @@
           1. Else,
             1. Let _rref_ be the result of evaluating |AssignmentExpression|.
             1. Let _rval_ be ? GetValue(_rref_).
-          1. Perform ? PutValue(_lref_, _rval_).
+          1. [id="step-assignmentexpression-evaluation-simple-putvalue"] Perform ? PutValue(_lref_, _rval_).
           1. Return _rval_.
         1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
         1. Let _rref_ be the result of evaluating |AssignmentExpression|.
@@ -15352,11 +15352,11 @@
             </table>
           </figure>
         1. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
-        1. Perform ? PutValue(_lref_, _r_).
+        1. [id="step-assignmentexpression-evaluation-compound-putvalue"] Perform ? PutValue(_lref_, _r_).
         1. Return _r_.
       </emu-alg>
       <emu-note>
-        <p>When an assignment occurs within strict mode code, it is a runtime error if _lref_ in step 1.e of the first algorithm or step 8 of the second algorithm is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, nor to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
+        <p>When an assignment occurs within strict mode code, it is a runtime error if _lref_ in step <emu-xref href="#step-assignmentexpression-evaluation-simple-putvalue"></emu-xref> of the first algorithm or step <emu-xref href="#step-assignmentexpression-evaluation-compound-putvalue"></emu-xref> of the second algorithm is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, nor to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
       </emu-note>
     </emu-clause>
 
@@ -15365,9 +15365,9 @@
       <p>The abstract operation ApplyStringOrNumericBinaryOperator takes arguments _lval_ (an ECMAScript language value), _opText_ (a sequence of Unicode code points), and _rval_ (an ECMAScript language value). It performs the following steps when called:</p>
       <emu-alg>
         1. If _opText_ is `+`, then
-          1. Let _lprim_ be ? ToPrimitive(_lval_).
-          1. Let _rprim_ be ? ToPrimitive(_rval_).
-          1. If Type(_lprim_) is String or Type(_rprim_) is String, then
+          1. [id="step-binary-op-toprimitive-lval"] Let _lprim_ be ? ToPrimitive(_lval_).
+          1. [id="step-binary-op-toprimitive-rval"] Let _rprim_ be ? ToPrimitive(_rval_).
+          1. [id="step-binary-op-string-check"] If Type(_lprim_) is String or Type(_rprim_) is String, then
             1. Let _lstr_ be ? ToString(_lprim_).
             1. Let _rstr_ be ? ToString(_rprim_).
             1. Return the string-concatenation of _lstr_ and _rstr_.
@@ -15401,10 +15401,10 @@
         1. Return ? _operation_(_lnum_, _rnum_).
       </emu-alg>
       <emu-note>
-        <p>No hint is provided in the calls to ToPrimitive in steps 1.a and 1.b. All standard objects except Date objects handle the absence of a hint as if the hint Number were given; Date objects handle the absence of a hint as if the hint String were given. Exotic objects may handle the absence of a hint in some other manner.</p>
+        <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Date objects handle the absence of a hint as if the hint Number were given; Date objects handle the absence of a hint as if the hint String were given. Exotic objects may handle the absence of a hint in some other manner.</p>
       </emu-note>
       <emu-note>
-        <p>Step 1.c differs from step 3 of the Abstract Relational Comparison algorithm, by using the logical-or operation instead of the logical-and operation.</p>
+        <p>Step <emu-xref href="#step-binary-op-string-check"></emu-xref> differs from step <emu-xref href="#step-arc-string-check"></emu-xref> of the Abstract Relational Comparison algorithm, by using the logical-or operation instead of the logical-and operation.</p>
       </emu-note>
     </emu-clause>
 
@@ -16356,11 +16356,11 @@
             1. If IsConstantDeclaration of _d_ is *true*, then
               1. Perform ! _env_.CreateImmutableBinding(_dn_, *true*).
             1. Else,
-              1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
+              1. [id="step-blockdeclarationinstantiation-createmutablebinding"] Perform ! _env_.CreateMutableBinding(_dn_, *false*).
           1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
             1. Let _fn_ be the sole element of the BoundNames of _d_.
             1. Let _fo_ be InstantiateFunctionObject of _d_ with argument _env_.
-            1. Perform _env_.InitializeBinding(_fn_, _fo_).
+            1. [id="step-blockdeclarationinstantiation-initializebinding"] Perform _env_.InitializeBinding(_fn_, _fo_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -16582,10 +16582,10 @@
           1. Else,
             1. Let _rhs_ be the result of evaluating |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. Return ? PutValue(_lhs_, _value_).
+          1. [id="step-vardecllist-evaluation-putvalue"] Return ? PutValue(_lhs_, _value_).
         </emu-alg>
         <emu-note>
-          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's object Environment Record, then step 5 will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
+          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's object Environment Record, then step <emu-xref href="#step-vardecllist-evaluation-putvalue"></emu-xref> will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
         </emu-note>
         <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
@@ -20147,12 +20147,12 @@
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |ArrowFunction|.
         1. Let _parameters_ be CoveredFormalsList of |ArrowParameters|.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _parameters_, |ConciseBody|, ~lexical-this~, _scope_).
+        1. [id="step-arrowfunction-evaluation-functioncreate"] Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _parameters_, |ConciseBody|, ~lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Return _closure_.
       </emu-alg>
       <emu-note>
-        <p>An |ArrowFunction| does not define local bindings for `arguments`, `super`, `this`, or `new.target`. Any reference to `arguments`, `super`, `this`, or `new.target` within an |ArrowFunction| must resolve to a binding in a lexically enclosing environment. Typically this will be the Function Environment of an immediately enclosing function. Even though an |ArrowFunction| may contain references to `super`, the function object created in step 4 is not made into a method by performing MakeMethod. An |ArrowFunction| that references `super` is always contained within a non-|ArrowFunction| and the necessary state to implement `super` is accessible via the _scope_ that is captured by the function object of the |ArrowFunction|.</p>
+        <p>An |ArrowFunction| does not define local bindings for `arguments`, `super`, `this`, or `new.target`. Any reference to `arguments`, `super`, `this`, or `new.target` within an |ArrowFunction| must resolve to a binding in a lexically enclosing environment. Typically this will be the Function Environment of an immediately enclosing function. Even though an |ArrowFunction| may contain references to `super`, the function object created in step <emu-xref href="#step-arrowfunction-evaluation-functioncreate"></emu-xref> is not made into a method by performing MakeMethod. An |ArrowFunction| that references `super` is always contained within a non-|ArrowFunction| and the necessary state to implement `super` is accessible via the _scope_ that is captured by the function object of the |ArrowFunction|.</p>
       </emu-note>
     </emu-clause>
 
@@ -22529,7 +22529,7 @@
                 1. If _vn_ is not an element of _declaredVarNames_, then
                   1. Append _vn_ to _declaredVarNames_.
         1. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviours that cause abnormal terminations in some of the following steps.
-        1. NOTE: Annex <emu-xref href="#sec-web-compat-globaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
+        1. [id="step-globaldeclarationinstantiation-web-compat-insertion-point"] NOTE: Annex <emu-xref href="#sec-web-compat-globaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
         1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _script_.
         1. For each element _d_ in _lexDeclarations_, do
           1. NOTE: Lexically declared names are only instantiated here but not initialized.
@@ -24965,7 +24965,7 @@
                 1. NOTE: The environment of with statements cannot contain any lexical declaration so it doesn't need to be checked for var/let hoisting conflicts.
                 1. For each _name_ in _varNames_, do
                   1. If _thisEnv_.HasBinding(_name_) is *true*, then
-                    1. Throw a *SyntaxError* exception.
+                    1. [id="step-evaldeclarationinstantiation-throw-duplicate-binding"] Throw a *SyntaxError* exception.
                     1. NOTE: Annex <emu-xref href="#sec-variablestatements-in-catch-blocks"></emu-xref> defines alternate semantics for the above step.
                   1. NOTE: A direct eval will not hoist var declaration over a like-named lexical declaration.
               1. Set _thisEnv_ to _thisEnv_.[[OuterEnv]].
@@ -24982,7 +24982,7 @@
                   1. If _fnDefinable_ is *false*, throw a *TypeError* exception.
                 1. Append _fn_ to _declaredFunctionNames_.
                 1. Insert _d_ as the first element of _functionsToInitialize_.
-          1. NOTE: Annex <emu-xref href="#sec-web-compat-evaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
+          1. [id="step-evaldeclarationinstantiation-web-compat-insertion-point"] NOTE: Annex <emu-xref href="#sec-web-compat-evaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
           1. Let _declaredVarNames_ be a new empty List.
           1. For each _d_ in _varDeclarations_, do
             1. If _d_ is a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
@@ -24993,7 +24993,7 @@
                     1. If _vnDefinable_ is *false*, throw a *TypeError* exception.
                   1. If _vn_ is not an element of _declaredVarNames_, then
                     1. Append _vn_ to _declaredVarNames_.
-          1. NOTE: No abnormal terminations occur after this algorithm step unless _varEnv_ is a global Environment Record and the global object is a Proxy exotic object.
+          1. [id="step-evaldeclarationinstantiation-post-validation"] NOTE: No abnormal terminations occur after this algorithm step unless _varEnv_ is a global Environment Record and the global object is a Proxy exotic object.
           1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _body_.
           1. For each element _d_ in _lexDeclarations_, do
             1. NOTE: Lexically declared names are only instantiated here but not initialized.
@@ -25011,7 +25011,7 @@
               1. Let _bindingExists_ be _varEnv_.HasBinding(_fn_).
               1. If _bindingExists_ is *false*, then
                 1. Let _status_ be ! _varEnv_.CreateMutableBinding(_fn_, *true*).
-                1. Assert: _status_ is not an abrupt completion because of validation preceding step 10.
+                1. Assert: _status_ is not an abrupt completion because of validation preceding step <emu-xref href="#step-evaldeclarationinstantiation-post-validation"></emu-xref>.
                 1. Perform ! _varEnv_.InitializeBinding(_fn_, _fo_).
               1. Else,
                 1. Perform ! _varEnv_.SetMutableBinding(_fn_, _fo_, *false*).
@@ -25022,7 +25022,7 @@
               1. Let _bindingExists_ be _varEnv_.HasBinding(_vn_).
               1. If _bindingExists_ is *false*, then
                 1. Let _status_ be ! _varEnv_.CreateMutableBinding(_vn_, *true*).
-                1. Assert: _status_ is not an abrupt completion because of validation preceding step 10.
+                1. Assert: _status_ is not an abrupt completion because of validation preceding step <emu-xref href="#step-evaldeclarationinstantiation-post-validation"></emu-xref>.
                 1. Perform ! _varEnv_.InitializeBinding(_vn_, *undefined*).
           1. Return NormalCompletion(~empty~).
         </emu-alg>
@@ -26023,12 +26023,12 @@
         <h1>Object.prototype.hasOwnProperty ( _V_ )</h1>
         <p>When the `hasOwnProperty` method is called with argument _V_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _P_ be ? ToPropertyKey(_V_).
-          1. Let _O_ be ? ToObject(*this* value).
+          1. [id="step-hasownproperty-topropertykey"] Let _P_ be ? ToPropertyKey(_V_).
+          1. [id="step-hasownproperty-toobject"] Let _O_ be ? ToObject(*this* value).
           1. Return ? HasOwnProperty(_O_, _P_).
         </emu-alg>
         <emu-note>
-          <p>The ordering of steps 1 and 2 is chosen to ensure that any exception that would have been thrown by step 1 in previous editions of this specification will continue to be thrown even if the *this* value is *undefined* or *null*.</p>
+          <p>The ordering of steps <emu-xref href="#step-hasownproperty-topropertykey"></emu-xref> and <emu-xref href="#step-hasownproperty-toobject"></emu-xref> is chosen to ensure that any exception that would have been thrown by step <emu-xref href="#step-hasownproperty-topropertykey"></emu-xref> in previous editions of this specification will continue to be thrown even if the *this* value is *undefined* or *null*.</p>
         </emu-note>
       </emu-clause>
 
@@ -26036,15 +26036,15 @@
         <h1>Object.prototype.isPrototypeOf ( _V_ )</h1>
         <p>When the `isPrototypeOf` method is called with argument _V_, the following steps are taken:</p>
         <emu-alg>
-          1. If Type(_V_) is not Object, return *false*.
-          1. Let _O_ be ? ToObject(*this* value).
+          1. [id="step-isprototypeof-check-object"] If Type(_V_) is not Object, return *false*.
+          1. [id="step-isprototypeof-toobject"] Let _O_ be ? ToObject(*this* value).
           1. Repeat,
             1. Set _V_ to ? _V_.[[GetPrototypeOf]]().
             1. If _V_ is *null*, return *false*.
             1. If SameValue(_O_, _V_) is *true*, return *true*.
         </emu-alg>
         <emu-note>
-          <p>The ordering of steps 1 and 2 preserves the behaviour specified by previous editions of this specification for the case where _V_ is not an object and the *this* value is *undefined* or *null*.</p>
+          <p>The ordering of steps <emu-xref href="#step-isprototypeof-check-object"></emu-xref> and <emu-xref href="#step-isprototypeof-toobject"></emu-xref> preserves the behaviour specified by previous editions of this specification for the case where _V_ is not an object and the *this* value is *undefined* or *null*.</p>
         </emu-note>
       </emu-clause>
 
@@ -26052,8 +26052,8 @@
         <h1>Object.prototype.propertyIsEnumerable ( _V_ )</h1>
         <p>When the `propertyIsEnumerable` method is called with argument _V_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _P_ be ? ToPropertyKey(_V_).
-          1. Let _O_ be ? ToObject(*this* value).
+          1. [id="step-propertyisenumerable-topropertykey"] Let _P_ be ? ToPropertyKey(_V_).
+          1. [id="step-propertyisenumerable-toobject"] Let _O_ be ? ToObject(*this* value).
           1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
           1. If _desc_ is *undefined*, return *false*.
           1. Return _desc_.[[Enumerable]].
@@ -26062,7 +26062,7 @@
           <p>This method does not consider objects in the prototype chain.</p>
         </emu-note>
         <emu-note>
-          <p>The ordering of steps 1 and 2 is chosen to ensure that any exception that would have been thrown by step 1 in previous editions of this specification will continue to be thrown even if the *this* value is *undefined* or *null*.</p>
+          <p>The ordering of steps <emu-xref href="#step-propertyisenumerable-topropertykey"></emu-xref> and <emu-xref href="#step-propertyisenumerable-toobject"></emu-xref> is chosen to ensure that any exception that would have been thrown by step <emu-xref href="#step-propertyisenumerable-topropertykey"></emu-xref> in previous editions of this specification will continue to be thrown even if the *this* value is *undefined* or *null*.</p>
         </emu-note>
       </emu-clause>
 
@@ -26303,13 +26303,13 @@
             1. Return ? Call(_func_, _thisArg_).
           1. Let _argList_ be ? CreateListFromArrayLike(_argArray_).
           1. Perform PrepareForTailCall().
-          1. Return ? Call(_func_, _thisArg_, _argList_).
+          1. [id="step-function-proto-apply-call"] Return ? Call(_func_, _thisArg_, _argList_).
         </emu-alg>
         <emu-note>
           <p>The _thisArg_ value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* _thisArg_ is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the _thisArg_ is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
         </emu-note>
         <emu-note>
-          <p>If _func_ is an arrow function or a bound function exotic object then the _thisArg_ will be ignored by the function [[Call]] in step 6.</p>
+          <p>If _func_ is an arrow function or a bound function exotic object then the _thisArg_ will be ignored by the function [[Call]] in step <emu-xref href="#step-function-proto-apply-call"></emu-xref>.</p>
         </emu-note>
       </emu-clause>
 
@@ -26352,13 +26352,13 @@
           1. Let _argList_ be a new empty List.
           1. If this method was called with more than one argument, then in left to right order, starting with the second argument, append each argument as the last element of _argList_.
           1. Perform PrepareForTailCall().
-          1. Return ? Call(_func_, _thisArg_, _argList_).
+          1. [id="step-function-proto-call-call"] Return ? Call(_func_, _thisArg_, _argList_).
         </emu-alg>
         <emu-note>
           <p>The _thisArg_ value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* _thisArg_ is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the _thisArg_ is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
         </emu-note>
         <emu-note>
-          <p>If _func_ is an arrow function or a bound function exotic object then the _thisArg_ will be ignored by the function [[Call]] in step 6.</p>
+          <p>If _func_ is an arrow function or a bound function exotic object then the _thisArg_ will be ignored by the function [[Call]] in step <emu-xref href="#step-function-proto-call-call"></emu-xref>.</p>
         </emu-note>
       </emu-clause>
 
@@ -26949,14 +26949,14 @@
           <p>When a _NativeError_ function is called with argument _message_, the following steps are taken:</p>
           <emu-alg>
             1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>.prototype%"</code>, &laquo; [[ErrorData]] &raquo;).
+            1. [id="step-nativerror-ordinarycreatefromconstructor"] Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>.prototype%"</code>, &laquo; [[ErrorData]] &raquo;).
             1. If _message_ is not *undefined*, then
               1. Let _msg_ be ? ToString(_message_).
               1. Let _msgDesc_ be the PropertyDescriptor { [[Value]]: _msg_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
               1. Perform ! DefinePropertyOrThrow(_O_, *"message"*, _msgDesc_).
             1. Return _O_.
           </emu-alg>
-          <p>The actual value of the string passed in step 2 is either *"%EvalError.prototype%"*, *"%RangeError.prototype%"*, *"%ReferenceError.prototype%"*, *"%SyntaxError.prototype%"*, *"%TypeError.prototype%"*, or *"%URIError.prototype%"* corresponding to which _NativeError_ constructor is being defined.</p>
+          <p>The actual value of the string passed in step <emu-xref href="#step-nativerror-ordinarycreatefromconstructor"></emu-xref> is either *"%EvalError.prototype%"*, *"%RangeError.prototype%"*, *"%ReferenceError.prototype%"*, *"%SyntaxError.prototype%"*, *"%TypeError.prototype%"*, or *"%URIError.prototype%"* corresponding to which _NativeError_ constructor is being defined.</p>
         </emu-clause>
       </emu-clause>
 
@@ -27211,7 +27211,7 @@
             1. If _fractionDigits_ is not *undefined*, then
               1. Let _e_ and _n_ be integers such that 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup> and for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_n_)</sup> - ℝ(_x_) is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is larger.
             1. Else,
-              1. Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is _x_, and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1<sub>ℝ</sub> digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
+              1. [id="step-number-proto-toexponential-intermediate-values"] Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is _x_, and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1<sub>ℝ</sub> digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
             1. Let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. If _f_ &ne; 0, then
             1. Let _a_ be the first code unit of _m_, and let _b_ be the remaining _f_ code units of _m_.
@@ -27230,8 +27230,8 @@
           1. Return the string-concatenation of _s_ and _m_.
         </emu-alg>
         <emu-note>
-          <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step 9.b.i be used as a guideline:</p>
-          <emu-alg type="i">
+          <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step <emu-xref href="#step-number-proto-toexponential-intermediate-values"></emu-xref> be used as a guideline:</p>
+          <emu-alg replaces-step="step-number-proto-toexponential-intermediate-values">
             1. Let _e_, _n_, and _f_ be integers such that _f_ &ge; 0, 10<sup>_f_</sup> &le; _n_ &lt; 10<sup>_f_ + 1</sup>, the Number value for ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is _x_, and _f_ is as small as possible. If there are multiple possibilities for _n_, choose the value of _n_ for which ℝ(_n_) &times; 10<sub>ℝ</sub><sup>ℝ(_e_) - ℝ(_f_)</sup> is closest in value to _x_. If there are two such possible values of _n_, choose the one that is even.
           </emu-alg>
         </emu-note>
@@ -31500,12 +31500,12 @@ THH:mm:ss.sss
             1. If _max_ is zero, return _c_(_x_).
             1. Let _d_ be a new Continuation with parameters (_y_) that captures _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, and _parenCount_ and performs the following steps when called:
               1. Assert: _y_ is a State.
-              1. If _min_ is zero and _y_'s _endIndex_ is equal to _x_'s _endIndex_, return ~failure~.
+              1. [id="step-repeatmatcher-done"] If _min_ is zero and _y_'s _endIndex_ is equal to _x_'s _endIndex_, return ~failure~.
               1. If _min_ is zero, let _min2_ be zero; otherwise let _min2_ be _min_ - 1.
               1. If _max_ is &infin;, let _max2_ be &infin;; otherwise let _max2_ be _max_ - 1.
               1. Call RepeatMatcher(_m_, _min2_, _max2_, _greedy_, _y_, _c_, _parenIndex_, _parenCount_) and return its result.
             1. Let _cap_ be a copy of _x_'s _captures_ List.
-            1. For each integer _k_ that satisfies _parenIndex_ &lt; _k_ and _k_ &le; _parenIndex_ + _parenCount_, set _cap_[_k_] to *undefined*.
+            1. [id="step-repeatmatcher-clear-captures"] For each integer _k_ that satisfies _parenIndex_ &lt; _k_ and _k_ &le; _parenIndex_ + _parenCount_, set _cap_[_k_] to *undefined*.
             1. Let _e_ be _x_'s _endIndex_.
             1. Let _xr_ be the State (_e_, _cap_).
             1. If _min_ is not zero, return _m_(_xr_, _d_).
@@ -31541,7 +31541,7 @@ THH:mm:ss.sss
             <p>which returns the gcd in unary notation *"aaaaa"*.</p>
           </emu-note>
           <emu-note>
-            <p>Step 4 of the RepeatMatcher clears |Atom|'s captures each time |Atom| is repeated. We can see its behaviour in the regular expression</p>
+            <p>Step <emu-xref href="#step-repeatmatcher-clear-captures"></emu-xref> of the RepeatMatcher clears |Atom|'s captures each time |Atom| is repeated. We can see its behaviour in the regular expression</p>
             <pre><code class="javascript">/(z)((a+)?(b+)?(c))*/.exec("zaacbbbcac")</code></pre>
             <p>which returns the array</p>
             <pre><code class="javascript">["zaacbbbcac", "z", "ac", "a", undefined, "c"]</code></pre>
@@ -31550,7 +31550,7 @@ THH:mm:ss.sss
             <p>because each iteration of the outermost `*` clears all captured Strings contained in the quantified |Atom|, which in this case includes capture Strings numbered 2, 3, 4, and 5.</p>
           </emu-note>
           <emu-note>
-            <p>Step 2.b of the RepeatMatcher states that once the minimum number of repetitions has been satisfied, any more expansions of |Atom| that match the empty character sequence are not considered for further repetitions. This prevents the regular expression engine from falling into an infinite loop on patterns such as:</p>
+            <p>Step <emu-xref href="#step-repeatmatcher-done"></emu-xref> of the RepeatMatcher states that once the minimum number of repetitions has been satisfied, any more expansions of |Atom| that match the empty character sequence are not considered for further repetitions. This prevents the regular expression engine from falling into an infinite loop on patterns such as:</p>
             <pre><code class="javascript">/(a*)*/.exec("b")</code></pre>
             <p>or the slightly more complicated:</p>
             <pre><code class="javascript">/(a*)b\1+/.exec("baaaac")</code></pre>
@@ -33416,12 +33416,12 @@ THH:mm:ss.sss
               1. If _n_ &ge; 2<sup>53</sup> - 1, throw a *TypeError* exception.
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _E_).
               1. Set _n_ to _n_ + 1.
-          1. Perform ? Set(_A_, *"length"*, _n_, *true*).
+          1. [id="step-array-proto-concat-set-length"] Perform ? Set(_A_, *"length"*, _n_, *true*).
           1. Return _A_.
         </emu-alg>
         <p>The *"length"* property of the `concat` method is 1.</p>
         <emu-note>
-          <p>The explicit setting of the *"length"* property in step 6 is necessary to ensure that its value is correct in situations where the trailing elements of the result Array are not present.</p>
+          <p>The explicit setting of the *"length"* property in step <emu-xref href="#step-array-proto-concat-set-length"></emu-xref> is necessary to ensure that its value is correct in situations where the trailing elements of the result Array are not present.</p>
         </emu-note>
         <emu-note>
           <p>The `concat` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -34133,11 +34133,11 @@ THH:mm:ss.sss
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_n_), _kValue_).
             1. Set _k_ to _k_ + 1.
             1. Set _n_ to _n_ + 1.
-          1. Perform ? Set(_A_, *"length"*, _n_, *true*).
+          1. [id="step-array-proto-slice-set-length"] Perform ? Set(_A_, *"length"*, _n_, *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The explicit setting of the *"length"* property of the result Array in step 11 was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
+          <p>The explicit setting of the *"length"* property of the result Array in step <emu-xref href="#step-array-proto-slice-set-length"></emu-xref> was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
         <emu-note>
           <p>The `slice` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -34290,8 +34290,8 @@ THH:mm:ss.sss
               1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
               1. If _v_ is *NaN*, return *+0*.
               1. Return _v_.
-            1. Let _xString_ be ? ToString(_x_).
-            1. Let _yString_ be ? ToString(_y_).
+            1. [id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).
+            1. [id="step-sortcompare-tostring-y"] Let _yString_ be ? ToString(_y_).
             1. Let _xSmaller_ be the result of performing Abstract Relational Comparison _xString_ &lt; _yString_.
             1. If _xSmaller_ is *true*, return -1.
             1. Let _ySmaller_ be the result of performing Abstract Relational Comparison _yString_ &lt; _xString_.
@@ -34302,7 +34302,7 @@ THH:mm:ss.sss
             <p>Because non-existent property values always compare greater than *undefined* property values, and *undefined* always compares greater than any other value, *undefined* property values always sort to the end of the result, followed by non-existent property values.</p>
           </emu-note>
           <emu-note>
-            <p>Method calls performed by the ToString abstract operations in steps 5 and 6 have the potential to cause SortCompare to not behave as a consistent comparison function.</p>
+            <p>Method calls performed by the ToString abstract operations in steps <emu-xref href="#step-sortcompare-tostring-x"></emu-xref> and <emu-xref href="#step-sortcompare-tostring-y"></emu-xref> have the potential to cause SortCompare to not behave as a consistent comparison function.</p>
           </emu-note>
         </emu-clause>
       </emu-clause>
@@ -34376,11 +34376,11 @@ THH:mm:ss.sss
             1. Remove the first element from _items_ and let _E_ be the value of that element.
             1. Perform ? Set(_O_, ! ToString(_k_), _E_, *true*).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_O_, *"length"*, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
+          1. [id="step-array-proto-splice-set-length"] Perform ? Set(_O_, *"length"*, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The explicit setting of the *"length"* property of the result Array in step 19 was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
+          <p>The explicit setting of the *"length"* property of the result Array in step <emu-xref href="#step-array-proto-splice-set-length"></emu-xref> was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
         <emu-note>
           <p>The `splice` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -38129,11 +38129,11 @@ THH:mm:ss.sss
       <p>The optional _reviver_ parameter is a function that takes two parameters, _key_ and _value_. It can filter and transform the results. It is called with each of the _key_/_value_ pairs produced by the parse, and its return value is used instead of the original value. If it returns what it received, the structure is not modified. If it returns *undefined* then the property is deleted from the result.</p>
       <emu-alg>
         1. Let _jsonString_ be ? ToString(_text_).
-        1. Parse ! UTF16DecodeString(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
+        1. [id="step-json-parse-validate"] Parse ! UTF16DecodeString(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
         1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
-        1. Let _completion_ be the result of parsing and evaluating ! UTF16DecodeString(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
+        1. [id="step-json-parse-parse"] Let _completion_ be the result of parsing and evaluating ! UTF16DecodeString(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
-        1. Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
+        1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then
           1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Let _rootName_ be the empty String.
@@ -38145,7 +38145,7 @@ THH:mm:ss.sss
       <p>This function is the <dfn>%JSONParse%</dfn> intrinsic object.</p>
       <p>The *"length"* property of the `parse` function is 2.</p>
       <emu-note>
-        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by step 4 above. Step 2 verifies that _jsonString_ conforms to that subset, and step 6 asserts that that parsing and evaluation returns a value of an appropriate type.</p>
+        <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by step <emu-xref href="#step-json-parse-parse"></emu-xref> above. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that that parsing and evaluation returns a value of an appropriate type.</p>
       </emu-note>
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">
@@ -40732,11 +40732,11 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _result_.[[Type]] is ~throw~.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).
-            1. Return.
+            1. [id="step-asyncfunctionstart-return-undefined"] Return.
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
-          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, step 4.g above.
+          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncfunctionstart-return-undefined"></emu-xref> above.
           1. Return.
         </emu-alg>
       </emu-clause>
@@ -43034,8 +43034,8 @@ THH:mm:ss.sss
       <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatibility semantics are applied and introduce observable differences from non-compatibility semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
       <emu-annex id="sec-web-compat-functiondeclarationinstantiation">
         <h1>Changes to FunctionDeclarationInstantiation</h1>
-        <p>During FunctionDeclarationInstantiation the following steps are performed in place of step 29:</p>
-        <emu-alg>
+        <p>During FunctionDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-functiondeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
+        <emu-alg replaces-step="step-functiondeclarationinstantiation-web-compat-insertion-point">
           1. If _strict_ is *false*, then
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|, do
               1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
@@ -43055,8 +43055,8 @@ THH:mm:ss.sss
       </emu-annex>
       <emu-annex id="sec-web-compat-globaldeclarationinstantiation">
         <h1>Changes to GlobalDeclarationInstantiation</h1>
-        <p>During GlobalDeclarationInstantiation the following steps are performed in place of step 13:</p>
-        <emu-alg>
+        <p>During GlobalDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-globaldeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
+        <emu-alg replaces-step="step-globaldeclarationinstantiation-web-compat-insertion-point">
           1. Let _strict_ be IsStrict of _script_.
           1. If _strict_ is *false*, then
             1. Let _declaredFunctionOrVarNames_ be a new empty List.
@@ -43082,8 +43082,8 @@ THH:mm:ss.sss
       </emu-annex>
       <emu-annex id="sec-web-compat-evaldeclarationinstantiation">
         <h1>Changes to EvalDeclarationInstantiation</h1>
-        <p>During EvalDeclarationInstantiation the following steps are performed in place of step 7:</p>
-        <emu-alg>
+        <p>During EvalDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-evaldeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
+        <emu-alg replaces-step="step-evaldeclarationinstantiation-web-compat-insertion-point">
           1. If _strict_ is *false*, then
             1. Let _declaredFunctionOrVarNames_ be a new empty List.
             1. Append to _declaredFunctionOrVarNames_ the elements of _declaredFunctionNames_.
@@ -43097,7 +43097,7 @@ THH:mm:ss.sss
                 1. Repeat, while _thisEnv_ is not the same as _varEnv_,
                   1. If _thisEnv_ is not an object Environment Record, then
                     1. If _thisEnv_.HasBinding(_F_) is *true*, then
-                      1. Let _bindingExists_ be *true*.
+                      1. [id="step-evaldeclarationinstantiation-web-compat-bindingexists"] Let _bindingExists_ be *true*.
                   1. Set _thisEnv_ to _thisEnv_.[[OuterEnv]].
                 1. If _bindingExists_ is *false* and _varEnv_ is a global Environment Record, then
                   1. If _varEnv_.HasLexicalDeclaration(_F_) is *false*, then
@@ -43146,13 +43146,13 @@ THH:mm:ss.sss
       </emu-annex>
       <emu-annex id="sec-web-compat-blockdeclarationinstantiation">
         <h1>Changes to BlockDeclarationInstantiation</h1>
-        <p>During BlockDeclarationInstantiation the following steps are performed in place of step 3.a.ii.1:</p>
-        <emu-alg>
+        <p>During BlockDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-blockdeclarationinstantiation-createmutablebinding"></emu-xref>:</p>
+        <emu-alg replaces-step="step-blockdeclarationinstantiation-createmutablebinding">
           1. If _env_.HasBinding(_dn_) is *false*, then
             1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
         </emu-alg>
-        <p>During BlockDeclarationInstantiation the following steps are performed in place of step 3.b.iii:</p>
-        <emu-alg>
+        <p>During BlockDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-blockdeclarationinstantiation-initializebinding"></emu-xref>:</p>
+        <emu-alg replaces-step="step-blockdeclarationinstantiation-initializebinding">
           1. If the binding for _fn_ in _env_ is an uninitialized binding, then
             1. Perform _env_.InitializeBinding(_fn_, _fo_).
           1. Else,
@@ -43194,12 +43194,12 @@ THH:mm:ss.sss
         <p>The |Block| of a |Catch| clause may contain `var` declarations that bind a name that is also bound by the |CatchParameter|. At runtime, such bindings are instantiated in the VariableDeclarationEnvironment. They do not shadow the same-named bindings introduced by the |CatchParameter| and hence the |Initializer| for such `var` declarations will assign to the corresponding catch parameter rather than the `var` binding.</p>
       </emu-note>
       <p>This modified behaviour also applies to `var` and `function` declarations introduced by direct eval calls contained within the |Block| of a |Catch| clause. This change is accomplished by modifying the algorithm of <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref> as follows:</p>
-      <p>Step 3.d.i.2.a.i is replaced by:</p>
-      <emu-alg type="i">
+      <p>Step <emu-xref href="#step-evaldeclarationinstantiation-throw-duplicate-binding"></emu-xref> is replaced by:</p>
+      <emu-alg replaces-step="step-evaldeclarationinstantiation-throw-duplicate-binding">
         1. If _thisEnv_ is not the Environment Record for a |Catch| clause, throw a *SyntaxError* exception.
       </emu-alg>
-      <p>Step 7.d.ii.4.a.i.i is replaced by:</p>
-      <emu-alg type="i">
+      <p>Step <emu-xref href="#step-evaldeclarationinstantiation-web-compat-bindingexists"></emu-xref> is replaced by:</p>
+      <emu-alg replaces-step="step-evaldeclarationinstantiation-web-compat-bindingexists">
         1. If _thisEnv_ is not the Environment Record for a |Catch| clause, let _bindingExists_ be *true*.
       </emu-alg>
     </emu-annex>
@@ -43285,7 +43285,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-IsHTMLDDA-internal-slot-aec">
         <h1>Changes to Abstract Equality Comparison</h1>
-        <p>The following steps are inserted after step 3 of the <emu-xref href="#sec-abstract-equality-comparison">Abstract Equality Comparison</emu-xref> algorithm:</p>
+        <p>The following steps are inserted after step <emu-xref href="#step-abstract-equality-comparison-web-compat-insertion-point"></emu-xref> of the <emu-xref href="#sec-abstract-equality-comparison">Abstract Equality Comparison</emu-xref> algorithm:</p>
         <emu-alg>
           1. If Type(_x_) is Object and _x_ has an [[IsHTMLDDA]] internal slot and _y_ is either *null* or *undefined*, return *true*.
           1. If _x_ is either *null* or *undefined* and Type(_y_) is Object and _y_ has an [[IsHTMLDDA]] internal slot, return *true*.


### PR DESCRIPTION
This fixes a persistent problem where step numbers would get stale and we'd forget to update them. Now, by given the steps (somewhat arbitrarily chosen) labels, we can refer and link to them explicitly. See https://github.com/tc39/ecmarkup/pull/217 for a description of the syntax.

~Marked as draft until a version of ecmarkup with support for the new syntax is published.~ Edit: done, this should be good to go. Deploy preview looks good to me.

Corresponding ecmarkdown PR at https://github.com/tc39/ecmarkdown/pull/74. Corresponding ecmarkup PR at https://github.com/tc39/ecmarkup/pull/217.
