### PR TITLE
Editorial: Relocate the definition of StringIndexOf

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -982,6 +982,27 @@
         <p>The rationale behind this design was to keep the implementation of Strings as simple and high-performing as possible. If ECMAScript source text is in Normalized Form C, string literals are guaranteed to also be normalized, as long as they do not contain any Unicode escape sequences.</p>
       </emu-note>
       <p>In this specification, the phrase "the <dfn>string-concatenation</dfn> of _A_, _B_, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
+
+      <emu-clause id="sec-stringindexof" aoid="StringIndexOf">
+        <h1>Runtime Semantics: StringIndexOf ( _string_, _searchValue_, _fromIndex_ )</h1>
+        <p>The abstract operation StringIndexOf takes arguments _string_ (a String), _searchValue_ (a String), and _fromIndex_ (a non-negative integer). It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: Type(_string_) is String.
+          1. Assert: Type(_searchValue_) is String.
+          1. Assert: ! IsNonNegativeInteger(_fromIndex_) is *true*.
+          1. Let _len_ be the length of _string_.
+          1. If _searchValue_ is the empty String and _fromIndex_ &le; _len_, return _fromIndex_.
+          1. Let _searchLen_ be the length of _searchValue_.
+          1. If there exists any integer _k_ such that _fromIndex_ &le; _k_ &le; _len_ - _searchLen_ and for all nonnegative integers _j_ less than _searchLen_, the code unit at index _k_ + _j_ within _string_ is the same as the code unit at index _j_ within _searchValue_, let _pos_ be the smallest (closest to *-&infin;*) such integer. Otherwise, let _pos_ be -1.
+          1. Return _pos_.
+        </emu-alg>
+        <emu-note>
+          <p>If _searchValue_ is empty and _fromIndex_ is less than or equal to the length of _string_, this algorithm returns _fromIndex_. An empty _searchValue_ is effectively found at every position within a string, including after the last code unit.</p>
+        </emu-note>
+        <emu-note>
+          <p>This algorithm always returns -1 if _fromIndex_ &gt; the length of _string_.</p>
+        </emu-note>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-ecmascript-language-types-symbol-type">
@@ -10454,27 +10475,6 @@
         1. Return _codePoints_.
       </emu-alg>
     </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-stringindexof" aoid="StringIndexOf">
-    <h1>Runtime Semantics: StringIndexOf ( _string_, _searchValue_, _fromIndex_ )</h1>
-    <p>The abstract operation StringIndexOf takes arguments _string_ (a String), _searchValue_ (a String), and _fromIndex_ (a non-negative integer). It performs the following steps when called:</p>
-    <emu-alg>
-      1. Assert: Type(_string_) is String.
-      1. Assert: Type(_searchValue_) is String.
-      1. Assert: ! IsNonNegativeInteger(_fromIndex_) is *true*.
-      1. Let _len_ be the length of _string_.
-      1. If _searchValue_ is the empty String and _fromIndex_ &le; _len_, return _fromIndex_.
-      1. Let _searchLen_ be the length of _searchValue_.
-      1. If there exists any integer _k_ such that _fromIndex_ &le; _k_ &le; _len_ - _searchLen_ and for all nonnegative integers _j_ less than _searchLen_, the code unit at index _k_ + _j_ within _string_ is the same as the code unit at index _j_ within _searchValue_, let _pos_ be the smallest (closest to *-&infin;*) such integer. Otherwise, let _pos_ be -1.
-      1. Return _pos_.
-    </emu-alg>
-    <emu-note>
-      <p>If _searchValue_ is empty and _fromIndex_ is less than or equal to the length of _string_, this algorithm returns _fromIndex_. An empty _searchValue_ is effectively found at every position within a string, including after the last code unit.</p>
-    </emu-note>
-    <emu-note>
-      <p>This algorithm always returns -1 if _fromIndex_ &gt; the length of _string_.</p>
-    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-types-of-source-code">


### PR DESCRIPTION
PR #2009 recently introduced StringIndexOf, locating its definition in a subclause of [10 ECMAScript Language: Source Code](https://tc39.es/ecma262/#sec-ecmascript-language-source-code). This placement doesn't make much sense, as StringIndexOf isn't particularly related to source code.

There are various plausible places where it could go:
- as a subclause of [6.1.4 The String Type](https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type).
- somewhere within [7 Abstract Operations](https://tc39.es/ecma262/#sec-abstract-operations) (though none of the existing subclauses is appropriate).
- as a subclause of one of the builtins that invokes it:
  - [String.p.includes](https://tc39.es/ecma262/#sec-string.prototype.includes)
  - [String.p.indexOf](https://tc39.es/ecma262/#sec-string.prototype.indexof)
  - [String.p.replaceAll](https://tc39.es/ecma262/#sec-string.prototype.replaceall)

This PR picks the first option. (I think there's a nice modularity to defining a String operation close to the definition of the String type.)