### PR TITLE
Editorial: a couple of fixes for Math

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27842,7 +27842,8 @@
           1. Let _onlyZero_ be *true*.
           1. For each element _number_ of _numbers_, do
             1. Let _n_ be ? ToNumber(_number_).
-            1. If _n_ is *NaN*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
+            1. If _n_ is *NaN* or _n_ is *+&infin;*, return _n_.
+            1. If _n_ is *-&infin;*, return *+&infin;*.
             1. If _n_ is neither *+0* nor *-0*, set _onlyZero_ to *false*.
             1. Append _n_ to _coerced_.
           1. If _onlyZero_ is *true*, return *+0*.

--- a/spec.html
+++ b/spec.html
@@ -27838,13 +27838,15 @@
         <p>When the `Math.hypot` method is called with at least two arguments _value1_ and _value2_ and any number of additional arguments which form the rest parameter ..._values_, the following steps are taken:</p>
         <emu-alg>
           1. Let _numbers_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
+          1. Let _coerced_ be a new empty List.
           1. Let _onlyZero_ be *true*.
           1. For each element _number_ of _numbers_, do
             1. Let _n_ be ? ToNumber(_number_).
             1. If _n_ is *NaN*, _n_ is *+&infin;*, or _n_ is *-&infin;*, return _n_.
             1. If _n_ is neither *+0* nor *-0*, set _onlyZero_ to *false*.
+            1. Append _n_ to _coerced_.
           1. If _onlyZero_ is *true*, return *+0*.
-          1. Return an implementation-approximated value representing the square root of the sum of squares of the elements of _numbers_.
+          1. Return an implementation-approximated value representing the square root of the sum of squares of the elements of _coerced_.
         </emu-alg>
         <emu-note>
           <p>Implementations should take care to avoid the loss of precision from overflows and underflows that are prone to occur in naive implementations when this function is called with two or more arguments.</p>

--- a/spec.html
+++ b/spec.html
@@ -27837,15 +27837,16 @@
         <p>Returns the square root of the sum of squares of its arguments.</p>
         <p>When the `Math.hypot` method is called with at least two arguments _value1_ and _value2_ and any number of additional arguments which form the rest parameter ..._values_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _numbers_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
+          1. Let _args_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
           1. Let _coerced_ be a new empty List.
-          1. Let _onlyZero_ be *true*.
-          1. For each element _number_ of _numbers_, do
-            1. Let _n_ be ? ToNumber(_number_).
-            1. If _n_ is *NaN* or _n_ is *+&infin;*, return _n_.
-            1. If _n_ is *-&infin;*, return *+&infin;*.
-            1. If _n_ is neither *+0* nor *-0*, set _onlyZero_ to *false*.
+          1. For each element _arg_ of _args_, do
+            1. Let _n_ be ? ToNumber(_arg_).
             1. Append _n_ to _coerced_.
+          1. Let _onlyZero_ be *true*.
+          1. For each element _number_ of _coerced_, do
+            1. If _number_ is *NaN* or _number_ is *+&infin;*, return _number_.
+            1. If _number_ is *-&infin;*, return *+&infin;*.
+            1. If _number_ is neither *+0* nor *-0*, set _onlyZero_ to *false*.
           1. If _onlyZero_ is *true*, return *+0*.
           1. Return an implementation-approximated value representing the square root of the sum of squares of the elements of _coerced_.
         </emu-alg>
@@ -27925,13 +27926,16 @@
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the largest of the resulting values.</p>
         <p>When the `Math.max` method is called with at least two arguments _value1_ and _value2_ and any number of additional arguments which form the rest parameter ..._values_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _numbers_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
+          1. Let _args_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
+          1. Let _coerced_ be a new empty List.
+          1. For each element _arg_ of _args_, do
+            1. Let _n_ be ? ToNumber(_arg_).
+            1. Append _n_ to _coerced_.
           1. Let _highest_ be *-&infin;*.
-          1. For each element _number_ of _numbers_, do
-            1. Let _n_ be ? ToNumber(_number_).
-            1. If _n_ is *NaN*, return *NaN*.
-            1. If _n_ is *+0* and _highest_ is *-0*, set _highest_ to *+0*.
-            1. If _n_ &gt; _highest_, set _highest_ to _n_.
+          1. For each element _number_ of _coerced_, do
+            1. If _number_ is *NaN*, return *NaN*.
+            1. If _number_ is *+0* and _highest_ is *-0*, set _highest_ to *+0*.
+            1. If _number_ &gt; _highest_, set _highest_ to _number_.
           1. Return _highest_.
         </emu-alg>
         <emu-note>
@@ -27944,13 +27948,16 @@
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the smallest of the resulting values.</p>
         <p>When the `Math.min` method is called with at least two arguments _value1_ and _value2_ and any number of additional arguments which form the rest parameter ..._values_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _numbers_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
+          1. Let _args_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
+          1. Let _coerced_ be a new empty List.
+          1. For each element _arg_ of _args_, do
+            1. Let _n_ be ? ToNumber(_arg_).
+            1. Append _n_ to _coerced_.
           1. Let _lowest_ be *+&infin;*.
-          1. For each element _number_ of _numbers_, do
-            1. Let _n_ be ? ToNumber(_number_).
-            1. If _n_ is *NaN*, return *NaN*.
-            1. If _n_ is *-0* and _lowest_ is *+0*, set _lowest_ to *-0*.
-            1. If _n_ &lt; _lowest_, set _lowest_ to _n_.
+          1. For each element _number_ of _coerced_, do
+            1. If _number_ is *NaN*, return *NaN*.
+            1. If _number_ is *-0* and _lowest_ is *+0*, set _lowest_ to *-0*.
+            1. If _number_ &lt; _lowest_, set _lowest_ to _number_.
           1. Return _lowest_.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
Followup to https://github.com/tc39/ecma262/pull/2122.

The first commit, https://github.com/tc39/ecma262/pull/2172/commits/75c3c480aec360a013e98890fb94bc204f1b7451, makes it explicit that coercion happens exactly once for each argument to Math.hypot. See https://github.com/tc39/ecma262/pull/2122#discussion_r487365913.

The second commit, https://github.com/tc39/ecma262/pull/2172/commits/fb2811b5b18e9d5cb9517554278acf015ec4ae81, ensures that `Math.hypot(-Infinity)` returns `Infinity`, not `-Infinity`.

The third commit, https://github.com/tc39/ecma262/pull/2172/commits/464d064159606b75f736d0e79b4269186762fd09, ensures that all possible side effects in `Math.hypot`, `Math.max`, and `Math.min` happen before the method returns.