### PR TITLE
Editorial: Tweak "length" handling in Function.prototype.bind

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26782,14 +26782,14 @@
           1. If IsCallable(_Target_) is *false*, throw a *TypeError* exception.
           1. Let _args_ be a new (possibly empty) List consisting of all of the argument values provided after _thisArg_ in order.
           1. Let _F_ be ? BoundFunctionCreate(_Target_, _thisArg_, _args_).
+          1. Let _L_ be 0.
           1. Let _targetHasLength_ be ? HasOwnProperty(_Target_, *"length"*).
           1. If _targetHasLength_ is *true*, then
             1. Let _targetLen_ be ? Get(_Target_, *"length"*).
-            1. If Type(_targetLen_) is not Number, let _L_ be 0.
-            1. Else,
+            1. If Type(_targetLen_) is Number, then
               1. Set _targetLen_ to ! ToInteger(_targetLen_).
-              1. Let _L_ be the larger of 0 and the result of _targetLen_ minus the number of elements of _args_.
-          1. Else, let _L_ be 0.
+              1. Let _argCount_ be the number of elements in _args_.
+              1. Set _L_ to max(_targetLen_ - _argCount_, 0).
           1. Perform ! SetFunctionLength(_F_, _L_).
           1. Let _targetName_ be ? Get(_Target_, *"name"*).
           1. If Type(_targetName_) is not String, set _targetName_ to the empty String.


### PR DESCRIPTION
With this PR:
* _L_ is initialized with default value and reassigned later, eliminating two `Else` clauses;
* "be the larger of ... and" prose is replaced with well-defined [`max`](https://tc39.es/ecma262/#eqn-max) operation, also improving readbility.