### PR TITLE
Editorial: remove unused %AggregateErrorPrototype% intrinsic

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2773,17 +2773,6 @@
             </tr>
             <tr>
               <td>
-                %AggregateErrorPrototype%
-              </td>
-              <td>
-                `AggregateError.prototype`
-              </td>
-              <td>
-                The initial value of the `prototype` data property of %AggregateError%; i.e., %AggregateError.prototype%
-              </td>
-            </tr>
-            <tr>
-              <td>
                 %Array%
               </td>
               <td>


### PR DESCRIPTION
This is non-normative since it is not a function, and nothing uses it in this or any other spec. It was mistakenly added in #2040.