### PR TITLE
Editorial: Reword StringIndexOf note and remove unused vars at its call sites

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1032,7 +1032,7 @@
           1. Return _pos_.
         </emu-alg>
         <emu-note>
-          <p>If _searchValue_ is empty and _fromIndex_ is less than or equal to the length of _string_, this algorithm returns _fromIndex_. An empty _searchValue_ is effectively found at every position within a string, including after the last code unit.</p>
+          <p>If _searchValue_ is the empty String and _fromIndex_ is less than or equal to the length of _string_, this algorithm returns _fromIndex_. The empty String is effectively found at every position within a string, including after the last code unit.</p>
         </emu-note>
         <emu-note>
           <p>This algorithm always returns -1 if _fromIndex_ &gt; the length of _string_.</p>
@@ -29979,7 +29979,6 @@ THH:mm:ss.sss
           1. Assert: If _position_ is *undefined*, then _pos_ is 0.
           1. Let _len_ be the length of _S_.
           1. Let _start_ be min(max(_pos_, 0), _len_).
-          1. Let _searchLen_ be the length of _searchStr_.
           1. Let _index_ be ! StringIndexOf(_S_, _searchStr_, _start_).
           1. If _index_ is not -1, return *true*.
           1. Return *false*.
@@ -30009,7 +30008,6 @@ THH:mm:ss.sss
           1. Assert: If _position_ is *undefined*, then _pos_ is 0.
           1. Let _len_ be the length of _S_.
           1. Let _start_ be min(max(_pos_, 0), _len_).
-          1. Let _searchLen_ be the length of _searchStr_.
           1. Return ! StringIndexOf(_S_, _searchStr_, _start_).
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
"_X_ is empty" prose is somewhat ambiguous: a reader may assume it refers to `~empty~` or absent parameters.