### PR TITLE
Editorial: Define required internal slots in `CreateBuiltinFunction` steps

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13416,12 +13416,12 @@
   <emu-clause id="sec-built-in-function-objects">
     <h1>Built-in Function Objects</h1>
     <p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>) whose behaviour is provided using ECMAScript code or as implementation provided function exotic objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.</p>
-    <p>If a built-in function object is implemented as an exotic object it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such function exotic objects also have [[Prototype]], [[Extensible]], and [[Realm]] internal slots.</p>
+    <p>If a built-in function object is implemented as an ECMAScript function object, it must have all the internal slots described in <emu-xref href="#sec-ecmascript-function-objects"></emu-xref> ([[Prototype]], [[Extensible]], and the slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>), plus [[InitialName]]. The value of the [[InitialName]] internal slot is a String value that is the initial name of the function. It is used by <emu-xref href="#sec-function.prototype.tostring"></emu-xref>.</p>
+    <p>If a built-in function object is implemented as an exotic object, it must have the ordinary object behaviour specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. All such function exotic objects have [[Prototype]], [[Extensible]], [[Realm]], and [[InitialName]] internal slots, with the same meanings as above.</p>
     <p>Unless otherwise specified every built-in function object has the %Function.prototype% object as the initial value of its [[Prototype]] internal slot.</p>
     <p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] _thisArgument_ provides the *this* value, the [[Call]] _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*. When invoked with [[Construct]], the *this* value is uninitialized, the [[Construct]] _argumentsList_ provides the named parameters, and the [[Construct]] _newTarget_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the ECMAScript code that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[IsClassConstructor]] internal slot to have the value *true*.</p>
     <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function. When a built-in constructor is called as part of a `new` expression the _argumentsList_ parameter of the invoked [[Construct]] internal method provides the values for the built-in constructor's named parameters.</p>
     <p>Built-in functions that are not constructors do not have a *"prototype"* property unless otherwise specified in the description of a particular function.</p>
-    <p>Built-in functions have an [[InitialName]] internal slot.</p>
     <p>If a built-in function object is not implemented as an ECMAScript function it must provide [[Call]] and [[Construct]] internal methods that conform to the following definitions:</p>
 
     <emu-clause id="sec-built-in-function-objects-call-thisargument-argumentslist" type="internal method">
@@ -13479,7 +13479,7 @@
           _behaviour_: unknown,
           _length_: a non-negative integer or +&infin;,
           _name_: a property key,
-          _internalSlotsList_: a List of names of internal slots,
+          _additionalInternalSlotsList_: a List of names of internal slots,
           optional _realm_: a Realm Record,
           optional _prototype_: an Object or *null*,
           optional _prefix_: a String,
@@ -13487,17 +13487,19 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>_internalSlotsList_ contains the names of additional internal slots that must be defined as part of the object. This operation creates a built-in function object.</dd>
+        <dd>_additionalInternalSlotsList_ contains the names of additional internal slots that must be defined as part of the object. This operation creates a built-in function object.</dd>
       </dl>
       <emu-alg>
         1. Assert: _behaviour_ is either an Abstract Closure, a set of algorithm steps, or some other definition of a function's behaviour provided in this specification.
         1. If _realm_ is not present, set _realm_ to the current Realm Record.
         1. Assert: _realm_ is a Realm Record.
         1. If _prototype_ is not present, set _prototype_ to _realm_.[[Intrinsics]].[[%Function.prototype%]].
+        1. Let _internalSlotsList_ be a List containing the names of all the internal slots that <emu-xref href="#sec-built-in-function-objects"></emu-xref> requires for the built-in function object that is about to be created.
+        1. Append to _internalSlotsList_ the elements of _additionalInternalSlotsList_.
         1. Let _func_ be a new built-in function object that, when called, performs the action described by _behaviour_ using the provided arguments as the values of the corresponding parameters specified by _behaviour_. The new function object has internal slots whose names are the elements of _internalSlotsList_, and an [[InitialName]] internal slot.
-        1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[Prototype]] to _prototype_.
         1. Set _func_.[[Extensible]] to *true*.
+        1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[InitialName]] to *null*.
         1. Perform ! SetFunctionLength(_func_, _length_).
         1. If _prefix_ is not present, then


### PR DESCRIPTION
~~The way <code>[CreateBuiltinFunction]</code> is currently specified would’ve resulted in it not having the `[[Prototype]]`, `[[Extensible]]`, `[[Realm]]` and `[[ScriptOrModule]]` internal slots unless they were explicitly passed using <code>[CreateBuiltinFunction][]\(<var>steps</var>, « [[Prototype]], [[Extensible]], [[Realm]], [[ScriptOrModule]] »\)</code>.~~

~~I’ve also made it optional in preparation for converting many of the built‑in functions to use abstract closures after <https://github.com/tc39/ecma262/pull/2109>.~~

[CreateBuiltinFunction]: https://tc39.es/ecma262/#sec-createbuiltinfunction

## See also:
- <https://github.com/tc39/ecma262/pull/2109>
- <https://github.com/tc39/ecma262/pull/2116>

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2115) ([#sec-createbuiltinfunction](https://ci.tc39.es/preview/tc39/ecma262/pull/2115#sec-createbuiltinfunction))