### PR TITLE
Editorial: rest parameters are reified as spec Lists

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -772,7 +772,7 @@
   <emu-clause id="sec-algorithm-conventions">
     <h1>Algorithm Conventions</h1>
     <p>The specification often uses a numbered list to specify steps in an algorithm. These algorithms are used to precisely specify the required semantics of ECMAScript language constructs. The algorithms are not intended to imply the use of any specific implementation technique. In practice, there may be more efficient algorithms available to implement a given feature.</p>
-    <p>Algorithms may be explicitly parameterized, in which case the names and usage of the parameters must be provided as part of the algorithm's definition.</p>
+    <p>Algorithms may be explicitly parameterized with an ordered, comma-separated sequence of alias names which may be used within the algorithm steps to reference the argument passed in that position. Optional parameters are denoted with surrounding brackets ([ , _name_ ]) and are no different from required parameters within algorithm steps. A rest parameter may appear at the end of a parameter list, denoted with leading ellipsis (, ..._name_). The rest parameter captures all of the arguments provided following the required and optional parameters into a List. If there are no such additional arguments, that List is empty.</p>
     <p>Algorithm steps may be subdivided into sequential substeps. Substeps are indented and may themselves be further divided into indented substeps. Outline numbering conventions are used to identify substeps with the first level of substeps labelled with lower case alphabetic characters and the second level of substeps labelled with lower case roman numerals. If more than three levels are required these rules repeat with the fourth level using numeric labels. For example:</p>
     <emu-alg type="example">
       1. Top-level step
@@ -25268,7 +25268,7 @@
   <p>Unless otherwise specified every built-in prototype object has the Object prototype object, which is the initial value of the expression `Object.prototype` (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>), as the value of its [[Prototype]] internal slot, except the Object prototype object itself.</p>
   <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function.</p>
   <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>).</p>
-  <p>Every built-in function object, including constructors, has a *"length"* property whose value is an integer. Unless otherwise specified, this value is equal to the largest number of named arguments shown in the subclause headings for the function description. Optional parameters (which are indicated with brackets: `[` `]`) or rest parameters (which are shown using the form &laquo;...name&raquo;) are not included in the default argument count.</p>
+  <p>Every built-in function object, including constructors, has a *"length"* property whose value is an integer. Unless otherwise specified, this value is equal to the number of required parameters shown in the subclause headings for the function description. Optional parameters and rest parameters are not included in the parameter count.</p>
   <emu-note>
     <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading &laquo;Array.prototype.map (callbackFn [ , thisArg])&raquo; which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is 1.</p>
   </emu-note>
@@ -26184,7 +26184,6 @@
         <emu-alg>
           1. Let _to_ be ? ToObject(_target_).
           1. If only one argument was passed, return _to_.
-          1. Let _sources_ be the List of argument values starting with the second argument.
           1. For each element _nextSource_ of _sources_, in ascending index order, do
             1. If _nextSource_ is neither *undefined* nor *null*, then
               1. Let _from_ be ! ToObject(_nextSource_).
@@ -26780,7 +26779,6 @@
         <emu-alg>
           1. Let _Target_ be the *this* value.
           1. If IsCallable(_Target_) is *false*, throw a *TypeError* exception.
-          1. Let _args_ be a new (possibly empty) List consisting of all of the argument values provided after _thisArg_ in order.
           1. Let _F_ be ? BoundFunctionCreate(_Target_, _thisArg_, _args_).
           1. Let _L_ be 0.
           1. Let _targetHasLength_ be ? HasOwnProperty(_Target_, *"length"*).
@@ -26810,10 +26808,8 @@
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
-          1. Let _argList_ be a new empty List.
-          1. If this method was called with more than one argument, then in left to right order, starting with the second argument, append each argument as the last element of _argList_.
           1. Perform PrepareForTailCall().
-          1. [id="step-function-proto-call-call"] Return ? Call(_func_, _thisArg_, _argList_).
+          1. [id="step-function-proto-call-call"] Return ? Call(_func_, _thisArg_, _args_).
         </emu-alg>
         <emu-note>
           <p>The _thisArg_ value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* _thisArg_ is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the _thisArg_ is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
@@ -30315,7 +30311,6 @@ THH:mm:ss.sss
         <h1>String.fromCharCode ( ..._codeUnits_ )</h1>
         <p>The `String.fromCharCode` function may be called with any number of arguments which form the rest parameter _codeUnits_. The following steps are taken:</p>
         <emu-alg>
-          1. Let _codeUnits_ be a List containing the arguments passed to this function.
           1. Let _length_ be the number of elements in _codeUnits_.
           1. Let _elements_ be a new empty List.
           1. Let _nextIndex_ be 0.
@@ -30333,7 +30328,6 @@ THH:mm:ss.sss
         <h1>String.fromCodePoint ( ..._codePoints_ )</h1>
         <p>The `String.fromCodePoint` function may be called with any number of arguments which form the rest parameter _codePoints_. The following steps are taken:</p>
         <emu-alg>
-          1. Let _codePoints_ be a List containing the arguments passed to this function.
           1. Let _length_ be the number of elements in _codePoints_.
           1. Let _elements_ be a new empty List.
           1. Let _nextIndex_ be 0.
@@ -30359,7 +30353,6 @@ THH:mm:ss.sss
         <h1>String.raw ( _template_, ..._substitutions_ )</h1>
         <p>The `String.raw` function may be called with a variable number of arguments. The first argument is _template_ and the remainder of the arguments form the List _substitutions_. The following steps are taken:</p>
         <emu-alg>
-          1. Let _substitutions_ be a List consisting of all of the arguments passed to this function, starting with the second argument. If fewer than two arguments were passed, the List is empty.
           1. Let _numberOfSubstitutions_ be the number of elements in _substitutions_.
           1. Let _cooked_ be ? ToObject(_template_).
           1. Let _raw_ be ? ToObject(? Get(_cooked_, *"raw"*)).
@@ -30474,7 +30467,6 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _args_ be a List whose elements are the arguments passed to this function.
           1. Let _R_ be _S_.
           1. Repeat, while _args_ is not empty,
             1. Remove the first element from _args_ and let _next_ be the value of that element.
@@ -33838,7 +33830,6 @@ THH:mm:ss.sss
           1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
           1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
           1. Let _k_ be 0.
-          1. Let _items_ be a zero-origined List containing the argument items in order.
           1. Repeat, while _k_ &lt; _numberOfArgs_,
             1. Let _Pk_ be ! ToString(_k_).
             1. Let _itemK_ be _items_[_k_].
@@ -33929,8 +33920,7 @@ THH:mm:ss.sss
         <h1>Array.of ( ..._items_ )</h1>
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
         <emu-alg>
-          1. Let _len_ be the actual number of arguments passed to this function.
-          1. Let _items_ be the List of arguments passed to this function.
+          1. Let _len_ be the number of elements in _items_.
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *true*, then
             1. Let _A_ be ? Construct(_C_, &laquo; _len_ &raquo;).
@@ -33986,14 +33976,14 @@ THH:mm:ss.sss
       </emu-note>
 
       <emu-clause id="sec-array.prototype.concat">
-        <h1>Array.prototype.concat ( ..._arguments_ )</h1>
+        <h1>Array.prototype.concat ( ..._items_ )</h1>
         <p>When the `concat` method is called with zero or more arguments, it returns an array containing the array elements of the object followed by the array elements of each argument in order.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _n_ be 0.
-          1. Let _items_ be a List whose first element is _O_ and whose subsequent elements are, in left to right order, the arguments that were passed to this function invocation.
+          1. Prepend _O_ to _items_.
           1. Repeat, while _items_ is not empty,
             1. Remove the first element from _items_ and let _E_ be the value of the element.
             1. Let _spreadable_ be ? IsConcatSpreadable(_E_).
@@ -34535,7 +34525,6 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _items_ be a List whose elements are, in left to right order, the arguments that were passed to this function invocation.
           1. Let _argCount_ be the number of elements in _items_.
           1. If _len_ + _argCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
           1. Repeat, while _items_ is not empty,
@@ -34917,14 +34906,14 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _relativeStart_ be ? ToInteger(_start_).
           1. If _relativeStart_ &lt; 0, let _actualStart_ be max((_len_ + _relativeStart_), 0); else let _actualStart_ be min(_relativeStart_, _len_).
-          1. If the number of actual arguments is 0, then
+          1. If _start_ is not present, then
             1. Let _insertCount_ be 0.
             1. Let _actualDeleteCount_ be 0.
-          1. Else if the number of actual arguments is 1, then
+          1. Else if _deleteCount_ is not present, then
             1. Let _insertCount_ be 0.
             1. Let _actualDeleteCount_ be _len_ - _actualStart_.
           1. Else,
-            1. Let _insertCount_ be the number of actual arguments minus 2.
+            1. Let _insertCount_ be the number of elements in _items_.
             1. Let _dc_ be ? ToInteger(_deleteCount_).
             1. Let _actualDeleteCount_ be min(max(_dc_, 0), _len_ - _actualStart_).
           1. If _len_ + _insertCount_ - _actualDeleteCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
@@ -34938,7 +34927,6 @@ THH:mm:ss.sss
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(_k_), _fromValue_).
             1. Set _k_ to _k_ + 1.
           1. Perform ? Set(_A_, *"length"*, _actualDeleteCount_, *true*).
-          1. Let _items_ be a List whose elements are, in left to right order, the portion of the actual argument list starting with the third argument. The list is empty if fewer than three arguments were passed.
           1. Let _itemCount_ be the number of elements in _items_.
           1. If _itemCount_ &lt; _actualDeleteCount_, then
             1. Set _k_ to _actualStart_.
@@ -35041,7 +35029,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _argCount_ be the number of actual arguments.
+          1. Let _argCount_ be the number of elements in _items_.
           1. If _argCount_ &gt; 0, then
             1. If _len_ + _argCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
             1. Let _k_ be _len_.
@@ -35057,7 +35045,6 @@ THH:mm:ss.sss
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Set _k_ to _k_ - 1.
             1. Let _j_ be 0.
-            1. Let _items_ be a List whose elements are, in left to right order, the arguments that were passed to this function invocation.
             1. Repeat, while _items_ is not empty,
               1. Remove the first element from _items_ and let _E_ be the value of that element.
               1. Perform ? Set(_O_, ! ToString(_j_), _E_, *true*).
@@ -35547,8 +35534,7 @@ THH:mm:ss.sss
         <h1>%TypedArray%.of ( ..._items_ )</h1>
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
         <emu-alg>
-          1. Let _len_ be the actual number of arguments passed to this function.
-          1. Let _items_ be the List of arguments passed to this function.
+          1. Let _len_ be the number of elements in _items_.
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
           1. Let _newObj_ be ? TypedArrayCreate(_C_, &laquo; _len_ &raquo;).


### PR DESCRIPTION
This PR is meant to be used as an example in the next editor call to decide whether we want rest parameters to be automatically reified in the associated algorithm steps as a spec List. We'll probably have to add a sentence to the Notational Conventions section to explicitly describe this.