### PR TITLE
Editorial: Remove notes on well-formed rest arguments

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33651,9 +33651,6 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The _items_ argument is assumed to be a well-formed rest argument value.</p>
-        </emu-note>
-        <emu-note>
           <p>The `of` function is an intentionally generic factory method; it does not require that its *this* value be the Array constructor. Therefore it can be transferred to or inherited by other constructors that may be called with a single numeric argument.</p>
         </emu-note>
       </emu-clause>
@@ -35261,9 +35258,6 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return _newObj_.
         </emu-alg>
-        <emu-note>
-          <p>The _items_ argument is assumed to be a well-formed rest argument value.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype">


### PR DESCRIPTION
#2139 clarified rest parameters, making these notes unnecessary.