### PR TITLE
Meta: add "Require Allow Edits" action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,6 @@ If you are changing the signature or behavior of an existing construct, please c
 
 * [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
 * [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
+
+Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
 -->

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -1,0 +1,14 @@
+name: Require “Allow Edits”
+
+on: [pull_request]
+
+jobs:
+  _:
+    name: "Require “Allow Edits”"
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: ljharb/require-allow-edits@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a github action to require "allow edits" to be checked.

I've created the PR while unchecking the box, so i can get a screenshot of it failing, and then i'll check it and rerun it, and then update the OP with the comparison.

---

<img width="846" alt="Screen Shot 2020-09-03 at 10 55 15 AM" src="https://user-images.githubusercontent.com/45469/92150372-2d795f00-edd4-11ea-984f-283b4e560db6.png">
<img width="630" alt="Screen Shot 2020-09-03 at 10 55 26 AM" src="https://user-images.githubusercontent.com/45469/92150371-2c483200-edd4-11ea-90f9-144a2204d59a.png">
<img width="586" alt="Screen Shot 2020-09-03 at 10 56 26 AM" src="https://user-images.githubusercontent.com/45469/92150369-2baf9b80-edd4-11ea-9477-44da8d025a05.png">

---

Note that the job has to be manually rerun (by rebasing or pushing to the PR, one of us clicking "rerun job" on the action, or by closing/reopening the PR); when I figure out how to make it automatically rerun when the box is checked, I'll update it to do so. imo this is Fine, though, because the benefit is automatically signaling to the PR author that they need to check the box.