### PR TITLE
Normative: Specify \8 and \9 in sloppy non-template strings.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11508,7 +11508,7 @@
           HexEscapeSequence
           UnicodeEscapeSequence
       </emu-grammar>
-      <p>A conforming implementation, when processing strict mode code, must not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.</p>
+      <p>A conforming implementation, when processing strict mode code, must not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> or <emu-xref href="#prod-annexB-NonOctalDecimalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.</p>
       <emu-grammar type="definition">
         CharacterEscapeSequence ::
           SingleEscapeCharacter
@@ -24943,7 +24943,7 @@
         When processing strict mode code, the syntax of |NumericLiteral| must not be extended to include <emu-xref href="#prod-annexB-LegacyOctalIntegerLiteral"></emu-xref> and the syntax of |DecimalIntegerLiteral| must not be extended to include <emu-xref href="#prod-annexB-NonOctalDecimalIntegerLiteral"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-numeric-literals"></emu-xref>.
       </li>
       <li>
-        |TemplateCharacter| must not be extended to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> as defined in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.
+        |TemplateCharacter| must not be extended to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> or <emu-xref href="#prod-annexB-NonOctalDecimalEscapeSequence"></emu-xref> as defined in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.
       </li>
       <li>
         When processing strict mode code, the extensions defined in <emu-xref href="#sec-labelled-function-declarations"></emu-xref>, <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>, <emu-xref href="#sec-functiondeclarations-in-ifstatement-statement-clauses"></emu-xref>, and <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref> must not be supported.
@@ -42477,6 +42477,7 @@ THH:mm:ss.sss
         EscapeSequence ::
           CharacterEscapeSequence
           LegacyOctalEscapeSequence
+          NonOctalDecimalEscapeSequence
           HexEscapeSequence
           UnicodeEscapeSequence
 
@@ -42491,15 +42492,15 @@ THH:mm:ss.sss
 
         FourToSeven :: one of
           `4` `5` `6` `7`
+
+        NonOctalDecimalEscapeSequence :: one of
+          `8` `9`
       </emu-grammar>
       <p>This definition of |EscapeSequence| is not used in strict mode or when parsing |TemplateCharacter|.</p>
 
       <emu-annex id="sec-additional-syntax-string-literals-static-semantics">
         <h1>Static Semantics</h1>
         <ul>
-          <li>
-            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the SV of |LegacyOctalEscapeSequence|.
-          </li>
           <li>
             The SV of <emu-grammar>LegacyOctalEscapeSequence :: OctalDigit</emu-grammar> is the code unit whose value is the MV of |OctalDigit|.
           </li>
@@ -42511,6 +42512,12 @@ THH:mm:ss.sss
           </li>
           <li>
             The SV of <emu-grammar>LegacyOctalEscapeSequence :: ZeroToThree OctalDigit OctalDigit</emu-grammar> is the code unit whose value is (64 (that is, 8<sup>2</sup>) times the MV of |ZeroToThree|) plus (8 times the MV of the first |OctalDigit|) plus the MV of the second |OctalDigit|.
+          </li>
+          <li>
+            The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `8`</emu-grammar> is the code unit 0x0038 (DIGIT EIGHT).
+          </li>
+          <li>
+            The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `9`</emu-grammar> is the code unit 0x0039 (DIGIT NINE).
           </li>
           <li>
             The MV of <emu-grammar>ZeroToThree :: `0`</emu-grammar> is 0.
@@ -43706,7 +43713,7 @@ THH:mm:ss.sss
       A conforming implementation, when processing strict mode code, must not extend, as described in <emu-xref href="#sec-additional-syntax-numeric-literals"></emu-xref>, the syntax of |NumericLiteral| to include |LegacyOctalIntegerLiteral|, nor extend the syntax of |DecimalIntegerLiteral| to include |NonOctalDecimalIntegerLiteral|.
     </li>
     <li>
-      A conforming implementation, when processing strict mode code, may not extend the syntax of |EscapeSequence| to include |LegacyOctalEscapeSequence| as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.
+      A conforming implementation, when processing strict mode code, may not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> or <emu-xref href="#prod-annexB-NonOctalDecimalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.
     </li>
     <li>
       Assignment to an undeclared identifier or otherwise unresolvable reference does not create a property in the global object. When a simple assignment occurs within strict mode code, its |LeftHandSideExpression| must not evaluate to an unresolvable Reference. If it does a *ReferenceError* exception is thrown (<emu-xref href="#sec-putvalue"></emu-xref>). The |LeftHandSideExpression| also may not be a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, nor to a non-existent property of an object whose [[Extensible]] internal slot has the value *false*. In these cases a `TypeError` exception is thrown (<emu-xref href="#sec-assignment-operators"></emu-xref>).


### PR DESCRIPTION
Resolves #2039.

Specifically:
- (Untagged) templates already have early errors for <code>\`\8\`</code> and <code>\`\9\`</code> so no action is needed there.
- All engines agree that `'\8'` and `'\9'` are just `'8'` and `'9'` in sloppy mode, so specify that in B.1.2.
- JSC has never(?) supported `'\8'` and `'\9'` in strict mode, so there should be no web compatibility risk.

Tests: https://github.com/tc39/test262/pull/2654