### PR TITLE
Editorial: Move Object type check out of ObjectDefineProperties

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25674,6 +25674,7 @@
         <h1>Object.defineProperties ( _O_, _Properties_ )</h1>
         <p>The `defineProperties` function is used to add own properties and/or update the attributes of existing own properties of an object. When the `defineProperties` function is called, the following steps are taken:</p>
         <emu-alg>
+          1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. Return ? ObjectDefineProperties(_O_, _Properties_).
         </emu-alg>
 
@@ -25681,7 +25682,7 @@
           <h1>Runtime Semantics: ObjectDefineProperties ( _O_, _Properties_ )</h1>
           <p>The abstract operation ObjectDefineProperties takes arguments _O_ and _Properties_. It performs the following steps when called:</p>
           <emu-alg>
-            1. If Type(_O_) is not Object, throw a *TypeError* exception.
+            1. Assert: Type(_O_) is Object.
             1. Let _props_ be ? ToObject(_Properties_).
             1. Let _keys_ be ? _props_.[[OwnPropertyKeys]]().
             1. Let _descriptors_ be a new empty List.


### PR DESCRIPTION
[`ObjectDefineProperties`](https://tc39.es/ecma262/#sec-objectdefineproperties) has two call sites: [`Object.create`](https://tc39.es/ecma262/#sec-object.create) and [`Object.defineProperties`](https://tc39.es/ecma262/#sec-object.defineproperties).
This change moves Object type check before the latter since [`Object.create`](https://tc39.es/ecma262/#sec-object.create) always passes a newly created object as the first argument.