### PR TITLE
Editorial: Use `RequireInternalSlot` in `RegExp.prototype.compile`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43724,8 +43724,7 @@ THH:mm:ss.sss
         <p>When the `compile` method is called with arguments _pattern_ and _flags_, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
-          1. If Type(_O_) is not Object or Type(_O_) is Object and _O_ does not have a [[RegExpMatcher]] internal slot, then
-            1. Throw a *TypeError* exception.
+          1. Perform ? RequireInternalSlot(_O_, [[RegExpMatcher]]).
           1. If Type(_pattern_) is Object and _pattern_ has a [[RegExpMatcher]] internal slot, then
             1. If _flags_ is not *undefined*, throw a *TypeError* exception.
             1. Let _P_ be _pattern_.[[OriginalSource]].


### PR DESCRIPTION
`RequireInternalSlot` has the same behaviour as what’s currently specified, so this can be simplified.

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2111) ([#sec-regexp.prototype.compile](https://ci.tc39.es/preview/tc39/ecma262/pull/2111#sec-regexp.prototype.compile))