### PR TITLE
Editorial: consistency around List iteration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -525,9 +525,9 @@
       }
     },
     "ecmarkup": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.0.0.tgz",
-      "integrity": "sha512-jSzTf5P2kpmFjmUPnYgPTyVhSxJsk3Foiw4eMsGn6d+z5wSgxUMLGLE6gNo5Ny1raAYmfAuDTCZ+SpAhqbFxHw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.1.0.tgz",
+      "integrity": "sha512-YMzGWBkOBJXNvNwuPfJ7Z+pbWet9Qm6SZ40HxPvXdExz/zMCt68k9xjn7OlHAijdsi97bVCWCKJmbCXmrwFG8g==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
@@ -748,11 +748,18 @@
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+        }
       }
     },
     "estraverse": {
@@ -1079,9 +1086,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^4.0.0"
+    "ecmarkup": "^4.1.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -4023,6 +4023,7 @@
     <emu-clause id="sec-list-and-record-specification-type">
       <h1>The List and Record Specification Types</h1>
       <p>The <dfn>List</dfn> type is used to explain the evaluation of argument lists (see <emu-xref href="#sec-argument-lists"></emu-xref>) in `new` expressions, in function calls, and in other algorithms where a simple ordered list of values is needed. Values of the List type are simply ordered sequences of list elements containing the individual values. These sequences may be of any length. The elements of a list may be randomly accessed using 0-origin indices. For notational convenience an array-like syntax can be used to access List elements. For example, _arguments_[2] is shorthand for saying the 3<sup>rd</sup> element of the List _arguments_.</p>
+      <p>When an algorithm iterates over the elements of a List without specifying an order, the order used is the order of the elements in the List.</p>
       <p>For notational convenience within this specification, a literal syntax can be used to express a new List value. For example, &laquo; 1, 2 &raquo; defines a List value that has two elements each of which is initialized to a specific value. A new empty List can be expressed as &laquo; &raquo;.</p>
       <p>The <dfn>Record</dfn> type is used to describe data aggregations within the algorithms of this specification. A Record type value consists of one or more named fields. The value of each field is either an ECMAScript value or an abstract value represented by a name associated with the Record type. Field names are always enclosed in double brackets, for example [[Value]].</p>
       <p>For notational convenience within this specification, an object literal-like syntax can be used to express a Record value. For example, { [[Field1]]: 42, [[Field2]]: *false*, [[Field3]]: ~empty~ } defines a Record value that has three fields, each of which is initialized to a specific value. Field name order is not significant. Any fields that are not explicitly listed are considered to be absent.</p>
@@ -4636,7 +4637,7 @@
             1. Let _methodNames_ be &laquo; *"toString"*, *"valueOf"* &raquo;.
           1. Else,
             1. Let _methodNames_ be &laquo; *"valueOf"*, *"toString"* &raquo;.
-          1. For each _name_ in _methodNames_ in List order, do
+          1. For each element _name_ of _methodNames_, do
             1. Let _method_ be ? Get(_O_, _name_).
             1. If IsCallable(_method_) is *true*, then
               1. Let _result_ be ? Call(_method_, _O_).
@@ -6058,7 +6059,7 @@
         1. Assert: Type(_O_) is Object.
         1. Let _ownKeys_ be ? _O_.[[OwnPropertyKeys]]().
         1. Let _properties_ be a new empty List.
-        1. For each element _key_ of _ownKeys_ in List order, do
+        1. For each element _key_ of _ownKeys_, do
           1. If Type(_key_) is String, then
             1. Let _desc_ be ? _O_.[[GetOwnProperty]](_key_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
@@ -6104,9 +6105,9 @@
         1. If _source_ is *undefined* or *null*, return _target_.
         1. Let _from_ be ! ToObject(_source_).
         1. Let _keys_ be ? _from_.[[OwnPropertyKeys]]().
-        1. For each element _nextKey_ of _keys_ in List order, do
+        1. For each element _nextKey_ of _keys_, do
           1. Let _excluded_ be *false*.
-          1. For each element _e_ of _excludedItems_ in List order, do
+          1. For each element _e_ of _excludedItems_, do
             1. If SameValue(_e_, _nextKey_) is *true*, then
               1. Set _excluded_ to *true*.
           1. If _excluded_ is *false*, then
@@ -8115,7 +8116,7 @@
       <p>At any time, if a set of objects _S_ is not live, an ECMAScript implementation may perform the following steps atomically:</p>
 
       <emu-alg>
-        1. For each _obj_ of _S_, do
+        1. For each element _obj_ of _S_, do
           1. For each WeakRef _ref_ such that _ref_.[[WeakRefTarget]] is _obj_, do
             1. Set _ref_.[[WeakRefTarget]] to ~empty~.
           1. For each FinalizationRegistry _fg_ such that _fg_.[[Cells]] contains a Record _cell_ such that _cell_.[[WeakRefTarget]] is _obj_, do
@@ -8971,7 +8972,7 @@
         1. Let _lexicalNames_ be the LexicallyDeclaredNames of _code_.
         1. Let _functionNames_ be a new empty List.
         1. Let _functionsToInitialize_ be a new empty List.
-        1. For each _d_ in _varDeclarations_, in reverse list order, do
+        1. For each element _d_ of _varDeclarations_, in reverse List order, do
           1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
             1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
             1. Let _fn_ be the sole element of the BoundNames of _d_.
@@ -8997,7 +8998,7 @@
           1. Let _env_ be NewDeclarativeEnvironment(_calleeEnv_).
           1. Assert: The VariableEnvironment of _calleeContext_ is _calleeEnv_.
           1. Set the LexicalEnvironment of _calleeContext_ to _env_.
-        1. For each String _paramName_ in _parameterNames_, do
+        1. For each String _paramName_ of _parameterNames_, do
           1. Let _alreadyDeclared_ be _env_.HasBinding(_paramName_).
           1. NOTE: Early errors ensure that duplicate parameter names can only occur in non-strict functions that do not have parameter default values or rest parameters.
           1. If _alreadyDeclared_ is *false*, then
@@ -9026,7 +9027,7 @@
         1. If _hasParameterExpressions_ is *false*, then
           1. NOTE: Only a single Environment Record is needed for the parameters and top-level vars.
           1. Let _instantiatedVarNames_ be a copy of the List _parameterBindings_.
-          1. For each _n_ in _varNames_, do
+          1. For each element _n_ of _varNames_, do
             1. If _n_ is not an element of _instantiatedVarNames_, then
               1. Append _n_ to _instantiatedVarNames_.
               1. Perform ! _env_.CreateMutableBinding(_n_, *false*).
@@ -9037,7 +9038,7 @@
           1. Let _varEnv_ be NewDeclarativeEnvironment(_env_).
           1. Set the VariableEnvironment of _calleeContext_ to _varEnv_.
           1. Let _instantiatedVarNames_ be a new empty List.
-          1. For each _n_ in _varNames_, do
+          1. For each element _n_ of _varNames_, do
             1. If _n_ is not an element of _instantiatedVarNames_, then
               1. Append _n_ to _instantiatedVarNames_.
               1. Perform ! _varEnv_.CreateMutableBinding(_n_, *false*).
@@ -9053,14 +9054,14 @@
         1. Else, let _lexEnv_ be _varEnv_.
         1. Set the LexicalEnvironment of _calleeContext_ to _lexEnv_.
         1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
-        1. For each element _d_ in _lexDeclarations_, do
+        1. For each element _d_ of _lexDeclarations_, do
           1. NOTE: A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated here but not initialized.
           1. For each element _dn_ of the BoundNames of _d_, do
             1. If IsConstantDeclaration of _d_ is *true*, then
               1. Perform ! _lexEnv_.CreateImmutableBinding(_dn_, *true*).
             1. Else,
               1. Perform ! _lexEnv_.CreateMutableBinding(_dn_, *false*).
-        1. For each Parse Node _f_ in _functionsToInitialize_, do
+        1. For each Parse Node _f_ of _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
           1. Let _fo_ be InstantiateFunctionObject of _f_ with argument _lexEnv_.
           1. Perform ! _varEnv_.SetMutableBinding(_fn_, _fo_, *false*).
@@ -10612,11 +10613,11 @@
         1. If _extensibleTarget_ is *true* and _targetNonconfigurableKeys_ is empty, then
           1. Return _trapResult_.
         1. Let _uncheckedResultKeys_ be a new List which is a copy of _trapResult_.
-        1. For each _key_ that is an element of _targetNonconfigurableKeys_, do
+        1. For each element _key_ of _targetNonconfigurableKeys_, do
           1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
           1. Remove _key_ from _uncheckedResultKeys_.
         1. If _extensibleTarget_ is *true*, return _trapResult_.
-        1. For each _key_ that is an element of _targetConfigurableKeys_, do
+        1. For each element _key_ of _targetConfigurableKeys_, do
           1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
           1. Remove _key_ from _uncheckedResultKeys_.
         1. If _uncheckedResultKeys_ is not empty, throw a *TypeError* exception.
@@ -10747,7 +10748,7 @@
       <p>The abstract operation CodePointsToString takes argument _text_ (a sequence of Unicode code points). It converts _text_ into a String value, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
       <emu-alg>
         1. Let _result_ be the empty String.
-        1. For each code point _cp_ in _text_, do
+        1. For each code point _cp_ of _text_, do
           1. Set _result_ to the string-concatenation of _result_ and ! CodePointToUTF16CodeUnits(_cp_).
         1. Return _result_.
       </emu-alg>
@@ -14415,7 +14416,7 @@
           1. If _importMeta_ is ~empty~, then
             1. Set _importMeta_ to ! OrdinaryObjectCreate(*null*).
             1. Let _importMetaValues_ be ! HostGetImportMetaProperties(_module_).
-            1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _importMetaValues_, do
+            1. For each Record { [[Key]], [[Value]] } _p_ of _importMetaValues_, do
               1. Perform ! CreateDataPropertyOrThrow(_importMeta_, _p_.[[Key]], _p_.[[Value]]).
             1. Perform ! HostFinalizeImportMeta(_importMeta_, _module_).
             1. Set _module_.[[ImportMeta]] to _importMeta_.
@@ -16760,7 +16761,7 @@
       <emu-alg>
         1. Assert: _env_ is a declarative Environment Record.
         1. Let _declarations_ be the LexicallyScopedDeclarations of _code_.
-        1. For each element _d_ in _declarations_, do
+        1. For each element _d_ of _declarations_, do
           1. For each element _dn_ of the BoundNames of _d_, do
             1. If IsConstantDeclaration of _d_ is *true*, then
               1. Perform ! _env_.CreateImmutableBinding(_dn_, *true*).
@@ -18363,7 +18364,7 @@
           1. If _uninitializedBoundNames_ is not an empty List, then
             1. Assert: _uninitializedBoundNames_ has no duplicate entries.
             1. Let _newEnv_ be NewDeclarativeEnvironment(_oldEnv_).
-            1. For each string _name_ in _uninitializedBoundNames_, do
+            1. For each String _name_ of _uninitializedBoundNames_, do
               1. Perform ! _newEnv_.CreateMutableBinding(_name_, *false*).
             1. Set the running execution context's LexicalEnvironment to _newEnv_.
           1. Let _exprRef_ be the result of evaluating _expr_.
@@ -18548,7 +18549,7 @@
               1. Repeat,
                 1. If _O_.[[ObjectWasVisited]] is *false*, then
                   1. Let _keys_ be ? _object_.[[OwnPropertyKeys]]().
-                  1. For each _key_ of _keys_ in List order, do
+                  1. For each element _key_ of _keys_, do
                     1. If Type(_key_) is String, then
                       1. Append _key_ to _remaining_.
                   1. Set _O_.[[ObjectWasVisited]] to *true*.
@@ -19151,7 +19152,7 @@
         1. Let _V_ be *undefined*.
         1. Let _A_ be the List of |CaseClause| items in |CaseClauses|, in source text order.
         1. Let _found_ be *false*.
-        1. For each |CaseClause| _C_ in _A_, do
+        1. For each |CaseClause| _C_ of _A_, do
           1. If _found_ is *false*, then
             1. Set _found_ to ? CaseClauseIsSelected(_C_, _input_).
           1. If _found_ is *true*, then
@@ -19168,7 +19169,7 @@
         1. Else,
           1. Let _A_ be &laquo; &raquo;.
         1. Let _found_ be *false*.
-        1. For each |CaseClause| _C_ in _A_, do
+        1. For each |CaseClause| _C_ of _A_, do
           1. If _found_ is *false*, then
             1. Set _found_ to ? CaseClauseIsSelected(_C_, _input_).
           1. If _found_ is *true*, then
@@ -19181,7 +19182,7 @@
         1. Else,
           1. Let _B_ be &laquo; &raquo;.
         1. If _found_ is *false*, then
-          1. For each |CaseClause| _C_ in _B_, do
+          1. For each |CaseClause| _C_ of _B_, do
             1. If _foundInB_ is *false*, then
               1. Set _foundInB_ to ? CaseClauseIsSelected(_C_, _input_).
             1. If _foundInB_ is *true*, then
@@ -19193,7 +19194,7 @@
         1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
         1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
         1. NOTE: The following is another complete iteration of the second |CaseClauses|.
-        1. For each |CaseClause| _C_ in _B_, do
+        1. For each |CaseClause| _C_ of _B_, do
           1. Let _R_ be the result of evaluating |CaseClause| _C_.
           1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
           1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
@@ -21678,7 +21679,7 @@
         1. Perform CreateMethodProperty(_proto_, *"constructor"*, _F_).
         1. If |ClassBody_opt| is not present, let _methods_ be a new empty List.
         1. Else, let _methods_ be NonConstructorMethodDefinitions of |ClassBody|.
-        1. For each |ClassElement| _m_ in order from _methods_, do
+        1. For each |ClassElement| _m_ of _methods_, do
           1. If IsStatic of _m_ is *false*, then
             1. Let _status_ be PropertyDefinitionEvaluation of _m_ with arguments _proto_ and *false*.
           1. Else,
@@ -22911,17 +22912,17 @@
         1. Assert: _env_ is a global Environment Record.
         1. Let _lexNames_ be the LexicallyDeclaredNames of _script_.
         1. Let _varNames_ be the VarDeclaredNames of _script_.
-        1. For each _name_ in _lexNames_, do
+        1. For each element _name_ of _lexNames_, do
           1. If _env_.HasVarDeclaration(_name_) is *true*, throw a *SyntaxError* exception.
           1. If _env_.HasLexicalDeclaration(_name_) is *true*, throw a *SyntaxError* exception.
           1. Let _hasRestrictedGlobal_ be ? _env_.HasRestrictedGlobalProperty(_name_).
           1. If _hasRestrictedGlobal_ is *true*, throw a *SyntaxError* exception.
-        1. For each _name_ in _varNames_, do
+        1. For each element _name_ of _varNames_, do
           1. If _env_.HasLexicalDeclaration(_name_) is *true*, throw a *SyntaxError* exception.
         1. Let _varDeclarations_ be the VarScopedDeclarations of _script_.
         1. Let _functionsToInitialize_ be a new empty List.
         1. Let _declaredFunctionNames_ be a new empty List.
-        1. For each _d_ in _varDeclarations_, in reverse list order, do
+        1. For each element _d_ of _varDeclarations_, in reverse List order, do
           1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
             1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
             1. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
@@ -22932,9 +22933,9 @@
               1. Append _fn_ to _declaredFunctionNames_.
               1. Insert _d_ as the first element of _functionsToInitialize_.
         1. Let _declaredVarNames_ be a new empty List.
-        1. For each _d_ in _varDeclarations_, do
+        1. For each element _d_ of _varDeclarations_, do
           1. If _d_ is a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
-            1. For each String _vn_ in the BoundNames of _d_, do
+            1. For each String _vn_ of the BoundNames of _d_, do
               1. If _vn_ is not an element of _declaredFunctionNames_, then
                 1. Let _vnDefinable_ be ? _env_.CanDeclareGlobalVar(_vn_).
                 1. If _vnDefinable_ is *false*, throw a *TypeError* exception.
@@ -22943,18 +22944,18 @@
         1. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviours that cause abnormal terminations in some of the following steps.
         1. [id="step-globaldeclarationinstantiation-web-compat-insertion-point"] NOTE: Annex <emu-xref href="#sec-web-compat-globaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
         1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _script_.
-        1. For each element _d_ in _lexDeclarations_, do
+        1. For each element _d_ of _lexDeclarations_, do
           1. NOTE: Lexically declared names are only instantiated here but not initialized.
           1. For each element _dn_ of the BoundNames of _d_, do
             1. If IsConstantDeclaration of _d_ is *true*, then
               1. Perform ? _env_.CreateImmutableBinding(_dn_, *true*).
             1. Else,
               1. Perform ? _env_.CreateMutableBinding(_dn_, *false*).
-        1. For each Parse Node _f_ in _functionsToInitialize_, do
+        1. For each Parse Node _f_ of _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
           1. Let _fo_ be InstantiateFunctionObject of _f_ with argument _env_.
           1. Perform ? _env_.CreateGlobalFunctionBinding(_fn_, _fo_, *false*).
-        1. For each String _vn_ in _declaredVarNames_, in list order, do
+        1. For each String _vn_ of _declaredVarNames_, do
           1. Perform ? _env_.CreateGlobalVarBinding(_vn_, *false*).
         1. Return NormalCompletion(~empty~).
       </emu-alg>
@@ -23184,7 +23185,7 @@
         <p>The abstract operation ImportedLocalNames takes argument _importEntries_ (a List of ImportEntry Records (see <emu-xref href="#table-39"></emu-xref>)). It creates a List of all of the local name bindings defined by _importEntries_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _localNames_ be a new empty List.
-          1. For each ImportEntry Record _i_ in _importEntries_, do
+          1. For each ImportEntry Record _i_ of _importEntries_, do
             1. Append _i_.[[LocalName]] to _localNames_.
           1. Return _localNames_.
         </emu-alg>
@@ -23550,7 +23551,7 @@
             1. Let _stack_ be a new empty List.
             1. Let _result_ be InnerModuleLinking(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion, then
-              1. For each Cyclic Module Record _m_ in _stack_, do
+              1. For each Cyclic Module Record _m_ of _stack_, do
                 1. Assert: _m_.[[Status]] is ~linking~.
                 1. Set _m_.[[Status]] to ~unlinked~.
                 1. Set _m_.[[Environment]] to *undefined*.
@@ -23579,7 +23580,7 @@
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Set _index_ to _index_ + 1.
               1. Append _module_ to _stack_.
-              1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+              1. For each String _required_ of _module_.[[RequestedModules]], do
                 1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
                 1. Set _index_ to ? InnerModuleLinking(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
@@ -23617,7 +23618,7 @@
             1. Let _stack_ be a new empty List.
             1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
             1. If _result_ is an abrupt completion, then
-              1. For each Cyclic Module Record _m_ in _stack_, do
+              1. For each Cyclic Module Record _m_ of _stack_, do
                 1. Assert: _m_.[[Status]] is ~evaluating~.
                 1. Set _m_.[[Status]] to ~evaluated~.
                 1. Set _m_.[[EvaluationError]] to _result_.
@@ -23646,7 +23647,7 @@
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Set _index_ to _index_ + 1.
               1. Append _module_ to _stack_.
-              1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+              1. For each String _required_ of _module_.[[RequestedModules]], do
                 1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
                 1. NOTE: Link must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
@@ -24228,7 +24229,7 @@
             1. Let _localExportEntries_ be a new empty List.
             1. Let _starExportEntries_ be a new empty List.
             1. Let _exportEntries_ be ExportEntries of _body_.
-            1. For each ExportEntry Record _ee_ in _exportEntries_, do
+            1. For each ExportEntry Record _ee_ of _exportEntries_, do
               1. If _ee_.[[ModuleRequest]] is *null*, then
                 1. If _ee_.[[LocalName]] is not an element of _importedBoundNames_, then
                   1. Append _ee_ to _localExportEntries_.
@@ -24264,13 +24265,13 @@
               1. Return a new empty List.
             1. Append _module_ to _exportStarSet_.
             1. Let _exportedNames_ be a new empty List.
-            1. For each ExportEntry Record _e_ in _module_.[[LocalExportEntries]], do
+            1. For each ExportEntry Record _e_ of _module_.[[LocalExportEntries]], do
               1. Assert: _module_ provides the direct binding for this export.
               1. Append _e_.[[ExportName]] to _exportedNames_.
-            1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
+            1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. Assert: _module_ imports a specific binding for this export.
               1. Append _e_.[[ExportName]] to _exportedNames_.
-            1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
+            1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
               1. Let _requestedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _starNames_ be ? _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
@@ -24295,16 +24296,16 @@
             1. If _resolveSet_ is not present, set _resolveSet_ to a new empty List.
             1. Assert: _resolveSet_ is a List of Record { [[Module]], [[ExportName]] }.
             1. Let _module_ be this Source Text Module Record.
-            1. For each Record { [[Module]], [[ExportName]] } _r_ in _resolveSet_, do
+            1. For each Record { [[Module]], [[ExportName]] } _r_ of _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
                 1. Assert: This is a circular import request.
                 1. Return *null*.
             1. Append the Record { [[Module]]: _module_, [[ExportName]]: _exportName_ } to _resolveSet_.
-            1. For each ExportEntry Record _e_ in _module_.[[LocalExportEntries]], do
+            1. For each ExportEntry Record _e_ of _module_.[[LocalExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Assert: _module_ provides the direct binding for this export.
                 1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _e_.[[LocalName]] }.
-            1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
+            1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. If _e_.[[ImportName]] is *"\*"*, then
@@ -24318,7 +24319,7 @@
               1. Return *null*.
               1. NOTE: A `default` export cannot be provided by an `export *` or `export * from "mod"` declaration.
             1. Let _starResolution_ be *null*.
-            1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
+            1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
               1. If _resolution_ is *"ambiguous"*, return *"ambiguous"*.
@@ -24339,7 +24340,7 @@
 
           <emu-alg>
             1. Let _module_ be this Source Text Module Record.
-            1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
+            1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]]).
               1. If _resolution_ is *null* or *"ambiguous"*, throw a *SyntaxError* exception.
               1. Assert: _resolution_ is a ResolvedBinding Record.
@@ -24348,7 +24349,7 @@
             1. Assert: _realm_ is not *undefined*.
             1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
             1. Set _module_.[[Environment]] to _env_.
-            1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
+            1. For each ImportEntry Record _in_ of _module_.[[ImportEntries]], do
               1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
               1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
               1. If _in_.[[ImportName]] is *"\*"*, then
@@ -24376,14 +24377,14 @@
             1. Let _code_ be _module_.[[ECMAScriptCode]].
             1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
             1. Let _declaredVarNames_ be a new empty List.
-            1. For each element _d_ in _varDeclarations_, do
+            1. For each element _d_ of _varDeclarations_, do
               1. For each element _dn_ of the BoundNames of _d_, do
                 1. If _dn_ is not an element of _declaredVarNames_, then
                   1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
                   1. Call _env_.InitializeBinding(_dn_, *undefined*).
                   1. Append _dn_ to _declaredVarNames_.
             1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
-            1. For each element _d_ in _lexDeclarations_, do
+            1. For each element _d_ of _lexDeclarations_, do
               1. For each element _dn_ of the BoundNames of _d_, do
                 1. If IsConstantDeclaration of _d_ is *true*, then
                   1. Perform ! _env_.CreateImmutableBinding(_dn_, *true*).
@@ -24514,7 +24515,7 @@
           1. If _namespace_ is *undefined*, then
             1. Let _exportedNames_ be ? _module_.GetExportedNames().
             1. Let _unambiguousNames_ be a new empty List.
-            1. For each _name_ that is an element of _exportedNames_, do
+            1. For each element _name_ of _exportedNames_, do
               1. Let _resolution_ be ? _module_.ResolveExport(_name_).
               1. If _resolution_ is a ResolvedBinding Record, append _name_ to _unambiguousNames_.
             1. Set _namespace_ to ModuleNamespaceCreate(_module_, _unambiguousNames_).
@@ -24935,7 +24936,7 @@
         <emu-alg>
           1. Let _entries_ be a new empty List.
           1. Let _names_ be the BoundNames of |VariableStatement|.
-          1. For each _name_ in _names_, do
+          1. For each element _name_ of _names_, do
             1. Append the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _name_, [[ExportName]]: _name_ } to _entries_.
           1. Return _entries_.
         </emu-alg>
@@ -24943,7 +24944,7 @@
         <emu-alg>
           1. Let _entries_ be a new empty List.
           1. Let _names_ be the BoundNames of |Declaration|.
-          1. For each _name_ in _names_, do
+          1. For each element _name_ of _names_, do
             1. Append the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _name_, [[ExportName]]: _name_ } to _entries_.
           1. Return _entries_.
         </emu-alg>
@@ -25367,7 +25368,7 @@
           1. Let _varDeclarations_ be the VarScopedDeclarations of _body_.
           1. If _strict_ is *false*, then
             1. If _varEnv_ is a global Environment Record, then
-              1. For each _name_ in _varNames_, do
+              1. For each element _name_ of _varNames_, do
                 1. If _varEnv_.HasLexicalDeclaration(_name_) is *true*, throw a *SyntaxError* exception.
                 1. NOTE: `eval` will not create a global var declaration that would be shadowed by a global lexical declaration.
             1. Let _thisEnv_ be _lexEnv_.
@@ -25375,7 +25376,7 @@
             1. Repeat, while _thisEnv_ is not the same as _varEnv_,
               1. If _thisEnv_ is not an object Environment Record, then
                 1. NOTE: The environment of with statements cannot contain any lexical declaration so it doesn't need to be checked for var/let hoisting conflicts.
-                1. For each _name_ in _varNames_, do
+                1. For each element _name_ of _varNames_, do
                   1. If _thisEnv_.HasBinding(_name_) is *true*, then
                     1. [id="step-evaldeclarationinstantiation-throw-duplicate-binding"] Throw a *SyntaxError* exception.
                     1. NOTE: Annex <emu-xref href="#sec-variablestatements-in-catch-blocks"></emu-xref> defines alternate semantics for the above step.
@@ -25383,7 +25384,7 @@
               1. Set _thisEnv_ to _thisEnv_.[[OuterEnv]].
           1. Let _functionsToInitialize_ be a new empty List.
           1. Let _declaredFunctionNames_ be a new empty List.
-          1. For each _d_ in _varDeclarations_, in reverse list order, do
+          1. For each element _d_ of _varDeclarations_, in reverse List order, do
             1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
               1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
               1. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
@@ -25396,9 +25397,9 @@
                 1. Insert _d_ as the first element of _functionsToInitialize_.
           1. [id="step-evaldeclarationinstantiation-web-compat-insertion-point"] NOTE: Annex <emu-xref href="#sec-web-compat-evaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
           1. Let _declaredVarNames_ be a new empty List.
-          1. For each _d_ in _varDeclarations_, do
+          1. For each element _d_ of _varDeclarations_, do
             1. If _d_ is a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
-              1. For each String _vn_ in the BoundNames of _d_, do
+              1. For each String _vn_ of the BoundNames of _d_, do
                 1. If _vn_ is not an element of _declaredFunctionNames_, then
                   1. If _varEnv_ is a global Environment Record, then
                     1. Let _vnDefinable_ be ? _varEnv_.CanDeclareGlobalVar(_vn_).
@@ -25407,14 +25408,14 @@
                     1. Append _vn_ to _declaredVarNames_.
           1. [id="step-evaldeclarationinstantiation-post-validation"] NOTE: No abnormal terminations occur after this algorithm step unless _varEnv_ is a global Environment Record and the global object is a Proxy exotic object.
           1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _body_.
-          1. For each element _d_ in _lexDeclarations_, do
+          1. For each element _d_ of _lexDeclarations_, do
             1. NOTE: Lexically declared names are only instantiated here but not initialized.
             1. For each element _dn_ of the BoundNames of _d_, do
               1. If IsConstantDeclaration of _d_ is *true*, then
                 1. Perform ? _lexEnv_.CreateImmutableBinding(_dn_, *true*).
               1. Else,
                 1. Perform ? _lexEnv_.CreateMutableBinding(_dn_, *false*).
-          1. For each Parse Node _f_ in _functionsToInitialize_, do
+          1. For each Parse Node _f_ of _functionsToInitialize_, do
             1. Let _fn_ be the sole element of the BoundNames of _f_.
             1. Let _fo_ be InstantiateFunctionObject of _f_ with argument _lexEnv_.
             1. If _varEnv_ is a global Environment Record, then
@@ -25427,7 +25428,7 @@
                 1. Perform ! _varEnv_.InitializeBinding(_fn_, _fo_).
               1. Else,
                 1. Perform ! _varEnv_.SetMutableBinding(_fn_, _fo_, *false*).
-          1. For each String _vn_ in _declaredVarNames_, in list order, do
+          1. For each String _vn_ of _declaredVarNames_, do
             1. If _varEnv_ is a global Environment Record, then
               1. Perform ? _varEnv_.CreateGlobalVarBinding(_vn_, *true*).
             1. Else,
@@ -25593,7 +25594,7 @@
                 1. If _cp_.[[IsUnpairedSurrogate]] is *true*, throw a *URIError* exception.
                 1. Set _k_ to _k_ + _cp_.[[CodeUnitCount]].
                 1. Let _Octets_ be the List of octets resulting by applying the UTF-8 transformation to _cp_.[[CodePoint]].
-                1. For each element _octet_ of _Octets_ in List order, do
+                1. For each element _octet_ of _Octets_, do
                   1. Set _R_ to the string-concatenation of:
                     * _R_
                     * *"%"*
@@ -26144,11 +26145,11 @@
         <emu-alg>
           1. Let _to_ be ? ToObject(_target_).
           1. If only one argument was passed, return _to_.
-          1. For each element _nextSource_ of _sources_, in ascending index order, do
+          1. For each element _nextSource_ of _sources_, do
             1. If _nextSource_ is neither *undefined* nor *null*, then
               1. Let _from_ be ! ToObject(_nextSource_).
               1. Let _keys_ be ? _from_.[[OwnPropertyKeys]]().
-              1. For each element _nextKey_ of _keys_ in List order, do
+              1. For each element _nextKey_ of _keys_, do
                 1. Let _desc_ be ? _from_.[[GetOwnProperty]](_nextKey_).
                 1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
                   1. Let _propValue_ be ? Get(_from_, _nextKey_).
@@ -26185,13 +26186,13 @@
             1. Let _props_ be ? ToObject(_Properties_).
             1. Let _keys_ be ? _props_.[[OwnPropertyKeys]]().
             1. Let _descriptors_ be a new empty List.
-            1. For each element _nextKey_ of _keys_ in List order, do
+            1. For each element _nextKey_ of _keys_, do
               1. Let _propDesc_ be ? _props_.[[GetOwnProperty]](_nextKey_).
               1. If _propDesc_ is not *undefined* and _propDesc_.[[Enumerable]] is *true*, then
                 1. Let _descObj_ be ? Get(_props_, _nextKey_).
                 1. Let _desc_ be ? ToPropertyDescriptor(_descObj_).
                 1. Append the pair (a two element List) consisting of _nextKey_ and _desc_ to the end of _descriptors_.
-            1. For each _pair_ from _descriptors_ in list order, do
+            1. For each element _pair_ of _descriptors_, do
               1. Let _P_ be the first element of _pair_.
               1. Let _desc_ be the second element of _pair_.
               1. Perform ? DefinePropertyOrThrow(_O_, _P_, _desc_).
@@ -26280,7 +26281,7 @@
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _ownKeys_ be ? _obj_.[[OwnPropertyKeys]]().
           1. Let _descriptors_ be ! OrdinaryObjectCreate(%Object.prototype%).
-          1. For each element _key_ of _ownKeys_ in List order, do
+          1. For each element _key_ of _ownKeys_, do
             1. Let _desc_ be ? _obj_.[[GetOwnProperty]](_key_).
             1. Let _descriptor_ be ! FromPropertyDescriptor(_desc_).
             1. If _descriptor_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_descriptors_, _key_, _descriptor_).
@@ -26310,7 +26311,7 @@
             1. Let _obj_ be ? ToObject(_O_).
             1. Let _keys_ be ? _obj_.[[OwnPropertyKeys]]().
             1. Let _nameList_ be a new empty List.
-            1. For each element _nextKey_ of _keys_ in List order, do
+            1. For each element _nextKey_ of _keys_, do
               1. If Type(_nextKey_) is Symbol and _type_ is ~symbol~ or Type(_nextKey_) is String and _type_ is ~string~, then
                 1. Append _nextKey_ as the last element of _nameList_.
             1. Return CreateArrayFromList(_nameList_).
@@ -30273,13 +30274,10 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _length_ be the number of elements in _codeUnits_.
           1. Let _elements_ be a new empty List.
-          1. Let _nextIndex_ be 0.
-          1. Repeat, while _nextIndex_ &lt; _length_,
-            1. Let _next_ be _codeUnits_[_nextIndex_].
+          1. For each element _next_ of _codeUnits_, do
             1. Let _nextCU_ be ? ToUint16(_next_).
             1. Append _nextCU_ to the end of _elements_.
-            1. Set _nextIndex_ to _nextIndex_ + 1.
-          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty String is returned.
+          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _codeUnits_ is empty, the empty String is returned.
         </emu-alg>
         <p>The *"length"* property of the `fromCharCode` function is 1.</p>
       </emu-clause>
@@ -30288,17 +30286,13 @@ THH:mm:ss.sss
         <h1>String.fromCodePoint ( ..._codePoints_ )</h1>
         <p>The `String.fromCodePoint` function may be called with any number of arguments which form the rest parameter _codePoints_. The following steps are taken:</p>
         <emu-alg>
-          1. Let _length_ be the number of elements in _codePoints_.
           1. Let _elements_ be a new empty List.
-          1. Let _nextIndex_ be 0.
-          1. Repeat, while _nextIndex_ &lt; _length_,
-            1. Let _next_ be _codePoints_[_nextIndex_].
+          1. For each element _next_ of _codePoints_, do
             1. Let _nextCP_ be ? ToNumber(_next_).
             1. If ! IsInteger(_nextCP_) is *false*, throw a *RangeError* exception.
             1. If _nextCP_ &lt; 0 or _nextCP_ &gt; 0x10FFFF, throw a *RangeError* exception.
             1. Append the elements of ! CodePointToUTF16CodeUnits(_nextCP_) to the end of _elements_.
-            1. Set _nextIndex_ to _nextIndex_ + 1.
-          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _length_ is 0, the empty String is returned.
+          1. Return the String value whose code units are, in order, the elements in the List _elements_. If _codePoints_ is empty, the empty String is returned.
         </emu-alg>
         <p>The *"length"* property of the `fromCodePoint` function is 1.</p>
       </emu-clause>
@@ -30428,8 +30422,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _R_ be _S_.
-          1. Repeat, while _args_ is not empty,
-            1. Remove the first element from _args_ and let _next_ be the value of that element.
+          1. For each element _next_ of _args_, do
             1. Let _nextString_ be ? ToString(_next_).
             1. Set _R_ to the string-concatenation of _R_ and _nextString_.
           1. Return _R_.
@@ -30901,7 +30894,7 @@ THH:mm:ss.sss
             1. Set _position_ to ! StringIndexOf(_string_, _searchString_, _position_ + _advanceBy_).
           1. Let _endOfLastMatch_ be 0.
           1. Let _result_ be the empty String.
-          1. For each _position_ in _matchPositions_, do
+          1. For each element _position_ of _matchPositions_, do
             1. Let _preserved_ be the substring of _string_ from _endOfLastMatch_ to _position_.
             1. If _functionalReplace_ is *true*, then
               1. Let _replacement_ be ? ToString(? Call(_replaceValue_, *undefined*, &laquo; _searchString_, _position_, _string_ &raquo;)).
@@ -33174,7 +33167,7 @@ THH:mm:ss.sss
                   1. Perform ? Set(_rx_, *"lastIndex"*, _nextIndex_, *true*).
           1. Let _accumulatedResult_ be the empty String.
           1. Let _nextSourcePosition_ be 0.
-          1. For each _result_ in _results_, do
+          1. For each element _result_ of _results_, do
             1. Let _resultLength_ be ? LengthOfArrayLike(_result_).
             1. Let _nCaptures_ be max(_resultLength_ - 1, 0).
             1. Let _matched_ be ? ToString(? Get(_result_, *"0"*)).
@@ -33192,7 +33185,7 @@ THH:mm:ss.sss
             1. Let _namedCaptures_ be ? Get(_result_, *"groups"*).
             1. If _functionalReplace_ is *true*, then
               1. Let _replacerArgs_ be &laquo; _matched_ &raquo;.
-              1. Append in list order the elements of _captures_ to the end of the List _replacerArgs_.
+              1. Append in List order the elements of _captures_ to the end of the List _replacerArgs_.
               1. Append _position_ and _S_ to _replacerArgs_.
               1. If _namedCaptures_ is not *undefined*, then
                 1. Append _namedCaptures_ as the last element of _replacerArgs_.
@@ -33696,8 +33689,7 @@ THH:mm:ss.sss
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _n_ be 0.
           1. Prepend _O_ to _items_.
-          1. Repeat, while _items_ is not empty,
-            1. Remove the first element from _items_ and let _E_ be the value of the element.
+          1. For each element _E_ of _items_, do
             1. Let _spreadable_ be ? IsConcatSpreadable(_E_).
             1. If _spreadable_ is *true*, then
               1. Let _k_ be 0.
@@ -34239,8 +34231,7 @@ THH:mm:ss.sss
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _argCount_ be the number of elements in _items_.
           1. If _len_ + _argCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
-          1. Repeat, while _items_ is not empty,
-            1. Remove the first element from _items_ and let _E_ be the value of the element.
+          1. For each element _E_ of _items_, do
             1. Perform ? Set(_O_, ! ToString(_len_), _E_, *true*).
             1. Set _len_ to _len_ + 1.
           1. Perform ? Set(_O_, *"length"*, _len_, *true*).
@@ -34671,8 +34662,7 @@ THH:mm:ss.sss
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Set _k_ to _k_ - 1.
           1. Set _k_ to _actualStart_.
-          1. Repeat, while _items_ is not empty,
-            1. Remove the first element from _items_ and let _E_ be the value of that element.
+          1. For each element _E_ of _items_, do
             1. Perform ? Set(_O_, ! ToString(_k_), _E_, *true*).
             1. Set _k_ to _k_ + 1.
           1. [id="step-array-proto-splice-set-length"] Perform ? Set(_O_, *"length"*, _len_ - _actualDeleteCount_ + _itemCount_, *true*).
@@ -34757,8 +34747,7 @@ THH:mm:ss.sss
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Set _k_ to _k_ - 1.
             1. Let _j_ be 0.
-            1. Repeat, while _items_ is not empty,
-              1. Remove the first element from _items_ and let _E_ be the value of that element.
+            1. For each element _E_ of _items_, do
               1. Perform ? Set(_O_, ! ToString(_j_), _E_, *true*).
               1. Set _j_ to _j_ + 1.
           1. Perform ? Set(_O_, *"length"*, _len_ + _argCount_, *true*).
@@ -36184,7 +36173,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. Set _p_.[[Key]] to ~empty~.
             1. Set _p_.[[Value]] to ~empty~.
           1. Return *undefined*.
@@ -36206,7 +36195,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Key]] to ~empty~.
               1. Set _p_.[[Value]] to ~empty~.
@@ -36235,7 +36224,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. For each Record { [[Key]], [[Value]] } _e_ that is an element of _entries_, in original key insertion order, do
+          1. For each Record { [[Key]], [[Value]] } _e_ of _entries_, in original key insertion order, do
             1. If _e_.[[Key]] is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _e_.[[Value]], _e_.[[Key]], _M_ &raquo;).
           1. Return *undefined*.
@@ -36255,7 +36244,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
           1. Return *undefined*.
         </emu-alg>
@@ -36268,7 +36257,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -36290,7 +36279,7 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Value]] to _value_.
               1. Return _M_.
@@ -36309,7 +36298,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Let _count_ be 0.
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~, set _count_ to _count_ + 1.
           1. Return _count_.
         </emu-alg>
@@ -36531,7 +36520,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
-          1. For each _e_ that is an element of _entries_, do
+          1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Return _S_.
           1. If _value_ is *-0*, set _value_ to *+0*.
@@ -36547,7 +36536,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
-          1. For each _e_ that is an element of _entries_, do
+          1. For each element _e_ of _entries_, do
             1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
           1. Return *undefined*.
         </emu-alg>
@@ -36568,7 +36557,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
-          1. For each _e_ that is an element of _entries_, do
+          1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
               1. Return *true*.
@@ -36599,7 +36588,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[SetData]].
-          1. For each _e_ that is an element of _entries_, in original insertion order, do
+          1. For each element _e_ of _entries_, in original insertion order, do
             1. If _e_ is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _e_, _e_, _S_ &raquo;).
           1. Return *undefined*.
@@ -36621,7 +36610,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
-          1. For each _e_ that is an element of _entries_, do
+          1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -36643,7 +36632,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Let _count_ be 0.
-          1. For each _e_ that is an element of _entries_, do
+          1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~, set _count_ to _count_ + 1.
           1. Return _count_.
         </emu-alg>
@@ -36859,7 +36848,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Key]] to ~empty~.
               1. Set _p_.[[Value]] to ~empty~.
@@ -36879,7 +36868,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *undefined*.
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
           1. Return *undefined*.
         </emu-alg>
@@ -36893,7 +36882,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -36907,7 +36896,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, throw a *TypeError* exception.
-          1. For each Record { [[Key]], [[Value]] } _p_ that is an element of _entries_, do
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Value]] to _value_.
               1. Return _M_.
@@ -37004,7 +36993,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
           1. If Type(_value_) is not Object, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
-          1. For each _e_ that is an element of _entries_, do
+          1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Return _S_.
           1. Append _value_ as the last element of _entries_.
@@ -37025,7 +37014,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
           1. If Type(_value_) is not Object, return *false*.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
-          1. For each _e_ that is an element of _entries_, do
+          1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
               1. Return *true*.
@@ -37044,7 +37033,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. If Type(_value_) is not Object, return *false*.
-          1. For each _e_ that is an element of _entries_, do
+          1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -38463,7 +38452,7 @@ THH:mm:ss.sss
                 1. Set _I_ to _I_ + 1.
             1. Else,
               1. Let _keys_ be ? EnumerableOwnPropertyNames(_val_, ~key~).
-              1. For each String _P_ in _keys_, do
+              1. For each String _P_ of _keys_, do
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_, _reviver_).
                 1. If _newElement_ is *undefined*, then
                   1. Perform ? _val_.[[Delete]](_P_).
@@ -38603,7 +38592,7 @@ THH:mm:ss.sss
         <p>The abstract operation QuoteJSONString takes argument _value_. It wraps _value_ in 0x0022 (QUOTATION MARK) code units and escapes certain other code units within it. This operation interprets _value_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
-          1. For each code point _C_ in ! StringToCodePoints(_value_), do
+          1. For each code point _C_ of ! StringToCodePoints(_value_), do
             1. If _C_ is listed in the &ldquo;Code Point&rdquo; column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
               1. Set _product_ to the string-concatenation of _product_ and the escape sequence for _C_ as specified in the &ldquo;Escape Sequence&rdquo; column of the corresponding row.
             1. Else if _C_ has a numeric value less than 0x0020 (SPACE), or if _C_ has the same numeric value as a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, then
@@ -39046,7 +39035,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
           1. If Type(_unregisterToken_) is not Object, throw a *TypeError* exception.
           1. Let _removed_ be *false*.
-          1. For each Record { [[WeakRefTarget]], [[HeldValue]], [[UnregisterToken]] } _cell_ that is an element of _finalizationRegistry_.[[Cells]], do
+          1. For each Record { [[WeakRefTarget]], [[HeldValue]], [[UnregisterToken]] } _cell_ of _finalizationRegistry_.[[Cells]], do
             1. If _cell_.[[UnregisterToken]] is not ~empty~ and SameValue(_cell_.[[UnregisterToken]], _unregisterToken_) is *true*, then
               1. Remove _cell_ from _finalizationRegistry_.[[Cells]].
               1. Set _removed_ to *true*.
@@ -40522,7 +40511,7 @@ THH:mm:ss.sss
         <h1>TriggerPromiseReactions ( _reactions_, _argument_ )</h1>
         <p>The abstract operation TriggerPromiseReactions takes arguments _reactions_ (a collection of PromiseReaction Records) and _argument_. It enqueues a new Job for each record in _reactions_. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReaction Record, and if the [[Handler]] is not ~empty~, calls it passing the given argument. If the [[Handler]] is ~empty~, the behaviour is determined by the [[Type]]. It performs the following steps when called:</p>
         <emu-alg>
-          1. For each _reaction_ in _reactions_, in original insertion order, do
+          1. For each element _reaction_ of _reactions_, in original insertion order, do
             1. Let _job_ be NewPromiseReactionJob(_reaction_, _argument_).
             1. Perform HostEnqueuePromiseJob(_job_.[[Job]], _job_.[[Realm]]).
           1. Return *undefined*.
@@ -41905,8 +41894,8 @@ THH:mm:ss.sss
       <p>The abstract operation EventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _events_ be an empty Set.
-        1. For each Agent Events Record _aer_ in _execution_.[[EventsRecords]], do
-          1. For each event _E_ in _aer_.[[EventList]], do
+        1. For each Agent Events Record _aer_ of _execution_.[[EventsRecords]], do
+          1. For each event _E_ of _aer_.[[EventList]], do
             1. Add _E_ to _events_.
         1. Return _events_.
       </emu-alg>
@@ -41917,7 +41906,7 @@ THH:mm:ss.sss
       <p>The abstract operation SharedDataBlockEventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _events_ be an empty Set.
-        1. For each event _E_ in EventSet(_execution_), do
+        1. For each event _E_ of EventSet(_execution_), do
           1. If _E_ is a ReadSharedMemory, WriteSharedMemory, or ReadModifyWriteSharedMemory event, add _E_ to _events_.
         1. Return _events_.
       </emu-alg>
@@ -41928,7 +41917,7 @@ THH:mm:ss.sss
       <p>The abstract operation HostEventSet takes argument _execution_ (a candidate execution). It performs the following steps when called:</p>
       <emu-alg>
         1. Let _events_ be an empty Set.
-        1. For each event _E_ in EventSet(_execution_), do
+        1. For each event _E_ of EventSet(_execution_), do
           1. If _E_ is not in SharedDataBlockEventSet(_execution_), add _E_ to _events_.
         1. Return _events_.
       </emu-alg>
@@ -41940,7 +41929,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _byteLocation_ be _byteIndex_.
         1. Let _bytesRead_ be a new empty List.
-        1. For each element _W_ of _Ws_ in List order, do
+        1. For each element _W_ of _Ws_, do
           1. Assert: _W_ has _byteLocation_ in its range.
           1. Let _payloadIndex_ be _byteLocation_ - _W_.[[ByteIndex]].
           1. If _W_ is a WriteSharedMemory event, then
@@ -42082,7 +42071,7 @@ THH:mm:ss.sss
       <h1>Valid Chosen Reads</h1>
       <p>A candidate execution _execution_ has valid chosen reads if the following abstract operation returns *true*.</p>
       <emu-alg>
-        1. For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ in SharedDataBlockEventSet(_execution_), do
+        1. For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ of SharedDataBlockEventSet(_execution_), do
           1. Let _chosenValueRecord_ be the element of _execution_.[[ChosenValues]] whose [[Event]] field is _R_.
           1. Let _chosenValue_ be _chosenValueRecord_.[[ChosenValue]].
           1. Let _readValue_ be ValueOfReadEvent(_execution_, _R_).
@@ -42100,10 +42089,10 @@ THH:mm:ss.sss
       <h1>Coherent Reads</h1>
       <p>A candidate execution _execution_ has coherent reads if the following abstract operation returns *true*.</p>
       <emu-alg>
-        1. For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ in SharedDataBlockEventSet(_execution_), do
+        1. For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ of SharedDataBlockEventSet(_execution_), do
           1. Let _Ws_ be _execution_.[[ReadsBytesFrom]](_R_).
           1. Let _byteLocation_ be _R_.[[ByteIndex]].
-          1. For each element _W_ of _Ws_ in List order, do
+          1. For each element _W_ of _Ws_, do
             1. If (_R_, _W_) is in _execution_.[[HappensBefore]], then
               1. Return *false*.
             1. If there is a WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ that has _byteLocation_ in its range such that the pairs (_W_, _V_) and (_V_, _R_) are in _execution_.[[HappensBefore]], then
@@ -42117,7 +42106,7 @@ THH:mm:ss.sss
       <h1>Tear Free Reads</h1>
       <p>A candidate execution _execution_ has tear free reads if the following abstract operation returns *true*.</p>
       <emu-alg>
-        1. For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ in SharedDataBlockEventSet(_execution_), do
+        1. For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ of SharedDataBlockEventSet(_execution_), do
           1. If _R_.[[NoTear]] is *true*, then
             1. Assert: The remainder of dividing _R_.[[ByteIndex]] by _R_.[[ElementSize]] is 0.
             1. For each event _W_ such that (_R_, _W_) is in _execution_.[[ReadsFrom]] and _W_.[[NoTear]] is *true*, do


### PR DESCRIPTION
Every place that an algorithm talks about iterating a List it now says `1. For each element _name_ of _list_, do`, rather than saying "in" or "that is a member of" or "from" or whatever. Sometimes an actual type is used in place of "element".

I also added a sentence to the description of the List type that explicitly says Lists are iterated in order, and removed the few places in the spec text which explicitly specified that the order of iteration was the order of the List. (Most places just assume it.)

~Marked as a draft until I get feedback on this and, if we are in favor of these changes, add a lint rule to ecmarkup to enforce this style where possible.~ Edit: ready to go. The first commit bumps ecmarkup, which fails linting, and the second commit changes the list iteration style and then passes linting. They should be landed in reverse order.

See also https://github.com/tc39/ecma262/pull/2142.