### PR TITLE
Editorial: quick fixes re Math functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27679,7 +27679,7 @@
       <emu-clause id="sec-math.atan2">
         <h1>Math.atan2 ( _y_, _x_ )</h1>
         <p>Returns the inverse tangent of the quotient <emu-eqn>_y_ / _x_</emu-eqn> of the arguments _y_ and _x_, where the signs of _y_ and _x_ are used to determine the quadrant of the result. Note that it is intentional and traditional for the two-argument inverse tangent function that the argument named _y_ be first and the argument named _x_ be second. The result is expressed in radians and ranges from -&pi; to +&pi;, inclusive.</p>
-        <p>When the `Math.atan2` method is called with arguments _x_ and _y_, the following steps are taken:</p>
+        <p>When the `Math.atan2` method is called with arguments _y_ and _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _ny_ be ? ToNumber(_y_).
           1. Let _nx_ be ? ToNumber(_x_).
@@ -27824,20 +27824,20 @@
         <h1>Math.fround ( _x_ )</h1>
         <p>When the `Math.fround` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
-          1. If _x_ is *NaN*, return *NaN*.
-          1. If _x_ is one of *+0*, *-0*, *+&infin;*, *-&infin;*, return _x_.
-          1. Let _x32_ be the result of converting _x_ to a value in IEEE 754-2019 binary32 format using roundTiesToEven mode.
-          1. Let _x64_ be the result of converting _x32_ to a value in IEEE 754-2019 binary64 format.
-          1. Return the ECMAScript Number value corresponding to _x64_.
+          1. Let _n_ be ? ToNumber(_x_).
+          1. If _n_ is *NaN*, return *NaN*.
+          1. If _n_ is one of *+0*, *-0*, *+&infin;*, or *-&infin;*, return _n_.
+          1. Let _n32_ be the result of converting _n_ to a value in IEEE 754-2019 binary32 format using roundTiesToEven mode.
+          1. Let _n64_ be the result of converting _n32_ to a value in IEEE 754-2019 binary64 format.
+          1. Return the ECMAScript Number value corresponding to _n64_.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-math.hypot">
-        <h1>Math.hypot ( _value1_, _value2_, ..._values_ )</h1>
+        <h1>Math.hypot ( ..._args_ )</h1>
         <p>Returns the square root of the sum of squares of its arguments.</p>
-        <p>When the `Math.hypot` method is called with at least two arguments _value1_ and _value2_ and any number of additional arguments which form the rest parameter ..._values_, the following steps are taken:</p>
+        <p>When the `Math.hypot` method is called with zero or more arguments which form the rest parameter ..._args_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _args_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
           1. Let _coerced_ be a new empty List.
           1. For each element _arg_ of _args_, do
             1. Let _n_ be ? ToNumber(_arg_).
@@ -27850,6 +27850,7 @@
           1. If _onlyZero_ is *true*, return *+0*.
           1. Return an implementation-approximated value representing the square root of the sum of squares of the elements of _coerced_.
         </emu-alg>
+        <p>The *"length"* property of the `hypot` method is 2.</p>
         <emu-note>
           <p>Implementations should take care to avoid the loss of precision from overflows and underflows that are prone to occur in naive implementations when this function is called with two or more arguments.</p>
         </emu-note>
@@ -27922,11 +27923,10 @@
       </emu-clause>
 
       <emu-clause id="sec-math.max">
-        <h1>Math.max ( _value1_, _value2_, ..._values_ )</h1>
+        <h1>Math.max ( ..._args_ )</h1>
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the largest of the resulting values.</p>
-        <p>When the `Math.max` method is called with at least two arguments _value1_ and _value2_ and any number of additional arguments which form the rest parameter ..._values_, the following steps are taken:</p>
+        <p>When the `Math.max` method is called with zero or more arguments which form the rest parameter ..._args_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _args_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
           1. Let _coerced_ be a new empty List.
           1. For each element _arg_ of _args_, do
             1. Let _n_ be ? ToNumber(_arg_).
@@ -27941,14 +27941,14 @@
         <emu-note>
           <p>The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0* is considered to be larger than *-0*.</p>
         </emu-note>
+        <p>The *"length"* property of the `max` method is 2.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.min">
-        <h1>Math.min ( _value1_, _value2_, ..._values_ )</h1>
+        <h1>Math.min ( ..._args_ )</h1>
         <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the smallest of the resulting values.</p>
-        <p>When the `Math.min` method is called with at least two arguments _value1_ and _value2_ and any number of additional arguments which form the rest parameter ..._values_, the following steps are taken:</p>
+        <p>When the `Math.min` method is called with zero or more arguments which form the rest parameter ..._args_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _args_ be a List containing _value1_, _value2_, and the elements of _values_ in List order.
           1. Let _coerced_ be a new empty List.
           1. For each element _arg_ of _args_, do
             1. Let _n_ be ? ToNumber(_arg_).
@@ -27963,6 +27963,7 @@
         <emu-note>
           <p>The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0* is considered to be larger than *-0*.</p>
         </emu-note>
+        <p>The *"length"* property of the `min` method is 2.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.pow">
@@ -27988,8 +27989,8 @@
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is an integral Number, return _n_.
-          1. If _x_ &lt; 0.5 and _x_ &gt; 0, return *+0*.
-          1. If _x_ &lt; 0 and _x_ &ge; -0.5, return *-0*.
+          1. If _n_ &lt; 0.5 and _n_ &gt; 0, return *+0*.
+          1. If _n_ &lt; 0 and _n_ &ge; -0.5, return *-0*.
           1. Return the integral Number closest to _n_, preferring the Number closer to *+&infin;* in the case of a tie.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
(Things I missed in my review of PR #2122.)

----
Brief history of 'max' ('min' is similar):

ES1, ES2:
- 15.8.2.11  max(x, y)
- Returns the larger of the two arguments.

ES3, ES5:
- 15.8.2.11  max( [ value1 [, value2 [, ...] ] ] )
- Given zero or more arguments, ...
- If no arguments are given, the result is -inf.
- The `length` property of the `max` method is 2.

Draft 23 of ES6 deleted the full-bracketing in the heading, unclear why...

ES6:
- 20.2.2.24 Math.max ( value1, value2 , ...values )
- Given zero or more arguments, ...
- If no arguments are given, the result is -inf.
- The `length` property of the `max` method is 2.

PR #266 removed the line about the `length` property...

ES7+:
- 20.2.2.24 Math.max ( value1, value2 , ...values )
- Given zero or more arguments, ...
- If no arguments are given, the result is -inf.