### PR TITLE
Editorial: Fix %Generator% and %AsyncGenerator% <dfn>s

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18144,7 +18144,7 @@
           <ul>
             <li>has properties that are inherited by all For-In Iterator Objects.</li>
             <li>is an ordinary object.</li>
-            <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+            <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
             <li>is never directly accessible to ECMAScript code.</li>
             <li>has the following properties:</li>
           </ul>
@@ -25710,7 +25710,7 @@
       <h1>The Object Constructor</h1>
       <p>The Object constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Object%</dfn>.</li>
+        <li>is <dfn>%Object%</dfn>.</li>
         <li>is the initial value of the *"Object"* property of the global object.</li>
         <li>creates a new ordinary object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
@@ -26030,7 +26030,7 @@
       <h1>Properties of the Object Prototype Object</h1>
       <p>The Object prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%ObjectPrototype%</dfn>.</li>
+        <li>is <dfn>%ObjectPrototype%</dfn>.</li>
         <li>has an [[Extensible]] internal slot whose value is *true*.</li>
         <li>has the internal methods defined for ordinary objects, except for the [[SetPrototypeOf]] method, which is as defined in <emu-xref href="#sec-immutable-prototype-exotic-objects-setprototypeof-v"></emu-xref>. (Thus, it is an immutable prototype exotic object.)</li>
         <li>has a [[Prototype]] internal slot whose value is *null*.</li>
@@ -26155,7 +26155,7 @@
       <h1>The Function Constructor</h1>
       <p>The Function constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Function%</dfn>.</li>
+        <li>is <dfn>%Function%</dfn>.</li>
         <li>is the initial value of the *"Function"* property of the global object.</li>
         <li>creates and initializes a new function object when called as a function rather than as a constructor. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Function behaviour must include a `super` call to the Function constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of Function. There is no syntactic means to create instances of Function subclasses except for the built-in GeneratorFunction, AsyncFunction, and AsyncGeneratorFunction subclasses.</li>
@@ -26471,7 +26471,7 @@
       <h1>The Boolean Constructor</h1>
       <p>The Boolean constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Boolean%</dfn>.</li>
+        <li>is <dfn>%Boolean%</dfn>.</li>
         <li>is the initial value of the *"Boolean"* property of the global object.</li>
         <li>creates and initializes a new Boolean object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
@@ -26510,7 +26510,7 @@
       <h1>Properties of the Boolean Prototype Object</h1>
       <p>The Boolean prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%BooleanPrototype%</dfn>.</li>
+        <li>is <dfn>%BooleanPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -26561,7 +26561,7 @@
       <h1>The Symbol Constructor</h1>
       <p>The Symbol constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Symbol%</dfn>.</li>
+        <li>is <dfn>%Symbol%</dfn>.</li>
         <li>is the initial value of the *"Symbol"* property of the global object.</li>
         <li>returns a new Symbol value when called as a function.</li>
         <li>is not intended to be used with the `new` operator.</li>
@@ -26744,7 +26744,7 @@
       <h1>Properties of the Symbol Prototype Object</h1>
       <p>The Symbol prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%SymbolPrototype%</dfn>.</li>
+        <li>is <dfn>%SymbolPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a Symbol instance and does not have a [[SymbolData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -26835,7 +26835,7 @@
       <h1>The Error Constructor</h1>
       <p>The Error constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Error%</dfn>.</li>
+        <li>is <dfn>%Error%</dfn>.</li>
         <li>is the initial value of the *"Error"* property of the global object.</li>
         <li>creates and initializes a new Error object when called as a function rather than as a constructor. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Error behaviour must include a `super` call to the Error constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
@@ -26875,7 +26875,7 @@
       <h1>Properties of the Error Prototype Object</h1>
       <p>The Error prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%ErrorPrototype%</dfn>.</li>
+        <li>is <dfn>%ErrorPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -26924,37 +26924,37 @@
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-evalerror">
         <h1>EvalError</h1>
-        <p>The EvalError constructor is the intrinsic object <dfn>%EvalError%</dfn>.</p>
+        <p>The EvalError constructor is <dfn>%EvalError%</dfn>.</p>
         <p>This exception is not currently used within this specification. This object remains for compatibility with previous editions of this specification.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-rangeerror">
         <h1>RangeError</h1>
-        <p>The RangeError constructor is the intrinsic object <dfn>%RangeError%</dfn>.</p>
+        <p>The RangeError constructor is <dfn>%RangeError%</dfn>.</p>
         <p>Indicates a value that is not in the set or range of allowable values.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-referenceerror">
         <h1>ReferenceError</h1>
-        <p>The ReferenceError constructor is the intrinsic object <dfn>%ReferenceError%</dfn>.</p>
+        <p>The ReferenceError constructor is <dfn>%ReferenceError%</dfn>.</p>
         <p>Indicate that an invalid reference value has been detected.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-syntaxerror">
         <h1>SyntaxError</h1>
-        <p>The SyntaxError constructor is the intrinsic object <dfn>%SyntaxError%</dfn>.</p>
+        <p>The SyntaxError constructor is <dfn>%SyntaxError%</dfn>.</p>
         <p>Indicates that a parsing error has occurred.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-typeerror">
         <h1>TypeError</h1>
-        <p>The TypeError constructor is the intrinsic object <dfn>%TypeError%</dfn>.</p>
+        <p>The TypeError constructor is <dfn>%TypeError%</dfn>.</p>
         <p>TypeError is used to indicate an unsuccessful operation when none of the other _NativeError_ objects are an appropriate indication of the failure cause.</p>
       </emu-clause>
 
       <emu-clause id="sec-native-error-types-used-in-this-standard-urierror">
         <h1>URIError</h1>
-        <p>The URIError constructor is the intrinsic object <dfn>%URIError%</dfn>.</p>
+        <p>The URIError constructor is <dfn>%URIError%</dfn>.</p>
         <p>Indicates that one of the global URI handling functions was used in a way that is incompatible with its definition.</p>
       </emu-clause>
     </emu-clause>
@@ -27047,7 +27047,7 @@
       <h1>The Number Constructor</h1>
       <p>The Number constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Number%</dfn>.</li>
+        <li>is <dfn>%Number%</dfn>.</li>
         <li>is the initial value of the *"Number"* property of the global object.</li>
         <li>creates and initializes a new Number object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
@@ -27197,7 +27197,7 @@
       <h1>Properties of the Number Prototype Object</h1>
       <p>The Number prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%NumberPrototype%</dfn>.</li>
+        <li>is <dfn>%NumberPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is itself a Number object; it has a [[NumberData]] internal slot with the value *+0*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -27390,7 +27390,7 @@
       <h1>The BigInt Constructor</h1>
       <p>The BigInt constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%BigInt%</dfn>.</li>
+        <li>is <dfn>%BigInt%</dfn>.</li>
         <li>is the initial value of the *"BigInt"* property of the global object.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
         <li>is not intended to be used with the `new` operator or to be subclassed. It may be used as the value of an `extends` clause of a class definition but a `super` call to the BigInt constructor will cause an exception.</li>
@@ -27420,7 +27420,7 @@
 
     <emu-clause id="sec-properties-of-the-bigint-constructor">
       <h1>Properties of the BigInt Constructor</h1>
-      <p>The value of the [[Prototype]] internal slot of the BigInt constructor is the intrinsic object %Function.prototype%.</p>
+      <p>The value of the [[Prototype]] internal slot of the BigInt constructor is %Function.prototype%.</p>
       <p>The BigInt constructor has the following properties:</p>
 
       <emu-clause id="sec-bigint.asintn">
@@ -27455,10 +27455,10 @@
       <h1>Properties of the BigInt Prototype Object</h1>
       <p>The BigInt prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%BigInt.prototype%</dfn>.</li>
+        <li>is <dfn>%BigInt.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a BigInt object; it does not have a [[BigIntData]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Object.prototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>The abstract operation <dfn id="sec-thisbigintvalue" aoid="thisBigIntValue">thisBigIntValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
@@ -27472,7 +27472,7 @@
 
       <emu-clause id="sec-bigint.prototype.constructor">
         <h1>BigInt.prototype.constructor</h1>
-        <p>The initial value of `BigInt.prototype.constructor` is the intrinsic object %BigInt%.</p>
+        <p>The initial value of `BigInt.prototype.constructor` is %BigInt%.</p>
       </emu-clause>
 
       <emu-clause id="sec-bigint.prototype.tolocalestring">
@@ -27518,7 +27518,7 @@
     <h1>The Math Object</h1>
     <p>The Math object:</p>
     <ul>
-      <li>is the intrinsic object <dfn>%Math%</dfn>.</li>
+      <li>is <dfn>%Math%</dfn>.</li>
       <li>is the initial value of the *"Math"* property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -28774,7 +28774,7 @@ THH:mm:ss.sss
       <h1>The Date Constructor</h1>
       <p>The Date constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Date%</dfn>.</li>
+        <li>is <dfn>%Date%</dfn>.</li>
         <li>is the initial value of the *"Date"* property of the global object.</li>
         <li>creates and initializes a new Date object when called as a constructor.</li>
         <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
@@ -28921,7 +28921,7 @@ THH:mm:ss.sss
       <h1>Properties of the Date Prototype Object</h1>
       <p>The Date prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%DatePrototype%</dfn>.</li>
+        <li>is <dfn>%DatePrototype%</dfn>.</li>
         <li>is itself an ordinary object.</li>
         <li>is not a Date instance and does not have a [[DateValue]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -29761,7 +29761,7 @@ THH:mm:ss.sss
       <h1>The String Constructor</h1>
       <p>The String constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%String%</dfn>.</li>
+        <li>is <dfn>%String%</dfn>.</li>
         <li>is the initial value of the *"String"* property of the global object.</li>
         <li>creates and initializes a new String object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
@@ -29868,7 +29868,7 @@ THH:mm:ss.sss
       <h1>Properties of the String Prototype Object</h1>
       <p>The String prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%StringPrototype%</dfn>.</li>
+        <li>is <dfn>%StringPrototype%</dfn>.</li>
         <li>is a String exotic object and has the internal methods specified for such objects.</li>
         <li>has a [[StringData]] internal slot whose value is the empty String.</li>
         <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
@@ -32487,7 +32487,7 @@ THH:mm:ss.sss
       <h1>The RegExp Constructor</h1>
       <p>The RegExp constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%RegExp%</dfn>.</li>
+        <li>is <dfn>%RegExp%</dfn>.</li>
         <li>is the initial value of the *"RegExp"* property of the global object.</li>
         <li>creates and initializes a new RegExp object when called as a function rather than as a constructor. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified RegExp behaviour must include a `super` call to the RegExp constructor to create and initialize subclass instances with the necessary internal slots.</li>
@@ -32629,7 +32629,7 @@ THH:mm:ss.sss
       <h1>Properties of the RegExp Prototype Object</h1>
       <p>The RegExp prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%RegExpPrototype%</dfn>.</li>
+        <li>is <dfn>%RegExpPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a RegExp instance and does not have a [[RegExpMatcher]] internal slot or any of the other internal slots of RegExp instance objects.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -33172,7 +33172,7 @@ THH:mm:ss.sss
         <ul>
           <li>has properties that are inherited by all RegExp String Iterator Objects.</li>
           <li>is an ordinary object.</li>
-          <li>has a [[Prototype]] internal slot whose value is the intrinsic object %IteratorPrototype%.</li>
+          <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
           <li>has the following properties:</li>
         </ul>
 
@@ -33262,7 +33262,7 @@ THH:mm:ss.sss
       <h1>The Array Constructor</h1>
       <p>The Array constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Array%</dfn>.</li>
+        <li>is <dfn>%Array%</dfn>.</li>
         <li>is the initial value of the *"Array"* property of the global object.</li>
         <li>creates and initializes a new Array exotic object when called as a constructor.</li>
         <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
@@ -33452,7 +33452,7 @@ THH:mm:ss.sss
       <h1>Properties of the Array Prototype Object</h1>
       <p>The Array prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%ArrayPrototype%</dfn>.</li>
+        <li>is <dfn>%ArrayPrototype%</dfn>.</li>
         <li>is an Array exotic object and has the internal methods specified for such objects.</li>
         <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -35886,7 +35886,7 @@ THH:mm:ss.sss
       <h1>The Map Constructor</h1>
       <p>The Map constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Map%</dfn>.</li>
+        <li>is <dfn>%Map%</dfn>.</li>
         <li>is the initial value of the *"Map"* property of the global object.</li>
         <li>creates and initializes a new Map object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
@@ -35967,7 +35967,7 @@ THH:mm:ss.sss
       <h1>Properties of the Map Prototype Object</h1>
       <p>The Map prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%MapPrototype%</dfn>.</li>
+        <li>is <dfn>%MapPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[MapData]] internal slot.</li>
@@ -36255,7 +36255,7 @@ THH:mm:ss.sss
       <h1>The Set Constructor</h1>
       <p>The Set constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Set%</dfn>.</li>
+        <li>is <dfn>%Set%</dfn>.</li>
         <li>is the initial value of the *"Set"* property of the global object.</li>
         <li>creates and initializes a new Set object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
@@ -36314,7 +36314,7 @@ THH:mm:ss.sss
       <h1>Properties of the Set Prototype Object</h1>
       <p>The Set prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%SetPrototype%</dfn>.</li>
+        <li>is <dfn>%SetPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[SetData]] internal slot.</li>
@@ -36593,7 +36593,7 @@ THH:mm:ss.sss
       <h1>The WeakMap Constructor</h1>
       <p>The WeakMap constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%WeakMap%</dfn>.</li>
+        <li>is <dfn>%WeakMap%</dfn>.</li>
         <li>is the initial value of the *"WeakMap"* property of the global object.</li>
         <li>creates and initializes a new WeakMap object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
@@ -36636,7 +36636,7 @@ THH:mm:ss.sss
       <h1>Properties of the WeakMap Prototype Object</h1>
       <p>The WeakMap prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%WeakMapPrototype%</dfn>.</li>
+        <li>is <dfn>%WeakMapPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[WeakMapData]] internal slot.</li>
@@ -36739,7 +36739,7 @@ THH:mm:ss.sss
       <h1>The WeakSet Constructor</h1>
       <p>The WeakSet constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%WeakSet%</dfn>.</li>
+        <li>is <dfn>%WeakSet%</dfn>.</li>
         <li>is the initial value of the *"WeakSet"* property of the global object.</li>
         <li>creates and initializes a new WeakSet object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
@@ -36786,7 +36786,7 @@ THH:mm:ss.sss
       <h1>Properties of the WeakSet Prototype Object</h1>
       <p>The WeakSet prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%WeakSetPrototype%</dfn>.</li>
+        <li>is <dfn>%WeakSetPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[WeakSetData]] internal slot.</li>
@@ -37095,7 +37095,7 @@ THH:mm:ss.sss
       <h1>The ArrayBuffer Constructor</h1>
       <p>The ArrayBuffer constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%ArrayBuffer%</dfn>.</li>
+        <li>is <dfn>%ArrayBuffer%</dfn>.</li>
         <li>is the initial value of the *"ArrayBuffer"* property of the global object.</li>
         <li>creates and initializes a new ArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
@@ -37154,7 +37154,7 @@ THH:mm:ss.sss
       <h1>Properties of the ArrayBuffer Prototype Object</h1>
       <p>The ArrayBuffer prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%ArrayBufferPrototype%</dfn>.</li>
+        <li>is <dfn>%ArrayBufferPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
@@ -37260,7 +37260,7 @@ THH:mm:ss.sss
       <h1>The SharedArrayBuffer Constructor</h1>
       <p>The SharedArrayBuffer constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%SharedArrayBuffer%</dfn>.</li>
+        <li>is <dfn>%SharedArrayBuffer%</dfn>.</li>
         <li>is the initial value of the *"SharedArrayBuffer"* property of the global object.</li>
         <li>creates and initializes a new SharedArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
@@ -37310,7 +37310,7 @@ THH:mm:ss.sss
       <h1>Properties of the SharedArrayBuffer Prototype Object</h1>
       <p>The SharedArrayBuffer prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%SharedArrayBufferPrototype%</dfn>.</li>
+        <li>is <dfn>%SharedArrayBufferPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have an [[ArrayBufferData]] or [[ArrayBufferByteLength]] internal slot.</li>
@@ -37427,7 +37427,7 @@ THH:mm:ss.sss
       <h1>The DataView Constructor</h1>
       <p>The DataView constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%DataView%</dfn>.</li>
+        <li>is <dfn>%DataView%</dfn>.</li>
         <li>is the initial value of the *"DataView"* property of the global object.</li>
         <li>creates and initializes a new DataView object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
@@ -37478,7 +37478,7 @@ THH:mm:ss.sss
       <h1>Properties of the DataView Prototype Object</h1>
       <p>The DataView prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%DataViewPrototype%</dfn>.</li>
+        <li>is <dfn>%DataViewPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], or [[ByteOffset]] internal slot.</li>
@@ -37741,7 +37741,7 @@ THH:mm:ss.sss
     <h1>The Atomics Object</h1>
     <p>The Atomics object:</p>
     <ul>
-      <li>is the intrinsic object <dfn>%Atomics%</dfn>.</li>
+      <li>is <dfn>%Atomics%</dfn>.</li>
       <li>is the initial value of the *"Atomics"* property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -38188,7 +38188,7 @@ THH:mm:ss.sss
     <h1>The JSON Object</h1>
     <p>The JSON object:</p>
     <ul>
-      <li>is the intrinsic object <dfn>%JSON%</dfn>.</li>
+      <li>is <dfn>%JSON%</dfn>.</li>
       <li>is the initial value of the *"JSON"* property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>contains two functions, `parse` and `stringify`, that are used to parse and construct JSON texts.</li>
@@ -39047,7 +39047,7 @@ THH:mm:ss.sss
       <h1>The GeneratorFunction Constructor</h1>
       <p>The GeneratorFunction constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%GeneratorFunction%</dfn>.</li>
+        <li>is <dfn>%GeneratorFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new GeneratorFunction object when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.</li>
@@ -39097,7 +39097,7 @@ THH:mm:ss.sss
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-56"></emu-xref>.</li>
         <li>is the value of the *"prototype"* property of %GeneratorFunction%.</li>
-        <li>is the intrinsic object <dfn>%Generator%</dfn> (see Figure 2).</li>
+        <li>is <dfn>%Generator%</dfn> (see Figure 2).</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
@@ -39154,7 +39154,7 @@ THH:mm:ss.sss
       <h1>The AsyncGeneratorFunction Constructor</h1>
       <p>The AsyncGeneratorFunction constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%AsyncGeneratorFunction%</dfn>.</li>
+        <li>is <dfn>%AsyncGeneratorFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new AsyncGeneratorFunction object when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncGeneratorFunction behaviour must include a `super` call to the AsyncGeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of AsyncGeneratorFunction. There is no syntactic means to create instances of AsyncGeneratorFunction subclasses.</li>
@@ -39192,7 +39192,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype">
         <h1>AsyncGeneratorFunction.prototype</h1>
-        <p>The initial value of `AsyncGeneratorFunction.prototype` is the intrinsic object <dfn>%AsyncGenerator%</dfn>.</p>
+        <p>The initial value of `AsyncGeneratorFunction.prototype` is <dfn>%AsyncGenerator%</dfn>.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -39263,7 +39263,7 @@ THH:mm:ss.sss
       <h1>Properties of the Generator Prototype Object</h1>
       <p>The Generator prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%GeneratorPrototype%</dfn>.</li>
+        <li>is <dfn>%GeneratorPrototype%</dfn>.</li>
         <li>is the initial value of the *"prototype"* property of %Generator% (the `GeneratorFunction.prototype`).</li>
         <li>is an ordinary object.</li>
         <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
@@ -39474,7 +39474,7 @@ THH:mm:ss.sss
       <h1>Properties of the AsyncGenerator Prototype Object</h1>
       <p>The AsyncGenerator prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%AsyncGeneratorPrototype%</dfn>.</li>
+        <li>is <dfn>%AsyncGeneratorPrototype%</dfn>.</li>
         <li>is the initial value of the *"prototype"* property of %AsyncGenerator% (the `AsyncGeneratorFunction.prototype`).</li>
         <li>is an ordinary object.</li>
         <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
@@ -40137,7 +40137,7 @@ THH:mm:ss.sss
       <h1>The Promise Constructor</h1>
       <p>The Promise constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Promise%</dfn>.</li>
+        <li>is <dfn>%Promise%</dfn>.</li>
         <li>is the initial value of the *"Promise"* property of the global object.</li>
         <li>creates and initializes a new Promise object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
@@ -40502,7 +40502,7 @@ THH:mm:ss.sss
       <h1>Properties of the Promise Prototype Object</h1>
       <p>The Promise prototype object:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%PromisePrototype%</dfn>.</li>
+        <li>is <dfn>%PromisePrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[PromiseState]] internal slot or any of the other internal slots of Promise instances.</li>
@@ -40705,7 +40705,7 @@ THH:mm:ss.sss
 
       <p>The AsyncFunction constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%AsyncFunction%</dfn>.</li>
+        <li>is <dfn>%AsyncFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new AsyncFunction object when called as a function rather than as a constructor. Thus the function call `AsyncFunction(&hellip;)` is equivalent to the object creation expression `new AsyncFunction(&hellip;)` with the same arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the AsyncFunction constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour. All ECMAScript syntactic forms for defining async function objects create direct instances of AsyncFunction. There is no syntactic means to create instances of AsyncFunction subclasses.</li>
@@ -40755,7 +40755,7 @@ THH:mm:ss.sss
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</li>
         <li>is the value of the *"prototype"* property of %AsyncFunction%.</li>
-        <li>is the intrinsic object <dfn>%AsyncFunctionPrototype%</dfn>.</li>
+        <li>is <dfn>%AsyncFunctionPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
@@ -40832,7 +40832,7 @@ THH:mm:ss.sss
     <h1>The Reflect Object</h1>
     <p>The Reflect object:</p>
     <ul>
-      <li>is the intrinsic object <dfn>%Reflect%</dfn>.</li>
+      <li>is <dfn>%Reflect%</dfn>.</li>
       <li>is the initial value of the *"Reflect"* property of the global object.</li>
       <li>is an ordinary object.</li>
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -40985,7 +40985,7 @@ THH:mm:ss.sss
       <h1>The Proxy Constructor</h1>
       <p>The Proxy constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%Proxy%</dfn>.</li>
+        <li>is <dfn>%Proxy%</dfn>.</li>
         <li>is the initial value of the *"Proxy"* property of the global object.</li>
         <li>creates and initializes a new proxy exotic object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>

--- a/spec.html
+++ b/spec.html
@@ -39094,10 +39094,10 @@ THH:mm:ss.sss
       <h1>Properties of the GeneratorFunction Prototype Object</h1>
       <p>The GeneratorFunction prototype object:</p>
       <ul>
+        <li>is <dfn>%Generator%</dfn> (see <emu-xref href="#figure-2"></emu-xref>).</li>
+        <li>is <dfn>%GeneratorFunction.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-56"></emu-xref>.</li>
-        <li>is the value of the *"prototype"* property of %GeneratorFunction%.</li>
-        <li>is <dfn>%Generator%</dfn> (see Figure 2).</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
@@ -39192,7 +39192,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype">
         <h1>AsyncGeneratorFunction.prototype</h1>
-        <p>The initial value of `AsyncGeneratorFunction.prototype` is <dfn>%AsyncGenerator%</dfn>.</p>
+        <p>The initial value of `AsyncGeneratorFunction.prototype` is %AsyncGenerator%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -39201,10 +39201,10 @@ THH:mm:ss.sss
       <h1>Properties of the AsyncGeneratorFunction Prototype Object</h1>
       <p>The AsyncGeneratorFunction prototype object:</p>
       <ul>
+        <li>is <dfn>%AsyncGenerator%</dfn>.</li>
+        <li>is <dfn>%AsyncGeneratorFunction.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
-        <li>is the value of the *"prototype"* property of %AsyncGeneratorFunction%.</li>
-        <li>is %AsyncGenerator%.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
@@ -39264,7 +39264,7 @@ THH:mm:ss.sss
       <p>The Generator prototype object:</p>
       <ul>
         <li>is <dfn>%GeneratorPrototype%</dfn>.</li>
-        <li>is the initial value of the *"prototype"* property of %Generator% (the `GeneratorFunction.prototype`).</li>
+        <li>is <dfn>%Generator.prototype%</dfn> (<dfn>%GeneratorFunction.prototype.prototype%</dfn>).</li>
         <li>is an ordinary object.</li>
         <li>is not a Generator instance and does not have a [[GeneratorState]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
@@ -39475,7 +39475,7 @@ THH:mm:ss.sss
       <p>The AsyncGenerator prototype object:</p>
       <ul>
         <li>is <dfn>%AsyncGeneratorPrototype%</dfn>.</li>
-        <li>is the initial value of the *"prototype"* property of %AsyncGenerator% (the `AsyncGeneratorFunction.prototype`).</li>
+        <li>is <dfn>%AsyncGenerator.prototype%</dfn> (<dfn>%AsyncGeneratorFunction.prototype.prototype%</dfn>).</li>
         <li>is an ordinary object.</li>
         <li>is not an AsyncGenerator instance and does not have an [[AsyncGeneratorState]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %AsyncIteratorPrototype%.</li>
@@ -40752,10 +40752,10 @@ THH:mm:ss.sss
       <h1>Properties of the AsyncFunction Prototype Object</h1>
       <p>The AsyncFunction prototype object:</p>
       <ul>
+        <li>is <dfn>%AsyncFunctionPrototype%</dfn>.</li>
+        <li>is <dfn>%AsyncFunction.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</li>
-        <li>is the value of the *"prototype"* property of %AsyncFunction%.</li>
-        <li>is <dfn>%AsyncFunctionPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 


### PR DESCRIPTION
Currently, `%AsyncGenerator%` auto‑links to <https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype> instead of <https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction-prototype>.

I also sorted the `<ul>` to match other definitions and made the “see Figure” text an `<emu‑xref>`.

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2059) ([#sec-well-known-intrinsic-objects](https://ci.tc39.es/preview/tc39/ecma262/pull/2059#sec-well-known-intrinsic-objects), [#sec-properties-of-asyncgeneratorfunction-prototype](https://ci.tc39.es/preview/tc39/ecma262/pull/2059#sec-properties-of-asyncgeneratorfunction-prototype))