### PR TITLE
Editorial: add missing WeakRef/Finalization well-known intrinsics to table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3160,6 +3160,17 @@
             </tr>
             <tr>
               <td>
+                %FinalizationRegistry%
+              </td>
+              <td>
+                `FinalizationRegistry`
+              </td>
+              <td>
+                The FinalizationRegistry constructor (<emu-xref href="#sec-finalization-registry-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 %Float32Array%
               </td>
               <td>
@@ -4002,6 +4013,17 @@
               </td>
               <td>
                 The initial value of the *"prototype"* data property of %WeakMap%; i.e., %WeakMap.prototype%
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %WeakRef%
+              </td>
+              <td>
+                `WeakRef`
+              </td>
+              <td>
+                The WeakRef constructor (<emu-xref href="#sec-weak-ref-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -38958,7 +38980,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-weak-ref-constructor">
       <h1>The WeakRef Constructor</h1>
-      <p>The WeakRef constructor:</p>
+      <p>The <dfn>WeakRef</dfn> constructor:</p>
       <ul>
         <li>is the intrinsic object %WeakRef%.</li>
         <li>
@@ -39090,7 +39112,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-finalization-registry-constructor">
       <h1>The FinalizationRegistry Constructor</h1>
-      <p>The FinalizationRegistry constructor:</p>
+      <p>The <dfn>FinalizationRegistry</dfn> constructor:</p>
       <ul>
         <li>is the intrinsic object <dfn>%FinalizationRegistry%</dfn>.</li>
         <li>


### PR DESCRIPTION
Unintentionally omitted from #2089.

Also added the `<dfn>`s for easier linking.