### PR TITLE
Editorial: consistently connect Prototype objects to the appropriate `.prototype` property

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26425,7 +26425,7 @@
 
       <emu-clause id="sec-object.prototype">
         <h1>Object.prototype</h1>
-        <p>The initial value of `Object.prototype` is %Object.prototype%.</p>
+        <p>The initial value of `Object.prototype` is the Object prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -26466,7 +26466,7 @@
 
     <emu-clause id="sec-properties-of-the-object-prototype-object">
       <h1>Properties of the Object Prototype Object</h1>
-      <p>The Object prototype object:</p>
+      <p>The <dfn>Object prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%ObjectPrototype%</dfn>.</li>
         <li>has an [[Extensible]] internal slot whose value is *true*.</li>
@@ -26730,14 +26730,14 @@
 
       <emu-clause id="sec-function.prototype">
         <h1>Function.prototype</h1>
-        <p>The value of `Function.prototype` is %Function.prototype%, the intrinsic Function prototype object.</p>
+        <p>The value of `Function.prototype` is the Function prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-function-prototype-object">
       <h1>Properties of the Function Prototype Object</h1>
-      <p>The Function prototype object:</p>
+      <p>The <dfn>Function prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%Function.prototype%</dfn>.</li>
         <li>is itself a built-in function object.</li>
@@ -26940,14 +26940,14 @@
 
       <emu-clause id="sec-boolean.prototype">
         <h1>Boolean.prototype</h1>
-        <p>The initial value of `Boolean.prototype` is %Boolean.prototype%.</p>
+        <p>The initial value of `Boolean.prototype` is the Boolean prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-boolean-prototype-object">
       <h1>Properties of the Boolean Prototype Object</h1>
-      <p>The Boolean prototype object:</p>
+      <p>The <dfn>Boolean prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%BooleanPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
@@ -27132,7 +27132,7 @@
 
       <emu-clause id="sec-symbol.prototype">
         <h1>Symbol.prototype</h1>
-        <p>The initial value of `Symbol.prototype` is %Symbol.prototype%.</p>
+        <p>The initial value of `Symbol.prototype` is the Symbol prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -27181,7 +27181,7 @@
 
     <emu-clause id="sec-properties-of-the-symbol-prototype-object">
       <h1>Properties of the Symbol Prototype Object</h1>
-      <p>The Symbol prototype object:</p>
+      <p>The <dfn>Symbol prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%SymbolPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
@@ -27306,14 +27306,14 @@
 
       <emu-clause id="sec-error.prototype">
         <h1>Error.prototype</h1>
-        <p>The initial value of `Error.prototype` is %Error.prototype%.</p>
+        <p>The initial value of `Error.prototype` is the Error prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-error-prototype-object">
       <h1>Properties of the Error Prototype Object</h1>
-      <p>The Error prototype object:</p>
+      <p>The <dfn>Error prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%ErrorPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
@@ -27446,7 +27446,7 @@
 
       <emu-clause id="sec-properties-of-the-nativeerror-prototype-objects">
         <h1>Properties of the _NativeError_ Prototype Objects</h1>
-        <p>Each _NativeError_ prototype object:</p>
+        <p>Each <dfn>_NativeError_ prototype object</dfn>:</p>
         <ul>
           <li>is an ordinary object.</li>
           <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
@@ -27522,7 +27522,7 @@
 
       <emu-clause id="sec-properties-of-the-aggregate-error-prototype-objects">
         <h1>Properties of the AggregateError Prototype Object</h1>
-        <p>The AggregateError prototype object:</p>
+        <p>The <dfn>AggregateError prototype object</dfn>:</p>
         <ul>
           <li>is the intrinsic object <dfn>%AggregateError.prototype%</dfn>.</li>
           <li>is an ordinary object.</li>
@@ -27689,12 +27689,12 @@
 
       <emu-clause id="sec-number.parsefloat">
         <h1>Number.parseFloat ( _string_ )</h1>
-        <p>The value of the `Number.parseFloat` data property is the same built-in function object that is the value of the *"parseFloat"* property of the global object defined in <emu-xref href="#sec-parsefloat-string"></emu-xref>.</p>
+        <p>The value of the `Number.parseFloat` data property is the same built-in function object that is the initial value of the *"parseFloat"* property of the global object defined in <emu-xref href="#sec-parsefloat-string"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.parseint">
         <h1>Number.parseInt ( _string_, _radix_ )</h1>
-        <p>The value of the `Number.parseInt` data property is the same built-in function object that is the value of the *"parseInt"* property of the global object defined in <emu-xref href="#sec-parseint-string-radix"></emu-xref>.</p>
+        <p>The value of the `Number.parseInt` data property is the same built-in function object that is the initial value of the *"parseInt"* property of the global object defined in <emu-xref href="#sec-parseint-string-radix"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.positive_infinity">
@@ -27705,14 +27705,14 @@
 
       <emu-clause id="sec-number.prototype">
         <h1>Number.prototype</h1>
-        <p>The initial value of `Number.prototype` is %Number.prototype%.</p>
+        <p>The initial value of `Number.prototype` is the Number prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-number-prototype-object">
       <h1>Properties of the Number Prototype Object</h1>
-      <p>The Number prototype object:</p>
+      <p>The <dfn>Number prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%NumberPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
@@ -27963,14 +27963,14 @@
 
       <emu-clause id="sec-bigint.prototype">
         <h1>BigInt.prototype</h1>
-        <p>The initial value of `BigInt.prototype` is %BigInt.prototype%.</p>
+        <p>The initial value of `BigInt.prototype` is the BigInt prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-bigint-prototype-object">
       <h1>Properties of the BigInt Prototype Object</h1>
-      <p>The BigInt prototype object:</p>
+      <p>The <dfn>BigInt prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%BigInt.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
@@ -29406,7 +29406,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype">
         <h1>Date.prototype</h1>
-        <p>The initial value of `Date.prototype` is %Date.prototype%.</p>
+        <p>The initial value of `Date.prototype` is the Date prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -29436,7 +29436,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-date-prototype-object">
       <h1>Properties of the Date Prototype Object</h1>
-      <p>The Date prototype object:</p>
+      <p>The <dfn>Date prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%DatePrototype%</dfn>.</li>
         <li>is itself an ordinary object.</li>
@@ -30345,7 +30345,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype">
         <h1>String.prototype</h1>
-        <p>The initial value of `String.prototype` is %String.prototype%.</p>
+        <p>The initial value of `String.prototype` is the String prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -30380,7 +30380,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-string-prototype-object">
       <h1>Properties of the String Prototype Object</h1>
-      <p>The String prototype object:</p>
+      <p>The <dfn>String prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%StringPrototype%</dfn>.</li>
         <li>is a String exotic object and has the internal methods specified for such objects.</li>
@@ -33124,7 +33124,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp.prototype">
         <h1>RegExp.prototype</h1>
-        <p>The initial value of `RegExp.prototype` is %RegExp.prototype%.</p>
+        <p>The initial value of `RegExp.prototype` is the RegExp prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -33143,7 +33143,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-regexp-prototype-object">
       <h1>Properties of the RegExp Prototype Object</h1>
-      <p>The RegExp prototype object:</p>
+      <p>The <dfn>RegExp prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%RegExpPrototype%</dfn>.</li>
         <li>is an ordinary object.</li>
@@ -33945,7 +33945,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype">
         <h1>Array.prototype</h1>
-        <p>The value of `Array.prototype` is %Array.prototype%, the intrinsic Array prototype object.</p>
+        <p>The value of `Array.prototype` is the Array prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -33964,7 +33964,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-array-prototype-object">
       <h1>Properties of the Array Prototype Object</h1>
-      <p>The Array prototype object:</p>
+      <p>The <dfn>Array prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%ArrayPrototype%</dfn>.</li>
         <li>is an Array exotic object and has the internal methods specified for such objects.</li>
@@ -35553,7 +35553,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype">
         <h1>%TypedArray%.prototype</h1>
-        <p>The initial value of %TypedArray%`.prototype` is the %TypedArray.prototype% intrinsic object.</p>
+        <p>The initial value of %TypedArray%`.prototype` is the %TypedArray% prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -35571,10 +35571,11 @@ THH:mm:ss.sss
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-%typedarrayprototype%-object">
-      <h1>Properties of the %TypedArray.prototype% Object</h1>
-      <p>The <dfn>%TypedArray.prototype%</dfn> object:</p>
+      <h1>Properties of the %TypedArray% Prototype Object</h1>
+      <p>The <dfn>%TypedArray% prototype object</dfn>:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+        <li>is <dfn>%TypedArray.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
         <li>does not have a [[ViewedArrayBuffer]] or any other of the internal slots that are specific to _TypedArray_ instance objects.</li>
       </ul>
@@ -36440,7 +36441,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype">
         <h1>Map.prototype</h1>
-        <p>The initial value of `Map.prototype` is %Map.prototype%.</p>
+        <p>The initial value of `Map.prototype` is the Map prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -36459,7 +36460,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-map-prototype-object">
       <h1>Properties of the Map Prototype Object</h1>
-      <p>The Map prototype object:</p>
+      <p>The <dfn>Map prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%MapPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -36787,7 +36788,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype">
         <h1>Set.prototype</h1>
-        <p>The initial value of `Set.prototype` is the intrinsic %SetPrototype% object.</p>
+        <p>The initial value of `Set.prototype` is the Set prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -36806,7 +36807,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-set-prototype-object">
       <h1>Properties of the Set Prototype Object</h1>
-      <p>The Set prototype object:</p>
+      <p>The <dfn>Set prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%SetPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -37121,14 +37122,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakmap.prototype">
         <h1>WeakMap.prototype</h1>
-        <p>The initial value of `WeakMap.prototype` is %WeakMap.prototype%.</p>
+        <p>The initial value of `WeakMap.prototype` is the WeakMap prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-weakmap-prototype-object">
       <h1>Properties of the WeakMap Prototype Object</h1>
-      <p>The WeakMap prototype object:</p>
+      <p>The <dfn>WeakMap prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%WeakMapPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -37271,14 +37272,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakset.prototype">
         <h1>WeakSet.prototype</h1>
-        <p>The initial value of `WeakSet.prototype` is the intrinsic %WeakSetPrototype% object.</p>
+        <p>The initial value of `WeakSet.prototype` is the WeakSet prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-weakset-prototype-object">
       <h1>Properties of the WeakSet Prototype Object</h1>
-      <p>The WeakSet prototype object:</p>
+      <p>The <dfn>WeakSet prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%WeakSetPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -37632,7 +37633,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-arraybuffer.prototype">
         <h1>ArrayBuffer.prototype</h1>
-        <p>The initial value of `ArrayBuffer.prototype` is %ArrayBuffer.prototype%.</p>
+        <p>The initial value of `ArrayBuffer.prototype` is the ArrayBuffer prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -37651,7 +37652,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-arraybuffer-prototype-object">
       <h1>Properties of the ArrayBuffer Prototype Object</h1>
-      <p>The ArrayBuffer prototype object:</p>
+      <p>The <dfn>ArrayBuffer prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%ArrayBufferPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -37793,7 +37794,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-sharedarraybuffer.prototype">
         <h1>SharedArrayBuffer.prototype</h1>
-        <p>The initial value of `SharedArrayBuffer.prototype` is %SharedArrayBuffer.prototype%.</p>
+        <p>The initial value of `SharedArrayBuffer.prototype` is the SharedArrayBuffer prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -37809,7 +37810,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-sharedarraybuffer-prototype-object">
       <h1>Properties of the SharedArrayBuffer Prototype Object</h1>
-      <p>The SharedArrayBuffer prototype object:</p>
+      <p>The <dfn>SharedArrayBuffer prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%SharedArrayBufferPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -37970,14 +37971,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype">
         <h1>DataView.prototype</h1>
-        <p>The initial value of `DataView.prototype` is %DataView.prototype%.</p>
+        <p>The initial value of `DataView.prototype` is the DataView prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-dataview-prototype-object">
       <h1>Properties of the DataView Prototype Object</h1>
-      <p>The DataView prototype object:</p>
+      <p>The <dfn>DataView prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%DataViewPrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -39854,14 +39855,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction.prototype">
         <h1>GeneratorFunction.prototype</h1>
-        <p>The initial value of `GeneratorFunction.prototype` is %Generator%.</p>
+        <p>The initial value of `GeneratorFunction.prototype` is the GeneratorFunction prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-generatorfunction-prototype-object">
       <h1>Properties of the GeneratorFunction Prototype Object</h1>
-      <p>The GeneratorFunction prototype object:</p>
+      <p>The <dfn>GeneratorFunction prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%Generator%</dfn> (see <emu-xref href="#figure-2"></emu-xref>).</li>
         <li>is <dfn>%GeneratorFunction.prototype%</dfn>.</li>
@@ -39878,7 +39879,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction.prototype.prototype">
         <h1>GeneratorFunction.prototype.prototype</h1>
-        <p>The value of `GeneratorFunction.prototype.prototype` is the %Generator.prototype% intrinsic object.</p>
+        <p>The initial value of `GeneratorFunction.prototype.prototype` is the Generator prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -39961,14 +39962,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype">
         <h1>AsyncGeneratorFunction.prototype</h1>
-        <p>The initial value of `AsyncGeneratorFunction.prototype` is %AsyncGenerator%.</p>
+        <p>The initial value of `AsyncGeneratorFunction.prototype` is the AsyncGeneratorFunction prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-asyncgeneratorfunction-prototype">
       <h1>Properties of the AsyncGeneratorFunction Prototype Object</h1>
-      <p>The AsyncGeneratorFunction prototype object:</p>
+      <p>The <dfn>AsyncGeneratorFunction prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%AsyncGenerator%</dfn>.</li>
         <li>is <dfn>%AsyncGeneratorFunction.prototype%</dfn>.</li>
@@ -39985,7 +39986,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype-prototype">
         <h1>AsyncGeneratorFunction.prototype.prototype</h1>
-        <p>The value of `AsyncGeneratorFunction.prototype.prototype` is the %AsyncGenerator.prototype% intrinsic object.</p>
+        <p>The initial value of `AsyncGeneratorFunction.prototype.prototype` is the AsyncGenerator prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -40026,11 +40027,11 @@ THH:mm:ss.sss
   <emu-clause id="sec-generator-objects">
     <h1>Generator Objects</h1>
     <p>A Generator object is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
-    <p>Generator instances directly inherit properties from the object that is the value of the *"prototype"* property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %Generator.prototype%.</p>
+    <p>Generator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %Generator.prototype%.</p>
 
     <emu-clause id="sec-properties-of-generator-prototype">
       <h1>Properties of the Generator Prototype Object</h1>
-      <p>The Generator prototype object:</p>
+      <p>The <dfn>Generator prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%GeneratorPrototype%</dfn>.</li>
         <li>is <dfn>%Generator.prototype%</dfn> (<dfn>%GeneratorFunction.prototype.prototype%</dfn>).</li>
@@ -40237,11 +40238,11 @@ THH:mm:ss.sss
     <h1>AsyncGenerator Objects</h1>
     <p>An AsyncGenerator object is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
 
-    <p>AsyncGenerator instances directly inherit properties from the object that is the value of the *"prototype"* property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGenerator.prototype%.</p>
+    <p>AsyncGenerator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGenerator.prototype%.</p>
 
     <emu-clause id="sec-properties-of-asyncgenerator-prototype">
       <h1>Properties of the AsyncGenerator Prototype Object</h1>
-      <p>The AsyncGenerator prototype object:</p>
+      <p>The <dfn>AsyncGenerator prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%AsyncGeneratorPrototype%</dfn>.</li>
         <li>is <dfn>%AsyncGenerator.prototype%</dfn> (<dfn>%AsyncGeneratorFunction.prototype.prototype%</dfn>).</li>
@@ -41250,7 +41251,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.prototype">
         <h1>Promise.prototype</h1>
-        <p>The initial value of `Promise.prototype` is %Promise.prototype%.</p>
+        <p>The initial value of `Promise.prototype` is the Promise prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -41357,7 +41358,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-promise-prototype-object">
       <h1>Properties of the Promise Prototype Object</h1>
-      <p>The Promise prototype object:</p>
+      <p>The <dfn>Promise prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%PromisePrototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
@@ -41604,14 +41605,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-async-function-constructor-prototype">
         <h1>AsyncFunction.prototype</h1>
-        <p>The initial value of `AsyncFunction.prototype` is %AsyncFunction.prototype%.</p>
+        <p>The initial value of `AsyncFunction.prototype` is the AsyncFunction prototype object.</p>
 
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
     <emu-clause id="sec-async-function-prototype-properties">
       <h1>Properties of the AsyncFunction Prototype Object</h1>
-      <p>The AsyncFunction prototype object:</p>
+      <p>The <dfn>AsyncFunction prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%AsyncFunctionPrototype%</dfn>.</li>
         <li>is <dfn>%AsyncFunction.prototype%</dfn>.</li>


### PR DESCRIPTION

 - also, add `<dfn>`s as needed so everything links nicely

This PR was extracted from #2065, and should land before it.