### PR TITLE
Normative: add `Reflect[Symbol.toStringTag]`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41010,6 +41010,12 @@ THH:mm:ss.sss
         1. Return ? _target_.[[SetPrototypeOf]](_proto_).
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-reflect-@@tostringtag">
+      <h1>Reflect [ @@toStringTag ]</h1>
+      <p>The initial value of the @@toStringTag property is the String value *"Reflect"*.</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-proxy-objects">


### PR DESCRIPTION
Fixes #1970.

Essentially, this PR makes Reflect no longer be the "odd one out" - ie, the only namespace-like builtin object that lacks a `Symbol.toStringTag`.

See also: https://github.com/tc39/ecma402/pull/430