### PR TITLE
Editorial: Module Record in InnerModuleEvaluation need not be a Source Text Module Record

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23576,7 +23576,7 @@
 
           <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
             <h1>InnerModuleEvaluation ( _module_, _stack_, _index_ )</h1>
-            <p>The abstract operation InnerModuleEvaluation takes arguments _module_ (a Source Text Module Record), _stack_, and _index_. It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking. It performs the following steps when called:</p>
+            <p>The abstract operation InnerModuleEvaluation takes arguments _module_ (a Module Record), _stack_, and _index_. It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking. It performs the following steps when called:</p>
 
             <emu-alg>
               1. If _module_ is not a Cyclic Module Record, then


### PR DESCRIPTION
In InnerModuleEvaluation, the argument _module_ is defined as `(a Source Text Module Record)`, but this could be a non-source text module record as well it looks like...