### PR TITLE
Editorial: Rewrite overloaded functions so each has a single definition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28466,51 +28466,23 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Date"* property of the global object.</li>
         <li>creates and initializes a new Date object when called as a constructor.</li>
         <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
-        <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
+        <li>is a function whose behaviour differs based upon the number and types of its arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Date behaviour must include a `super` call to the Date constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
         <li>has a *"length"* property whose value is 7.</li>
       </ul>
 
-      <emu-clause id="sec-date-year-month-date-hours-minutes-seconds-ms">
-        <h1>Date ( _year_, _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] )</h1>
-        <p>This description applies only if the Date constructor is called with at least two arguments.</p>
+      <emu-clause id="sec-date" oldids="sec-date-constructor-date,sec-date-value,sec-date-year-month-date-hours-minutes-seconds-ms">
+        <h1>Date ( ..._values_ )</h1>
         <p>When the `Date` function is called, the following steps are taken:</p>
         <emu-alg>
-          1. Let _numberOfArgs_ be the number of arguments passed to this function call.
-          1. Assert: _numberOfArgs_ &ge; 2.
           1. If NewTarget is *undefined*, then
             1. Let _now_ be the time value (UTC) identifying the current time.
             1. Return ToDateString(_now_).
-          1. Else,
-            1. Let _y_ be ? ToNumber(_year_).
-            1. Let _m_ be ? ToNumber(_month_).
-            1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be *1*<sub>𝔽</sub>.
-            1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be *+0*<sub>𝔽</sub>.
-            1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be *+0*<sub>𝔽</sub>.
-            1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be *+0*<sub>𝔽</sub>.
-            1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be *+0*<sub>𝔽</sub>.
-            1. If _y_ is *NaN*, let _yr_ be *NaN*.
-            1. Else,
-              1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
-              1. If 0 &le; _yi_ &le; 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
-            1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
-            1. Set _O_.[[DateValue]] to TimeClip(UTC(_finalDate_)).
-            1. Return _O_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-date-value">
-        <h1>Date ( _value_ )</h1>
-        <p>This description applies only if the Date constructor is called with exactly one argument.</p>
-        <p>When the `Date` function is called, the following steps are taken:</p>
-        <emu-alg>
-          1. Let _numberOfArgs_ be the number of arguments passed to this function call.
-          1. Assert: _numberOfArgs_ = 1.
-          1. If NewTarget is *undefined*, then
-            1. Let _now_ be the time value (UTC) identifying the current time.
-            1. Return ToDateString(_now_).
-          1. Else,
+          1. Let _numberOfArgs_ be the number of elements in _values_.
+          1. If _numberOfArgs_ = 0, then
+            1. Let _dv_ be the time value (UTC) identifying the current time.
+          1. Else if _numberOfArgs_ = 1, then
+            1. Let _value_ be _values_[0].
             1. If Type(_value_) is Object and _value_ has a [[DateValue]] internal slot, then
               1. Let _tv_ be ! thisTimeValue(_value_).
             1. Else,
@@ -28520,26 +28492,25 @@ THH:mm:ss.sss
                 1. Let _tv_ be the result of parsing _v_ as a date, in exactly the same manner as for the `parse` method (<emu-xref href="#sec-date.parse"></emu-xref>).
               1. Else,
                 1. Let _tv_ be ? ToNumber(_v_).
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
-            1. Set _O_.[[DateValue]] to TimeClip(_tv_).
-            1. Return _O_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-date-constructor-date">
-        <h1>Date ( )</h1>
-        <p>This description applies only if the Date constructor is called with no arguments.</p>
-        <p>When the `Date` function is called, the following steps are taken:</p>
-        <emu-alg>
-          1. Let _numberOfArgs_ be the number of arguments passed to this function call.
-          1. Assert: _numberOfArgs_ = 0.
-          1. If NewTarget is *undefined*, then
-            1. Let _now_ be the time value (UTC) identifying the current time.
-            1. Return ToDateString(_now_).
+            1. Let _dv_ be TimeClip(_tv_).
           1. Else,
-            1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
-            1. Set _O_.[[DateValue]] to the time value (UTC) identifying the current time.
-            1. Return _O_.
+            1. Assert: _numberOfArgs_ &ge; 2.
+            1. Let _y_ be ? ToNumber(_values_[0]).
+            1. Let _m_ be ? ToNumber(_values_[1]).
+            1. If _numberOfArgs_ &gt; 2, let _dt_ be ? ToNumber(_values_[2]); else let _dt_ be *1*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ &gt; 3, let _h_ be ? ToNumber(_values_[3]); else let _h_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ &gt; 4, let _min_ be ? ToNumber(_values_[4]); else let _min_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ &gt; 5, let _s_ be ? ToNumber(_values_[5]); else let _s_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ &gt; 6, let _milli_ be ? ToNumber(_values_[6]); else let _milli_ be *+0*<sub>𝔽</sub>.
+            1. If _y_ is *NaN*, let _yr_ be *NaN*.
+            1. Else,
+              1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
+              1. If 0 &le; _yi_ &le; 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
+            1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
+            1. Let _dv_ be TimeClip(UTC(_finalDate_)).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, &laquo; [[DateValue]] &raquo;).
+          1. Set _O_.[[DateValue]] to _dv_.
+          1. Return _O_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -32703,61 +32674,42 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Array"* property of the global object.</li>
         <li>creates and initializes a new Array exotic object when called as a constructor.</li>
         <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
-        <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments.</li>
+        <li>is a function whose behaviour differs based upon the number and types of its arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic Array behaviour must include a `super` call to the Array constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
         <li>has a *"length"* property whose value is 1.</li>
       </ul>
 
-      <emu-clause id="sec-array-constructor-array">
-        <h1>Array ( )</h1>
-        <p>This description applies if and only if the Array constructor is called with no arguments.</p>
-        <emu-alg>
-          1. Let _numberOfArgs_ be the number of arguments passed to this function call.
-          1. Assert: _numberOfArgs_ = 0.
-          1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
-          1. Return ! ArrayCreate(0, _proto_).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-array-len">
-        <h1>Array ( _len_ )</h1>
-        <p>This description applies if and only if the Array constructor is called with exactly one argument.</p>
-        <emu-alg>
-          1. Let _numberOfArgs_ be the number of arguments passed to this function call.
-          1. Assert: _numberOfArgs_ = 1.
-          1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
-          1. Let _array_ be ! ArrayCreate(0, _proto_).
-          1. If Type(_len_) is not Number, then
-            1. Perform ! CreateDataPropertyOrThrow(_array_, *"0"*, _len_).
-            1. Let _intLen_ be *1*<sub>𝔽</sub>.
-          1. Else,
-            1. Let _intLen_ be ! ToUint32(_len_).
-            1. If _intLen_ is not the same value as _len_, throw a *RangeError* exception.
-          1. Perform ! Set(_array_, *"length"*, _intLen_, *true*).
-          1. Return _array_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-array-items">
-        <h1>Array ( ..._items_ )</h1>
-        <p>This description applies if and only if the Array constructor is called with at least two arguments.</p>
+      <emu-clause id="sec-array" oldids="sec-array-constructor-array,sec-array-len,sec-array-items">
+        <h1>Array ( ..._values_ )</h1>
         <p>When the `Array` function is called, the following steps are taken:</p>
         <emu-alg>
-          1. Let _numberOfArgs_ be the number of arguments passed to this function call.
-          1. Assert: _numberOfArgs_ &ge; 2.
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
           1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
-          1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
-          1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _numberOfArgs_,
-            1. Let _Pk_ be ! ToString(𝔽(_k_)).
-            1. Let _itemK_ be _items_[_k_].
-            1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
-            1. Set _k_ to _k_ + 1.
-          1. Assert: The mathematical value of _array_'s *"length"* property is _numberOfArgs_.
-          1. Return _array_.
+          1. Let _numberOfArgs_ be the number of elements in _values_.
+          1. If _numberOfArgs_ = 0, then
+            1. Return ! ArrayCreate(0, _proto_).
+          1. Else if _numberOfArgs_ = 1, then
+            1. Let _len_ be _values_[0].
+            1. Let _array_ be ! ArrayCreate(0, _proto_).
+            1. If Type(_len_) is not Number, then
+              1. Perform ! CreateDataPropertyOrThrow(_array_, *"0"*, _len_).
+              1. Let _intLen_ be *1*<sub>𝔽</sub>.
+            1. Else,
+              1. Let _intLen_ be ! ToUint32(_len_).
+              1. If _intLen_ is not the same value as _len_, throw a *RangeError* exception.
+            1. Perform ! Set(_array_, *"length"*, _intLen_, *true*).
+            1. Return _array_.
+          1. Else,
+            1. Assert: _numberOfArgs_ &ge; 2.
+            1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
+            1. Let _k_ be 0.
+            1. Repeat, while _k_ &lt; _numberOfArgs_,
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
+              1. Let _itemK_ be _values_[_k_].
+              1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
+              1. Set _k_ to _k_ + 1.
+            1. Assert: The mathematical value of _array_'s *"length"* property is _numberOfArgs_.
+            1. Return _array_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -34781,80 +34733,51 @@ THH:mm:ss.sss
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.set-overloaded-offset">
-        <h1>%TypedArray%.prototype.set ( _overloaded_ [ , _offset_ ] )</h1>
-        <p>%TypedArray%`.prototype.set` is a single function whose behaviour is overloaded based upon the type of its first argument.</p>
+      <emu-clause id="sec-%typedarray%.prototype.set" oldids="sec-%typedarray%.prototype.set-overloaded-offset">
+        <h1>%TypedArray%.prototype.set ( _source_ [ , _offset_ ] )</h1>
+        <p>%TypedArray%`.prototype.set` is a function whose behaviour differs based upon the type of its first argument.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>Sets multiple values in this _TypedArray_, reading the values from _source_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
+        <emu-alg>
+          1. Let _target_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
+          1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
+          1. Let _targetOffset_ be ? ToIntegerOrInfinity(_offset_).
+          1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
+          1. If _source_ is an Object that has a [[TypedArrayName]] internal slot, then
+            1. Perform ? SetTypedArrayFromTypedArray(_target_, _targetOffset_, _source_).
+          1. Else,
+            1. Perform ? SetTypedArrayFromArrayLike(_target_, _targetOffset_, _source_).
+          1. Return *undefined*.
+        </emu-alg>
 
-        <emu-clause id="sec-%typedarray%.prototype.set-array-offset">
-          <h1>%TypedArray%.prototype.set ( _array_ [ , _offset_ ] )</h1>
-          <p>Sets multiple values in this _TypedArray_, reading the values from the object _array_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
+        <emu-clause id="sec-settypedarrayfromtypedarray" aoid="SetTypedArrayFromTypedArray" oldids="sec-%typedarray%.prototype.set-typedarray-offset">
+          <h1>SetTypedArrayFromTypedArray ( _target_, _targetOffset_, _source_ )</h1>
+          <p>The abstract operation SetTypedArrayFromTypedArray takes arguments _target_ (a TypedArray object), _targetOffset_ (a non-negative integer or +&infin;), and _source_ (a TypedArray object). It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Assert: _array_ is any ECMAScript language value other than an Object with a [[TypedArrayName]] internal slot. If it is such an Object, the definition in <emu-xref href="#sec-%typedarray%.prototype.set-typedarray-offset"></emu-xref> applies.
-            1. Let _target_ be the *this* value.
-            1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
-            1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
-            1. Let _targetOffset_ be ? ToIntegerOrInfinity(_offset_).
-            1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
+            1. Assert: _source_ is an Object that has a [[TypedArrayName]] internal slot.
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetLength_ be _target_.[[ArrayLength]].
-            1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
-            1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
-            1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
-            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
-            1. Let _src_ be ? ToObject(_array_).
-            1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
-            1. If _targetOffset_ is +&infin;, throw a *RangeError* exception.
-            1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
-            1. Let _targetByteIndex_ be _targetOffset_ &times; _targetElementSize_ + _targetByteOffset_.
-            1. Let _k_ be 0.
-            1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ &times; _srcLength_.
-            1. Repeat, while _targetByteIndex_ &lt; _limit_,
-              1. Let _Pk_ be ! ToString(𝔽(_k_)).
-              1. Let _value_ be ? Get(_src_, _Pk_).
-              1. If _target_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
-              1. Otherwise, set _value_ to ? ToNumber(_value_).
-              1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
-              1. Set _k_ to _k_ + 1.
-              1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
-            1. Return *undefined*.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-%typedarray%.prototype.set-typedarray-offset">
-          <h1>%TypedArray%.prototype.set ( _typedArray_ [ , _offset_ ] )</h1>
-          <p>Sets multiple values in this _TypedArray_, reading the values from the _typedArray_ argument object. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
-          <emu-alg>
-            1. Assert: _typedArray_ has a [[TypedArrayName]] internal slot. If it does not, the definition in <emu-xref href="#sec-%typedarray%.prototype.set-array-offset"></emu-xref> applies.
-            1. Let _target_ be the *this* value.
-            1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
-            1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
-            1. Let _targetOffset_ be ? ToIntegerOrInfinity(_offset_).
-            1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
-            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
-            1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetLength_ be _target_.[[ArrayLength]].
-            1. Let _srcBuffer_ be _typedArray_.[[ViewedArrayBuffer]].
+            1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
             1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
             1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
             1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
-            1. Let _srcName_ be the String value of _typedArray_.[[TypedArrayName]].
+            1. Let _srcName_ be the String value of _source_.[[TypedArrayName]].
             1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
             1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
-            1. Let _srcLength_ be _typedArray_.[[ArrayLength]].
-            1. Let _srcByteOffset_ be _typedArray_.[[ByteOffset]].
+            1. Let _srcLength_ be _source_.[[ArrayLength]].
+            1. Let _srcByteOffset_ be _source_.[[ByteOffset]].
             1. If _targetOffset_ is +&infin;, throw a *RangeError* exception.
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
-            1. If _target_.[[ContentType]] &ne; _typedArray_.[[ContentType]], throw a *TypeError* exception.
+            1. If _target_.[[ContentType]] &ne; _source_.[[ContentType]], throw a *TypeError* exception.
             1. If both IsSharedArrayBuffer(_srcBuffer_) and IsSharedArrayBuffer(_targetBuffer_) are *true*, then
               1. If _srcBuffer_.[[ArrayBufferData]] and _targetBuffer_.[[ArrayBufferData]] are the same Shared Data Block values, let _same_ be *true*; else let _same_ be *false*.
             1. Else, let _same_ be SameValue(_srcBuffer_, _targetBuffer_).
             1. If _same_ is *true*, then
-              1. Let _srcByteLength_ be _typedArray_.[[ByteLength]].
+              1. Let _srcByteLength_ be _source_.[[ByteLength]].
               1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_, %ArrayBuffer%).
               1. NOTE: %ArrayBuffer% is used to clone _srcBuffer_ because is it known to not have any observable side-effects.
               1. Let _srcByteIndex_ be 0.
@@ -34874,7 +34797,37 @@ THH:mm:ss.sss
                 1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
-            1. Return *undefined*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-settypedarrayfromarraylike" aoid="SetTypedArrayFromArrayLike" oldids="sec-%typedarray%.prototype.set-array-offset">
+          <h1>SetTypedArrayFromArrayLike ( _target_, _targetOffset_, _source_ )</h1>
+          <p>The abstract operation SetTypedArrayFromArrayLike takes arguments _target_ (a TypedArray object), _targetOffset_ (a non-negative integer or +&infin;), and _source_ (an ECMAScript value other than a TypedArray object). It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_. It performs the following steps when called:</p>
+          <emu-alg>
+            1. Assert: _source_ is any ECMAScript language value other than an Object with a [[TypedArrayName]] internal slot.
+            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
+            1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
+            1. Let _targetLength_ be _target_.[[ArrayLength]].
+            1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
+            1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
+            1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
+            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
+            1. Let _src_ be ? ToObject(_source_).
+            1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
+            1. If _targetOffset_ is +&infin;, throw a *RangeError* exception.
+            1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
+            1. Let _targetByteIndex_ be _targetOffset_ &times; _targetElementSize_ + _targetByteOffset_.
+            1. Let _k_ be 0.
+            1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ &times; _srcLength_.
+            1. Repeat, while _targetByteIndex_ &lt; _limit_,
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
+              1. Let _value_ be ? Get(_src_, _Pk_).
+              1. If _target_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
+              1. Otherwise, set _value_ to ? ToNumber(_value_).
+              1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
+              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
+              1. Set _k_ to _k_ + 1.
+              1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -35089,37 +35042,51 @@ THH:mm:ss.sss
       <p>Each _TypedArray_ constructor:</p>
       <ul>
         <li>is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.</li>
-        <li>is a single function whose behaviour is overloaded based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</li>
+        <li>is a function whose behaviour differs based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray%`.prototype` built-in methods.</li>
         <li>has a *"length"* property whose value is 3.</li>
       </ul>
 
-      <emu-clause id="sec-typedarray">
-        <h1>_TypedArray_ ( )</h1>
-        <p>This description applies only if the _TypedArray_ function is called with no arguments.</p>
+      <emu-clause id="sec-typedarray" oldids="sec-typedarray-length,sec-typedarray-object">
+        <h1>_TypedArray_ ( ..._args_ )</h1>
+        <p>Each _TypedArray_ constructor performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>.prototype%"</code>, 0).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-typedarray-length">
-        <h1>_TypedArray_ ( _length_ )</h1>
-        <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is not Object.</p>
-        <p>_TypedArray_ called with argument _length_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_length_) is not Object.
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _elementLength_ be ? ToIndex(_length_).
-          1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>.prototype%"</code>, _elementLength_).
+          1. Let _proto_ be <code>"%<var>TypedArray</var>.prototype%"</code>.
+          1. Let _numberOfArgs_ be the number of elements in _args_.
+          1. If _numberOfArgs_ = 0, then
+            1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, 0).
+          1. Else,
+            1. Let _firstArgument_ be _args_[0].
+            1. If Type(_firstArgument_) is Object, then
+              1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
+              1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
+                1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
+              1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
+                1. If _numberOfArgs_ &gt; 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
+                1. If _numberOfArgs_ &gt; 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
+                1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
+              1. Else,
+                1. Assert: Type(_firstArgument_) is Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
+                1. Let _usingIterator_ be ? GetMethod(_firstArgument_, @@iterator).
+                1. If _usingIterator_ is not *undefined*, then
+                  1. Let _values_ be ? IterableToList(_firstArgument_, _usingIterator_).
+                  1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
+                1. Else,
+                  1. NOTE: _firstArgument_ is not an Iterable so assume it is already an array-like object.
+                  1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
+              1. Return _O_.
+            1. Else,
+              1. Assert: _firstArgument_ is not an Object.
+              1. Let _elementLength_ be ? ToIndex(_firstArgument_).
+              1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
         </emu-alg>
 
         <emu-clause id="sec-allocatetypedarray" aoid="AllocateTypedArray">
           <h1>AllocateTypedArray ( _constructorName_, _newTarget_, _defaultProto_ [ , _length_ ] )</h1>
-          <p>The abstract operation AllocateTypedArray takes arguments _constructorName_ (a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>), _newTarget_, and _defaultProto_ and optional argument _length_ (a non-negative integer). It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by all of the _TypedArray_ overloads. It performs the following steps when called:</p>
+          <p>The abstract operation AllocateTypedArray takes arguments _constructorName_ (a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>), _newTarget_, and _defaultProto_ and optional argument _length_ (a non-negative integer). It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by _TypedArray_. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
             1. Let _obj_ be ! IntegerIndexedObjectCreate(_proto_).
@@ -35134,6 +35101,110 @@ THH:mm:ss.sss
             1. Else,
               1. Perform ? AllocateTypedArrayBuffer(_obj_, _length_).
             1. Return _obj_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-initializetypedarrayfromtypedarray" aoid="InitializeTypedArrayFromTypedArray" oldids="sec-typedarray-typedarray">
+          <h1>InitializeTypedArrayFromTypedArray ( _O_, _srcArray_ )</h1>
+          <p>The abstract operation InitializeTypedArrayFromTypedArray takes arguments _O_ (a TypedArray object) and _srcArray_ (a TypedArray object). It performs the following steps when called:</p>
+          <emu-alg>
+            1. Assert: _O_ is an Object that has a [[TypedArrayName]] internal slot.
+            1. Assert: _srcArray_ is an Object that has a [[TypedArrayName]] internal slot.
+            1. Let _srcData_ be _srcArray_.[[ViewedArrayBuffer]].
+            1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
+            1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
+            1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
+            1. Let _elementLength_ be _srcArray_.[[ArrayLength]].
+            1. Let _srcName_ be the String value of _srcArray_.[[TypedArrayName]].
+            1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
+            1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
+            1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
+            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
+            1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
+            1. If IsSharedArrayBuffer(_srcData_) is *false*, then
+              1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
+            1. Else,
+              1. Let _bufferConstructor_ be %ArrayBuffer%.
+            1. If _elementType_ is the same as _srcType_, then
+              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).
+            1. Else,
+              1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
+              1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
+              1. If _srcArray_.[[ContentType]] &ne; _O_.[[ContentType]], throw a *TypeError* exception.
+              1. Let _srcByteIndex_ be _srcByteOffset_.
+              1. Let _targetByteIndex_ be 0.
+              1. Let _count_ be _elementLength_.
+              1. Repeat, while _count_ &gt; 0,
+                1. Let _value_ be GetValueFromBuffer(_srcData_, _srcByteIndex_, _srcType_, *true*, ~Unordered~).
+                1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_, *true*, ~Unordered~).
+                1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
+                1. Set _targetByteIndex_ to _targetByteIndex_ + _elementSize_.
+                1. Set _count_ to _count_ - 1.
+            1. Set _O_.[[ViewedArrayBuffer]] to _data_.
+            1. Set _O_.[[ByteLength]] to _byteLength_.
+            1. Set _O_.[[ByteOffset]] to 0.
+            1. Set _O_.[[ArrayLength]] to _elementLength_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-initializetypedarrayfromarraybuffer" aoid="InitializeTypedArrayFromArrayBuffer" oldids="sec-typedarray-buffer-byteoffset-length">
+          <h1>InitializeTypedArrayFromArrayBuffer ( _O_, _buffer_, _byteOffset_, _length_ )</h1>
+          <p>The abstract operation InitializeTypedArrayFromArrayBuffer takes arguments _O_ (a TypedArray object), _buffer_ (an ArrayBuffer object), _byteOffset_ (an ECMAScript language value), and _length_ (an ECMAScript language value). It performs the following steps when called:</p>
+          <emu-alg>
+            1. Assert: _O_ is an Object that has a [[TypedArrayName]] internal slot.
+            1. Assert: _buffer_ is an Object that has an [[ArrayBufferData]] internal slot.
+            1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
+            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
+            1. Let _offset_ be ? ToIndex(_byteOffset_).
+            1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
+            1. If _length_ is not *undefined*, then
+              1. Let _newLength_ be ? ToIndex(_length_).
+            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+            1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
+            1. If _length_ is *undefined*, then
+              1. If _bufferByteLength_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
+              1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
+              1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
+            1. Else,
+              1. Let _newByteLength_ be _newLength_ &times; _elementSize_.
+              1. If _offset_ + _newByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
+            1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
+            1. Set _O_.[[ByteLength]] to _newByteLength_.
+            1. Set _O_.[[ByteOffset]] to _offset_.
+            1. Set _O_.[[ArrayLength]] to _newByteLength_ / _elementSize_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-initializetypedarrayfromlist" aoid="InitializeTypedArrayFromList">
+          <h1>InitializeTypedArrayFromList ( _O_, _values_ )</h1>
+          <p>The abstract operation InitializeTypedArrayFromList takes arguments _O_ (a TypedArray object) and _values_ (a List of ECMAScript language values). It performs the following steps when called:</p>
+          <emu-alg>
+            1. Assert: _O_ is an Object that has a [[TypedArrayName]] internal slot.
+            1. Let _len_ be the number of elements in _values_.
+            1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
+            1. Let _k_ be 0.
+            1. Repeat, while _k_ &lt; _len_,
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
+              1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
+              1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
+              1. Set _k_ to _k_ + 1.
+            1. Assert: _values_ is now an empty List.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-initializetypedarrayfromarraylike" aoid="InitializeTypedArrayFromArrayLike">
+          <h1>InitializeTypedArrayFromArrayLike ( _O_, _arrayLike_ )</h1>
+          <p>The abstract operation InitializeTypedArrayFromArrayLike takes arguments _O_ (a TypedArray object) and _arrayLike_ (an Object that is neither a TypedArray object nor an ArrayBuffer object). It performs the following steps when called:</p>
+          <emu-alg>
+            1. Assert: _O_ is an Object that has a [[TypedArrayName]] internal slot.
+            1. Let _len_ be ? LengthOfArrayLike(_arrayLike_).
+            1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
+            1. Let _k_ be 0.
+            1. Repeat, while _k_ &lt; _len_,
+              1. Let _Pk_ be ! ToString(𝔽(_k_)).
+              1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
+              1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
+              1. Set _k_ to _k_ + 1.
           </emu-alg>
         </emu-clause>
 
@@ -35154,120 +35225,6 @@ THH:mm:ss.sss
             1. Return _O_.
           </emu-alg>
         </emu-clause>
-      </emu-clause>
-
-      <emu-clause id="sec-typedarray-typedarray">
-        <h1>_TypedArray_ ( _typedArray_ )</h1>
-        <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object has a [[TypedArrayName]] internal slot.</p>
-        <p>_TypedArray_ called with argument _typedArray_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_typedArray_) is Object and _typedArray_ has a [[TypedArrayName]] internal slot.
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>.prototype%"</code>).
-          1. Let _srcArray_ be _typedArray_.
-          1. Let _srcData_ be _srcArray_.[[ViewedArrayBuffer]].
-          1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
-          1. Let _elementLength_ be _srcArray_.[[ArrayLength]].
-          1. Let _srcName_ be the String value of _srcArray_.[[TypedArrayName]].
-          1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
-          1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
-          1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
-          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
-          1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
-          1. If IsSharedArrayBuffer(_srcData_) is *false*, then
-            1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
-          1. Else,
-            1. Let _bufferConstructor_ be %ArrayBuffer%.
-          1. If _elementType_ is the same as _srcType_, then
-            1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).
-          1. Else,
-            1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
-            1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-            1. If _srcArray_.[[ContentType]] &ne; _O_.[[ContentType]], throw a *TypeError* exception.
-            1. Let _srcByteIndex_ be _srcByteOffset_.
-            1. Let _targetByteIndex_ be 0.
-            1. Let _count_ be _elementLength_.
-            1. Repeat, while _count_ &gt; 0,
-              1. Let _value_ be GetValueFromBuffer(_srcData_, _srcByteIndex_, _srcType_, *true*, ~Unordered~).
-              1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_, *true*, ~Unordered~).
-              1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
-              1. Set _targetByteIndex_ to _targetByteIndex_ + _elementSize_.
-              1. Set _count_ to _count_ - 1.
-          1. Set _O_.[[ViewedArrayBuffer]] to _data_.
-          1. Set _O_.[[ByteLength]] to _byteLength_.
-          1. Set _O_.[[ByteOffset]] to 0.
-          1. Set _O_.[[ArrayLength]] to _elementLength_.
-          1. Return _O_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-typedarray-object">
-        <h1>_TypedArray_ ( _object_ )</h1>
-        <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.</p>
-        <p>_TypedArray_ called with argument _object_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_object_) is Object and _object_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>.prototype%"</code>).
-          1. Let _usingIterator_ be ? GetMethod(_object_, @@iterator).
-          1. If _usingIterator_ is not *undefined*, then
-            1. Let _values_ be ? IterableToList(_object_, _usingIterator_).
-            1. Let _len_ be the number of elements in _values_.
-            1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
-            1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _len_,
-              1. Let _Pk_ be ! ToString(𝔽(_k_)).
-              1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
-              1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
-              1. Set _k_ to _k_ + 1.
-            1. Assert: _values_ is now an empty List.
-            1. Return _O_.
-          1. NOTE: _object_ is not an Iterable so assume it is already an array-like object.
-          1. Let _arrayLike_ be _object_.
-          1. Let _len_ be ? LengthOfArrayLike(_arrayLike_).
-          1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
-          1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _len_,
-            1. Let _Pk_ be ! ToString(𝔽(_k_)).
-            1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
-            1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
-            1. Set _k_ to _k_ + 1.
-          1. Return _O_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-typedarray-buffer-byteoffset-length">
-        <h1>_TypedArray_ ( _buffer_ [ , _byteOffset_ [ , _length_ ] ] )</h1>
-        <p>This description applies only if the _TypedArray_ function is called with at least one argument and the Type of the first argument is Object and that object has an [[ArrayBufferData]] internal slot.</p>
-        <p>_TypedArray_ called with at least one argument _buffer_ performs the following steps:</p>
-        <emu-alg>
-          1. Assert: Type(_buffer_) is Object and _buffer_ has an [[ArrayBufferData]] internal slot.
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this <var>TypedArray</var> constructor.
-          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, <code>"%<var>TypedArray</var>.prototype%"</code>).
-          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
-          1. Let _offset_ be ? ToIndex(_byteOffset_).
-          1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
-          1. If _length_ is not *undefined*, then
-            1. Let _newLength_ be ? ToIndex(_length_).
-          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Let _bufferByteLength_ be _buffer_.[[ArrayBufferByteLength]].
-          1. If _length_ is *undefined*, then
-            1. If _bufferByteLength_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
-            1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
-            1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
-          1. Else,
-            1. Let _newByteLength_ be _newLength_ &times; _elementSize_.
-            1. If _offset_ + _newByteLength_ &gt; _bufferByteLength_, throw a *RangeError* exception.
-          1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
-          1. Set _O_.[[ByteLength]] to _newByteLength_.
-          1. Set _O_.[[ByteOffset]] to _offset_.
-          1. Set _O_.[[ArrayLength]] to _newByteLength_ / _elementSize_.
-          1. Return _O_.
-        </emu-alg>
       </emu-clause>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -34599,18 +34599,6 @@ THH:mm:ss.sss
               1. Set _countBytes_ to _countBytes_ - 1.
           1. Return _O_.
         </emu-alg>
-
-        <emu-clause id="sec-validatetypedarray" aoid="ValidateTypedArray">
-          <h1>ValidateTypedArray ( _O_ )</h1>
-          <p>The abstract operation ValidateTypedArray takes argument _O_. It performs the following steps when called:</p>
-          <emu-alg>
-            1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
-            1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
-            1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
-            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-            1. Return _buffer_.
-          </emu-alg>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.entries">
@@ -35054,6 +35042,48 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
+    <emu-clause id="sec-abstract-operations-for-typedarray-objects">
+      <h1>Abstract Operations for TypedArray Objects</h1>
+
+      <emu-clause id="typedarray-species-create" aoid="TypedArraySpeciesCreate">
+        <h1>TypedArraySpeciesCreate ( _exemplar_, _argumentList_ )</h1>
+        <p>The abstract operation TypedArraySpeciesCreate takes arguments _exemplar_ and _argumentList_. It is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: _exemplar_ is an Object that has [[TypedArrayName]] and [[ContentType]] internal slots.
+          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _exemplar_.[[TypedArrayName]].
+          1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
+          1. Let _result_ be ? TypedArrayCreate(_constructor_, _argumentList_).
+          1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
+          1. If _result_.[[ContentType]] &ne; _exemplar_.[[ContentType]], throw a *TypeError* exception.
+          1. Return _result_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="typedarray-create" aoid="TypedArrayCreate">
+        <h1>TypedArrayCreate ( _constructor_, _argumentList_ )</h1>
+        <p>The abstract operation TypedArrayCreate takes arguments _constructor_ and _argumentList_. It is used to specify the creation of a new TypedArray object using a constructor function. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
+          1. Perform ? ValidateTypedArray(_newTypedArray_).
+          1. If _argumentList_ is a List of a single Number, then
+            1. If _newTypedArray_.[[ArrayLength]] &lt; ℝ(_argumentList_[0]), throw a *TypeError* exception.
+          1. Return _newTypedArray_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-validatetypedarray" aoid="ValidateTypedArray">
+        <h1>ValidateTypedArray ( _O_ )</h1>
+        <p>The abstract operation ValidateTypedArray takes argument _O_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
+          1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
+          1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+          1. Return _buffer_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
     <emu-clause id="sec-typedarray-constructors">
       <h1>The _TypedArray_ Constructors</h1>
       <p>Each _TypedArray_ constructor:</p>
@@ -35237,32 +35267,6 @@ THH:mm:ss.sss
           1. Set _O_.[[ByteOffset]] to _offset_.
           1. Set _O_.[[ArrayLength]] to _newByteLength_ / _elementSize_.
           1. Return _O_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="typedarray-create" aoid="TypedArrayCreate">
-        <h1>TypedArrayCreate ( _constructor_, _argumentList_ )</h1>
-        <p>The abstract operation TypedArrayCreate takes arguments _constructor_ and _argumentList_. It is used to specify the creation of a new TypedArray object using a constructor function. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
-          1. Perform ? ValidateTypedArray(_newTypedArray_).
-          1. If _argumentList_ is a List of a single Number, then
-            1. If _newTypedArray_.[[ArrayLength]] &lt; ℝ(_argumentList_[0]), throw a *TypeError* exception.
-          1. Return _newTypedArray_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="typedarray-species-create" aoid="TypedArraySpeciesCreate">
-        <h1>TypedArraySpeciesCreate ( _exemplar_, _argumentList_ )</h1>
-        <p>The abstract operation TypedArraySpeciesCreate takes arguments _exemplar_ and _argumentList_. It is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: _exemplar_ is an Object that has [[TypedArrayName]] and [[ContentType]] internal slots.
-          1. Let _defaultConstructor_ be the intrinsic object listed in column one of <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _exemplar_.[[TypedArrayName]].
-          1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
-          1. Let _result_ be ? TypedArrayCreate(_constructor_, _argumentList_).
-          1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
-          1. If _result_.[[ContentType]] &ne; _exemplar_.[[ContentType]], throw a *TypeError* exception.
-          1. Return _result_.
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
- `Date(...)` [before](https://tc39.es/ecma262/#sec-date-year-month-date-hours-minutes-seconds-ms) [after](https://ci.tc39.es/preview/tc39/ecma262/sha/c085a92dcaec12b98c5f8446afd47679928d45ec/#sec-date)
- `Array(...)`  [before](https://tc39.es/ecma262/#sec-array-constructor-array) [after](https://ci.tc39.es/preview/tc39/ecma262/sha/c085a92dcaec12b98c5f8446afd47679928d45ec/#sec-array)
- `%TypedArray%.prototype.set(...)` [before](https://tc39.es/ecma262/#sec-%typedarray%.prototype.set-overloaded-offset) [after](https://ci.tc39.es/preview/tc39/ecma262/sha/c085a92dcaec12b98c5f8446afd47679928d45ec/#sec-%typedarray%.prototype.set)
- `_TypedArray_` [before](https://tc39.es/ecma262/#sec-typedarray) [after](https://ci.tc39.es/preview/tc39/ecma262/sha/c085a92dcaec12b98c5f8446afd47679928d45ec/#sec-typedarray)

The all-in-one diff may not make a lot of sense. The individual commits should be better (though not every intermediate state is a valid spec).