### PR TITLE
Normative: explicitly specify order of operations in MakeTime

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28257,7 +28257,7 @@
           1. Let _m_ be ! ToInteger(_min_).
           1. Let _s_ be ! ToInteger(_sec_).
           1. Let _milli_ be ! ToInteger(_ms_).
-          1. Let _t_ be _h_ `*` msPerHour `+` _m_ `*` msPerMinute `+` _s_ `*` msPerSecond `+` _milli_, performing the arithmetic according to IEEE 754-2019 rules (that is, as if using the ECMAScript operators `*` and `+`).
+          1. Let _t_ be ((_h_ `*` msPerHour `+` _m_ `*` msPerMinute) `+` _s_ `*` msPerSecond) `+` _milli_, performing the arithmetic according to IEEE 754-2019 rules (that is, as if using the ECMAScript operators `*` and `+`).
           1. Return _t_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
While reviewing https://github.com/tc39/ecma262/pull/2007, @michaelficarra and I noticed that [`MakeTime`](https://tc39.es/ecma262/#sec-maketime) is underspecified: it has a step which reads

> Let t be h * msPerHour + m * msPerMinute + s * msPerSecond + milli, performing the arithmetic according to IEEE 754-2019 rules (that is, as if using the ECMAScript operators * and +)

but does not specify in which order to perform the additions. The choice of order is observable when using IEEE double-precision floats: for example,

- `((80063993375 * 3600000 + 29 * 60000) + 1 * 1000) + -288230376151711744` is `29312`, but 
- `80063993375 * 3600000 + (29 * 60000 + (1 * 1000 + -288230376151711744))` is `29248`.

(The actual value is `29256`.) So [`Date.UTC`](https://tc39.es/ecma262/#sec-date.utc)`(1970, 0, 1, 80063993375, 29, 1, -288230376151711740)` can have either of those results depending on your choice of order.

SpiderMonkey, ChakraCore, V8, and XS all appear to perform the arithmetic in left-to-right order, producing `29312`. Graal produces `29248`. (JSC [bounds all arguments above by 2^31](https://bugs.webkit.org/show_bug.cgi?id=215034), so it cannot observe this case, and quickJS produces `29256` because it internally uses 64-bit integers for this arithmetic, rather than the IEEE floats required, and so does not lose precision.)

In this PR I've chosen to go with the majority and enforce left-to-right evaluation order.