### PR TITLE
Editorial: reference correct nonterminals in IteratorDestructuringAssignmentEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16026,7 +16026,7 @@
               1. ReturnIfAbrupt(_value_).
           1. If _iteratorRecord_.[[Done]] is *true*, let _value_ be *undefined*.
           1. If |Initializer| is present and _value_ is *undefined*, then
-            1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
+            1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
               1. Let _v_ be NamedEvaluation of |Initializer| with argument GetReferencedName(_lref_).
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.


### PR DESCRIPTION
The referenced nonterminals don't exist. This was changed in #2030, presumably by accident (cc @jridgewell), and this PR puts it back (while keeping the tweaked wording @michaelficarra preferred).

Thanks to @devsnek for spotting it.