### PR TITLE
Editorial: Add missing ReturnIfAbrupt to PropertyDefinitionEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12789,7 +12789,7 @@
           1. Let _propKey_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_propKey_).
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
-            1. Let _propValue_ be NamedEvaluation of |AssignmentExpression| with argument _propKey_.
+            1. Let _propValue_ be ? NamedEvaluation of |AssignmentExpression| with argument _propKey_.
           1. Else,
             1. Let _exprValueRef_ be the result of evaluating |AssignmentExpression|.
             1. Let _propValue_ be ? GetValue(_exprValueRef_).
@@ -15631,7 +15631,7 @@
           1. If _iteratorRecord_.[[Done]] is *true*, let _value_ be *undefined*.
           1. If |Initializer| is present and _value_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
-              1. Let _v_ be NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
+              1. Let _v_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Let _v_ be ? GetValue(_defaultValue_).
@@ -15680,7 +15680,7 @@
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
-              1. Let _rhsValue_ be NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
+              1. Let _rhsValue_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Let _rhsValue_ be ? GetValue(_defaultValue_).
@@ -24633,7 +24633,7 @@
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
-            1. Let _value_ be NamedEvaluation of |AssignmentExpression| with argument *"default"*.
+            1. Let _value_ be ? NamedEvaluation of |AssignmentExpression| with argument *"default"*.
           1. Else,
             1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
@@ -42832,7 +42832,7 @@ THH:mm:ss.sss
         1. Else,
           1. Let _isProtoSetter_ be *false*.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and _isProtoSetter_ is *false*, then
-          1. Let _propValue_ be NamedEvaluation of |AssignmentExpression| with argument _propKey_.
+          1. Let _propValue_ be ? NamedEvaluation of |AssignmentExpression| with argument _propKey_.
         1. Else,
           1. Let _exprValueRef_ be the result of evaluating |AssignmentExpression|.
           1. Let _propValue_ be ? GetValue(_exprValueRef_).


### PR DESCRIPTION
In `PropertyDefinition : PropertyName : AssignmentExpression` rule of ["12.2.6.8 Runtime Semantics: PropertyDefinitionEvaluation"](https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-propertydefinitionevaluation), abrupt completion can be created by NamedEvaluation of AssignmentExpression at step 3.a. Therefore, it seems that adding `ReturnIfAbrupt` call at step 3 would be appropriate. 