### PR TITLE
Meta: fix watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-snapshot": "npm run build-master && node scripts/insert_snapshot_warning.js",
     "clean": "rm -rf out",
     "test": "exit 0",
-    "watch": "npm run build-master -- --watch",
+    "watch": "npm run build-only -- --lint-spec --watch",
     "wipe-es6biblio": "echo \"{}\" > node_modules/ecmarkup/es6biblio.json",
     "check-commit": "node scripts/check-commit"
   },


### PR DESCRIPTION
Fixes #2083. The relevant difference is that `npm run watch` no longer passes `--strict` (which is necessary because `--strict` cannot be combined with `--lint-spec`).