### PR TITLE
Normative: Move `__proto__` initializer out of Annex B

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12605,6 +12605,19 @@
         <emu-note>
           <p>This production exists so that |ObjectLiteral| can serve as a cover grammar for |ObjectAssignmentPattern|. It cannot occur in an actual object initializer.</p>
         </emu-note>
+        <emu-grammar>
+          ObjectLiteral : `{` PropertyDefinitionList `}`
+
+          ObjectLiteral : `{` PropertyDefinitionList `,` `}`
+        </emu-grammar>
+        <ul>
+          <li>
+            When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the Early Error rule is <b>not</b> applied. In addition, it is not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|. In addition, it is not applied when parsing JSON text in step <emu-xref href="#step-json-parse-parse" title></emu-xref> of <emu-xref href="#sec-json.parse"></emu-xref>.
+          </li>
+          <li>
+            It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
+          </li>
+        </ul>
       </emu-clause>
 
       <emu-clause id="sec-object-initializer-static-semantics-computedpropertycontains">
@@ -12738,7 +12751,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-object-initializer-runtime-semantics-propertydefinitionevaluation">
+      <emu-clause id="sec-object-initializer-runtime-semantics-propertydefinitionevaluation" oldids="sec-__proto__-property-names-in-object-initializers">
         <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
         <p>With parameters _object_ and _enumerable_.</p>
         <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
@@ -12767,18 +12780,24 @@
         <emu-alg>
           1. Let _propKey_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_propKey_).
-          1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
+          1. [id="step-object-initializer-runtime-semantics-propertydefinitionevaluation-__proto__-property-name"] If this production is not JSON text parsed by step <emu-xref href="#step-json-parse-parse" title></emu-xref> of <emu-xref href="#sec-json.parse"></emu-xref>, _propKey_ is the String value *"__proto__"*, and if IsComputedPropertyKey(|PropertyName|) is *false*, then
+            1. Let _isProtoSetter_ be *true*.
+          1. Else,
+            1. Let _isProtoSetter_ be *false*.
+          1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and _isProtoSetter_ is *false*, then
             1. Let _propValue_ be NamedEvaluation of |AssignmentExpression| with argument _propKey_.
           1. Else,
             1. Let _exprValueRef_ be the result of evaluating |AssignmentExpression|.
             1. Let _propValue_ be ? GetValue(_exprValueRef_).
+          1. If _isProtoSetter_ is *true*, then
+            1. Assert: This production is not JSON text parsed by step <emu-xref href="#step-json-parse-parse"></emu-xref> of <emu-xref href="#sec-json.parse"></emu-xref>.
+            1. If Type(_propValue_) is either Object or Null, then
+              1. Return _object_.[[SetPrototypeOf]](_propValue_).
+            1. Return NormalCompletion(~empty~).
           1. Assert: _enumerable_ is *true*.
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
           1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
         </emu-alg>
-        <emu-note>
-          <p>An alternative semantics for this production is given in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref>.</p>
-        </emu-note>
       </emu-clause>
     </emu-clause>
 
@@ -37603,7 +37622,7 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. [id="step-json-parse-validate"] Parse ! StringToCodePoints(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
         1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
-        1. [id="step-json-parse-parse"] Let _completion_ be the result of parsing and evaluating ! StringToCodePoints(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> must not be used during the evaluation.
+        1. [id="step-json-parse-parse"] Let _completion_ be the result of parsing and evaluating ! StringToCodePoints(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended <emu-xref href="#sec-object-initializer-runtime-semantics-propertydefinitionevaluation">PropertyDefinitionEvaluation</emu-xref> semantics defined in step <emu-xref href="#step-object-initializer-runtime-semantics-propertydefinitionevaluation-__proto__-property-name"></emu-xref> of <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar> must not be used during the evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then
@@ -42758,50 +42777,6 @@ THH:mm:ss.sss
 
   <emu-annex id="sec-other-additional-features">
     <h1>Other Additional Features</h1>
-
-    <emu-annex id="sec-__proto__-property-names-in-object-initializers">
-      <h1>__proto__ Property Names in Object Initializers</h1>
-      <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the Early Error rule is <b>not</b> applied. In addition, it is not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|.</p>
-      <emu-grammar>
-        ObjectLiteral : `{` PropertyDefinitionList `}`
-
-        ObjectLiteral : `{` PropertyDefinitionList `,` `}`
-      </emu-grammar>
-      <ul>
-        <li>
-          It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
-        </li>
-      </ul>
-      <emu-note>
-        <p>The List returned by PropertyNameList does not include string literal property names defined as using a |ComputedPropertyName|.</p>
-      </emu-note>
-      <p>In <emu-xref href="#sec-object-initializer-runtime-semantics-propertydefinitionevaluation"></emu-xref> the PropertyDefinitionEvaluation algorithm for the production
-        <br>
-        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
-        <br>
-        is replaced with the following definition:</p>
-      <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
-      <emu-alg>
-        1. Let _propKey_ be the result of evaluating |PropertyName|.
-        1. ReturnIfAbrupt(_propKey_).
-        1. If _propKey_ is the String value *"__proto__"* and if IsComputedPropertyKey(|PropertyName|) is *false*, then
-          1. Let _isProtoSetter_ be *true*.
-        1. Else,
-          1. Let _isProtoSetter_ be *false*.
-        1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and _isProtoSetter_ is *false*, then
-          1. Let _propValue_ be NamedEvaluation of |AssignmentExpression| with argument _propKey_.
-        1. Else,
-          1. Let _exprValueRef_ be the result of evaluating |AssignmentExpression|.
-          1. Let _propValue_ be ? GetValue(_exprValueRef_).
-        1. If _isProtoSetter_ is *true*, then
-          1. If Type(_propValue_) is either Object or Null, then
-            1. Return _object_.[[SetPrototypeOf]](_propValue_).
-          1. Return NormalCompletion(~empty~).
-        1. Assert: _enumerable_ is *true*.
-        1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
-        1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
-      </emu-alg>
-    </emu-annex>
 
     <emu-annex id="sec-labelled-function-declarations">
       <h1>Labelled Function Declarations</h1>


### PR DESCRIPTION
Unlike <https://github.com/tc39/ecma262/pull/2125>, this only moves the “[`__proto__` Property Names in Object Initializers](https://tc39.es/ecma262/#sec-__proto__-property-names-in-object-initializers)” out of **Annex B**.

This also preserves the existing behaviour of **JSON** text, [_ObjectAssignmentPattern_](https://tc39.es/ecma262/#prod-ObjectAssignmentPattern), [_CoverParenthesizedExpressionAndArrowParameterList_](https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList) and [_CoverCallExpressionAndAsyncArrowHead_](https://tc39.es/ecma262/#prod-CoverCallExpressionAndAsyncArrowHead).

---

Part of <https://github.com/tc39/ecma262/issues/1595>
Supersedes and closes <https://github.com/tc39/ecma262/pull/2125>

---

[Preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2175) ([#step-object-initializer-runtime-semantics-propertydefinitionevaluation-\_\_proto\_\_-property-name](https://ci.tc39.es/preview/tc39/ecma262/pull/2175#step-object-initializer-runtime-semantics-propertydefinitionevaluation-__proto__-property-name), [#step-json-parse-parse](https://ci.tc39.es/preview/tc39/ecma262/pull/2175#step-json-parse-parse))