### PR TITLE
Editorial: remove legacy intrinsics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2773,17 +2773,6 @@
             </tr>
             <tr>
               <td>
-                %AggregateErrorPrototype%
-              </td>
-              <td>
-                `AggregateError.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %AggregateError%; i.e., %AggregateError.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Array%
               </td>
               <td>
@@ -2806,78 +2795,12 @@
             </tr>
             <tr>
               <td>
-                %ArrayBufferPrototype%
-              </td>
-              <td>
-                `ArrayBuffer.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %ArrayBuffer%; i.e., %ArrayBuffer.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %ArrayIteratorPrototype%
               </td>
               <td>
               </td>
               <td>
                 The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"></emu-xref>); i.e., %ArrayIterator.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ArrayPrototype%
-              </td>
-              <td>
-                `Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Array% (<emu-xref href="#sec-properties-of-the-array-prototype-object"></emu-xref>); i.e., %Array.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ArrayProto_entries%
-              </td>
-              <td>
-                `Array.prototype.entries`
-              </td>
-              <td>
-                The initial value of the *"entries"* data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.entries"></emu-xref>); i.e., %Array.prototype.entries%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ArrayProto_forEach%
-              </td>
-              <td>
-                `Array.prototype.forEach`
-              </td>
-              <td>
-                The initial value of the *"forEach"* data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.foreach"></emu-xref>); i.e., %Array.prototype.forEach%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ArrayProto_keys%
-              </td>
-              <td>
-                `Array.prototype.keys`
-              </td>
-              <td>
-                The initial value of the *"keys"* data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.keys"></emu-xref>); i.e., %Array.prototype.keys%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ArrayProto_values%
-              </td>
-              <td>
-                `Array.prototype.values`
-              </td>
-              <td>
-                The initial value of the *"values"* data property of %Array.prototype% (<emu-xref href="#sec-array.prototype.values"></emu-xref>); i.e., %Array.prototype.values%
               </td>
             </tr>
             <tr>
@@ -2898,16 +2821,6 @@
               </td>
               <td>
                 The constructor of async function objects (<emu-xref href="#sec-async-function-constructor"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %AsyncFunctionPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %AsyncFunction%; i.e., %AsyncFunction.prototype%
               </td>
             </tr>
             <tr>
@@ -2987,17 +2900,6 @@
             </tr>
             <tr>
               <td>
-                %BooleanPrototype%
-              </td>
-              <td>
-                `Boolean.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Boolean% (<emu-xref href="#sec-properties-of-the-boolean-prototype-object"></emu-xref>); i.e., %Boolean.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %DataView%
               </td>
               <td>
@@ -3009,17 +2911,6 @@
             </tr>
             <tr>
               <td>
-                %DataViewPrototype%
-              </td>
-              <td>
-                `DataView.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %DataView%; i.e., %DataView.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Date%
               </td>
               <td>
@@ -3027,17 +2918,6 @@
               </td>
               <td>
                 The Date constructor (<emu-xref href="#sec-date-constructor"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %DatePrototype%
-              </td>
-              <td>
-                `Date.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Date%.; i.e., %Date.prototype%
               </td>
             </tr>
             <tr>
@@ -3097,17 +2977,6 @@
             </tr>
             <tr>
               <td>
-                %ErrorPrototype%
-              </td>
-              <td>
-                `Error.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Error%; i.e., %Error.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %eval%
               </td>
               <td>
@@ -3126,17 +2995,6 @@
               </td>
               <td>
                 The EvalError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %EvalErrorPrototype%
-              </td>
-              <td>
-                `EvalError.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %EvalError%; i.e., %EvalError.prototype%
               </td>
             </tr>
             <tr>
@@ -3163,17 +3021,6 @@
             </tr>
             <tr>
               <td>
-                %Float32ArrayPrototype%
-              </td>
-              <td>
-                `Float32Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Float32Array%; i.e., %Float32Array.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Float64Array%
               </td>
               <td>
@@ -3181,17 +3028,6 @@
               </td>
               <td>
                 The Float64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %Float64ArrayPrototype%
-              </td>
-              <td>
-                `Float64Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Float64Array%; i.e., %Float64Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3217,17 +3053,6 @@
             </tr>
             <tr>
               <td>
-                %FunctionPrototype%
-              </td>
-              <td>
-                `Function.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Function%; i.e., %Function.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %GeneratorFunction%
               </td>
               <td>
@@ -3249,17 +3074,6 @@
             </tr>
             <tr>
               <td>
-                %Int8ArrayPrototype%
-              </td>
-              <td>
-                `Int8Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Int8Array%; i.e., %Int8Array.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Int16Array%
               </td>
               <td>
@@ -3271,17 +3085,6 @@
             </tr>
             <tr>
               <td>
-                %Int16ArrayPrototype%
-              </td>
-              <td>
-                `Int16Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Int16Array%; i.e., %Int16Array.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Int32Array%
               </td>
               <td>
@@ -3289,17 +3092,6 @@
               </td>
               <td>
                 The Int32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %Int32ArrayPrototype%
-              </td>
-              <td>
-                `Int32Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Int32Array%; i.e., %Int32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3347,28 +3139,6 @@
             </tr>
             <tr>
               <td>
-                %JSONParse%
-              </td>
-              <td>
-                `JSON.parse`
-              </td>
-              <td>
-                The initial value of the *"parse"* data property of %JSON%; i.e., %JSON.parse%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %JSONStringify%
-              </td>
-              <td>
-                `JSON.stringify`
-              </td>
-              <td>
-                The initial value of the *"stringify"* data property of %JSON%; i.e., %JSON.stringify%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Map%
               </td>
               <td>
@@ -3386,17 +3156,6 @@
               </td>
               <td>
                 The prototype of Map iterator objects (<emu-xref href="#sec-map-iterator-objects"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %MapPrototype%
-              </td>
-              <td>
-                `Map.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Map%; i.e., %Map.prototype%
               </td>
             </tr>
             <tr>
@@ -3423,17 +3182,6 @@
             </tr>
             <tr>
               <td>
-                %NumberPrototype%
-              </td>
-              <td>
-                `Number.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Number%; i.e., %Number.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Object%
               </td>
               <td>
@@ -3441,39 +3189,6 @@
               </td>
               <td>
                 The Object constructor (<emu-xref href="#sec-object-constructor"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ObjectPrototype%
-              </td>
-              <td>
-                `Object.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Object% (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>); i.e., %Object.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ObjProto_toString%
-              </td>
-              <td>
-                `Object.prototype.toString`
-              </td>
-              <td>
-                The initial value of the *"toString"* data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>); i.e., %Object.prototype.toString%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ObjProto_valueOf%
-              </td>
-              <td>
-                `Object.prototype.valueOf`
-              </td>
-              <td>
-                The initial value of the *"valueOf"* data property of %Object.prototype% (<emu-xref href="#sec-object.prototype.valueof"></emu-xref>); i.e., %Object.prototype.valueOf%
               </td>
             </tr>
             <tr>
@@ -3511,61 +3226,6 @@
             </tr>
             <tr>
               <td>
-                %PromisePrototype%
-              </td>
-              <td>
-                `Promise.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Promise%; i.e., %Promise.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %PromiseProto_then%
-              </td>
-              <td>
-                `Promise.prototype.then`
-              </td>
-              <td>
-                The initial value of the *"then"* data property of %Promise.prototype% (<emu-xref href="#sec-promise.prototype.then"></emu-xref>); i.e., %Promise.prototype.then%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %Promise_all%
-              </td>
-              <td>
-                `Promise.all`
-              </td>
-              <td>
-                The initial value of the *"all"* data property of %Promise% (<emu-xref href="#sec-promise.all"></emu-xref>); i.e., %Promise.all%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %Promise_reject%
-              </td>
-              <td>
-                `Promise.reject`
-              </td>
-              <td>
-                The initial value of the *"reject"* data property of %Promise% (<emu-xref href="#sec-promise.reject"></emu-xref>); i.e., %Promise.reject%
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %Promise_resolve%
-              </td>
-              <td>
-                `Promise.resolve`
-              </td>
-              <td>
-                The initial value of the *"resolve"* data property of %Promise% (<emu-xref href="#sec-promise.resolve"></emu-xref>); i.e., %Promise.resolve%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Proxy%
               </td>
               <td>
@@ -3588,17 +3248,6 @@
             </tr>
             <tr>
               <td>
-                %RangeErrorPrototype%
-              </td>
-              <td>
-                `RangeError.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %RangeError%; i.e., %RangeError.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %ReferenceError%
               </td>
               <td>
@@ -3606,17 +3255,6 @@
               </td>
               <td>
                 The ReferenceError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %ReferenceErrorPrototype%
-              </td>
-              <td>
-                `ReferenceError.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %ReferenceError%; i.e., %ReferenceError.prototype%
               </td>
             </tr>
             <tr>
@@ -3639,17 +3277,6 @@
               </td>
               <td>
                 The RegExp constructor (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %RegExpPrototype%
-              </td>
-              <td>
-                `RegExp.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %RegExp%; i.e., %RegExp.prototype%
               </td>
             </tr>
             <tr>
@@ -3685,17 +3312,6 @@
             </tr>
             <tr>
               <td>
-                %SetPrototype%
-              </td>
-              <td>
-                `Set.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Set%; i.e., %Set.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %SharedArrayBuffer%
               </td>
               <td>
@@ -3703,17 +3319,6 @@
               </td>
               <td>
                 The SharedArrayBuffer constructor (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %SharedArrayBufferPrototype%
-              </td>
-              <td>
-                `SharedArrayBuffer.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %SharedArrayBuffer%; i.e., %SharedArrayBuffer.prototype%
               </td>
             </tr>
             <tr>
@@ -3739,17 +3344,6 @@
             </tr>
             <tr>
               <td>
-                %StringPrototype%
-              </td>
-              <td>
-                `String.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %String%; i.e., %String.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Symbol%
               </td>
               <td>
@@ -3761,17 +3355,6 @@
             </tr>
             <tr>
               <td>
-                %SymbolPrototype%
-              </td>
-              <td>
-                `Symbol.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Symbol% (<emu-xref href="#sec-properties-of-the-symbol-prototype-object"></emu-xref>); i.e., %Symbol.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %SyntaxError%
               </td>
               <td>
@@ -3779,17 +3362,6 @@
               </td>
               <td>
                 The SyntaxError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %SyntaxErrorPrototype%
-              </td>
-              <td>
-                `SyntaxError.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %SyntaxError%; i.e., %SyntaxError.prototype%
               </td>
             </tr>
             <tr>
@@ -3814,16 +3386,6 @@
             </tr>
             <tr>
               <td>
-                %TypedArrayPrototype%
-              </td>
-              <td>
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %TypedArray%; i.e., %TypedArray.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %TypeError%
               </td>
               <td>
@@ -3831,17 +3393,6 @@
               </td>
               <td>
                 The TypeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %TypeErrorPrototype%
-              </td>
-              <td>
-                `TypeError.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %TypeError%; i.e., %TypeError.prototype%
               </td>
             </tr>
             <tr>
@@ -3857,17 +3408,6 @@
             </tr>
             <tr>
               <td>
-                %Uint8ArrayPrototype%
-              </td>
-              <td>
-                `Uint8Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Uint8Array%; i.e., %Uint8Array.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Uint8ClampedArray%
               </td>
               <td>
@@ -3875,17 +3415,6 @@
               </td>
               <td>
                 The Uint8ClampedArray constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %Uint8ClampedArrayPrototype%
-              </td>
-              <td>
-                `Uint8ClampedArray.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Uint8ClampedArray%; i.e., %Uint8ClampedArray.prototype%
               </td>
             </tr>
             <tr>
@@ -3901,17 +3430,6 @@
             </tr>
             <tr>
               <td>
-                %Uint16ArrayPrototype%
-              </td>
-              <td>
-                `Uint16Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Uint16Array%; i.e., %Uint16Array.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Uint32Array%
               </td>
               <td>
@@ -3919,17 +3437,6 @@
               </td>
               <td>
                 The Uint32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %Uint32ArrayPrototype%
-              </td>
-              <td>
-                `Uint32Array.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %Uint32Array%; i.e., %Uint32Array.prototype%
               </td>
             </tr>
             <tr>
@@ -3945,17 +3452,6 @@
             </tr>
             <tr>
               <td>
-                %URIErrorPrototype%
-              </td>
-              <td>
-                `URIError.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %URIError%; i.e., %URIError.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %WeakMap%
               </td>
               <td>
@@ -3963,17 +3459,6 @@
               </td>
               <td>
                 The WeakMap constructor (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %WeakMapPrototype%
-              </td>
-              <td>
-                `WeakMap.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %WeakMap%; i.e., %WeakMap.prototype%
               </td>
             </tr>
             <tr>
@@ -3996,17 +3481,6 @@
               </td>
               <td>
                 The WeakSet constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                %WeakSetPrototype%
-              </td>
-              <td>
-                `WeakSet.prototype`
-              </td>
-              <td>
-                The initial value of the *"prototype"* data property of %WeakSet%; i.e., %WeakSet.prototype%
               </td>
             </tr>
             </tbody>
@@ -10051,7 +9525,7 @@
       <p>An object is an <dfn id="immutable-prototype-exotic-object">immutable prototype exotic object</dfn> if its [[SetPrototypeOf]] internal method uses the following implementation. (Its other essential internal methods may use any implementation, depending on the specific immutable prototype exotic object in question.)</p>
 
       <emu-note>
-        <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %ObjectPrototype% and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>
+        <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %Object.prototype% and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>
       </emu-note>
 
       <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v">
@@ -26429,7 +25903,7 @@
       <h1>Properties of the Object Prototype Object</h1>
       <p>The <dfn>Object prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%ObjectPrototype%</dfn>.</li>
+        <li>is <dfn>%Object.prototype%</dfn>.</li>
         <li>has an [[Extensible]] internal slot whose value is *true*.</li>
         <li>has the internal methods defined for ordinary objects, except for the [[SetPrototypeOf]] method, which is as defined in <emu-xref href="#sec-immutable-prototype-exotic-objects-setprototypeof-v"></emu-xref>. (Thus, it is an immutable prototype exotic object.)</li>
         <li>has a [[Prototype]] internal slot whose value is *null*.</li>
@@ -26525,7 +25999,6 @@
           1. If Type(_tag_) is not String, set _tag_ to _builtinTag_.
           1. Return the string-concatenation of *"[object "*, _tag_, and *"]"*.
         </emu-alg>
-        <p>This function is the <dfn>%ObjProto_toString%</dfn> intrinsic object.</p>
         <emu-note>
           <p>Historically, this function was occasionally used to access the String value of the [[Class]] internal slot that was used in previous editions of this specification as a nominal type tag for various built-in objects. The above definition of `toString` preserves compatibility for legacy code that uses `toString` as a test for those specific kinds of built-in objects. It does not provide a reliable type testing mechanism for other kinds of built-in or program defined objects. In addition, programs can use @@toStringTag in ways that will invalidate the reliability of such legacy type tests.</p>
         </emu-note>
@@ -26537,7 +26010,6 @@
         <emu-alg>
           1. Return ? ToObject(*this* value).
         </emu-alg>
-        <p>This function is the <dfn>%ObjProto_valueOf%</dfn> intrinsic object.</p>
       </emu-clause>
     </emu-clause>
 
@@ -26910,7 +26382,7 @@
       <h1>Properties of the Boolean Prototype Object</h1>
       <p>The <dfn>Boolean prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%BooleanPrototype%</dfn>.</li>
+        <li>is <dfn>%Boolean.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -27144,7 +26616,7 @@
       <h1>Properties of the Symbol Prototype Object</h1>
       <p>The <dfn>Symbol prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%SymbolPrototype%</dfn>.</li>
+        <li>is <dfn>%Symbol.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a Symbol instance and does not have a [[SymbolData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -27276,7 +26748,7 @@
       <h1>Properties of the Error Prototype Object</h1>
       <p>The <dfn>Error prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%ErrorPrototype%</dfn>.</li>
+        <li>is <dfn>%Error.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -27443,7 +26915,7 @@
         <h1>The AggregateError Constructor</h1>
         <p>The AggregateError constructor:</p>
         <ul>
-          <li>is the intrinsic object <dfn>%AggregateError%</dfn>.</li>
+          <li>is <dfn>%AggregateError%</dfn>.</li>
           <li>is the initial value of the *"AggregateError"* property of the global object.</li>
           <li>creates and initializes a new AggregateError object when called as a function rather than as a constructor. Thus the function call `AggregateError(&hellip;)` is equivalent to the object creation expression `new AggregateError(&hellip;)` with the same arguments.</li>
           <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AggregateError behaviour must include a `super` call to the AggregateError constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
@@ -27470,13 +26942,13 @@
         <h1>Properties of the AggregateError Constructor</h1>
         <p>The AggregateError constructor:</p>
         <ul>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Error%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %Error%.</li>
           <li>has the following properties:</li>
         </ul>
 
         <emu-clause id="sec-aggregate-error.prototype">
           <h1>AggregateError.prototype</h1>
-          <p>The initial value of `AggregateError.prototype` is the intrinsic object %AggregateError.prototype%.</p>
+          <p>The initial value of `AggregateError.prototype` is %AggregateError.prototype%.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         </emu-clause>
       </emu-clause>
@@ -27485,15 +26957,15 @@
         <h1>Properties of the AggregateError Prototype Object</h1>
         <p>The <dfn>AggregateError prototype object</dfn>:</p>
         <ul>
-          <li>is the intrinsic object <dfn>%AggregateError.prototype%</dfn>.</li>
+          <li>is <dfn>%AggregateError.prototype%</dfn>.</li>
           <li>is an ordinary object.</li>
           <li>is not an Error instance or an AggregateError instance and does not have an [[ErrorData]] internal slot.</li>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Error.prototype%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %Error.prototype%.</li>
         </ul>
 
         <emu-clause id="sec-aggregate-error.prototype.constructor">
           <h1>AggregateError.prototype.constructor</h1>
-          <p>The initial value of `AggregateError.prototype.constructor` is the intrinsic object %AggregateError%.</p>
+          <p>The initial value of `AggregateError.prototype.constructor` is %AggregateError%.</p>
         </emu-clause>
 
         <emu-clause id="sec-aggregate-error.prototype.message">
@@ -27675,7 +27147,7 @@
       <h1>Properties of the Number Prototype Object</h1>
       <p>The <dfn>Number prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%NumberPrototype%</dfn>.</li>
+        <li>is <dfn>%Number.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -29399,7 +28871,7 @@ THH:mm:ss.sss
       <h1>Properties of the Date Prototype Object</h1>
       <p>The <dfn>Date prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%DatePrototype%</dfn>.</li>
+        <li>is <dfn>%Date.prototype%</dfn>.</li>
         <li>is itself an ordinary object.</li>
         <li>is not a Date instance and does not have a [[DateValue]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -30336,7 +29808,7 @@ THH:mm:ss.sss
       <h1>Properties of the String Prototype Object</h1>
       <p>The <dfn>String prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%StringPrototype%</dfn>.</li>
+        <li>is <dfn>%String.prototype%</dfn>.</li>
         <li>is a String exotic object and has the internal methods specified for such objects.</li>
         <li>has a [[StringData]] internal slot whose value is the empty String.</li>
         <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
@@ -32853,7 +32325,7 @@ THH:mm:ss.sss
       <h1>Properties of the RegExp Prototype Object</h1>
       <p>The <dfn>RegExp prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%RegExpPrototype%</dfn>.</li>
+        <li>is <dfn>%RegExp.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a RegExp instance and does not have a [[RegExpMatcher]] internal slot or any of the other internal slots of RegExp instance objects.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -33671,7 +33143,7 @@ THH:mm:ss.sss
       <h1>Properties of the Array Prototype Object</h1>
       <p>The <dfn>Array prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%ArrayPrototype%</dfn>.</li>
+        <li>is <dfn>%Array.prototype%</dfn>.</li>
         <li>is an Array exotic object and has the internal methods specified for such objects.</li>
         <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -33786,7 +33258,6 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~key+value~).
         </emu-alg>
-        <p>This function is the <dfn>%ArrayProto_entries%</dfn> intrinsic object.</p>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.every">
@@ -34021,7 +33492,6 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
         </emu-alg>
-        <p>This function is the <dfn>%ArrayProto_forEach%</dfn> intrinsic object.</p>
         <emu-note>
           <p>The `forEach` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -34130,7 +33600,6 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~key~).
         </emu-alg>
-        <p>This function is the <dfn>%ArrayProto_keys%</dfn> intrinsic object.</p>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.lastindexof">
@@ -34766,7 +34235,6 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~value~).
         </emu-alg>
-        <p>This function is the <dfn>%ArrayProto_values%</dfn> intrinsic object.</p>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype-@@iterator">
@@ -36160,7 +35628,7 @@ THH:mm:ss.sss
       <h1>Properties of the Map Prototype Object</h1>
       <p>The <dfn>Map prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%MapPrototype%</dfn>.</li>
+        <li>is <dfn>%Map.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[MapData]] internal slot.</li>
@@ -36507,7 +35975,7 @@ THH:mm:ss.sss
       <h1>Properties of the Set Prototype Object</h1>
       <p>The <dfn>Set prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%SetPrototype%</dfn>.</li>
+        <li>is <dfn>%Set.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[SetData]] internal slot.</li>
@@ -36829,7 +36297,7 @@ THH:mm:ss.sss
       <h1>Properties of the WeakMap Prototype Object</h1>
       <p>The <dfn>WeakMap prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%WeakMapPrototype%</dfn>.</li>
+        <li>is <dfn>%WeakMap.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[WeakMapData]] internal slot.</li>
@@ -36979,7 +36447,7 @@ THH:mm:ss.sss
       <h1>Properties of the WeakSet Prototype Object</h1>
       <p>The <dfn>WeakSet prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%WeakSetPrototype%</dfn>.</li>
+        <li>is <dfn>%WeakSet.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[WeakSetData]] internal slot.</li>
@@ -37352,7 +36820,7 @@ THH:mm:ss.sss
       <h1>Properties of the ArrayBuffer Prototype Object</h1>
       <p>The <dfn>ArrayBuffer prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%ArrayBufferPrototype%</dfn>.</li>
+        <li>is <dfn>%ArrayBuffer.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
@@ -37510,7 +36978,7 @@ THH:mm:ss.sss
       <h1>Properties of the SharedArrayBuffer Prototype Object</h1>
       <p>The <dfn>SharedArrayBuffer prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%SharedArrayBufferPrototype%</dfn>.</li>
+        <li>is <dfn>%SharedArrayBuffer.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
@@ -37678,7 +37146,7 @@ THH:mm:ss.sss
       <h1>Properties of the DataView Prototype Object</h1>
       <p>The <dfn>DataView prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%DataViewPrototype%</dfn>.</li>
+        <li>is <dfn>%DataView.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</li>
@@ -38424,7 +37892,6 @@ THH:mm:ss.sss
         1. Else,
           1. Return _unfiltered_.
       </emu-alg>
-      <p>This function is the <dfn>%JSONParse%</dfn> intrinsic object.</p>
       <p>The *"length"* property of the `parse` function is 2.</p>
       <emu-note>
         <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax as modified by step <emu-xref href="#step-json-parse-parse"></emu-xref> above. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that that parsing and evaluation returns a value of an appropriate type.</p>
@@ -38511,7 +37978,6 @@ THH:mm:ss.sss
         1. Let _state_ be the Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
         1. Return ? SerializeJSONProperty(_state_, the empty String, _wrapper_).
       </emu-alg>
-      <p>This function is the <dfn>%JSONStringify%</dfn> intrinsic object.</p>
       <p>The *"length"* property of the `stringify` function is 3.</p>
       <emu-note>
         <p>JSON structures are allowed to be nested to any depth, but they must be acyclic. If _value_ is or contains a cyclic structure, then the stringify function must throw a *TypeError* exception. This is an example of a value that cannot be stringified:</p>
@@ -38807,7 +38273,7 @@ THH:mm:ss.sss
       <h1>The WeakRef Constructor</h1>
       <p>The <dfn>WeakRef</dfn> constructor:</p>
       <ul>
-        <li>is the intrinsic object %WeakRef%.</li>
+        <li>is %WeakRef%.</li>
         <li>
           is the initial value of the *"WeakRef"* property of the global object.
         </li>
@@ -38841,7 +38307,7 @@ THH:mm:ss.sss
       <p>The WeakRef constructor:</p>
       <ul>
         <li>
-          has a [[Prototype]] internal slot whose value is the intrinsic object %Function.prototype%.
+          has a [[Prototype]] internal slot whose value is %Function.prototype%.
         </li>
         <li>has the following properties:</li>
       </ul>
@@ -38857,7 +38323,7 @@ THH:mm:ss.sss
       <h1>Properties of the WeakRef Prototype Object</h1>
       <p>The WeakRef prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%WeakRef.prototype%</dfn>.</li>
+        <li>is <dfn>%WeakRef.prototype%</dfn>.</li>
         <li>
           has a [[Prototype]] internal slot whose value is %Object.prototype%.
         </li>
@@ -38868,7 +38334,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-weak-ref.prototype.constructor" normative-optional>
         <h1>WeakRef.prototype.constructor</h1>
 
-        <p>The initial value of `WeakRef.prototype.constructor` is the intrinsic object %WeakRef%.</p>
+        <p>The initial value of `WeakRef.prototype.constructor` is %WeakRef%.</p>
 
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
@@ -38939,7 +38405,7 @@ THH:mm:ss.sss
       <h1>The FinalizationRegistry Constructor</h1>
       <p>The <dfn>FinalizationRegistry</dfn> constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%FinalizationRegistry%</dfn>.</li>
+        <li>is <dfn>%FinalizationRegistry%</dfn>.</li>
         <li>
           is the initial value of the *"FinalizationRegistry"* property of the global object.
         </li>
@@ -38975,7 +38441,7 @@ THH:mm:ss.sss
       <p>The FinalizationRegistry constructor:</p>
       <ul>
         <li>
-          has a [[Prototype]] internal slot whose value is the intrinsic object %Function.prototype%.
+          has a [[Prototype]] internal slot whose value is %Function.prototype%.
         </li>
         <li>has the following properties:</li>
       </ul>
@@ -38991,7 +38457,7 @@ THH:mm:ss.sss
       <h1>Properties of the FinalizationRegistry Prototype Object</h1>
       <p>The FinalizationRegistry prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%FinalizationRegistry.prototype%</dfn>.</li>
+        <li>is <dfn>%FinalizationRegistry.prototype%</dfn>.</li>
         <li>
           has a [[Prototype]] internal slot whose value is %Object.prototype%.
         </li>
@@ -39003,7 +38469,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-finalization-registry.prototype.constructor">
         <h1>FinalizationRegistry.prototype.constructor</h1>
-        <p>The initial value of `FinalizationRegistry.prototype.constructor` is the intrinsic object %FinalizationRegistry%.</p>
+        <p>The initial value of `FinalizationRegistry.prototype.constructor` is %FinalizationRegistry%.</p>
       </emu-clause>
 
       <emu-clause id="sec-finalization-registry.prototype.register">
@@ -40662,7 +40128,6 @@ THH:mm:ss.sss
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Return Completion(_result_).
         </emu-alg>
-        <p>This function is the <dfn>%Promise_all%</dfn> intrinsic object.</p>
         <emu-note>
           <p>The `all` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
@@ -41003,7 +40468,6 @@ THH:mm:ss.sss
           1. Perform ? Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _r_ &raquo;).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
-        <p>This function is the <dfn>%Promise_reject%</dfn> intrinsic object.</p>
         <emu-note>
           <p>The `reject` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
@@ -41017,7 +40481,6 @@ THH:mm:ss.sss
           1. If Type(_C_) is not Object, throw a *TypeError* exception.
           1. Return ? PromiseResolve(_C_, _x_).
         </emu-alg>
-        <p>This function is the <dfn>%Promise_resolve%</dfn> intrinsic object.</p>
         <emu-note>
           <p>The `resolve` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
@@ -41054,7 +40517,7 @@ THH:mm:ss.sss
       <h1>Properties of the Promise Prototype Object</h1>
       <p>The <dfn>Promise prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%PromisePrototype%</dfn>.</li>
+        <li>is <dfn>%Promise.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</li>
@@ -41144,7 +40607,6 @@ THH:mm:ss.sss
           1. Let _resultCapability_ be ? NewPromiseCapability(_C_).
           1. Return PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_, _resultCapability_).
         </emu-alg>
-        <p>This function is the <dfn>%PromiseProto_then%</dfn> intrinsic object.</p>
 
         <emu-clause id="sec-performpromisethen" aoid="PerformPromiseThen">
           <h1>PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_ [ , _resultCapability_ ] )</h1>
@@ -41308,7 +40770,6 @@ THH:mm:ss.sss
       <h1>Properties of the AsyncFunction Prototype Object</h1>
       <p>The <dfn>AsyncFunction prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%AsyncFunctionPrototype%</dfn>.</li>
         <li>is <dfn>%AsyncFunction.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</li>


### PR DESCRIPTION
All uses of these have been removed from HTML and 402:
 - https://github.com/heycam/webidl/pull/898
 - https://github.com/whatwg/html/pull/5655
 - https://github.com/whatwg/infra/pull/316
 - https://github.com/tc39/ecma402/pull/474

Closes #2023. Closes #2124.