### PR TITLE
Normative: Fix out-of-range NaNs in date set methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32616,8 +32616,10 @@ THH:mm:ss.sss
         <h1>Date.prototype.setDate ( _date_ )</h1>
         <p>The following steps are performed:</p>
         <emu-alg>
-          1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
+          1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _dt_ be ? ToNumber(_date_).
+          1. If _t_ is *NaN*, return *NaN*.
+          1. Set _t_ to LocalTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -32630,8 +32632,8 @@ THH:mm:ss.sss
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
-          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
           1. Let _y_ be ? ToNumber(_year_).
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
           1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
@@ -32649,11 +32651,16 @@ THH:mm:ss.sss
         <h1>Date.prototype.setHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
         <p>The following steps are performed:</p>
         <emu-alg>
-          1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
+          1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _h_ be ? ToNumber(_hour_).
-          1. If _min_ is not present, let _m_ be MinFromTime(_t_); otherwise, let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
+          1. If _min_ is present, let _m_ be ? ToNumber(_min_).
+          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
+          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. If _t_ is *NaN*, return *NaN*.
+          1. Set _t_ to LocalTime(_t_).
+          1. If _min_ is not present, let _m_ be MinFromTime(_t_).
+          1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -32669,8 +32676,10 @@ THH:mm:ss.sss
         <h1>Date.prototype.setMilliseconds ( _ms_ )</h1>
         <p>The following steps are performed:</p>
         <emu-alg>
-          1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
+          1. Let _t_ be ? thisTimeValue(*this* value).
           1. Set _ms_ to ? ToNumber(_ms_).
+          1. If _t_ is *NaN*, return *NaN*.
+          1. Set _t_ to LocalTime(_t_).
           1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _ms_).
           1. Let _u_ be TimeClip(UTC(MakeDate(Day(_t_), _time_))).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -32682,10 +32691,14 @@ THH:mm:ss.sss
         <h1>Date.prototype.setMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
         <p>The following steps are performed:</p>
         <emu-alg>
-          1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
+          1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
+          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
+          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. If _t_ is *NaN*, return *NaN*.
+          1. Set _t_ to LocalTime(_t_).
+          1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -32701,9 +32714,12 @@ THH:mm:ss.sss
         <h1>Date.prototype.setMonth ( _month_ [ , _date_ ] )</h1>
         <p>The following steps are performed:</p>
         <emu-alg>
-          1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
+          1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
+          1. If _t_ is *NaN*, return *NaN*.
+          1. Set _t_ to LocalTime(_t_).
+          1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -32719,9 +32735,12 @@ THH:mm:ss.sss
         <h1>Date.prototype.setSeconds ( _sec_ [ , _ms_ ] )</h1>
         <p>The following steps are performed:</p>
         <emu-alg>
-          1. Let _t_ be LocalTime(? thisTimeValue(*this* value)).
+          1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
+          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. If _t_ is *NaN*, return *NaN*.
+          1. Set _t_ to LocalTime(_t_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
@@ -32751,6 +32770,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _dt_ be ? ToNumber(_date_).
+          1. If _t_ is *NaN*, return *NaN*.
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), TimeWithinDay(_t_)).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
@@ -32784,11 +32804,15 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _h_ be ? ToNumber(_hour_).
-          1. If _min_ is not present, let _m_ be MinFromTime(_t_); otherwise, let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_t_); otherwise, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_); otherwise, let _milli_ be ? ToNumber(_ms_).
-          1. Let _newDate_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
-          1. Let _v_ be TimeClip(_newDate_).
+          1. If _min_ is present, let _m_ be ? ToNumber(_min_).
+          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
+          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. If _t_ is *NaN*, return *NaN*.
+          1. If _min_ is not present, let _m_ be MinFromTime(_t_).
+          1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
+          1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. Let _v_ be TimeClip(_date_).
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
@@ -32803,8 +32827,9 @@ THH:mm:ss.sss
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
-          1. Let _milli_ be ? ToNumber(_ms_).
-          1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _milli_).
+          1. Set _ms_ to ? ToNumber(_ms_).
+          1. If _t_ is *NaN*, return *NaN*.
+          1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _ms_).
           1. Let _v_ be TimeClip(MakeDate(Day(_t_), _time_)).
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
@@ -32817,12 +32842,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_min_).
+          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
+          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. If _t_ is *NaN*, return *NaN*.
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
-          1. Else,
-            1. Let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
-          1. Else,
-            1. Let _milli_ be ? ToNumber(_ms_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
@@ -32840,9 +32864,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_month_).
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
+          1. If _t_ is *NaN*, return *NaN*.
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
-          1. Else,
-            1. Let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
@@ -32860,9 +32884,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _s_ be ? ToNumber(_sec_).
+          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. If _t_ is *NaN*, return *NaN*.
           1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
-          1. Else,
-            1. Let _milli_ be ? ToNumber(_ms_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
@@ -47125,8 +47149,8 @@ THH:mm:ss.sss
         <p>When the `setYear` method is called with one argument _year_, the following steps are taken:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
-          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
           1. Let _y_ be ? ToNumber(_year_).
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
           1. If _y_ is *NaN*, then
             1. Set the [[DateValue]] internal slot of this Date object to *NaN*.
             1. Return *NaN*.


### PR DESCRIPTION
Marked as editoral due to current text being nonsensical and new text matching implementations.