### PR TITLE
Editorial: consistent capitalization for "Proxy exotic object"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41010,7 +41010,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%Proxy%</dfn>.</li>
         <li>is the initial value of the *"Proxy"* property of the global object.</li>
-        <li>creates and initializes a new proxy exotic object when called as a constructor.</li>
+        <li>creates and initializes a new Proxy exotic object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
       </ul>
 
@@ -41029,7 +41029,7 @@ THH:mm:ss.sss
       <p>The Proxy constructor:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>does not have a *"prototype"* property because proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
+        <li>does not have a *"prototype"* property because Proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
         <li>has the following properties:</li>
       </ul>
 


### PR DESCRIPTION
The term "Proxy exotic object" appears 24 times, including once as a definition (with a `<dfn>`), whereas "proxy exotic object" appears twice. This PR changes those two cases to be capitalized, matching the other usages.