### PR TITLE
Editorial: Assert that [[HomeObject]] is an ordinary object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6769,9 +6769,12 @@
             1. Let _envRec_ be the function Environment Record for which the method was invoked.
             1. Let _home_ be _envRec_.[[HomeObject]].
             1. If _home_ has the value *undefined*, return *undefined*.
-            1. Assert: Type(_home_) is Object.
-            1. Return ? _home_.[[GetPrototypeOf]]().
+            1. [id="step-getsuperbase-assert"] Assert: _home_ is an ordinary object.
+            1. Return ! _home_.[[GetPrototypeOf]]().
           </emu-alg>
+          <emu-note>
+            <p>The assert in step <emu-xref href="#step-getsuperbase-assert"></emu-xref> is due to no observable facility to redefine the [[HomeObject]] internal slot from ECMAScript code, rather than an intentional design decision.</p>
+          </emu-note>
         </emu-clause>
       </emu-clause>
 
@@ -13876,7 +13879,7 @@
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
           1. Assert: _env_.HasSuperBinding() is *true*.
-          1. Let _baseValue_ be ? _env_.GetSuperBase().
+          1. Let _baseValue_ be ! _env_.GetSuperBase().
           1. Let _bv_ be ? RequireObjectCoercible(_baseValue_).
           1. Return a value of type Reference that is a Super Reference whose base value component is _bv_, whose referenced name component is _propertyKey_, whose thisValue component is _actualThis_, and whose strict reference flag is _strict_.
         </emu-alg>


### PR DESCRIPTION
This change makes it clearer that `home.[[GetPrototypeOf]]` is an [`OrdinaryGetPrototypeOf`](https://tc39.es/ecma262/#sec-ordinarygetprototypeof) method, enabling runtimes to optimize `super.prop` lookup.
There is similar assert at step 4 of [`GetSuperConstructor`](https://tc39.es/ecma262/#sec-getsuperconstructor).