### PR TITLE
Editorial: Use semantic table IDs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1049,8 +1049,8 @@
       <emu-clause id="sec-well-known-symbols">
         <h1>Well-Known Symbols</h1>
         <p>Well-known symbols are built-in Symbol values that are explicitly referenced by algorithms of this specification. They are typically used as the keys of properties whose values serve as extension points of a specification algorithm. Unless otherwise specified, well-known symbols values are shared by all realms (<emu-xref href="#sec-code-realms"></emu-xref>).</p>
-        <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where &ldquo;name&rdquo; is one of the values listed in <emu-xref href="#table-1"></emu-xref>.</p>
-        <emu-table id="table-1" caption="Well-known Symbols">
+        <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where &ldquo;name&rdquo; is one of the values listed in <emu-xref href="#table-well-known-symbols"></emu-xref>.</p>
+        <emu-table id="table-well-known-symbols" caption="Well-known Symbols" oldids="table-1">
           <table>
             <tbody>
             <tr>
@@ -2162,8 +2162,8 @@
 
       <emu-clause id="sec-property-attributes">
         <h1>Property Attributes</h1>
-        <p>Attributes are used in this specification to define and explain the state of Object properties. A data property associates a key value with the attributes listed in <emu-xref href="#table-2"></emu-xref>.</p>
-        <emu-table id="table-2" caption="Attributes of a Data Property">
+        <p>Attributes are used in this specification to define and explain the state of Object properties. A data property associates a key value with the attributes listed in <emu-xref href="#table-data-property-attributes"></emu-xref>.</p>
+        <emu-table id="table-data-property-attributes" caption="Attributes of a Data Property" oldids="table-2">
           <table>
             <tbody>
             <tr>
@@ -2224,8 +2224,8 @@
             </tbody>
           </table>
         </emu-table>
-        <p>An accessor property associates a key value with the attributes listed in <emu-xref href="#table-3"></emu-xref>.</p>
-        <emu-table id="table-3" caption="Attributes of an Accessor Property">
+        <p>An accessor property associates a key value with the attributes listed in <emu-xref href="#table-accessor-property-attributes"></emu-xref>.</p>
+        <emu-table id="table-accessor-property-attributes" caption="Attributes of an Accessor Property" oldids="table-3">
           <table>
             <tbody>
             <tr>
@@ -2247,7 +2247,7 @@
                 Object | Undefined
               </td>
               <td>
-                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-6"></emu-xref>) is called with an empty arguments list to retrieve the property value each time a get access of the property is performed.
+                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an empty arguments list to retrieve the property value each time a get access of the property is performed.
               </td>
             </tr>
             <tr>
@@ -2258,7 +2258,7 @@
                 Object | Undefined
               </td>
               <td>
-                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-6"></emu-xref>) is called with an arguments list containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
+                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an arguments list containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
               </td>
             </tr>
             <tr>
@@ -2357,11 +2357,11 @@
         <p>Internal method names are polymorphic. This means that different object values may perform different algorithms when a common internal method name is invoked upon them. That actual object upon which an internal method is invoked is the &ldquo;target&rdquo; of the invocation. If, at runtime, the implementation of an algorithm attempts to use an internal method of an object that the object does not support, a *TypeError* exception is thrown.</p>
         <p>Internal slots correspond to internal state that is associated with objects and used by various ECMAScript specification algorithms. Internal slots are not object properties and they are not inherited. Depending upon the specific internal slot specification, such state may consist of values of any ECMAScript language type or of specific ECMAScript specification type values. Unless explicitly specified otherwise, internal slots are allocated as part of the process of creating an object and may not be dynamically added to an object. Unless specified otherwise, the initial value of an internal slot is the value *undefined*. Various algorithms within this specification create objects that have internal slots. However, the ECMAScript language provides no direct way to associate internal slots with an object.</p>
         <p>Internal methods and internal slots are identified within this specification using names enclosed in double square brackets [[ ]].</p>
-        <p><emu-xref href="#table-5"></emu-xref> summarizes the <em>essential internal methods</em> used by this specification that are applicable to all objects created or manipulated by ECMAScript code. Every object must have algorithms for all of the essential internal methods. However, all objects do not necessarily use the same algorithms for those methods.</p>
+        <p><emu-xref href="#table-essential-internal-methods"></emu-xref> summarizes the <em>essential internal methods</em> used by this specification that are applicable to all objects created or manipulated by ECMAScript code. Every object must have algorithms for all of the essential internal methods. However, all objects do not necessarily use the same algorithms for those methods.</p>
         <p>An <dfn id="ordinary-object">ordinary object</dfn> is an object that satisfies all of the following criteria:</p>
         <ul>
           <li>
-            For the internal methods listed in <emu-xref href="#table-5"></emu-xref>, the object uses those defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
+            For the internal methods listed in <emu-xref href="#table-essential-internal-methods"></emu-xref>, the object uses those defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
           </li>
           <li>
             If the object has a [[Call]] internal method, it uses the one defined in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
@@ -2372,10 +2372,10 @@
         </ul>
         <p>An <dfn id="exotic-object">exotic object</dfn> is an object that is not an ordinary object.</p>
         <p>This specification recognizes different kinds of exotic objects by those objects' internal methods. An object that is behaviourally equivalent to a particular kind of exotic object (such as an Array exotic object or a bound function exotic object), but does not have the same collection of internal methods specified for that kind, is not recognized as that kind of exotic object.</p>
-        <p>The &ldquo;Signature&rdquo; column of <emu-xref href="#table-5"></emu-xref> and other similar tables describes the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names. If a parameter name is the same as an ECMAScript type name then the name describes the required type of the parameter value. If an internal method explicitly returns a value, its parameter list is followed by the symbol &ldquo;&rarr;&rdquo; and the type name of the returned value. The type names used in signatures refer to the types defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> augmented by the following additional names. &ldquo;<em>any</em>&rdquo; means the value may be any ECMAScript language type.</p>
+        <p>The &ldquo;Signature&rdquo; column of <emu-xref href="#table-essential-internal-methods"></emu-xref> and other similar tables describes the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names. If a parameter name is the same as an ECMAScript type name then the name describes the required type of the parameter value. If an internal method explicitly returns a value, its parameter list is followed by the symbol &ldquo;&rarr;&rdquo; and the type name of the returned value. The type names used in signatures refer to the types defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> augmented by the following additional names. &ldquo;<em>any</em>&rdquo; means the value may be any ECMAScript language type.</p>
         <p>In addition to its parameters, an internal method always has access to the object that is the target of the method invocation.</p>
         <p>An internal method implicitly returns a Completion Record, either a normal completion that wraps a value of the return type shown in its invocation pattern, or a throw completion.</p>
-        <emu-table id="table-5" caption="Essential Internal Methods">
+        <emu-table id="table-essential-internal-methods" caption="Essential Internal Methods" oldids="table-5">
           <table>
             <tbody>
             <tr>
@@ -2513,8 +2513,8 @@
             </tbody>
           </table>
         </emu-table>
-        <p><emu-xref href="#table-6"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.</p>
-        <emu-table id="table-6" caption="Additional Essential Internal Methods of Function Objects">
+        <p><emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.</p>
+        <emu-table id="table-additional-essential-internal-methods-of-function-objects" caption="Additional Essential Internal Methods of Function Objects" oldids="table-6">
           <table>
             <tbody>
             <tr>
@@ -2745,8 +2745,8 @@
       <emu-clause id="sec-well-known-intrinsic-objects">
         <h1>Well-Known Intrinsic Objects</h1>
         <p>Well-known intrinsics are built-in objects that are explicitly referenced by the algorithms of this specification and which usually have realm-specific identities. Unless otherwise specified each intrinsic object actually corresponds to a set of similar objects, one per realm.</p>
-        <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. A reference such as %name.a.b% means, as if the "b" property of the "a" property of the intrinsic object %name% was accessed prior to any ECMAScript code being evaluated. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-7"></emu-xref>.</p>
-        <emu-table id="table-7" caption="Well-Known Intrinsic Objects">
+        <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. A reference such as %name.a.b% means, as if the "b" property of the "a" property of the intrinsic object %name% was accessed prior to any ECMAScript code being evaluated. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>.</p>
+        <emu-table id="table-well-known-intrinsic-objects" caption="Well-Known Intrinsic Objects" oldids="table-7">
           <table>
             <tbody>
             <tr>
@@ -3541,8 +3541,8 @@
     <emu-clause id="sec-completion-record-specification-type" aoid="Completion">
       <h1>The Completion Record Specification Type</h1>
       <p>The Completion type is a Record used to explain the runtime propagation of values and control flow such as the behaviour of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
-      <p>Values of the Completion type are Record values whose fields are defined as by <emu-xref href="#table-8"></emu-xref>. Such values are referred to as <dfn>Completion Record</dfn>s.</p>
-      <emu-table id="table-8" caption="Completion Record Fields">
+      <p>Values of the Completion type are Record values whose fields are defined as by <emu-xref href="#table-completion-record-fields"></emu-xref>. Such values are referred to as <dfn>Completion Record</dfn>s.</p>
+      <emu-table id="table-completion-record-fields" caption="Completion Record Fields" oldids="table-8">
         <table>
           <tbody>
           <tr>
@@ -3864,7 +3864,7 @@
     <emu-clause id="sec-property-descriptor-specification-type">
       <h1>The Property Descriptor Specification Type</h1>
       <p>The <dfn>Property Descriptor</dfn> type is used to explain the manipulation and reification of Object property attributes. Values of the Property Descriptor type are Records. Each field's name is an attribute name and its value is a corresponding attribute value as specified in <emu-xref href="#sec-property-attributes"></emu-xref>. In addition, any field may be present or absent. The schema name used within this specification to tag literal descriptions of Property Descriptor records is &ldquo;PropertyDescriptor&rdquo;.</p>
-      <p>Property Descriptor values may be further classified as data Property Descriptors and accessor Property Descriptors based upon the existence or use of certain fields. A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]]. An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]]. Any Property Descriptor may have fields named [[Enumerable]] and [[Configurable]]. A Property Descriptor value may not be both a data Property Descriptor and an accessor Property Descriptor; however, it may be neither. A generic Property Descriptor is a Property Descriptor value that is neither a data Property Descriptor nor an accessor Property Descriptor. A fully populated Property Descriptor is one that is either an accessor Property Descriptor or a data Property Descriptor and that has all of the fields that correspond to the property attributes defined in either <emu-xref href="#table-2"></emu-xref> or <emu-xref href="#table-3"></emu-xref>.</p>
+      <p>Property Descriptor values may be further classified as data Property Descriptors and accessor Property Descriptors based upon the existence or use of certain fields. A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]]. An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]]. Any Property Descriptor may have fields named [[Enumerable]] and [[Configurable]]. A Property Descriptor value may not be both a data Property Descriptor and an accessor Property Descriptor; however, it may be neither. A generic Property Descriptor is a Property Descriptor value that is neither a data Property Descriptor nor an accessor Property Descriptor. A fully populated Property Descriptor is one that is either an accessor Property Descriptor or a data Property Descriptor and that has all of the fields that correspond to the property attributes defined in either <emu-xref href="#table-data-property-attributes"></emu-xref> or <emu-xref href="#table-accessor-property-attributes"></emu-xref>.</p>
       <p>The following abstract operations are used in this specification to operate upon Property Descriptor values:</p>
 
       <emu-clause id="sec-isaccessordescriptor" aoid="IsAccessorDescriptor">
@@ -4123,8 +4123,8 @@
 
     <emu-clause id="sec-toboolean" aoid="ToBoolean">
       <h1>ToBoolean ( _argument_ )</h1>
-      <p>The abstract operation ToBoolean takes argument _argument_. It converts _argument_ to a value of type Boolean according to <emu-xref href="#table-10"></emu-xref>:</p>
-      <emu-table id="table-10" caption="ToBoolean Conversions">
+      <p>The abstract operation ToBoolean takes argument _argument_. It converts _argument_ to a value of type Boolean according to <emu-xref href="#table-toboolean-conversions"></emu-xref>:</p>
+      <emu-table id="table-toboolean-conversions" caption="ToBoolean Conversions" oldids="table-10">
         <table>
           <tbody>
           <tr>
@@ -4216,8 +4216,8 @@
 
     <emu-clause id="sec-tonumber" aoid="ToNumber">
       <h1>ToNumber ( _argument_ )</h1>
-      <p>The abstract operation ToNumber takes argument _argument_. It converts _argument_ to a value of type Number according to <emu-xref href="#table-11"></emu-xref>:</p>
-      <emu-table id="table-11" caption="ToNumber Conversions">
+      <p>The abstract operation ToNumber takes argument _argument_. It converts _argument_ to a value of type Number according to <emu-xref href="#table-tonumber-conversions"></emu-xref>:</p>
+      <emu-table id="table-tonumber-conversions" caption="ToNumber Conversions" oldids="table-11">
         <table>
           <tbody>
           <tr>
@@ -4670,8 +4670,8 @@
 
     <emu-clause id="sec-tostring" aoid="ToString">
       <h1>ToString ( _argument_ )</h1>
-      <p>The abstract operation ToString takes argument _argument_. It converts _argument_ to a value of type String according to <emu-xref href="#table-12"></emu-xref>:</p>
-      <emu-table id="table-12" caption="ToString Conversions">
+      <p>The abstract operation ToString takes argument _argument_. It converts _argument_ to a value of type String according to <emu-xref href="#table-tostring-conversions"></emu-xref>:</p>
+      <emu-table id="table-tostring-conversions" caption="ToString Conversions" oldids="table-12">
         <table>
           <tbody>
           <tr>
@@ -4758,8 +4758,8 @@
 
     <emu-clause id="sec-toobject" aoid="ToObject">
       <h1>ToObject ( _argument_ )</h1>
-      <p>The abstract operation ToObject takes argument _argument_. It converts _argument_ to a value of type Object according to <emu-xref href="#table-13"></emu-xref>:</p>
-      <emu-table id="table-13" caption="ToObject Conversions">
+      <p>The abstract operation ToObject takes argument _argument_. It converts _argument_ to a value of type Object according to <emu-xref href="#table-toobject-conversions"></emu-xref>:</p>
+      <emu-table id="table-toobject-conversions" caption="ToObject Conversions" oldids="table-13">
         <table>
           <tbody>
           <tr>
@@ -4894,8 +4894,8 @@
 
     <emu-clause id="sec-requireobjectcoercible" aoid="RequireObjectCoercible">
       <h1>RequireObjectCoercible ( _argument_ )</h1>
-      <p>The abstract operation RequireObjectCoercible takes argument _argument_. It throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-14"></emu-xref>:</p>
-      <emu-table id="table-14" caption="RequireObjectCoercible Results">
+      <p>The abstract operation RequireObjectCoercible takes argument _argument_. It throws an error if _argument_ is a value that cannot be converted to an Object using ToObject. It is defined by <emu-xref href="#table-requireobjectcoercible-results"></emu-xref>:</p>
+      <emu-table id="table-requireobjectcoercible-results" caption="RequireObjectCoercible Results" oldids="table-14">
         <table>
           <tbody>
           <tr>
@@ -5808,8 +5808,8 @@
         </li>
       </ul>
 
-      <p>The Environment Record abstract class includes the abstract specification methods defined in <emu-xref href="#table-15"></emu-xref>. These abstract methods have distinct concrete algorithms for each of the concrete subclasses.</p>
-      <emu-table id="table-15" caption="Abstract Methods of Environment Records">
+      <p>The Environment Record abstract class includes the abstract specification methods defined in <emu-xref href="#table-abstract-methods-of-environment-records"></emu-xref>. These abstract methods have distinct concrete algorithms for each of the concrete subclasses.</p>
+      <emu-table id="table-abstract-methods-of-environment-records" caption="Abstract Methods of Environment Records" oldids="table-15">
         <table>
           <tbody>
           <tr>
@@ -6143,8 +6143,8 @@
       <emu-clause id="sec-function-environment-records" oldids="function-environment">
         <h1>Function Environment Records</h1>
         <p>A <dfn>function Environment Record</dfn> is a declarative Environment Record that is used to represent the top-level scope of a function and, if the function is not an |ArrowFunction|, provides a `this` binding. If a function is not an |ArrowFunction| function and references `super`, its function Environment Record also contains the state that is used to perform `super` method invocations from within the function.</p>
-        <p>Function Environment Records have the additional state fields listed in <emu-xref href="#table-16"></emu-xref>.</p>
-        <emu-table id="table-16" caption="Additional Fields of Function Environment Records">
+        <p>Function Environment Records have the additional state fields listed in <emu-xref href="#table-additional-fields-of-function-environment-records"></emu-xref>.</p>
+        <emu-table id="table-additional-fields-of-function-environment-records" caption="Additional Fields of Function Environment Records" oldids="table-16">
           <table>
             <tbody>
             <tr>
@@ -6216,8 +6216,8 @@
             </tbody>
           </table>
         </emu-table>
-        <p>Function Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and share the same specifications for all of those methods except for HasThisBinding and HasSuperBinding. In addition, function Environment Records support the methods listed in <emu-xref href="#table-17"></emu-xref>:</p>
-        <emu-table id="table-17" caption="Additional Methods of Function Environment Records">
+        <p>Function Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-abstract-methods-of-environment-records"></emu-xref> and share the same specifications for all of those methods except for HasThisBinding and HasSuperBinding. In addition, function Environment Records support the methods listed in <emu-xref href="#table-additional-methods-of-function-environment-records"></emu-xref>:</p>
+        <emu-table id="table-additional-methods-of-function-environment-records" caption="Additional Methods of Function Environment Records" oldids="table-17">
           <table>
             <tbody>
             <tr>
@@ -6313,8 +6313,8 @@
         <p>A <dfn>global Environment Record</dfn> is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm. A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-block-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-block-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
         <p>A global Environment Record is logically a single record but it is specified as a composite encapsulating an object Environment Record and a declarative Environment Record. The object Environment Record has as its base object the global object of the associated Realm Record. This global object is the value returned by the global Environment Record's GetThisBinding concrete method. The object Environment Record component of a global Environment Record contains the bindings for all built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>) and all bindings introduced by a |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, or |VariableStatement| contained in global code. The bindings for all other ECMAScript declarations in global code are contained in the declarative Environment Record component of the global Environment Record.</p>
         <p>Properties may be created directly on a global object. Hence, the object Environment Record component of a global Environment Record may contain both bindings created explicitly by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, or |VariableDeclaration| declarations and bindings created implicitly as properties of the global object. In order to identify which bindings were explicitly created using declarations, a global Environment Record maintains a list of the names bound using its CreateGlobalVarBinding and CreateGlobalFunctionBinding concrete methods.</p>
-        <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-18"></emu-xref> and the additional methods listed in <emu-xref href="#table-19"></emu-xref>.</p>
-        <emu-table id="table-18" caption="Additional Fields of Global Environment Records">
+        <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-additional-fields-of-global-environment-records"></emu-xref> and the additional methods listed in <emu-xref href="#table-additional-methods-of-global-environment-records"></emu-xref>.</p>
+        <emu-table id="table-additional-fields-of-global-environment-records" caption="Additional Fields of Global Environment Records" oldids="table-18">
           <table>
             <tbody>
             <tr>
@@ -6375,7 +6375,7 @@
             </tbody>
           </table>
         </emu-table>
-        <emu-table id="table-19" caption="Additional Methods of Global Environment Records">
+        <emu-table id="table-additional-methods-of-global-environment-records" caption="Additional Methods of Global Environment Records" oldids="table-19">
           <table>
             <tbody>
             <tr>
@@ -6693,8 +6693,8 @@
       <emu-clause id="sec-module-environment-records" oldids="module-environment">
         <h1>Module Environment Records</h1>
         <p>A <dfn>module Environment Record</dfn> is a declarative Environment Record that is used to represent the outer scope of an ECMAScript |Module|. In additional to normal mutable and immutable bindings, module Environment Records also provide immutable import bindings which are bindings that provide indirect access to a target binding that exists in another Environment Record.</p>
-        <p>Module Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-15"></emu-xref> and share the same specifications for all of those methods except for GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding. In addition, module Environment Records support the methods listed in <emu-xref href="#table-20"></emu-xref>:</p>
-        <emu-table id="table-20" caption="Additional Methods of Module Environment Records">
+        <p>Module Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-abstract-methods-of-environment-records"></emu-xref> and share the same specifications for all of those methods except for GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding. In addition, module Environment Records support the methods listed in <emu-xref href="#table-additional-methods-of-module-environment-records"></emu-xref>:</p>
+        <emu-table id="table-additional-methods-of-module-environment-records" caption="Additional Methods of Module Environment Records" oldids="table-20">
           <table>
             <tbody>
             <tr>
@@ -6875,8 +6875,8 @@
   <emu-clause id="sec-code-realms">
     <h1>Realms</h1>
     <p>Before it is evaluated, all ECMAScript code must be associated with a <dfn id="realm">realm</dfn>. Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript global environment, all of the ECMAScript code that is loaded within the scope of that global environment, and other associated state and resources.</p>
-    <p>A realm is represented in this specification as a <dfn id="realm-record">Realm Record</dfn> with the fields specified in <emu-xref href="#table-21"></emu-xref>:</p>
-    <emu-table id="table-21" caption="Realm Record Fields">
+    <p>A realm is represented in this specification as a <dfn id="realm-record">Realm Record</dfn> with the fields specified in <emu-xref href="#table-realm-record-fields"></emu-xref>:</p>
+    <emu-table id="table-realm-record-fields" caption="Realm Record Fields" oldids="table-21">
       <table>
         <tbody>
         <tr>
@@ -6969,7 +6969,7 @@
       <emu-alg>
         1. Let _intrinsics_ be a new Record.
         1. Set _realmRec_.[[Intrinsics]] to _intrinsics_.
-        1. Set fields of _intrinsics_ with the values listed in <emu-xref href="#table-7"></emu-xref>. The field names are the names listed in column one of the table. The value of each field is a new object value fully and recursively populated with property values as defined by the specification of each object in clauses <emu-xref href="#sec-global-object"></emu-xref> through <emu-xref href="#sec-reflection"></emu-xref>. All object property values are newly created object values. All values that are built-in function objects are created by performing CreateBuiltinFunction(_steps_, _slots_, _realmRec_, _prototype_) where _steps_ is the definition of that function provided by this specification, _slots_ is a list of the names, if any, of the function's specified internal slots, and _prototype_ is the specified value of the function's [[Prototype]] internal slot. The creation of the intrinsics and their properties must be ordered to avoid any dependencies upon objects that have not yet been created.
+        1. Set fields of _intrinsics_ with the values listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>. The field names are the names listed in column one of the table. The value of each field is a new object value fully and recursively populated with property values as defined by the specification of each object in clauses <emu-xref href="#sec-global-object"></emu-xref> through <emu-xref href="#sec-reflection"></emu-xref>. All object property values are newly created object values. All values that are built-in function objects are created by performing CreateBuiltinFunction(_steps_, _slots_, _realmRec_, _prototype_) where _steps_ is the definition of that function provided by this specification, _slots_ is a list of the names, if any, of the function's specified internal slots, and _prototype_ is the specified value of the function's [[Prototype]] internal slot. The creation of the intrinsics and their properties must be ordered to avoid any dependencies upon objects that have not yet been created.
         1. Perform AddRestrictedFunctionProperties(_intrinsics_.[[%Function.prototype%]], _realmRec_).
         1. Return _intrinsics_.
       </emu-alg>
@@ -7009,8 +7009,8 @@
     <h1>Execution Contexts</h1>
     <p>An <dfn>execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
     <p>The <dfn id="execution-context-stack">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
-    <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-22"></emu-xref>.</p>
-    <emu-table id="table-22" caption="State Components for All Execution Contexts">
+    <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
         <tbody>
         <tr>
@@ -7058,8 +7058,8 @@
     </emu-table>
     <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
     <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
-    <p>Execution contexts for ECMAScript code have the additional state components listed in <emu-xref href="#table-23"></emu-xref>.</p>
-    <emu-table id="table-23" caption="Additional State Components for ECMAScript Code Execution Contexts">
+    <p>Execution contexts for ECMAScript code have the additional state components listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional State Components for ECMAScript Code Execution Contexts" oldids="table-23">
       <table>
         <tbody>
         <tr>
@@ -7090,8 +7090,8 @@
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
-    <p>Execution contexts representing the evaluation of generator objects have the additional state components listed in <emu-xref href="#table-24"></emu-xref>.</p>
-    <emu-table id="table-24" caption="Additional State Components for Generator Execution Contexts">
+    <p>Execution contexts representing the evaluation of generator objects have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
       <table>
         <tbody>
         <tr>
@@ -8061,8 +8061,8 @@
   <emu-clause id="sec-ecmascript-function-objects">
     <h1>ECMAScript Function Objects</h1>
     <p>ECMAScript function objects encapsulate parameterized ECMAScript code closed over a lexical environment and support the dynamic evaluation of that code. An ECMAScript function object is an ordinary object and has the same internal slots and the same internal methods as other ordinary objects. The code of an ECMAScript function object may be either strict mode code (<emu-xref href="#sec-strict-mode-code"></emu-xref>) or non-strict code. An ECMAScript function object whose code is strict mode code is called a <dfn id="strict-function">strict function</dfn>. One whose code is not strict mode code is called a <dfn id="non-strict-function">non-strict function</dfn>.</p>
-    <p>In addition to [[Extensible]] and [[Prototype]], ECMAScript function objects also have the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</p>
-    <emu-table id="table-27" caption="Internal Slots of ECMAScript Function Objects">
+    <p>In addition to [[Extensible]] and [[Prototype]], ECMAScript function objects also have the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>.</p>
+    <emu-table id="table-internal-slots-of-ecmascript-function-objects" caption="Internal Slots of ECMAScript Function Objects" oldids="table-27">
       <table>
         <tbody>
         <tr>
@@ -8305,7 +8305,7 @@
       <p>The abstract operation OrdinaryFunctionCreate takes arguments _functionPrototype_ (an Object), _sourceText_ (a sequence of Unicode code points), _ParameterList_ (a Parse Node), _Body_ (a Parse Node), _thisMode_ (either ~lexical-this~ or ~non-lexical-this~), and _Scope_ (an Environment Record). _sourceText_ is the source text of the syntactic definition of the function to be created. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_functionPrototype_) is Object.
-        1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-27"></emu-xref>.
+        1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>.
         1. Let _F_ be ! OrdinaryObjectCreate(_functionPrototype_, _internalSlotsList_).
         1. Set _F_.[[Call]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
         1. Set _F_.[[SourceText]] to _sourceText_.
@@ -8621,8 +8621,8 @@
 
       <p>An object is a <dfn id="bound-function-exotic-object">bound function exotic object</dfn> if its [[Call]] and (if applicable) [[Construct]] internal methods use the following implementations, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in BoundFunctionCreate.</p>
 
-      <p>Bound function exotic objects do not have the internal slots of ECMAScript function objects listed in <emu-xref href="#table-27"></emu-xref>. Instead they have the internal slots listed in <emu-xref href="#table-28"></emu-xref>, in addition to [[Prototype]] and [[Extensible]].</p>
-      <emu-table id="table-28" caption="Internal Slots of Bound Function Exotic Objects">
+      <p>Bound function exotic objects do not have the internal slots of ECMAScript function objects listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. Instead they have the internal slots listed in <emu-xref href="#table-internal-slots-of-bound-function-exotic-objects"></emu-xref>, in addition to [[Prototype]] and [[Extensible]].</p>
+      <emu-table id="table-internal-slots-of-bound-function-exotic-objects" caption="Internal Slots of Bound Function Exotic Objects" oldids="table-28">
         <table>
           <tbody>
           <tr>
@@ -8704,7 +8704,7 @@
         <emu-alg>
           1. Assert: Type(_targetFunction_) is Object.
           1. Let _proto_ be ? _targetFunction_.[[GetPrototypeOf]]().
-          1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-28"></emu-xref>, plus [[Prototype]] and [[Extensible]].
+          1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-internal-slots-of-bound-function-exotic-objects"></emu-xref>, plus [[Prototype]] and [[Extensible]].
           1. Let _obj_ be ! MakeBasicObject(_internalSlotsList_).
           1. Set _obj_.[[Prototype]] to _proto_.
           1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-bound-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
@@ -9324,8 +9324,8 @@
       <h1>Module Namespace Exotic Objects</h1>
       <p>A module namespace exotic object is an exotic object that exposes the bindings exported from an ECMAScript |Module| (See <emu-xref href="#sec-exports"></emu-xref>). There is a one-to-one correspondence between the String-keyed own properties of a module namespace exotic object and the binding names exported by the |Module|. The exported bindings include any bindings that are indirectly exported using `export *` export items. Each String-valued own property key is the StringValue of the corresponding exported binding name. These are the only String-keyed properties of a module namespace exotic object. Each such property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }. Module namespace exotic objects are not extensible.</p>
       <p>An object is a <dfn id="module-namespace-exotic-object">module namespace exotic object</dfn> if its [[SetPrototypeOf]], [[IsExtensible]], [[PreventExtensions]], [[GetOwnProperty]], [[DefineOwnProperty]], [[HasProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by ModuleNamespaceCreate.</p>
-      <p>Module namespace exotic objects have the internal slots defined in <emu-xref href="#table-29"></emu-xref>.</p>
-      <emu-table id="table-29" caption="Internal Slots of Module Namespace Exotic Objects">
+      <p>Module namespace exotic objects have the internal slots defined in <emu-xref href="#table-internal-slots-of-module-namespace-exotic-objects"></emu-xref>.</p>
+      <emu-table id="table-internal-slots-of-module-namespace-exotic-objects" caption="Internal Slots of Module Namespace Exotic Objects" oldids="table-29">
         <table>
           <tbody>
           <tr>
@@ -9504,7 +9504,7 @@
           1. Assert: _module_ is a Module Record.
           1. Assert: _module_.[[Namespace]] is *undefined*.
           1. Assert: _exports_ is a List of String values.
-          1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-29"></emu-xref>.
+          1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-internal-slots-of-module-namespace-exotic-objects"></emu-xref>.
           1. Let _M_ be ! MakeBasicObject(_internalSlotsList_).
           1. Set _M_'s essential internal methods to the definitions specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref>.
           1. Set _M_.[[Prototype]] to *null*.
@@ -9551,11 +9551,11 @@
 
   <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots">
     <h1>Proxy Object Internal Methods and Internal Slots</h1>
-    <p>A proxy object is an exotic object whose essential internal methods are partially implemented using ECMAScript code. Every proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's <em>handler object</em>, or *null*. Methods (see <emu-xref href="#table-30"></emu-xref>) of a handler object may be used to augment the implementation for one or more of the proxy object's internal methods. Every proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the *null* value. This object is called the proxy's <em>target object</em>.</p>
+    <p>A proxy object is an exotic object whose essential internal methods are partially implemented using ECMAScript code. Every proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's <em>handler object</em>, or *null*. Methods (see <emu-xref href="#table-proxy-handler-methods"></emu-xref>) of a handler object may be used to augment the implementation for one or more of the proxy object's internal methods. Every proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the *null* value. This object is called the proxy's <em>target object</em>.</p>
 
     <p>An object is a <dfn id="proxy-exotic-object">Proxy exotic object</dfn> if its essential internal methods (including [[Call]] and [[Construct]], if applicable) use the definitions in this section. These internal methods are installed in ProxyCreate.</p>
 
-    <emu-table id="table-30" caption="Proxy Handler Methods">
+    <emu-table id="table-proxy-handler-methods" caption="Proxy Handler Methods" oldids="table-30">
       <table>
         <tbody>
         <tr>
@@ -10395,8 +10395,8 @@
     <p>It is useful to allow format-control characters in source text to facilitate editing and display. All format control characters may be used within comments, and within string literals, template literals, and regular expression literals.</p>
     <p>U+200C (ZERO WIDTH NON-JOINER) and U+200D (ZERO WIDTH JOINER) are format-control characters that are used to make necessary distinctions when forming words or phrases in certain languages. In ECMAScript source text these code points may also be used in an |IdentifierName| after the first character.</p>
     <p>U+FEFF (ZERO WIDTH NO-BREAK SPACE) is a format-control character used primarily at the start of a text to mark it as Unicode and to allow detection of the text's encoding and byte order. &lt;ZWNBSP&gt; characters intended for this purpose can sometimes also appear after the start of a text, for example as a result of concatenating files. In ECMAScript source text &lt;ZWNBSP&gt; code points are treated as white space characters (see <emu-xref href="#sec-white-space"></emu-xref>).</p>
-    <p>The special treatment of certain format-control characters outside of comments, string literals, and regular expression literals is summarized in <emu-xref href="#table-31"></emu-xref>.</p>
-    <emu-table id="table-31" caption="Format-Control Code Point Usage">
+    <p>The special treatment of certain format-control characters outside of comments, string literals, and regular expression literals is summarized in <emu-xref href="#table-format-control-code-point-usage"></emu-xref>.</p>
+    <emu-table id="table-format-control-code-point-usage" caption="Format-Control Code Point Usage" oldids="table-31">
       <table>
         <tbody>
         <tr>
@@ -10463,8 +10463,8 @@
   <emu-clause id="sec-white-space">
     <h1>White Space</h1>
     <p>White space code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other, but are otherwise insignificant. White space code points may occur between any two tokens and at the start or end of input. White space code points may occur within a |StringLiteral|, a |RegularExpressionLiteral|, a |Template|, or a |TemplateSubstitutionTail| where they are considered significant code points forming part of a literal value. They may also occur within a |Comment|, but cannot appear within any other kind of token.</p>
-    <p>The ECMAScript white space code points are listed in <emu-xref href="#table-32"></emu-xref>.</p>
-    <emu-table id="table-32" caption="White Space Code Points">
+    <p>The ECMAScript white space code points are listed in <emu-xref href="#table-white-space-code-points"></emu-xref>.</p>
+    <emu-table id="table-white-space-code-points" caption="White Space Code Points" oldids="table-32">
       <table>
         <tbody>
         <tr>
@@ -10560,7 +10560,7 @@
     </emu-table>
     <p>ECMAScript implementations must recognize as |WhiteSpace| code points listed in the &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;) category.</p>
     <emu-note>
-      <p>Other than for the code points listed in <emu-xref href="#table-32"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
+      <p>Other than for the code points listed in <emu-xref href="#table-white-space-code-points"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
     </emu-note>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
@@ -10580,8 +10580,8 @@
     <p>Like white space code points, line terminator code points are used to improve source text readability and to separate tokens (indivisible lexical units) from each other. However, unlike white space code points, line terminators have some influence over the behaviour of the syntactic grammar. In general, line terminators may occur between any two tokens, but there are a few places where they are forbidden by the syntactic grammar. Line terminators also affect the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A line terminator cannot occur within any token except a |StringLiteral|, |Template|, or |TemplateSubstitutionTail|. &lt;LF&gt; and &lt;CR&gt; line terminators cannot occur within a |StringLiteral| token except as part of a |LineContinuation|.</p>
     <p>A line terminator can occur within a |MultiLineComment| but cannot occur within a |SingleLineComment|.</p>
     <p>Line terminators are included in the set of white space code points that are matched by the `\\s` class in regular expressions.</p>
-    <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-33"></emu-xref>.</p>
-    <emu-table id="table-33" caption="Line Terminator Code Points">
+    <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-line-terminator-code-points"></emu-xref>.</p>
+    <emu-table id="table-line-terminator-code-points" caption="Line Terminator Code Points" oldids="table-33">
       <table>
         <tbody>
         <tr>
@@ -10642,7 +10642,7 @@
         </tbody>
       </table>
     </emu-table>
-    <p>Only the Unicode code points in <emu-xref href="#table-33"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-32"></emu-xref>. The sequence &lt;CR&gt;&lt;LF&gt; is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
+    <p>Only the Unicode code points in <emu-xref href="#table-line-terminator-code-points"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-white-space-code-points"></emu-xref>. The sequence &lt;CR&gt;&lt;LF&gt; is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       LineTerminator ::
@@ -11329,10 +11329,10 @@
             The SV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the code unit 0x0000 (NULL).
           </li>
           <li>
-            The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-34"></emu-xref>.
+            The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-string-single-character-escape-sequences"></emu-xref>.
           </li>
         </ul>
-        <emu-table id="table-34" caption="String Single Character Escape Sequences">
+        <emu-table id="table-string-single-character-escape-sequences" caption="String Single Character Escape Sequences" oldids="table-34">
           <table>
             <tbody>
             <tr>
@@ -14196,9 +14196,9 @@
           1. If Type(_val_) is Reference, then
             1. If IsUnresolvableReference(_val_) is *true*, return *"undefined"*.
           1. Set _val_ to ? GetValue(_val_).
-          1. Return a String according to <emu-xref href="#table-35"></emu-xref>.
+          1. Return a String according to <emu-xref href="#table-typeof-operator-results"></emu-xref>.
         </emu-alg>
-        <emu-table id="table-35" caption="typeof Operator Results">
+        <emu-table id="table-typeof-operator-results" caption="typeof Operator Results" oldids="table-35">
           <table>
             <tbody>
             <tr>
@@ -22656,7 +22656,7 @@
 
       <emu-clause id="sec-importedlocalnames" aoid="ImportedLocalNames">
         <h1>Static Semantics: ImportedLocalNames ( _importEntries_ )</h1>
-        <p>The abstract operation ImportedLocalNames takes argument _importEntries_ (a List of ImportEntry Records (see <emu-xref href="#table-39"></emu-xref>)). It creates a List of all of the local name bindings defined by _importEntries_. It performs the following steps when called:</p>
+        <p>The abstract operation ImportedLocalNames takes argument _importEntries_ (a List of ImportEntry Records (see <emu-xref href="#table-importentry-record-fields"></emu-xref>)). It creates a List of all of the local name bindings defined by _importEntries_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _localNames_ be a new empty List.
           1. For each ImportEntry Record _i_ of _importEntries_, do
@@ -22790,8 +22790,8 @@
         <h1>Abstract Module Records</h1>
         <p>A <dfn>Module Record</dfn> encapsulates structural information about the imports and exports of a single module. This information is used to link the imports and exports of sets of connected modules. A Module Record includes four fields that are only used when evaluating a module.</p>
         <p>For specification purposes Module Record values are values of the Record specification type and can be thought of as existing in a simple object-oriented hierarchy where Module Record is an abstract class with both abstract and concrete subclasses. This specification defines the abstract subclass named Cyclic Module Record and its concrete subclass named Source Text Module Record. Other specifications and implementations may define additional Module Record subclasses corresponding to alternative module definition facilities that they defined.</p>
-        <p>Module Record defines the fields listed in <emu-xref href="#table-36"></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-37"></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
-        <emu-table id="table-36" caption="Module Record Fields">
+        <p>Module Record defines the fields listed in <emu-xref href="#table-module-record-fields"></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-abstract-methods-of-module-records"></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
+        <emu-table id="table-module-record-fields" caption="Module Record Fields" oldids="table-36">
           <table>
             <thead>
             <tr>
@@ -22854,7 +22854,7 @@
             </tbody>
           </table>
         </emu-table>
-        <emu-table id="table-37" caption="Abstract Methods of Module Records">
+        <emu-table id="table-abstract-methods-of-module-records" caption="Abstract Methods of Module Records" oldids="table-37">
           <table>
             <tbody>
             <tr>
@@ -22907,7 +22907,7 @@
       <emu-clause id="sec-cyclic-module-records">
         <h1>Cyclic Module Records</h1>
         <p>A <dfn id="cyclic-module-record">Cyclic Module Record</dfn> is used to represent information about a module that can participate in dependency cycles with other modules that are subclasses of the Cyclic Module Record type. Module Records that are not subclasses of the Cyclic Module Record type must not participate in dependency cycles with Source Text Module Records.</p>
-        <p>In addition to the fields defined in <emu-xref href="#table-36"></emu-xref> Cyclic Module Records have the additional fields listed in <emu-xref href="#table-cyclic-module-fields"></emu-xref></p>
+        <p>In addition to the fields defined in <emu-xref href="#table-module-record-fields"></emu-xref> Cyclic Module Records have the additional fields listed in <emu-xref href="#table-cyclic-module-fields"></emu-xref></p>
         <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records">
           <table>
             <tbody>
@@ -22981,7 +22981,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p>In addition to the methods defined in <emu-xref href="#table-37"></emu-xref> Cyclic Module Records have the additional methods listed in <emu-xref href="#table-cyclic-module-methods"></emu-xref></p>
+        <p>In addition to the methods defined in <emu-xref href="#table-abstract-methods-of-module-records"></emu-xref> Cyclic Module Records have the additional methods listed in <emu-xref href="#table-cyclic-module-methods"></emu-xref></p>
         <emu-table id="table-cyclic-module-methods" caption="Additional Abstract Methods of Cyclic Module Records">
           <table>
             <tbody>
@@ -23196,8 +23196,8 @@
 
         <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type, and can participate in cycles with other subclasses of the Cyclic Module Record type.</p>
 
-        <p>In addition to the fields defined in <emu-xref href="#table-cyclic-module-fields"></emu-xref>, Source Text Module Records have the additional fields listed in <emu-xref href="#table-38"></emu-xref>. Each of these fields is initially set in ParseModule.</p>
-        <emu-table id="table-38" caption="Additional Fields of Source Text Module Records">
+        <p>In addition to the fields defined in <emu-xref href="#table-cyclic-module-fields"></emu-xref>, Source Text Module Records have the additional fields listed in <emu-xref href="#table-additional-fields-of-source-text-module-records"></emu-xref>. Each of these fields is initially set in ParseModule.</p>
+        <emu-table id="table-additional-fields-of-source-text-module-records" caption="Additional Fields of Source Text Module Records" oldids="table-38">
           <table>
             <tbody>
             <tr>
@@ -23291,8 +23291,8 @@
             </tbody>
           </table>
         </emu-table>
-        <p>An <dfn id="importentry-record">ImportEntry Record</dfn> is a Record that digests information about a single declarative import. Each ImportEntry Record has the fields defined in <emu-xref href="#table-39"></emu-xref>:</p>
-        <emu-table id="table-39" caption="ImportEntry Record Fields">
+        <p>An <dfn id="importentry-record">ImportEntry Record</dfn> is a Record that digests information about a single declarative import. Each ImportEntry Record has the fields defined in <emu-xref href="#table-importentry-record-fields"></emu-xref>:</p>
+        <emu-table id="table-importentry-record-fields" caption="ImportEntry Record Fields" oldids="table-39">
           <table>
             <tbody>
             <tr>
@@ -23343,8 +23343,8 @@
           </table>
         </emu-table>
         <emu-note>
-          <p><emu-xref href="#table-40"></emu-xref> gives examples of ImportEntry records fields used to represent the syntactic import forms:</p>
-          <emu-table id="table-40" caption="Import Forms Mappings to ImportEntry Records" informative>
+          <p><emu-xref href="#table-import-forms-mapping-to-importentry-records"></emu-xref> gives examples of ImportEntry records fields used to represent the syntactic import forms:</p>
+          <emu-table id="table-import-forms-mapping-to-importentry-records" caption="Import Forms Mappings to ImportEntry Records" informative oldids="table-40">
             <table>
               <tbody>
               <tr>
@@ -23429,8 +23429,8 @@
             </table>
           </emu-table>
         </emu-note>
-        <p>An <dfn id="exportentry-record">ExportEntry Record</dfn> is a Record that digests information about a single declarative export. Each ExportEntry Record has the fields defined in <emu-xref href="#table-41"></emu-xref>:</p>
-        <emu-table id="table-41" caption="ExportEntry Record Fields">
+        <p>An <dfn id="exportentry-record">ExportEntry Record</dfn> is a Record that digests information about a single declarative export. Each ExportEntry Record has the fields defined in <emu-xref href="#table-exportentry-records"></emu-xref>:</p>
+        <emu-table id="table-exportentry-records" caption="ExportEntry Record Fields" oldids="table-41">
           <table>
             <tbody>
             <tr>
@@ -23492,8 +23492,8 @@
           </table>
         </emu-table>
         <emu-note>
-          <p><emu-xref href="#table-42"></emu-xref> gives examples of the ExportEntry record fields used to represent the syntactic export forms:</p>
-          <emu-table id="table-42" caption="Export Forms Mappings to ExportEntry Records" informative>
+          <p><emu-xref href="#table-export-forms-mapping-to-exportentry-records"></emu-xref> gives examples of the ExportEntry record fields used to represent the syntactic export forms:</p>
+          <emu-table id="table-export-forms-mapping-to-exportentry-records" caption="Export Forms Mappings to ExportEntry Records" informative oldids="table-42">
             <table>
               <tbody>
               <tr>
@@ -25123,8 +25123,8 @@
           </emu-alg>
           <emu-note>
             <p>This syntax of Uniform Resource Identifiers is based upon RFC 2396 and does not reflect the more recent RFC 3986 which replaces RFC 2396. A formal description and implementation of UTF-8 is given in RFC 3629.</p>
-            <p>In UTF-8, characters are encoded using sequences of 1 to 6 octets. The only octet of a sequence of one has the higher-order bit set to 0, the remaining 7 bits being used to encode the character value. In a sequence of n octets, n &gt; 1, the initial octet has the n higher-order bits set to 1, followed by a bit set to 0. The remaining bits of that octet contain bits from the value of the character to be encoded. The following octets all have the higher-order bit set to 1 and the following bit set to 0, leaving 6 bits in each to contain bits from the character to be encoded. The possible UTF-8 encodings of ECMAScript characters are specified in <emu-xref href="#table-43"></emu-xref>.</p>
-            <emu-table id="table-43" caption="UTF-8 Encodings" informative>
+            <p>In UTF-8, characters are encoded using sequences of 1 to 6 octets. The only octet of a sequence of one has the higher-order bit set to 0, the remaining 7 bits being used to encode the character value. In a sequence of n octets, n &gt; 1, the initial octet has the n higher-order bits set to 1, followed by a bit set to 0. The remaining bits of that octet contain bits from the value of the character to be encoded. The following octets all have the higher-order bit set to 1 and the following bit set to 0, leaving 6 bits in each to contain bits from the character to be encoded. The possible UTF-8 encodings of ECMAScript characters are specified in <emu-xref href="#table-utf-8-encodings"></emu-xref>.</p>
+            <emu-table id="table-utf-8-encodings" caption="UTF-8 Encodings" informative oldids="table-43">
               <table>
                 <tbody>
                 <tr>
@@ -26305,7 +26305,7 @@
 
     <emu-clause id="sec-function-instances">
       <h1>Function Instances</h1>
-      <p>Every Function instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. Function objects created using the `Function.prototype.bind` method (<emu-xref href="#sec-function.prototype.bind"></emu-xref>) have the internal slots listed in <emu-xref href="#table-28"></emu-xref>.</p>
+      <p>Every Function instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. Function objects created using the `Function.prototype.bind` method (<emu-xref href="#sec-function.prototype.bind"></emu-xref>) have the internal slots listed in <emu-xref href="#table-internal-slots-of-bound-function-exotic-objects"></emu-xref>.</p>
       <p>Function instances have the following properties:</p>
 
       <emu-clause id="sec-function-instances-length">
@@ -26463,7 +26463,7 @@
 
       <emu-clause id="sec-symbol.asynciterator">
         <h1>Symbol.asyncIterator</h1>
-        <p>The initial value of `Symbol.asyncIterator` is the well known symbol @@asyncIterator (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.asyncIterator` is the well known symbol @@asyncIterator (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26479,8 +26479,8 @@
           1. Append the Record { [[Key]]: _stringKey_, [[Symbol]]: _newSymbol_ } to the GlobalSymbolRegistry List.
           1. Return _newSymbol_.
         </emu-alg>
-        <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-44"></emu-xref>.</p>
-        <emu-table id="table-44" caption="GlobalSymbolRegistry Record Fields">
+        <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-globalsymbolregistry-record-fields"></emu-xref>.</p>
+        <emu-table id="table-globalsymbolregistry-record-fields" caption="GlobalSymbolRegistry Record Fields" oldids="table-44">
           <table>
             <tbody>
             <tr>
@@ -26523,19 +26523,19 @@
 
       <emu-clause id="sec-symbol.hasinstance">
         <h1>Symbol.hasInstance</h1>
-        <p>The initial value of `Symbol.hasInstance` is the well-known symbol @@hasInstance (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.hasInstance` is the well-known symbol @@hasInstance (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.isconcatspreadable">
         <h1>Symbol.isConcatSpreadable</h1>
-        <p>The initial value of `Symbol.isConcatSpreadable` is the well-known symbol @@isConcatSpreadable (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.isConcatSpreadable` is the well-known symbol @@isConcatSpreadable (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.iterator">
         <h1>Symbol.iterator</h1>
-        <p>The initial value of `Symbol.iterator` is the well-known symbol @@iterator (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.iterator` is the well-known symbol @@iterator (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26553,13 +26553,13 @@
 
       <emu-clause id="sec-symbol.match">
         <h1>Symbol.match</h1>
-        <p>The initial value of `Symbol.match` is the well-known symbol @@match (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.match` is the well-known symbol @@match (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.matchall">
         <h1>Symbol.matchAll</h1>
-        <p>The initial value of `Symbol.matchAll` is the well-known symbol @@matchAll (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.matchAll` is the well-known symbol @@matchAll (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26571,43 +26571,43 @@
 
       <emu-clause id="sec-symbol.replace">
         <h1>Symbol.replace</h1>
-        <p>The initial value of `Symbol.replace` is the well-known symbol @@replace (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.replace` is the well-known symbol @@replace (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.search">
         <h1>Symbol.search</h1>
-        <p>The initial value of `Symbol.search` is the well-known symbol @@search (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.search` is the well-known symbol @@search (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.species">
         <h1>Symbol.species</h1>
-        <p>The initial value of `Symbol.species` is the well-known symbol @@species (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.species` is the well-known symbol @@species (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.split">
         <h1>Symbol.split</h1>
-        <p>The initial value of `Symbol.split` is the well-known symbol @@split (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.split` is the well-known symbol @@split (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.toprimitive">
         <h1>Symbol.toPrimitive</h1>
-        <p>The initial value of `Symbol.toPrimitive` is the well-known symbol @@toPrimitive (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.toPrimitive` is the well-known symbol @@toPrimitive (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.tostringtag">
         <h1>Symbol.toStringTag</h1>
-        <p>The initial value of `Symbol.toStringTag` is the well-known symbol @@toStringTag (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.toStringTag` is the well-known symbol @@toStringTag (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.unscopables">
         <h1>Symbol.unscopables</h1>
-        <p>The initial value of `Symbol.unscopables` is the well-known symbol @@unscopables (<emu-xref href="#table-1"></emu-xref>).</p>
+        <p>The initial value of `Symbol.unscopables` is the well-known symbol @@unscopables (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
@@ -30204,10 +30204,10 @@ THH:mm:ss.sss
             1. Assert: Type(_replacement_) is String.
             1. Let _tailPos_ be _position_ + _matchLength_.
             1. Let _m_ be the number of elements in _captures_.
-            1. Let _result_ be the String value derived from _replacement_ by copying code unit elements from _replacement_ to _result_ while performing replacements as specified in <emu-xref href="#table-45"></emu-xref>. These `$` replacements are done left-to-right, and, once such a replacement is performed, the new replacement text is not subject to further replacements.
+            1. Let _result_ be the String value derived from _replacement_ by copying code unit elements from _replacement_ to _result_ while performing replacements as specified in <emu-xref href="#table-replacement-text-symbol-substitutions"></emu-xref>. These `$` replacements are done left-to-right, and, once such a replacement is performed, the new replacement text is not subject to further replacements.
             1. Return _result_.
           </emu-alg>
-          <emu-table id="table-45" caption="Replacement Text Symbol Substitutions">
+          <emu-table id="table-replacement-text-symbol-substitutions" caption="Replacement Text Symbol Substitutions" oldids="table-45">
             <table>
               <tbody>
               <tr>
@@ -30743,8 +30743,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-properties-of-string-iterator-instances">
         <h1>Properties of String Iterator Instances</h1>
-        <p>String Iterator instances are ordinary objects that inherit properties from the %StringIteratorPrototype% intrinsic object. String Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-46"></emu-xref>.</p>
-        <emu-table id="table-46" caption="Internal Slots of String Iterator Instances">
+        <p>String Iterator instances are ordinary objects that inherit properties from the %StringIteratorPrototype% intrinsic object. String Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-internal-slots-of-string-iterator-instances"></emu-xref>.</p>
+        <emu-table id="table-internal-slots-of-string-iterator-instances" caption="Internal Slots of String Iterator Instances" oldids="table-46">
           <table>
             <tbody>
             <tr>
@@ -31145,9 +31145,9 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>CharacterEscape :: ControlEscape</emu-grammar>
         <emu-alg>
-          1. Return the code point value according to <emu-xref href="#table-47"></emu-xref>.
+          1. Return the code point value according to <emu-xref href="#table-controlescape-code-point-values"></emu-xref>.
         </emu-alg>
-        <emu-table id="table-47" caption="ControlEscape Code Point Values">
+        <emu-table id="table-controlescape-code-point-values" caption="ControlEscape Code Point Values" oldids="table-47">
           <table>
             <tbody>
             <tr>
@@ -34348,8 +34348,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-properties-of-array-iterator-instances">
         <h1>Properties of Array Iterator Instances</h1>
-        <p>Array Iterator instances are ordinary objects that inherit properties from the %ArrayIteratorPrototype% intrinsic object. Array Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-48"></emu-xref>.</p>
-        <emu-table id="table-48" caption="Internal Slots of Array Iterator Instances">
+        <p>Array Iterator instances are ordinary objects that inherit properties from the %ArrayIteratorPrototype% intrinsic object. Array Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-internal-slots-of-array-iterator-instances"></emu-xref>.</p>
+        <emu-table id="table-internal-slots-of-array-iterator-instances" caption="Internal Slots of Array Iterator Instances" oldids="table-48">
           <table>
             <tbody>
             <tr>
@@ -35864,8 +35864,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-properties-of-map-iterator-instances">
         <h1>Properties of Map Iterator Instances</h1>
-        <p>Map Iterator instances are ordinary objects that inherit properties from the %MapIteratorPrototype% intrinsic object. Map Iterator instances are initially created with the internal slots described in <emu-xref href="#table-50"></emu-xref>.</p>
-        <emu-table id="table-50" caption="Internal Slots of Map Iterator Instances">
+        <p>Map Iterator instances are ordinary objects that inherit properties from the %MapIteratorPrototype% intrinsic object. Map Iterator instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-map-iterator-instances"></emu-xref>.</p>
+        <emu-table id="table-internal-slots-of-map-iterator-instances" caption="Internal Slots of Map Iterator Instances" oldids="table-50">
           <table>
             <tbody>
             <tr>
@@ -36196,8 +36196,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-properties-of-set-iterator-instances">
         <h1>Properties of Set Iterator Instances</h1>
-        <p>Set Iterator instances are ordinary objects that inherit properties from the %SetIteratorPrototype% intrinsic object. Set Iterator instances are initially created with the internal slots specified in <emu-xref href="#table-51"></emu-xref>.</p>
-        <emu-table id="table-51" caption="Internal Slots of Set Iterator Instances">
+        <p>Set Iterator instances are ordinary objects that inherit properties from the %SetIteratorPrototype% intrinsic object. Set Iterator instances are initially created with the internal slots specified in <emu-xref href="#table-internal-slots-of-set-iterator-instances"></emu-xref>.</p>
+        <emu-table id="table-internal-slots-of-set-iterator-instances" caption="Internal Slots of Set Iterator Instances" oldids="table-51">
           <table>
             <tbody>
             <tr>
@@ -38535,8 +38535,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-iterable-interface">
         <h1>The <i>Iterable</i> Interface</h1>
-        <p>The <i>Iterable</i> interface includes the property described in <emu-xref href="#table-52"></emu-xref>:</p>
-        <emu-table id="table-52" caption="<i>Iterable</i> Interface Required Properties">
+        <p>The <i>Iterable</i> interface includes the property described in <emu-xref href="#table-iterable-interface-required-properties"></emu-xref>:</p>
+        <emu-table id="table-iterable-interface-required-properties" caption="<i>Iterable</i> Interface Required Properties" oldids="table-52">
           <table>
             <tbody>
             <tr>
@@ -38568,8 +38568,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-iterator-interface">
         <h1>The <i>Iterator</i> Interface</h1>
-        <p>An object that implements the <i>Iterator</i> interface must include the property in <emu-xref href="#table-53"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-54"></emu-xref>.</p>
-        <emu-table id="table-53" caption="<i>Iterator</i> Interface Required Properties">
+        <p>An object that implements the <i>Iterator</i> interface must include the property in <emu-xref href="#table-iterator-interface-required-properties"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-iterator-interface-optional-properties"></emu-xref>.</p>
+        <emu-table id="table-iterator-interface-required-properties" caption="<i>Iterator</i> Interface Required Properties" oldids="table-53">
           <table>
             <tbody>
             <tr>
@@ -38600,7 +38600,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>Arguments may be passed to the `next` function but their interpretation and validity is dependent upon the target <i>Iterator</i>. The for-of statement and other common users of <em>Iterators</em> do not pass any arguments, so <i>Iterator</i> objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
         </emu-note>
-        <emu-table id="table-54" caption="<i>Iterator</i> Interface Optional Properties">
+        <emu-table id="table-iterator-interface-optional-properties" caption="<i>Iterator</i> Interface Optional Properties" oldids="table-54">
           <table>
             <tbody>
             <tr>
@@ -38727,8 +38727,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-iteratorresult-interface">
         <h1>The <i>IteratorResult</i> Interface</h1>
-        <p>The <i>IteratorResult</i> interface includes the properties listed in <emu-xref href="#table-55"></emu-xref>:</p>
-        <emu-table id="table-55" caption="<i>IteratorResult</i> Interface Properties">
+        <p>The <i>IteratorResult</i> interface includes the properties listed in <emu-xref href="#table-iteratorresult-interface-properties"></emu-xref>:</p>
+        <emu-table id="table-iteratorresult-interface-properties" caption="<i>IteratorResult</i> Interface Properties" oldids="table-55">
           <table>
             <tbody>
             <tr>
@@ -39030,7 +39030,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%GeneratorFunction.prototype%</dfn> (see <emu-xref href="#figure-2"></emu-xref>).</li>
         <li>is an ordinary object.</li>
-        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-56"></emu-xref>.</li>
+        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref> or <emu-xref href="#table-internal-slots-of-generator-instances"></emu-xref>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
@@ -39055,7 +39055,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-generatorfunction-instances">
       <h1>GeneratorFunction Instances</h1>
-      <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
+      <p>Every GeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
       <p>Each GeneratorFunction instance has the following own properties:</p>
 
       <emu-clause id="sec-generatorfunction-instances-length">
@@ -39136,7 +39136,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%AsyncGeneratorFunction.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
-        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
+        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref> or <emu-xref href="#table-internal-slots-of-asyncgenerator-instances"></emu-xref>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
@@ -39161,7 +39161,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-asyncgeneratorfunction-instances">
       <h1>AsyncGeneratorFunction Instances</h1>
-      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
+      <p>Every AsyncGeneratorFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*.</p>
       <p>Each AsyncGeneratorFunction instance has the following own properties:</p>
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-length">
@@ -39246,8 +39246,8 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-generator-instances">
       <h1>Properties of Generator Instances</h1>
-      <p>Generator instances are initially created with the internal slots described in <emu-xref href="#table-56"></emu-xref>.</p>
-      <emu-table id="table-56" caption="Internal Slots of Generator Instances">
+      <p>Generator instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-generator-instances"></emu-xref>.</p>
+      <emu-table id="table-internal-slots-of-generator-instances" caption="Internal Slots of Generator Instances" oldids="table-56">
         <table>
           <tbody>
           <tr>
@@ -39709,8 +39709,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-promisecapability-records">
         <h1>PromiseCapability Records</h1>
         <p>A <dfn>PromiseCapability Record</dfn> is a Record value used to encapsulate a promise object along with the functions that are capable of resolving or rejecting that promise object. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
-        <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-57"></emu-xref>.</p>
-        <emu-table id="table-57" caption="PromiseCapability Record Fields">
+        <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-promisecapability-record-fields"></emu-xref>.</p>
+        <emu-table id="table-promisecapability-record-fields" caption="PromiseCapability Record Fields" oldids="table-57">
           <table>
             <tbody>
             <tr>
@@ -39780,8 +39780,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-promisereaction-records">
         <h1>PromiseReaction Records</h1>
         <p>The PromiseReaction is a Record value used to store information about how a promise should react when it becomes resolved or rejected with a given value. PromiseReaction records are created by the PerformPromiseThen abstract operation, and are used by the Abstract Closure returned by NewPromiseReactionJob.</p>
-        <p>PromiseReaction records have the fields listed in <emu-xref href="#table-58"></emu-xref>.</p>
-        <emu-table id="table-58" caption="PromiseReaction Record Fields">
+        <p>PromiseReaction records have the fields listed in <emu-xref href="#table-promisereaction-record-fields"></emu-xref>.</p>
+        <emu-table id="table-promisereaction-record-fields" caption="PromiseReaction Record Fields" oldids="table-58">
           <table>
             <tbody>
             <tr>
@@ -40656,8 +40656,8 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-promise-instances">
       <h1>Properties of Promise Instances</h1>
-      <p>Promise instances are ordinary objects that inherit properties from the Promise prototype object (the intrinsic, %Promise.prototype%). Promise instances are initially created with the internal slots described in <emu-xref href="#table-59"></emu-xref>.</p>
-      <emu-table id="table-59" caption="Internal Slots of Promise Instances">
+      <p>Promise instances are ordinary objects that inherit properties from the Promise prototype object (the intrinsic, %Promise.prototype%). Promise instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-promise-instances"></emu-xref>.</p>
+      <emu-table id="table-internal-slots-of-promise-instances" caption="Internal Slots of Promise Instances" oldids="table-59">
         <table>
           <tbody>
           <tr>
@@ -40772,7 +40772,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%AsyncFunction.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
-        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-27"></emu-xref>.</li>
+        <li>is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
 
@@ -40796,7 +40796,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-async-function-instances">
       <h1>AsyncFunction Instances</h1>
 
-      <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-27"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructible.</p>
+      <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructible.</p>
       <p>Each AsyncFunction instance has the following own properties:</p>
       <emu-clause id="sec-async-function-instances-length">
         <h1>length</h1>
@@ -42579,8 +42579,8 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-additional-properties-of-the-global-object">
       <h1>Additional Properties of the Global Object</h1>
-      <p>The entries in <emu-xref href="#table-60"></emu-xref> are added to <emu-xref href="#table-7"></emu-xref>.</p>
-      <emu-table id="table-60" caption="Additional Well-known Intrinsic Objects">
+      <p>The entries in <emu-xref href="#table-additional-well-known-intrinsic-objects"></emu-xref> are added to <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>.</p>
+      <emu-table id="table-additional-well-known-intrinsic-objects" caption="Additional Well-known Intrinsic Objects" oldids="table-60">
         <table>
           <tbody>
           <tr>
@@ -43394,7 +43394,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-IsHTMLDDA-internal-slot-to-boolean">
         <h1>Changes to ToBoolean</h1>
-        <p>The result column in <emu-xref href="#table-10"></emu-xref> for an argument type of Object is replaced with the following algorithm:</p>
+        <p>The result column in <emu-xref href="#table-toboolean-conversions"></emu-xref> for an argument type of Object is replaced with the following algorithm:</p>
         <emu-alg>
           1. If _argument_ has an [[IsHTMLDDA]] internal slot, return *false*.
           1. Return *true*.
@@ -43412,7 +43412,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-IsHTMLDDA-internal-slot-typeof">
         <h1>Changes to the `typeof` Operator</h1>
-        <p>The following table entry is inserted into <emu-xref href="#table-35"></emu-xref> immediately preceeding the entry for "Object (implements [[Call]])":</p>
+        <p>The following table entry is inserted into <emu-xref href="#table-typeof-operator-results"></emu-xref> immediately preceeding the entry for "Object (implements [[Call]])":</p>
         <emu-table>
           <emu-caption>
             Additional <emu-xref href="#sec-typeof-operator">`typeof`</emu-xref> Operator Results
@@ -43521,9 +43521,9 @@ THH:mm:ss.sss
   </emu-annex>
   <emu-annex id="sec-host-defined-fields-summary">
     <h1>Host-defined Fields</h1>
-    <p>[[HostDefined]] on Realm Records: See <emu-xref href="#table-21"></emu-xref>.</p>
+    <p>[[HostDefined]] on Realm Records: See <emu-xref href="#table-realm-record-fields"></emu-xref>.</p>
     <p>[[HostDefined]] on Script Records: See <emu-xref href="#table-script-records"></emu-xref>.</p>
-    <p>[[HostDefined]] on Module Records: See <emu-xref href="#table-36"></emu-xref>.</p>
+    <p>[[HostDefined]] on Module Records: See <emu-xref href="#table-module-record-fields"></emu-xref>.</p>
     <p>[[HostDefined]] on JobCallback Records: See <emu-xref href="#table-jobcallback-records"></emu-xref>.</p>
     <p>[[HostSynchronizesWith]] on Candidate Executions: See <emu-xref href="#table-candidate-execution-records"></emu-xref>.</p>
     <p>[[IsHTMLDDA]]: See <emu-xref href="#sec-IsHTMLDDA-internal-slot"></emu-xref>.</p>
@@ -43538,7 +43538,7 @@ THH:mm:ss.sss
   </emu-annex>
   <emu-annex id="sec-host-internal-methods-of-exotic-objects">
     <h1>Internal Methods of Exotic Objects</h1>
-    <p>Any of the essential internal methods in <emu-xref href="#table-5"></emu-xref> for any exotic object not specified within this specification.</p>
+    <p>Any of the essential internal methods in <emu-xref href="#table-essential-internal-methods"></emu-xref> for any exotic object not specified within this specification.</p>
   </emu-annex>
   <emu-annex id="sec-host-built-in-objects-and-methods">
     <h1>Built-in Objects and Methods</h1>


### PR DESCRIPTION
This was previously done for [`#table‑4`][table-4] in <https://github.com/tc39/ecma262/pull/1614> and for [`#table‑49`][table-49] in <https://github.com/tc39/ecma262/pull/1734>.

I did this because of <https://github.com/tc39/proposal-realms/pull/263#discussion_r444387192>.

[table-4]: https://tc39.es/ecma262/#table-default-attribute-values
[table-49]: https://tc39.es/ecma262/#table-the-typedarray-constructors