### PR TITLE
Editorial: Use consistent "...generally do not look into function definitions" language

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19879,7 +19879,7 @@
         1. Return |ConciseBody| Contains _symbol_.
       </emu-alg>
       <emu-note>
-        <p>Normally, Contains does not look inside most function forms. However, Contains is used to detect `new.target`, `this`, and `super` usage within an |ArrowFunction|.</p>
+        <p>Static semantic rules that depend upon substructure generally do not look into function definitions. However, Contains is used to detect `new.target`, `this`, and `super` usage within an |ArrowFunction|.</p>
       </emu-note>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
@@ -21364,6 +21364,9 @@
       <emu-alg>
         1. Return *false*.
       </emu-alg>
+      <emu-note>
+        <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-async-function-definitions-static-semantics-HasDirectSuper">
@@ -21642,7 +21645,9 @@
         1. If _head_ Contains _symbol_ is *true*, return *true*.
         1. Return |AsyncConciseBody| Contains _symbol_.
       </emu-alg>
-      <emu-note>Normally, Contains does not look inside most function forms. However, Contains is used to detect `new.target`, `this`, and `super` usage within an AsyncArrowFunction.</emu-note>
+      <emu-note>
+        <p>Static semantic rules that depend upon substructure generally do not look into function definitions. However, Contains is used to detect `new.target`, `this`, and `super` usage within an |AsyncArrowFunction|.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-ContainsExpression">


### PR DESCRIPTION
There is a general pattern in which Contains abstract operations do not descend into function bodies, called out with notes like "Static semantic rules that depend upon substructure generally do not look into function definitions." ([example](https://tc39.es/ecma262/#sec-function-definitions-static-semantics-contains)). But the note is missing for [`async function` productions](https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-Contains) and is strangely worded (with "normally") for concise functions (both [sync](https://tc39.es/ecma262/#sec-arrow-function-definitions-static-semantics-contains) and [async](https://tc39.es/ecma262/#sec-async-arrow-function-definitions-static-semantics-Contains)).

This PR fixes those issues.