### PR TITLE
Editorial: add missing `!` on calls to `OrdinaryObjectCreate`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3902,7 +3902,7 @@
         <p>The abstract operation FromPropertyDescriptor takes argument _Desc_ (a Property Descriptor or *undefined*). It performs the following steps when called:</p>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *undefined*.
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. If _Desc_ has a [[Value]] field, then
             1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _Desc_.[[Value]]).
@@ -5709,7 +5709,7 @@
       <p>The abstract operation CreateIterResultObject takes arguments _value_ and _done_. It creates an object that supports the IteratorResult interface. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_done_) is Boolean.
-        1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _value_).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, *"done"*, _done_).
         1. Return _obj_.
@@ -5720,7 +5720,7 @@
       <h1>CreateListIteratorRecord ( _list_ )</h1>
       <p>The abstract operation CreateListIteratorRecord takes argument _list_. It creates an Iterator (<emu-xref href="#sec-iterator-interface"></emu-xref>) object record whose next method returns the successive elements of _list_. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _iterator_ be OrdinaryObjectCreate(%IteratorPrototype%, &laquo; [[IteratedList]], [[ListNextIndex]] &raquo;).
+        1. Let _iterator_ be ! OrdinaryObjectCreate(%IteratorPrototype%, &laquo; [[IteratedList]], [[ListNextIndex]] &raquo;).
         1. Set _iterator_.[[IteratedList]] to _list_.
         1. Set _iterator_.[[ListNextIndex]] to 0.
         1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-listiteratornext-functions" title></emu-xref>.
@@ -6981,7 +6981,7 @@
       <emu-alg>
         1. If _globalObj_ is *undefined*, then
           1. Let _intrinsics_ be _realmRec_.[[Intrinsics]].
-          1. Set _globalObj_ to OrdinaryObjectCreate(_intrinsics_.[[%Object.prototype%]]).
+          1. Set _globalObj_ to ! OrdinaryObjectCreate(_intrinsics_.[[%Object.prototype%]]).
         1. Assert: Type(_globalObj_) is Object.
         1. If _thisValue_ is *undefined*, set _thisValue_ to _globalObj_.
         1. Set _realmRec_.[[GlobalObject]] to _globalObj_.
@@ -8027,7 +8027,7 @@
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Let _proto_ be ? GetPrototypeFromConstructor(_constructor_, _intrinsicDefaultProto_).
-        1. Return OrdinaryObjectCreate(_proto_, _internalSlotsList_).
+        1. Return ! OrdinaryObjectCreate(_proto_, _internalSlotsList_).
       </emu-alg>
     </emu-clause>
 
@@ -8360,7 +8360,7 @@
         1. Set _F_.[[ConstructorKind]] to ~base~.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then
-          1. Set _prototype_ to OrdinaryObjectCreate(%Object.prototype%).
+          1. Set _prototype_ to ! OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ! DefinePropertyOrThrow(_prototype_, *"constructor"*, PropertyDescriptor { [[Value]]: _F_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return NormalCompletion(*undefined*).
@@ -9047,7 +9047,7 @@
         <p>The abstract operation CreateUnmappedArgumentsObject takes argument _argumentsList_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _argumentsList_.
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
+          1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
           1. Set _obj_.[[ParameterMap]] to *undefined*.
           1. Perform DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: _len_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _index_ be 0.
@@ -9074,7 +9074,7 @@
           1. Set _obj_.[[Set]] as specified in <emu-xref href="#sec-arguments-exotic-objects-set-p-v-receiver"></emu-xref>.
           1. Set _obj_.[[Delete]] as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
           1. Set _obj_.[[Prototype]] to %Object.prototype%.
-          1. Let _map_ be OrdinaryObjectCreate(*null*).
+          1. Let _map_ be ! OrdinaryObjectCreate(*null*).
           1. Set _obj_.[[ParameterMap]] to _map_.
           1. Let _parameterNames_ be the BoundNames of _formals_.
           1. Let _numberOfParameters_ be the number of elements in _parameterNames_.
@@ -12680,7 +12680,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ObjectLiteral : `{` `}`</emu-grammar>
         <emu-alg>
-          1. Return OrdinaryObjectCreate(%Object.prototype%).
+          1. Return ! OrdinaryObjectCreate(%Object.prototype%).
         </emu-alg>
         <emu-grammar>
           ObjectLiteral :
@@ -12688,7 +12688,7 @@
             `{` PropertyDefinitionList `,` `}`
         </emu-grammar>
         <emu-alg>
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_ and *true*.
           1. Return _obj_.
         </emu-alg>
@@ -15515,7 +15515,7 @@
         <emu-alg>
           1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
           1. ReturnIfAbrupt(_lref_).
-          1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _restObj_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
           1. Return PutValue(_lref_, _restObj_).
         </emu-alg>
@@ -16792,7 +16792,7 @@
         <emu-grammar>BindingRestProperty : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
-          1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _restObj_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
           1. If _environment_ is *undefined*, return PutValue(_lhs_, _restObj_).
           1. Return InitializeReferencedBinding(_lhs_, _restObj_).
@@ -17991,7 +17991,7 @@
           <p>The abstract operation CreateForInIterator takes argument _object_. It is used to create a For-In Iterator object which iterates over the own and inherited enumerable string properties of _object_ in a specific order. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_object_) is Object.
-            1. Let _iterator_ be OrdinaryObjectCreate(%ForInIteratorPrototype%, &laquo; [[Object]], [[ObjectWasVisited]], [[VisitedKeys]], [[RemainingKeys]] &raquo;).
+            1. Let _iterator_ be ! OrdinaryObjectCreate(%ForInIteratorPrototype%, &laquo; [[Object]], [[ObjectWasVisited]], [[VisitedKeys]], [[RemainingKeys]] &raquo;).
             1. Set _iterator_.[[Object]] to _object_.
             1. Set _iterator_.[[ObjectWasVisited]] to *false*.
             1. Set _iterator_.[[VisitedKeys]] to a new empty List.
@@ -20440,7 +20440,7 @@
         1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_F_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
@@ -20449,7 +20449,7 @@
         1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_F_, *"default"*).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
@@ -20471,7 +20471,7 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
@@ -20487,7 +20487,7 @@
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _closure_.
       </emu-alg>
@@ -20508,7 +20508,7 @@
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform _funcEnv_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
@@ -20777,7 +20777,7 @@
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_F_, *"default"*).
-        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
         1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
@@ -21131,7 +21131,7 @@
             1. Let _protoParent_ be ? Get(_superclass_, *"prototype"*).
             1. If Type(_protoParent_) is neither Object nor Null, throw a *TypeError* exception.
             1. Let _constructorParent_ be _superclass_.
-        1. Let _proto_ be OrdinaryObjectCreate(_protoParent_).
+        1. Let _proto_ be ! OrdinaryObjectCreate(_protoParent_).
         1. If |ClassBody_opt| is not present, let _constructor_ be ~empty~.
         1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
         1. If _constructor_ is ~empty~, then
@@ -25597,7 +25597,7 @@
         <emu-alg>
           1. If NewTarget is neither *undefined* nor the active function, then
             1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
-          1. If _value_ is *undefined* or *null*, return OrdinaryObjectCreate(%Object.prototype%).
+          1. If _value_ is *undefined* or *null*, return ! OrdinaryObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
         <p>The *"length"* property of the `Object` function is 1.</p>
@@ -25638,7 +25638,7 @@
         <p>The `create` function creates a new object with a specified prototype. When the `create` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_O_) is neither Object nor Null, throw a *TypeError* exception.
-          1. Let _obj_ be OrdinaryObjectCreate(_O_).
+          1. Let _obj_ be ! OrdinaryObjectCreate(_O_).
           1. If _Properties_ is not *undefined*, then
             1. Return ? ObjectDefineProperties(_obj_, _Properties_).
           1. Return _obj_.
@@ -25713,7 +25713,7 @@
         <p>When the `fromEntries` method is called with argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_iterable_).
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. Let _stepsDefine_ be the algorithm steps defined in <emu-xref href="#sec-create-data-property-on-object-functions" title></emu-xref>.
           1. Let _adder_ be ! CreateBuiltinFunction(_stepsDefine_, &laquo; &raquo;).
@@ -26119,10 +26119,10 @@
             1. Let _F_ be ! OrdinaryFunctionCreate(_proto_, _sourceText_, _parameters_, _body_, ~non-lexical-this~, _scope_).
             1. Perform SetFunctionName(_F_, *"anonymous"*).
             1. If _kind_ is ~generator~, then
-              1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+              1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
               1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~asyncGenerator~, then
-              1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+              1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
               1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~normal~, perform MakeConstructor(_F_).
             1. NOTE: Functions whose _kind_ is ~async~ are not constructible and do not have a [[Construct]] internal method or a *"prototype"* property.
@@ -30696,7 +30696,7 @@ THH:mm:ss.sss
         <p>The abstract operation CreateStringIterator takes argument _string_. This operation is used to create iterator objects for String methods that return such iterators. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_string_) is String.
-          1. Let _iterator_ be OrdinaryObjectCreate(%StringIteratorPrototype%, &laquo; [[IteratedString]], [[StringNextIndex]] &raquo;).
+          1. Let _iterator_ be ! OrdinaryObjectCreate(%StringIteratorPrototype%, &laquo; [[IteratedString]], [[StringNextIndex]] &raquo;).
           1. Set _iterator_.[[IteratedString]] to _string_.
           1. Set _iterator_.[[StringNextIndex]] to 0.
           1. Return _iterator_.
@@ -32413,7 +32413,7 @@ THH:mm:ss.sss
             1. Let _matchedSubstr_ be the substring of _S_ from _lastIndex_ to _e_.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _matchedSubstr_).
             1. If _R_ contains any |GroupName|, then
-              1. Let _groups_ be OrdinaryObjectCreate(*null*).
+              1. Let _groups_ be ! OrdinaryObjectCreate(*null*).
             1. Else,
               1. Let _groups_ be *undefined*.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
@@ -32582,7 +32582,7 @@ THH:mm:ss.sss
             1. Assert: Type(_S_) is String.
             1. Assert: Type(_global_) is Boolean.
             1. Assert: Type(_fullUnicode_) is Boolean.
-            1. Let _iterator_ be OrdinaryObjectCreate(%RegExpStringIteratorPrototype%, &laquo; [[IteratingRegExp]], [[IteratedString]], [[Global]], [[Unicode]], [[Done]] &raquo;).
+            1. Let _iterator_ be ! OrdinaryObjectCreate(%RegExpStringIteratorPrototype%, &laquo; [[IteratingRegExp]], [[IteratedString]], [[Global]], [[Unicode]], [[Done]] &raquo;).
             1. Set _iterator_.[[IteratingRegExp]] to _R_.
             1. Set _iterator_.[[IteratedString]] to _S_.
             1. Set _iterator_.[[Global]] to _global_.
@@ -34246,7 +34246,7 @@ THH:mm:ss.sss
         <h1>Array.prototype [ @@unscopables ]</h1>
         <p>The initial value of the @@unscopables data property is an object created by the following steps:</p>
         <emu-alg>
-          1. Let _unscopableList_ be OrdinaryObjectCreate(*null*).
+          1. Let _unscopableList_ be ! OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"copyWithin"*, *true*).
           1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"entries"*, *true*).
           1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"fill"*, *true*).
@@ -34291,7 +34291,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: Type(_array_) is Object.
           1. Assert: _kind_ is ~key+value~, ~key~, or ~value~.
-          1. Let _iterator_ be OrdinaryObjectCreate(%ArrayIteratorPrototype%, &laquo; [[IteratedArrayLike]], [[ArrayLikeNextIndex]], [[ArrayLikeIterationKind]] &raquo;).
+          1. Let _iterator_ be ! OrdinaryObjectCreate(%ArrayIteratorPrototype%, &laquo; [[IteratedArrayLike]], [[ArrayLikeNextIndex]], [[ArrayLikeIterationKind]] &raquo;).
           1. Set _iterator_.[[IteratedArrayLike]] to _array_.
           1. Set _iterator_.[[ArrayLikeNextIndex]] to 0.
           1. Set _iterator_.[[ArrayLikeIterationKind]] to _kind_.
@@ -35807,7 +35807,7 @@ THH:mm:ss.sss
         <p>The abstract operation CreateMapIterator takes arguments _map_ and _kind_. This operation is used to create iterator objects for Map methods that return such iterators. It performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
-          1. Let _iterator_ be OrdinaryObjectCreate(%MapIteratorPrototype%, &laquo; [[IteratedMap]], [[MapNextIndex]], [[MapIterationKind]] &raquo;).
+          1. Let _iterator_ be ! OrdinaryObjectCreate(%MapIteratorPrototype%, &laquo; [[IteratedMap]], [[MapNextIndex]], [[MapIterationKind]] &raquo;).
           1. Set _iterator_.[[IteratedMap]] to _map_.
           1. Set _iterator_.[[MapNextIndex]] to 0.
           1. Set _iterator_.[[MapIterationKind]] to _kind_.
@@ -36141,7 +36141,7 @@ THH:mm:ss.sss
         <p>The abstract operation CreateSetIterator takes arguments _set_ and _kind_. This operation is used to create iterator objects for Set methods that return such iterators. It performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_set_, [[SetData]]).
-          1. Let _iterator_ be OrdinaryObjectCreate(%SetIteratorPrototype%, &laquo; [[IteratedSet]], [[SetNextIndex]], [[SetIterationKind]] &raquo;).
+          1. Let _iterator_ be ! OrdinaryObjectCreate(%SetIteratorPrototype%, &laquo; [[IteratedSet]], [[SetNextIndex]], [[SetIterationKind]] &raquo;).
           1. Set _iterator_.[[IteratedSet]] to _set_.
           1. Set _iterator_.[[SetNextIndex]] to 0.
           1. Set _iterator_.[[SetIterationKind]] to _kind_.
@@ -37885,7 +37885,7 @@ THH:mm:ss.sss
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then
-          1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _root_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Let _rootName_ be the empty String.
           1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
           1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_).
@@ -37973,7 +37973,7 @@ THH:mm:ss.sss
           1. If the length of _space_ is 10 or less, let _gap_ be _space_; otherwise let _gap_ be the substring of _space_ from 0 to 10.
         1. Else,
           1. Let _gap_ be the empty String.
-        1. Let _wrapper_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _wrapper_ be ! OrdinaryObjectCreate(%Object.prototype%).
         1. Perform ! CreateDataPropertyOrThrow(_wrapper_, the empty String, _value_).
         1. Let _state_ be the Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
         1. Return ? SerializeJSONProperty(_state_, the empty String, _wrapper_).
@@ -41041,7 +41041,7 @@ THH:mm:ss.sss
           1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-proxy-revocation-functions" title></emu-xref>.
           1. Let _revoker_ be ! CreateBuiltinFunction(_steps_, &laquo; [[RevocableProxy]] &raquo;).
           1. Set _revoker_.[[RevocableProxy]] to _p_.
-          1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _result_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _p_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, *"revoke"*, _revoker_).
           1. Return _result_.


### PR DESCRIPTION
Fixes #2097.