### PR TITLE
Editorial: Add note on ignored argument of Symbol.prototype[@@toPrimitive]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26704,13 +26704,16 @@
 
       <emu-clause id="sec-symbol.prototype-@@toprimitive">
         <h1>Symbol.prototype [ @@toPrimitive ] ( _hint_ )</h1>
-        <p>This function is called by ECMAScript language operators to convert a Symbol object to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*.</p>
+        <p>This function is called by ECMAScript language operators to convert a Symbol object to a primitive value.</p>
         <p>When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:</p>
         <emu-alg>
           1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <emu-note>
+          <p>The argument is ignored.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-symbol.prototype-@@tostringtag">


### PR DESCRIPTION
Aligns it with [`Date.prototype.toJSON`](https://tc39.es/ecma262/#sec-date.prototype.tojson) and removes incorrect "allowed values" note.