### PR TITLE
Normative: Add missing case in 'Static Semantics: TV and TRV'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12148,6 +12148,9 @@
             The TRV of <emu-grammar>NotEscapeSequence :: `0` DecimalDigit</emu-grammar> is the sequence consisting of the code unit 0x0030 (DIGIT ZERO) followed by the code units of the TRV of |DecimalDigit|.
           </li>
           <li>
+            The TRV of <emu-grammar>NotEscapeSequence :: DecimalDigit but not `0`</emu-grammar> is the code unit of the TRV of |DecimalDigit|.
+          </li>
+          <li>
             The TRV of <emu-grammar>NotEscapeSequence :: `x` [lookahead &lt;! HexDigit]</emu-grammar> is the code unit 0x0078 (LATIN SMALL LETTER X).
           </li>
           <li>


### PR DESCRIPTION
In current [Static Semantics: TV and TRV](https://tc39.es/ecma262/#sec-static-semantics-tv-and-trv), [`NotEscapeSequence :: DecimalDigit but not 0`](https://tc39.es/ecma262/#prod-NotEscapeSequence) case is undefined.