### PR TITLE
Editorial: Simplify String.prototype.split with empty separator

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30932,9 +30932,8 @@ THH:mm:ss.sss
             1. Return _A_.
           1. Let _s_ be the length of _S_.
           1. If _s_ = 0, then
-            1. Let _z_ be SplitMatch(_S_, 0, _R_).
-            1. If _z_ is not *false*, return _A_.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
+            1. If _R_ is not the empty String, then
+              1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
             1. Return _A_.
           1. Let _p_ be 0.
           1. Let _q_ be _p_.


### PR DESCRIPTION
If `S` is an empty string, `SplitMatch(S, 0, R)` can succeed only if `R` is an empty string too.
Since it isn't immediately visible from [`SplitMatch`](https://tc39.es/ecma262/#sec-splitmatch) definition, and its index result is unused, this PR simplifies the check.
Both [V8](https://github.com/v8/v8/blob/ddc9a9bae3386524f741954addf6855a1dd20b91/src/builtins/builtins-string-gen.cc#L1771) and [JSC](https://github.com/WebKit/webkit/blob/e647f5978f0d7a5fd91cc87bdc811ceef4cbbae7/Source/JavaScriptCore/runtime/StringPrototype.cpp#L1288) check separator for emptiness instead of performing extra [`SplitMatch`](https://tc39.es/ecma262/#sec-splitmatch).