### PR TITLE
Editorial: Don't use "sec-" prefix for dfn ids

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -180,13 +180,13 @@
     <h1>Hosts and Implementations</h1>
     <p>To aid integrating ECMAScript into host environments, this specification defers the definition certain facilities (e.g., abstract operations), either in whole or in part, to a source outside of this specification. Editorially, this specification distinguishes the following kinds of deferrals.</p>
     <!-- "implementation" below is not a dfn but an em to avoid excessive auto-linking. -->
-    <p>An <em id="sec-implementation">implementation</em> is an external source that further defines facilities enumerated in Annex <emu-xref href="#sec-host-layering-points"></emu-xref> or those that are marked as implementation-defined or implementation-approximated. In informal use, an implementation refers to a concrete artefact, such as a particular web browser.</p>
-    <p>An <dfn id="sec-implementation-defined">implementation-defined</dfn> facility is one that defers its definition to an external source without further qualification. This specification does not make any recommendations for particular behaviours, and conforming implementations are free to choose any behaviour within the constraints put forth by this specification.</p>
-    <p>An <dfn id="sec-implementation-approximated">implementation-approximated</dfn> facility is one that defers its definition to an external source while recommending an ideal behaviour. While conforming implementations are free to choose any behaviour within the constraints put forth by this specification, they are encouraged to strive to approximate the ideal. Some mathematical operations, such as <emu-xref href="#sec-math.exp"><code>Math.exp</code></emu-xref>, are implementation-approximated.</p>
-    <p>A <dfn id="sec-host">host</dfn> is an external source that further defines facilities listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref> but does not further define other implementation-defined or implementation-approximated facilities. In informal use, a host refers to the set of all implementations, such as the set of all web browsers, that interface with this specification in the same way via Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host is often an external specification, such as WHATWG HTML (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>). In other words, facilities that are host-defined are often further defined in external specifications.</p>
-    <p>A <dfn id="sec-host-hook">host hook</dfn> is an abstract operation that is defined in whole or in part by an external source. All host hooks must be listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>.</p>
-    <p>A <dfn id="sec-host-defined">host-defined</dfn> facility is one that defers its definition to an external source without further qualification and is listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. Implementations that are not hosts may also provide definitions for host-defined facilities.</p>
-    <p>A <dfn id="sec-host-environment">host environment</dfn> is a particular choice of definition for all host-defined facilities. A host environment typically includes objects or functions which allow obtaining input and providing output as host-defined properties of the global object.</p>
+    <p>An <em id="implementation">implementation</em> is an external source that further defines facilities enumerated in Annex <emu-xref href="#sec-host-layering-points"></emu-xref> or those that are marked as implementation-defined or implementation-approximated. In informal use, an implementation refers to a concrete artefact, such as a particular web browser.</p>
+    <p>An <dfn id="implementation-defined">implementation-defined</dfn> facility is one that defers its definition to an external source without further qualification. This specification does not make any recommendations for particular behaviours, and conforming implementations are free to choose any behaviour within the constraints put forth by this specification.</p>
+    <p>An <dfn id="implementation-approximated">implementation-approximated</dfn> facility is one that defers its definition to an external source while recommending an ideal behaviour. While conforming implementations are free to choose any behaviour within the constraints put forth by this specification, they are encouraged to strive to approximate the ideal. Some mathematical operations, such as <emu-xref href="#sec-math.exp"><code>Math.exp</code></emu-xref>, are implementation-approximated.</p>
+    <p>A <dfn id="host">host</dfn> is an external source that further defines facilities listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref> but does not further define other implementation-defined or implementation-approximated facilities. In informal use, a host refers to the set of all implementations, such as the set of all web browsers, that interface with this specification in the same way via Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host is often an external specification, such as WHATWG HTML (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>). In other words, facilities that are host-defined are often further defined in external specifications.</p>
+    <p>A <dfn id="host-hook">host hook</dfn> is an abstract operation that is defined in whole or in part by an external source. All host hooks must be listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>.</p>
+    <p>A <dfn id="host-defined">host-defined</dfn> facility is one that defers its definition to an external source without further qualification and is listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. Implementations that are not hosts may also provide definitions for host-defined facilities.</p>
+    <p>A <dfn id="host-environment">host environment</dfn> is a particular choice of definition for all host-defined facilities. A host environment typically includes objects or functions which allow obtaining input and providing output as host-defined properties of the global object.</p>
     <p>This specification follows the editorial convention of always using the most specific term. For example, if a facility is host-defined, it should not be referred to as implementation-defined.</p>
     <p>Both hosts and implementations may interface with this specification via the language types, specification types, abstract operations, grammar productions, intrinsic objects, and intrinsic symbols defined herein.</p>
   </emu-clause>
@@ -26549,7 +26549,7 @@
         <li>is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-      <p>The abstract operation <dfn id="sec-thisbooleanvalue" aoid="thisBooleanValue">thisBooleanValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <p>The abstract operation <dfn id="thisbooleanvalue" aoid="thisBooleanValue" oldids="sec-thisbooleanvalue">thisBooleanValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is Boolean, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[BooleanData]] internal slot, then
@@ -26783,7 +26783,7 @@
         <li>is not a Symbol instance and does not have a [[SymbolData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-      <p>The abstract operation <dfn id="sec-thissymbolvalue" aoid="thisSymbolValue">thisSymbolValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <p>The abstract operation <dfn id="thissymbolvalue" aoid="thisSymbolValue" oldids="sec-thissymbolvalue">thisSymbolValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is Symbol, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[SymbolData]] internal slot, then
@@ -27237,7 +27237,7 @@
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
-      <p>The abstract operation <dfn id="sec-thisnumbervalue" aoid="thisNumberValue">thisNumberValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <p>The abstract operation <dfn id="thisnumbervalue" aoid="thisNumberValue" oldids="sec-thisnumbervalue">thisNumberValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is Number, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[NumberData]] internal slot, then
@@ -27494,7 +27494,7 @@
         <li>is not a BigInt object; it does not have a [[BigIntData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-      <p>The abstract operation <dfn id="sec-thisbigintvalue" aoid="thisBigIntValue">thisBigIntValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <p>The abstract operation <dfn id="thisbigintvalue" aoid="thisBigIntValue" oldids="sec-thisbigintvalue">thisBigIntValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is BigInt, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[BigIntData]] internal slot, then
@@ -28961,7 +28961,7 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly defined otherwise, the methods of the Date prototype object defined below are not generic and the *this* value passed to them must be an object that has a [[DateValue]] internal slot that has been initialized to a time value.</p>
-      <p>The abstract operation <dfn id="sec-thistimevalue" aoid="thisTimeValue">thisTimeValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <p>The abstract operation <dfn id="thistimevalue" aoid="thisTimeValue" oldids="sec-thistimevalue">thisTimeValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is Object and _value_ has a [[DateValue]] internal slot, then
           1. Return _value_.[[DateValue]].
@@ -29909,7 +29909,7 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
-      <p>The abstract operation <dfn id="sec-thisstringvalue" aoid="thisStringValue">thisStringValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <p>The abstract operation <dfn id="thisstringvalue" aoid="thisStringValue" oldids="sec-thisstringvalue">thisStringValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_value_) is String, return _value_.
         1. If Type(_value_) is Object and _value_ has a [[StringData]] internal slot, then


### PR DESCRIPTION
I didn't add `oldids` for the terms that were just introduced in #1951, only for the ones that's been around for longer.