### PR TITLE
Editorial: Remove "Runtime Semantics" prefix from abstract operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1019,7 +1019,7 @@
       <p>The phrase "the <dfn id="substring">substring</dfn> of _S_ from _inclusiveStart_ to _exclusiveEnd_" (where _S_ is a String value or a sequence of code units and _inclusiveStart_ and _exclusiveEnd_ are integers) denotes the String value consisting of the consecutive code units of _S_ beginning at index _inclusiveStart_ and ending immediately before index _exclusiveEnd_ (which is the empty String when _inclusiveStart_ = _exclusiveEnd_). If the "to" suffix is omitted, the length of _S_ is used as the value of _exclusiveEnd_.</p>
 
       <emu-clause id="sec-stringindexof" aoid="StringIndexOf">
-        <h1>Runtime Semantics: StringIndexOf ( _string_, _searchValue_, _fromIndex_ )</h1>
+        <h1>StringIndexOf ( _string_, _searchValue_, _fromIndex_ )</h1>
         <p>The abstract operation StringIndexOf takes arguments _string_ (a String), _searchValue_ (a String), and _fromIndex_ (a non-negative integer). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_string_) is String.
@@ -5751,7 +5751,7 @@
     </emu-clause>
 
     <emu-clause id="sec-iterabletolist" aoid="IterableToList">
-      <h1>Runtime Semantics: IterableToList ( _items_ [ , _method_ ] )</h1>
+      <h1>IterableToList ( _items_ [ , _method_ ] )</h1>
       <p>The abstract operation IterableToList takes argument _items_ and optional argument _method_. It performs the following steps when called:</p>
       <emu-alg>
         1. If _method_ is present, then
@@ -12187,7 +12187,7 @@
       </emu-alg>
 
       <emu-clause id="sec-initializeboundname" aoid="InitializeBoundName">
-        <h1>Runtime Semantics: InitializeBoundName ( _name_, _value_, _environment_ )</h1>
+        <h1>InitializeBoundName ( _name_, _value_, _environment_ )</h1>
         <p>The abstract operation InitializeBoundName takes arguments _name_, _value_, and _environment_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_name_) is String.
@@ -12987,7 +12987,7 @@
       </emu-clause>
 
       <emu-clause id="sec-gettemplateobject" aoid="GetTemplateObject">
-        <h1>Runtime Semantics: GetTemplateObject ( _templateLiteral_ )</h1>
+        <h1>GetTemplateObject ( _templateLiteral_ )</h1>
         <p>The abstract operation GetTemplateObject takes argument _templateLiteral_ (a Parse Node). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _realm_ be the current Realm Record.
@@ -13536,7 +13536,7 @@
     </emu-clause>
 
     <emu-clause id="sec-evaluate-property-access-with-expression-key" aoid="EvaluatePropertyAccessWithExpressionKey" oldids="sec-evaluate-expression-key-property-access">
-      <h1>Runtime Semantics: EvaluatePropertyAccessWithExpressionKey ( _baseValue_, _expression_, _strict_ )</h1>
+      <h1>EvaluatePropertyAccessWithExpressionKey ( _baseValue_, _expression_, _strict_ )</h1>
       <p>The abstract operation EvaluatePropertyAccessWithExpressionKey takes arguments _baseValue_ (an ECMAScript language value), _expression_ (a Parse Node), and _strict_ (a Boolean). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _propertyNameReference_ be the result of evaluating _expression_.
@@ -13547,7 +13547,7 @@
       </emu-alg>
     </emu-clause>
     <emu-clause id="sec-evaluate-property-access-with-identifier-key" aoid="EvaluatePropertyAccessWithIdentifierKey" oldids="sec-evaluate-identifier-key-property-access">
-      <h1>Runtime Semantics: EvaluatePropertyAccessWithIdentifierKey ( _baseValue_, _identifierName_, _strict_ )</h1>
+      <h1>EvaluatePropertyAccessWithIdentifierKey ( _baseValue_, _identifierName_, _strict_ )</h1>
       <p>The abstract operation EvaluatePropertyAccessWithIdentifierKey takes arguments _baseValue_ (an ECMAScript language value), _identifierName_ (a Parse Node), and _strict_ (a Boolean). It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _identifierName_ is an |IdentifierName|.
@@ -13572,7 +13572,7 @@
         </emu-alg>
 
         <emu-clause id="sec-evaluatenew" aoid="EvaluateNew">
-          <h1>Runtime Semantics: EvaluateNew ( _constructExpr_, _arguments_ )</h1>
+          <h1>EvaluateNew ( _constructExpr_, _arguments_ )</h1>
           <p>The abstract operation EvaluateNew takes arguments _constructExpr_ and _arguments_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _constructExpr_ is either a |NewExpression| or a |MemberExpression|.
@@ -13625,7 +13625,7 @@
       </emu-clause>
 
       <emu-clause id="sec-evaluatecall" aoid="EvaluateCall" oldids="sec-evaluatedirectcall">
-        <h1>Runtime Semantics: EvaluateCall ( _func_, _ref_, _arguments_, _tailPosition_ )</h1>
+        <h1>EvaluateCall ( _func_, _ref_, _arguments_, _tailPosition_ )</h1>
         <p>The abstract operation EvaluateCall takes arguments _func_ (an ECMAScript language value), _ref_ (an ECMAScript language value), _arguments_ (a Parse Node), and _tailPosition_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_ref_) is Reference, then
@@ -13686,7 +13686,7 @@
       </emu-clause>
 
       <emu-clause id="sec-getsuperconstructor" aoid="GetSuperConstructor">
-        <h1>Runtime Semantics: GetSuperConstructor ( )</h1>
+        <h1>GetSuperConstructor ( )</h1>
         <p>The abstract operation GetSuperConstructor takes no arguments. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _envRec_ be GetThisEnvironment().
@@ -13699,7 +13699,7 @@
       </emu-clause>
 
       <emu-clause id="sec-makesuperpropertyreference" aoid="MakeSuperPropertyReference">
-        <h1>Runtime Semantics: MakeSuperPropertyReference ( _actualThis_, _propertyKey_, _strict_ )</h1>
+        <h1>MakeSuperPropertyReference ( _actualThis_, _propertyKey_, _strict_ )</h1>
         <p>The abstract operation MakeSuperPropertyReference takes arguments _actualThis_, _propertyKey_, and _strict_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
@@ -13926,7 +13926,7 @@
         </emu-alg>
 
         <emu-clause id="sec-hostgetimportmetaproperties" aoid="HostGetImportMetaProperties">
-          <h1>Runtime Semantics: HostGetImportMetaProperties ( _moduleRecord_ )</h1>
+          <h1>HostGetImportMetaProperties ( _moduleRecord_ )</h1>
           <p>HostGetImportMetaProperties is a host-defined abstract operation that allows hosts to provide property keys and values for the object returned from `import.meta`.</p>
 
           <p>The implementation of HostGetImportMetaProperties must conform to the following requirements:</p>
@@ -13941,7 +13941,7 @@
         </emu-clause>
 
         <emu-clause id="sec-hostfinalizeimportmeta" aoid="HostFinalizeImportMeta">
-          <h1>Runtime Semantics: HostFinalizeImportMeta ( _importMeta_, _moduleRecord_ )</h1>
+          <h1>HostFinalizeImportMeta ( _importMeta_, _moduleRecord_ )</h1>
           <p>HostFinalizeImportMeta is a host-defined abstract operation that allows hosts to perform any extraordinary operations to prepare the object returned from `import.meta`.</p>
 
           <p>Most hosts will be able to simply define HostGetImportMetaProperties, and leave HostFinalizeImportMeta with its default behaviour. However, HostFinalizeImportMeta provides an "escape hatch" for hosts which need to directly manipulate the object before it is exposed to ECMAScript code.</p>
@@ -14737,7 +14737,7 @@
     </emu-clause>
 
     <emu-clause id="sec-instanceofoperator" aoid="InstanceofOperator">
-      <h1>Runtime Semantics: InstanceofOperator ( _V_, _target_ )</h1>
+      <h1>InstanceofOperator ( _V_, _target_ )</h1>
       <p>The abstract operation InstanceofOperator takes arguments _V_ (an ECMAScript language value) and _target_ (an ECMAScript language value). It implements the generic algorithm for determining if _V_ is an instance of _target_ either by consulting _target_'s @@hasInstance method or, if absent, determining whether the value of _target_'s *"prototype"* property is present in _V_'s prototype chain. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
@@ -15270,7 +15270,7 @@
     </emu-clause>
 
     <emu-clause id="sec-applystringornumericbinaryoperator" aoid="ApplyStringOrNumericBinaryOperator">
-      <h1>Runtime Semantics: ApplyStringOrNumericBinaryOperator ( _lval_, _opText_, _rval_ )</h1>
+      <h1>ApplyStringOrNumericBinaryOperator ( _lval_, _opText_, _rval_ )</h1>
       <p>The abstract operation ApplyStringOrNumericBinaryOperator takes arguments _lval_ (an ECMAScript language value), _opText_ (a sequence of Unicode code points), and _rval_ (an ECMAScript language value). It performs the following steps when called:</p>
       <emu-alg>
         1. If _opText_ is `+`, then
@@ -15318,7 +15318,7 @@
     </emu-clause>
 
     <emu-clause id="sec-evaluatestringornumericbinaryexpression" aoid="EvaluateStringOrNumericBinaryExpression">
-      <h1>Runtime Semantics: EvaluateStringOrNumericBinaryExpression ( _leftOperand_, _opText_, _rightOperand_ )</h1>
+      <h1>EvaluateStringOrNumericBinaryExpression ( _leftOperand_, _opText_, _rightOperand_ )</h1>
       <p>The abstract operation EvaluateStringOrNumericBinaryExpression takes arguments _leftOperand_ (a Parse Node), _opText_ (a sequence of Unicode code points), and _rightOperand_ (a Parse Node). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _lref_ be the result of evaluating _leftOperand_.
@@ -16247,7 +16247,7 @@
     </emu-clause>
 
     <emu-clause id="sec-blockdeclarationinstantiation" aoid="BlockDeclarationInstantiation">
-      <h1>Runtime Semantics: BlockDeclarationInstantiation ( _code_, _env_ )</h1>
+      <h1>BlockDeclarationInstantiation ( _code_, _env_ )</h1>
       <emu-note>
         <p>When a |Block| or |CaseBlock| is evaluated a new declarative Environment Record is created and bindings for each block scoped variable, constant, function, or class declared in the block are instantiated in the Environment Record.</p>
       </emu-note>
@@ -17231,7 +17231,7 @@
       </emu-clause>
 
       <emu-clause id="sec-loopcontinues" aoid="LoopContinues">
-        <h1>Runtime Semantics: LoopContinues ( _completion_, _labelSet_ )</h1>
+        <h1>LoopContinues ( _completion_, _labelSet_ )</h1>
         <p>The abstract operation LoopContinues takes arguments _completion_ and _labelSet_. It performs the following steps when called:</p>
         <emu-alg>
           1. If _completion_.[[Type]] is ~normal~, return *true*.
@@ -17521,7 +17521,7 @@
       </emu-clause>
 
       <emu-clause id="sec-forbodyevaluation" aoid="ForBodyEvaluation">
-        <h1>Runtime Semantics: ForBodyEvaluation ( _test_, _increment_, _stmt_, _perIterationBindings_, _labelSet_ )</h1>
+        <h1>ForBodyEvaluation ( _test_, _increment_, _stmt_, _perIterationBindings_, _labelSet_ )</h1>
         <p>The abstract operation ForBodyEvaluation takes arguments _test_, _increment_, _stmt_, _perIterationBindings_, and _labelSet_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _V_ be *undefined*.
@@ -17542,7 +17542,7 @@
       </emu-clause>
 
       <emu-clause id="sec-createperiterationenvironment" aoid="CreatePerIterationEnvironment">
-        <h1>Runtime Semantics: CreatePerIterationEnvironment ( _perIterationBindings_ )</h1>
+        <h1>CreatePerIterationEnvironment ( _perIterationBindings_ )</h1>
         <p>The abstract operation CreatePerIterationEnvironment takes argument _perIterationBindings_. It performs the following steps when called:</p>
         <emu-alg>
           1. If _perIterationBindings_ has any elements, then
@@ -17856,7 +17856,7 @@
       </emu-clause>
 
       <emu-clause id="sec-runtime-semantics-forinofheadevaluation" oldids="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
-        <h1>Runtime Semantics: ForIn/OfHeadEvaluation ( _uninitializedBoundNames_, _expr_, _iterationKind_ )</h1>
+        <h1>ForIn/OfHeadEvaluation ( _uninitializedBoundNames_, _expr_, _iterationKind_ )</h1>
         <p>The abstract operation ForIn/OfHeadEvaluation takes arguments _uninitializedBoundNames_, _expr_, and _iterationKind_ (either ~enumerate~, ~iterate~, or ~async-iterate~). It performs the following steps when called:</p>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
@@ -17885,7 +17885,7 @@
       </emu-clause>
 
       <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" aoid="ForIn/OfBodyEvaluation">
-        <h1>Runtime Semantics: ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ] )</h1>
+        <h1>ForIn/OfBodyEvaluation ( _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_, _labelSet_ [ , _iteratorKind_ ] )</h1>
         <p>The abstract operation ForIn/OfBodyEvaluation takes arguments _lhs_, _stmt_, _iteratorRecord_, _iterationKind_, _lhsKind_ (either ~assignment~, ~varBinding~ or ~lexicalBinding~), and _labelSet_ and optional argument _iteratorKind_ (either ~sync~ or ~async~). It performs the following steps when called:</p>
         <emu-alg>
           1. If _iteratorKind_ is not present, set _iteratorKind_ to ~sync~.
@@ -18703,7 +18703,7 @@
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-caseclauseisselected" aoid="CaseClauseIsSelected" oldids="sec-runtime-semantics-caseselectorevaluation">
-      <h1>Runtime Semantics: CaseClauseIsSelected ( _C_, _input_ )</h1>
+      <h1>CaseClauseIsSelected ( _C_, _input_ )</h1>
       <p>The abstract operation CaseClauseIsSelected takes arguments _C_ (a Parse Node for |CaseClause|) and _input_ (an ECMAScript language value). It determines whether _C_ matches _input_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _C_ is an instance of the production <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>.
@@ -22169,7 +22169,7 @@
     </emu-clause>
 
     <emu-clause id="sec-preparefortailcall" aoid="PrepareForTailCall">
-      <h1>Runtime Semantics: PrepareForTailCall ( )</h1>
+      <h1>PrepareForTailCall ( )</h1>
       <p>The abstract operation PrepareForTailCall takes no arguments. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _leafContext_ be the running execution context.
@@ -22398,7 +22398,7 @@
     </emu-clause>
 
     <emu-clause id="sec-globaldeclarationinstantiation" aoid="GlobalDeclarationInstantiation">
-      <h1>Runtime Semantics: GlobalDeclarationInstantiation ( _script_, _env_ )</h1>
+      <h1>GlobalDeclarationInstantiation ( _script_, _env_ )</h1>
       <emu-note>
         <p>When an execution context is established for evaluating scripts, declarations are instantiated in the current global environment. Each global binding declared in the code is instantiated.</p>
       </emu-note>
@@ -23917,7 +23917,7 @@
       </emu-clause>
 
       <emu-clause id="sec-hostresolveimportedmodule" aoid="HostResolveImportedModule">
-        <h1>Runtime Semantics: HostResolveImportedModule ( _referencingScriptOrModule_, _specifier_ )</h1>
+        <h1>HostResolveImportedModule ( _referencingScriptOrModule_, _specifier_ )</h1>
         <p>HostResolveImportedModule is a host-defined abstract operation that provides the concrete Module Record subclass instance that corresponds to the |ModuleSpecifier| String, _specifier_, occurring within the context of the script or module represented by the Script Record or Module Record _referencingScriptOrModule_. _referencingScriptOrModule_ may also be *null*, if the resolution is being performed in the context of an <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression, and there is no active script or module at that time.</p>
 
         <emu-note>
@@ -23944,7 +23944,7 @@
       </emu-clause>
 
       <emu-clause id="sec-hostimportmoduledynamically" aoid="HostImportModuleDynamically">
-        <h1>Runtime Semantics: HostImportModuleDynamically ( _referencingScriptOrModule_, _specifier_, _promiseCapability_ )</h1>
+        <h1>HostImportModuleDynamically ( _referencingScriptOrModule_, _specifier_, _promiseCapability_ )</h1>
         <p>HostImportModuleDynamically is a host-defined abstract operation that performs any necessary setup work in order to make available the module corresponding to the |ModuleSpecifier| String, _specifier_, occurring within the context of the script or module represented by the Script Record or Module Record _referencingScriptOrModule_. (_referencingScriptOrModule_ may also be *null*, if there is no active script or module when the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression occurs.) It then performs FinishDynamicImport to finish the dynamic import process.</p>
 
         <p>The implementation of HostImportModuleDynamically must conform to the following requirements:</p>
@@ -23989,7 +23989,7 @@
       </emu-clause>
 
       <emu-clause id="sec-finishdynamicimport" aoid="FinishDynamicImport">
-        <h1>Runtime Semantics: FinishDynamicImport ( _referencingScriptOrModule_, _specifier_, _promiseCapability_, _completion_ )</h1>
+        <h1>FinishDynamicImport ( _referencingScriptOrModule_, _specifier_, _promiseCapability_, _completion_ )</h1>
         <p>The abstract operation FinishDynamicImport takes arguments _referencingScriptOrModule_, _specifier_, _promiseCapability_ (a PromiseCapability Record), and _completion_. FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically. It performs the following steps when called:</p>
 
         <emu-alg>
@@ -24005,7 +24005,7 @@
       </emu-clause>
 
       <emu-clause id="sec-getmodulenamespace" aoid="GetModuleNamespace">
-        <h1>Runtime Semantics: GetModuleNamespace ( _module_ )</h1>
+        <h1>GetModuleNamespace ( _module_ )</h1>
         <p>The abstract operation GetModuleNamespace takes argument _module_. It retrieves the Module Namespace Object representing _module_'s exports, lazily creating it the first time it was requested, and storing it in _module_.[[Namespace]] for future retrieval. It performs the following steps when called:</p>
 
         <emu-alg>
@@ -24790,7 +24790,7 @@
       </emu-alg>
 
       <emu-clause id="sec-performeval" aoid="PerformEval" oldids="sec-performeval-rules-outside-functions,sec-performeval-rules-outside-methods,sec-performeval-rules-outside-constructors">
-        <h1>Runtime Semantics: PerformEval ( _x_, _callerRealm_, _strictCaller_, _direct_ )</h1>
+        <h1>PerformEval ( _x_, _callerRealm_, _strictCaller_, _direct_ )</h1>
         <p>The abstract operation PerformEval takes arguments _x_, _callerRealm_, _strictCaller_, and _direct_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
@@ -24855,7 +24855,7 @@
       </emu-clause>
 
       <emu-clause id="sec-evaldeclarationinstantiation" aoid="EvalDeclarationInstantiation">
-        <h1>Runtime Semantics: EvalDeclarationInstantiation ( _body_, _varEnv_, _lexEnv_, _strict_ )</h1>
+        <h1>EvalDeclarationInstantiation ( _body_, _varEnv_, _lexEnv_, _strict_ )</h1>
         <p>The abstract operation EvalDeclarationInstantiation takes arguments _body_, _varEnv_, _lexEnv_, and _strict_. It performs the following steps when called:</p>
         <!--
           WARNING: If you add, remove, rename, or repurpose any variable names
@@ -25077,7 +25077,7 @@
         <p>When a code unit to be included in a URI is not listed above or is not intended to have the special meaning sometimes given to the reserved code units, that code unit must be encoded. The code unit is transformed into its UTF-8 encoding, with <emu-xref href="#surrogate-pair">surrogate pairs</emu-xref> first converted from UTF-16 to the corresponding code point value. (Note that for code units in the range [0, 127] this results in a single octet with the same value.) The resulting sequence of octets is then transformed into a String with each octet represented by an escape sequence of the form *"%xx"*.</p>
 
         <emu-clause id="sec-encode" aoid="Encode">
-          <h1>Runtime Semantics: Encode ( _string_, _unescapedSet_ )</h1>
+          <h1>Encode ( _string_, _unescapedSet_ )</h1>
           <p>The abstract operation Encode takes arguments _string_ (a String) and _unescapedSet_ (a String). It performs URI encoding and escaping. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _strLen_ be the number of code units in _string_.
@@ -25103,7 +25103,7 @@
         </emu-clause>
 
         <emu-clause id="sec-decode" aoid="Decode">
-          <h1>Runtime Semantics: Decode ( _string_, _reservedSet_ )</h1>
+          <h1>Decode ( _string_, _reservedSet_ )</h1>
           <p>The abstract operation Decode takes arguments _string_ (a String) and _reservedSet_ (a String). It performs URI unescaping and decoding. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _strLen_ be the length of _string_.
@@ -25680,7 +25680,7 @@
         </emu-alg>
 
         <emu-clause id="sec-objectdefineproperties" aoid="ObjectDefineProperties">
-          <h1>Runtime Semantics: ObjectDefineProperties ( _O_, _Properties_ )</h1>
+          <h1>ObjectDefineProperties ( _O_, _Properties_ )</h1>
           <p>The abstract operation ObjectDefineProperties takes arguments _O_ and _Properties_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_O_) is Object.
@@ -25806,7 +25806,7 @@
         </emu-alg>
 
         <emu-clause id="sec-getownpropertykeys" aoid="GetOwnPropertyKeys">
-          <h1>Runtime Semantics: GetOwnPropertyKeys ( _O_, _type_ )</h1>
+          <h1>GetOwnPropertyKeys ( _O_, _type_ )</h1>
           <p>The abstract operation GetOwnPropertyKeys takes arguments _O_ and _type_ (either ~string~ or ~symbol~). It performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(_O_).
@@ -26078,7 +26078,7 @@
         </emu-note>
 
         <emu-clause id="sec-createdynamicfunction" aoid="CreateDynamicFunction">
-          <h1>Runtime Semantics: CreateDynamicFunction ( _constructor_, _newTarget_, _kind_, _args_ )</h1>
+          <h1>CreateDynamicFunction ( _constructor_, _newTarget_, _kind_, _args_ )</h1>
           <p>The abstract operation CreateDynamicFunction takes arguments _constructor_ (a constructor), _newTarget_ (a constructor), _kind_ (either ~normal~, ~generator~, ~async~, or ~asyncGenerator~), and _args_ (a List of ECMAScript language values). _constructor_ is the constructor function that is performing this action. _newTarget_ is the constructor that `new` was initially applied to. _args_ is the argument values that were passed to _constructor_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: The execution context stack has at least two elements.
@@ -26682,7 +26682,7 @@
         </emu-alg>
 
         <emu-clause id="sec-symboldescriptivestring" aoid="SymbolDescriptiveString">
-          <h1>Runtime Semantics: SymbolDescriptiveString ( _sym_ )</h1>
+          <h1>SymbolDescriptiveString ( _sym_ )</h1>
           <p>The abstract operation SymbolDescriptiveString takes argument _sym_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_sym_) is Symbol.
@@ -27390,7 +27390,7 @@
         </emu-alg>
 
         <emu-clause id="sec-numbertobigint" aoid="NumberToBigInt">
-          <h1>Runtime Semantics: NumberToBigInt ( _number_ )</h1>
+          <h1>NumberToBigInt ( _number_ )</h1>
           <p>The abstract operation NumberToBigInt takes argument _number_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_number_) is Number.
@@ -29147,7 +29147,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-timestring" aoid="TimeString">
-          <h1>Runtime Semantics: TimeString ( _tv_ )</h1>
+          <h1>TimeString ( _tv_ )</h1>
           <p>The abstract operation TimeString takes argument _tv_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
@@ -29160,7 +29160,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-datestring" aoid="DateString">
-          <h1>Runtime Semantics: DateString ( _tv_ )</h1>
+          <h1>DateString ( _tv_ )</h1>
           <p>The abstract operation DateString takes argument _tv_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
@@ -29357,7 +29357,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-timezoneestring" aoid="TimeZoneString">
-          <h1>Runtime Semantics: TimeZoneString ( _tv_ )</h1>
+          <h1>TimeZoneString ( _tv_ )</h1>
           <p>The abstract operation TimeZoneString takes argument _tv_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
@@ -29372,7 +29372,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-todatestring" aoid="ToDateString">
-          <h1>Runtime Semantics: ToDateString ( _tv_ )</h1>
+          <h1>ToDateString ( _tv_ )</h1>
           <p>The abstract operation ToDateString takes argument _tv_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_tv_) is Number.
@@ -29859,7 +29859,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-stringpad" aoid="StringPad">
-          <h1>Runtime Semantics: StringPad ( _O_, _maxLength_, _fillString_, _placement_ )</h1>
+          <h1>StringPad ( _O_, _maxLength_, _fillString_, _placement_ )</h1>
           <p>The abstract operation StringPad takes arguments _O_, _maxLength_, _fillString_, and _placement_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _placement_ is ~start~ or ~end~.
@@ -29935,7 +29935,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-getsubstitution" aoid="GetSubstitution">
-          <h1>Runtime Semantics: GetSubstitution ( _matched_, _str_, _position_, _captures_, _namedCaptures_, _replacement_ )</h1>
+          <h1>GetSubstitution ( _matched_, _str_, _position_, _captures_, _namedCaptures_, _replacement_ )</h1>
           <p>The abstract operation GetSubstitution takes arguments _matched_, _str_, _position_, _captures_, _namedCaptures_, and _replacement_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_matched_) is String.
@@ -30216,7 +30216,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-splitmatch" aoid="SplitMatch">
-          <h1>Runtime Semantics: SplitMatch ( _S_, _q_, _R_ )</h1>
+          <h1>SplitMatch ( _S_, _q_, _R_ )</h1>
           <p>The abstract operation SplitMatch takes arguments _S_ (a String), _q_ (an integer), and _R_ (a String). It returns either *false* or the end index of a match. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_R_) is String.
@@ -30357,7 +30357,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-trimstring" aoid="TrimString">
-          <h1>Runtime Semantics: TrimString ( _string_, _where_ )</h1>
+          <h1>TrimString ( _string_, _where_ )</h1>
           <p>The abstract operation TrimString takes arguments _string_ and _where_. It interprets _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _str_ be ? RequireObjectCoercible(_string_).
@@ -31256,7 +31256,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" aoid="RepeatMatcher">
-          <h1>Runtime Semantics: RepeatMatcher ( _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_ )</h1>
+          <h1>RepeatMatcher ( _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, _parenCount_ )</h1>
           <p>The abstract operation RepeatMatcher takes arguments _m_ (a Matcher), _min_ (an integer), _max_ (an integer or &infin;), _greedy_ (a Boolean), _x_ (a State), _c_ (a Continuation), _parenIndex_ (an integer), and _parenCount_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
             1. If _max_ is zero, return _c_(_x_).
@@ -31431,7 +31431,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-runtime-semantics-iswordchar-abstract-operation" aoid="IsWordChar">
-          <h1>Runtime Semantics: IsWordChar ( _e_ )</h1>
+          <h1>IsWordChar ( _e_ )</h1>
           <p>The abstract operation IsWordChar takes argument _e_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
             1. If _e_ is -1 or _e_ is _InputLength_, return *false*.
@@ -31538,7 +31538,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" aoid="CharacterSetMatcher">
-          <h1>Runtime Semantics: CharacterSetMatcher ( _A_, _invert_, _direction_ )</h1>
+          <h1>CharacterSetMatcher ( _A_, _invert_, _direction_ )</h1>
           <p>The abstract operation CharacterSetMatcher takes arguments _A_ (a CharSet), _invert_ (a Boolean), and _direction_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
             1. Return a new Matcher with parameters (_x_, _c_) that captures _A_, _invert_, and _direction_ and performs the following steps when called:
@@ -31560,7 +31560,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-runtime-semantics-canonicalize-ch" aoid="Canonicalize">
-          <h1>Runtime Semantics: Canonicalize ( _ch_ )</h1>
+          <h1>Canonicalize ( _ch_ )</h1>
           <p>The abstract operation Canonicalize takes argument _ch_ (a character). It performs the following steps when called:</p>
           <emu-alg>
             1. If _Unicode_ is *true* and _IgnoreCase_ is *true*, then
@@ -31603,7 +31603,7 @@ THH:mm:ss.sss
           </emu-note>
         </emu-clause>
         <emu-clause id="sec-runtime-semantics-unicodematchproperty-p" aoid="UnicodeMatchProperty">
-          <h1>Runtime Semantics: UnicodeMatchProperty ( _p_ )</h1>
+          <h1>UnicodeMatchProperty ( _p_ )</h1>
           <p>The abstract operation UnicodeMatchProperty takes argument _p_ (a List of Unicode code points). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _p_ is a List of Unicode code points that is identical to a List of Unicode code points that is a Unicode <emu-not-ref>property name</emu-not-ref> or property alias listed in the &ldquo;<emu-not-ref>Property name</emu-not-ref> and aliases&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref> or <emu-xref href="#table-binary-unicode-properties"></emu-xref>.
@@ -31621,7 +31621,7 @@ THH:mm:ss.sss
           <emu-import href="table-binary-unicode-properties.html"></emu-import>
         </emu-clause>
         <emu-clause id="sec-runtime-semantics-unicodematchpropertyvalue-p-v" aoid="UnicodeMatchPropertyValue">
-          <h1>Runtime Semantics: UnicodeMatchPropertyValue ( _p_, _v_ )</h1>
+          <h1>UnicodeMatchPropertyValue ( _p_, _v_ )</h1>
           <p>The abstract operation UnicodeMatchPropertyValue takes arguments _p_ (a List of Unicode code points) and _v_ (a List of Unicode code points). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _p_ is a List of Unicode code points that is identical to a List of Unicode code points that is a canonical, unaliased Unicode property name listed in the &ldquo;Canonical property name&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
@@ -31673,7 +31673,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-backreference-matcher" aoid="BackreferenceMatcher">
-          <h1>Runtime Semantics: BackreferenceMatcher ( _n_, _direction_ )</h1>
+          <h1>BackreferenceMatcher ( _n_, _direction_ )</h1>
           <p>The abstract operation BackreferenceMatcher takes arguments _n_ (an integer) and _direction_ (an integer). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _n_ &ge; 1.
@@ -31827,7 +31827,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-runtime-semantics-characterrange-abstract-operation" aoid="CharacterRange">
-          <h1>Runtime Semantics: CharacterRange ( _A_, _B_ )</h1>
+          <h1>CharacterRange ( _A_, _B_ )</h1>
           <p>The abstract operation CharacterRange takes arguments _A_ (a CharSet) and _B_ (a CharSet). It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _A_ and _B_ each contain exactly one character.
@@ -31968,7 +31968,7 @@ THH:mm:ss.sss
         <h1>Abstract Operations for the RegExp Constructor</h1>
 
         <emu-clause id="sec-regexpalloc" aoid="RegExpAlloc">
-          <h1>Runtime Semantics: RegExpAlloc ( _newTarget_ )</h1>
+          <h1>RegExpAlloc ( _newTarget_ )</h1>
           <p>The abstract operation RegExpAlloc takes argument _newTarget_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%RegExp.prototype%"*, &laquo; [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] &raquo;).
@@ -31978,7 +31978,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-regexpinitialize" aoid="RegExpInitialize">
-          <h1>Runtime Semantics: RegExpInitialize ( _obj_, _pattern_, _flags_ )</h1>
+          <h1>RegExpInitialize ( _obj_, _pattern_, _flags_ )</h1>
           <p>The abstract operation RegExpInitialize takes arguments _obj_, _pattern_, and _flags_. It performs the following steps when called:</p>
           <emu-alg>
             1. If _pattern_ is *undefined*, let _P_ be the empty String.
@@ -32018,7 +32018,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-regexpcreate" aoid="RegExpCreate">
-          <h1>Runtime Semantics: RegExpCreate ( _P_, _F_ )</h1>
+          <h1>RegExpCreate ( _P_, _F_ )</h1>
           <p>The abstract operation RegExpCreate takes arguments _P_ and _F_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? RegExpAlloc(%RegExp%).
@@ -32027,7 +32027,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-escaperegexppattern" aoid="EscapeRegExpPattern">
-          <h1>Runtime Semantics: EscapeRegExpPattern ( _P_, _F_ )</h1>
+          <h1>EscapeRegExpPattern ( _P_, _F_ )</h1>
           <p>The abstract operation EscapeRegExpPattern takes arguments _P_ and _F_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _S_ be a String in the form of a |Pattern[~U]| (|Pattern[+U]| if _F_ contains *"u"*) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the Abstract Closure that would result from evaluating _S_ as a |Pattern[~U]| (|Pattern[+U]| if _F_ contains *"u"*) must behave identically to the Abstract Closure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
@@ -32095,7 +32095,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-regexpexec" aoid="RegExpExec">
-          <h1>Runtime Semantics: RegExpExec ( _R_, _S_ )</h1>
+          <h1>RegExpExec ( _R_, _S_ )</h1>
           <p>The abstract operation RegExpExec takes arguments _R_ and _S_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: Type(_R_) is Object.
@@ -32114,7 +32114,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-regexpbuiltinexec" aoid="RegExpBuiltinExec">
-          <h1>Runtime Semantics: RegExpBuiltinExec ( _R_, _S_ )</h1>
+          <h1>RegExpBuiltinExec ( _R_, _S_ )</h1>
           <p>The abstract operation RegExpBuiltinExec takes arguments _R_ and _S_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _R_ is an initialized RegExp instance.
@@ -32935,7 +32935,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-isconcatspreadable" aoid="IsConcatSpreadable">
-          <h1>Runtime Semantics: IsConcatSpreadable ( _O_ )</h1>
+          <h1>IsConcatSpreadable ( _O_ )</h1>
           <p>The abstract operation IsConcatSpreadable takes argument _O_. It performs the following steps when called:</p>
           <emu-alg>
             1. If Type(_O_) is not Object, return *false*.
@@ -33783,7 +33783,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-sortcompare" aoid="SortCompare">
-          <h1>Runtime Semantics: SortCompare ( _x_, _y_ )</h1>
+          <h1>SortCompare ( _x_, _y_ )</h1>
           <p>The abstract operation SortCompare takes arguments _x_ and _y_. It also has access to the _comparefn_ argument passed to the current invocation of the `sort` method. It performs the following steps when called:</p>
           <emu-alg>
             1. If _x_ and _y_ are both *undefined*, return *+0*.
@@ -34575,7 +34575,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-validatetypedarray" aoid="ValidateTypedArray">
-          <h1>Runtime Semantics: ValidateTypedArray ( _O_ )</h1>
+          <h1>ValidateTypedArray ( _O_ )</h1>
           <p>The abstract operation ValidateTypedArray takes argument _O_. It performs the following steps when called:</p>
           <emu-alg>
             1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
@@ -35048,7 +35048,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
-          <h1>Runtime Semantics: AllocateTypedArray ( _constructorName_, _newTarget_, _defaultProto_ [ , _length_ ] )</h1>
+          <h1>AllocateTypedArray ( _constructorName_, _newTarget_, _defaultProto_ [ , _length_ ] )</h1>
           <p>The abstract operation AllocateTypedArray takes arguments _constructorName_ (a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>), _newTarget_, and _defaultProto_ and optional argument _length_. It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypedArray_ overloads. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
@@ -35068,7 +35068,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-allocatetypedarraybuffer" aoid="AllocateTypedArrayBuffer">
-          <h1>Runtime Semantics: AllocateTypedArrayBuffer ( _O_, _length_ )</h1>
+          <h1>AllocateTypedArrayBuffer ( _O_, _length_ )</h1>
           <p>The abstract operation AllocateTypedArrayBuffer takes arguments _O_ (a TypedArray object) and _length_. It allocates and associates an ArrayBuffer with _O_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: _O_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
@@ -37619,7 +37619,7 @@ THH:mm:ss.sss
       </emu-note>
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">
-        <h1>Runtime Semantics: InternalizeJSONProperty ( _holder_, _name_, _reviver_ )</h1>
+        <h1>InternalizeJSONProperty ( _holder_, _name_, _reviver_ )</h1>
         <p>The abstract operation InternalizeJSONProperty takes arguments _holder_ (an Object), _name_ (a String), and _reviver_ (a function object). It performs the following steps when called:</p>
         <emu-note>
           <p>This algorithm intentionally does not throw an exception if either [[Delete]] or CreateDataProperty return *false*.</p>
@@ -37739,7 +37739,7 @@ THH:mm:ss.sss
       </emu-note>
 
       <emu-clause id="sec-serializejsonproperty" aoid="SerializeJSONProperty">
-        <h1>Runtime Semantics: SerializeJSONProperty ( _state_, _key_, _holder_ )</h1>
+        <h1>SerializeJSONProperty ( _state_, _key_, _holder_ )</h1>
         <p>The abstract operation SerializeJSONProperty takes arguments _state_, _key_, and _holder_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _value_ be ? Get(_holder_, _key_).
@@ -37775,7 +37775,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-quotejsonstring" aoid="QuoteJSONString">
-        <h1>Runtime Semantics: QuoteJSONString ( _value_ )</h1>
+        <h1>QuoteJSONString ( _value_ )</h1>
         <p>The abstract operation QuoteJSONString takes argument _value_. It wraps _value_ in 0x0022 (QUOTATION MARK) code units and escapes certain other code units within it. This operation interprets _value_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
@@ -37887,7 +37887,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-unicodeescape" aoid="UnicodeEscape">
-        <h1>Runtime Semantics: UnicodeEscape ( _C_ )</h1>
+        <h1>UnicodeEscape ( _C_ )</h1>
         <p>The abstract operation UnicodeEscape takes argument _C_ (a code unit). It represents _C_ as a Unicode escape sequence. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be the numeric value of _C_.
@@ -37900,7 +37900,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-serializejsonobject" aoid="SerializeJSONObject">
-        <h1>Runtime Semantics: SerializeJSONObject ( _state_, _value_ )</h1>
+        <h1>SerializeJSONObject ( _state_, _value_ )</h1>
         <p>The abstract operation SerializeJSONObject takes arguments _state_ and _value_. It serializes an object. It performs the following steps when called:</p>
         <emu-alg>
           1. If _state_.[[Stack]] contains _value_, throw a *TypeError* exception because the structure is cyclical.
@@ -37938,7 +37938,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-serializejsonarray" aoid="SerializeJSONArray">
-        <h1>Runtime Semantics: SerializeJSONArray ( _state_, _value_ )</h1>
+        <h1>SerializeJSONArray ( _state_, _value_ )</h1>
         <p>The abstract operation SerializeJSONArray takes arguments _state_ and _value_. It serializes an array. It performs the following steps when called:</p>
         <emu-alg>
           1. If _state_.[[Stack]] contains _value_, throw a *TypeError* exception because the structure is cyclical.
@@ -39856,7 +39856,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-getpromiseresolve" aoid="GetPromiseResolve">
-          <h1>Runtime Semantics: GetPromiseResolve ( _promiseConstructor_ )</h1>
+          <h1>GetPromiseResolve ( _promiseConstructor_ )</h1>
           <p>The abstract operation GetPromiseResolve takes argument _promiseConstructor_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsConstructor(_promiseConstructor_) is *true*.
@@ -39867,7 +39867,7 @@ THH:mm:ss.sss
         </emu-clause>
 
         <emu-clause id="sec-performpromiseall" aoid="PerformPromiseAll">
-          <h1>Runtime Semantics: PerformPromiseAll ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
+          <h1>PerformPromiseAll ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
           <p>The abstract operation PerformPromiseAll takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
@@ -39949,7 +39949,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-performpromiseallsettled" aoid="PerformPromiseAllSettled">
-          <h1>Runtime Semantics: PerformPromiseAllSettled ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
+          <h1>PerformPromiseAllSettled ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
           <p>The abstract operation PerformPromiseAllSettled takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: ! IsConstructor(_constructor_) is *true*.
@@ -40068,7 +40068,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-performpromiseany" aoid="PerformPromiseAny">
-          <h1>Runtime Semantics: PerformPromiseAny ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
+          <h1>PerformPromiseAny ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
           <p>The abstract operation PerformPromiseAny takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: ! IsConstructor(_constructor_) is *true*.
@@ -40161,7 +40161,7 @@ THH:mm:ss.sss
         </emu-note>
 
         <emu-clause id="sec-performpromiserace" aoid="PerformPromiseRace">
-          <h1>Runtime Semantics: PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
+          <h1>PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
           <p>The abstract operation PerformPromiseRace takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
@@ -42284,7 +42284,7 @@ THH:mm:ss.sss
         <emu-note>This production can only be reached from the sequence `\c` within a character class where it is not followed by an acceptable control character.</emu-note>
 
         <emu-annex id="sec-runtime-semantics-characterrangeorunion-abstract-operation" aoid="CharacterRangeOrUnion">
-          <h1>Runtime Semantics: CharacterRangeOrUnion ( _A_, _B_ )</h1>
+          <h1>CharacterRangeOrUnion ( _A_, _B_ )</h1>
           <p>The abstract operation CharacterRangeOrUnion takes arguments _A_ (a CharSet) and _B_ (a CharSet). It performs the following steps when called:</p>
           <emu-alg>
             1. If _Unicode_ is *false*, then
@@ -42532,7 +42532,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-annex id="sec-createhtml" aoid="CreateHTML">
-          <h1>Runtime Semantics: CreateHTML ( _string_, _tag_, _attribute_, _value_ )</h1>
+          <h1>CreateHTML ( _string_, _tag_, _attribute_, _value_ )</h1>
           <p>The abstract operation CreateHTML takes arguments _string_, _tag_ (a String), _attribute_ (a String), and _value_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _str_ be ? RequireObjectCoercible(_string_).


### PR DESCRIPTION
A significant minority of abstract operations have a "Runtime Semantics" prefix that doesn't seem very useful (since the operations can only be used by reference from elsewhere, RS or otherwise). This PR updates them to match the rest of the spec.