### PR TITLE
Editorial: replace some more internal usage of strings with spec enums

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4078,27 +4078,27 @@
     <p>The BigInt type has no implicit conversions in the ECMAScript language; programmers must call BigInt explicitly to convert values from other types.</p>
 
     <emu-clause id="sec-toprimitive" aoid="ToPrimitive" oldids="table-9">
-      <h1>ToPrimitive ( _input_ [ , _PreferredType_ ] )</h1>
-      <p>The abstract operation ToPrimitive takes argument _input_ and optional argument _PreferredType_. It converts its _input_ argument to a non-Object type. If an object is capable of converting to more than one primitive type, it may use the optional hint _PreferredType_ to favour that type. It performs the following steps when called:</p>
+      <h1>ToPrimitive ( _input_ [ , _preferredType_ ] )</h1>
+      <p>The abstract operation ToPrimitive takes argument _input_ and optional argument _preferredType_. It converts its _input_ argument to a non-Object type. If an object is capable of converting to more than one primitive type, it may use the optional hint _preferredType_ to favour that type. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: _input_ is an ECMAScript language value.
         1. If Type(_input_) is Object, then
-          1. If _PreferredType_ is not present, let _hint_ be *"default"*.
-          1. Else if _PreferredType_ is hint String, let _hint_ be *"string"*.
-          1. Else,
-            1. Assert: _PreferredType_ is hint Number.
-            1. Let _hint_ be *"number"*.
           1. Let _exoticToPrim_ be ? GetMethod(_input_, @@toPrimitive).
           1. If _exoticToPrim_ is not *undefined*, then
+            1. If _preferredType_ is not present, let _hint_ be *"default"*.
+            1. Else if _preferredType_ is ~string~, let _hint_ be *"string"*.
+            1. Else,
+              1. Assert: _preferredType_ is ~number~.
+              1. Let _hint_ be *"number"*.
             1. Let _result_ be ? Call(_exoticToPrim_, _input_, &laquo; _hint_ &raquo;).
             1. If Type(_result_) is not Object, return _result_.
             1. Throw a *TypeError* exception.
-          1. If _hint_ is *"default"*, set _hint_ to *"number"*.
-          1. Return ? OrdinaryToPrimitive(_input_, _hint_).
+          1. If _preferredType_ is not present, let _preferredType_ be ~number~.
+          1. Return ? OrdinaryToPrimitive(_input_, _preferredType_).
         1. Return _input_.
       </emu-alg>
       <emu-note>
-        <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were Number. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Date objects treat no hint as if the hint were String.</p>
+        <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were ~number~. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Date objects treat no hint as if the hint were ~string~.</p>
       </emu-note>
 
       <emu-clause id="sec-ordinarytoprimitive" aoid="OrdinaryToPrimitive">
@@ -4106,8 +4106,8 @@
         <p>The abstract operation OrdinaryToPrimitive takes arguments _O_ and _hint_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: Type(_O_) is Object.
-          1. Assert: Type(_hint_) is String and its value is either *"string"* or *"number"*.
-          1. If _hint_ is *"string"*, then
+          1. Assert: _hint_ is either ~string~ or ~number~.
+          1. If _hint_ is ~string~, then
             1. Let _methodNames_ be &laquo; *"toString"*, *"valueOf"* &raquo;.
           1. Else,
             1. Let _methodNames_ be &laquo; *"valueOf"*, *"toString"* &raquo;.
@@ -4208,7 +4208,7 @@
       <h1>ToNumeric ( _value_ )</h1>
       <p>The abstract operation ToNumeric takes argument _value_. It returns _value_ converted to a numeric value of type Number or BigInt. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _primValue_ be ? ToPrimitive(_value_, hint Number).
+        1. Let _primValue_ be ? ToPrimitive(_value_, ~number~).
         1. If Type(_primValue_) is BigInt, return _primValue_.
         1. Return ? ToNumber(_primValue_).
       </emu-alg>
@@ -4291,7 +4291,7 @@
             <td>
               <p>Apply the following steps:</p>
               <emu-alg>
-                1. Let _primValue_ be ? ToPrimitive(_argument_, hint Number).
+                1. Let _primValue_ be ? ToPrimitive(_argument_, ~number~).
                 1. Return ? ToNumber(_primValue_).
               </emu-alg>
             </td>
@@ -4560,7 +4560,7 @@
       <h1>ToBigInt ( _argument_ )</h1>
       <p>The abstract operation ToBigInt takes argument _argument_. It converts _argument_ to a BigInt value, or throws if an implicit conversion from Number would be required. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _prim_ be ? ToPrimitive(_argument_, hint Number).
+        1. Let _prim_ be ? ToPrimitive(_argument_, ~number~).
         1. Return the value that _prim_ corresponds to in <emu-xref href="#table-tobigint"></emu-xref>.
       </emu-alg>
       <emu-table id="table-tobigint" caption="BigInt Conversions">
@@ -4746,7 +4746,7 @@
             <td>
               <p>Apply the following steps:</p>
               <emu-alg>
-                1. Let _primValue_ be ? ToPrimitive(_argument_, hint String).
+                1. Let _primValue_ be ? ToPrimitive(_argument_, ~string~).
                 1. Return ? ToString(_primValue_).
               </emu-alg>
             </td>
@@ -4843,7 +4843,7 @@
       <h1>ToPropertyKey ( _argument_ )</h1>
       <p>The abstract operation ToPropertyKey takes argument _argument_. It converts _argument_ to a value that can be used as a property key. It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _key_ be ? ToPrimitive(_argument_, hint String).
+        1. Let _key_ be ? ToPrimitive(_argument_, ~string~).
         1. If Type(_key_) is Symbol, then
           1. Return _key_.
         1. Return ! ToString(_key_).
@@ -5124,12 +5124,12 @@
       <p>The comparison _x_ &lt; _y_, where _x_ and _y_ are values, produces *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). In addition to _x_ and _y_ the algorithm takes a Boolean flag named _LeftFirst_ as a parameter. The flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. The default value of _LeftFirst_ is *true* and indicates that the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_. Such a comparison is performed as follows:</p>
       <emu-alg>
         1. If the _LeftFirst_ flag is *true*, then
-          1. Let _px_ be ? ToPrimitive(_x_, hint Number).
-          1. Let _py_ be ? ToPrimitive(_y_, hint Number).
+          1. Let _px_ be ? ToPrimitive(_x_, ~number~).
+          1. Let _py_ be ? ToPrimitive(_y_, ~number~).
         1. Else,
           1. NOTE: The order of evaluation needs to be reversed to preserve left to right evaluation.
-          1. Let _py_ be ? ToPrimitive(_y_, hint Number).
-          1. Let _px_ be ? ToPrimitive(_x_, hint Number).
+          1. Let _py_ be ? ToPrimitive(_y_, ~number~).
+          1. Let _px_ be ? ToPrimitive(_x_, ~number~).
         1. [id="step-arc-string-check"] If Type(_px_) is String and Type(_py_) is String, then
           1. If IsStringPrefix(_py_, _px_) is *true*, return *false*.
           1. If IsStringPrefix(_px_, _py_) is *true*, return *true*.
@@ -15310,7 +15310,7 @@
         1. Return ? _operation_(_lnum_, _rnum_).
       </emu-alg>
       <emu-note>
-        <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Date objects handle the absence of a hint as if the hint Number were given; Date objects handle the absence of a hint as if the hint String were given. Exotic objects may handle the absence of a hint in some other manner.</p>
+        <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Date objects handle the absence of a hint as if ~number~ were given; Date objects handle the absence of a hint as if ~string~ were given. Exotic objects may handle the absence of a hint in some other manner.</p>
       </emu-note>
       <emu-note>
         <p>Step <emu-xref href="#step-binary-op-string-check"></emu-xref> differs from step <emu-xref href="#step-arc-string-check"></emu-xref> of the Abstract Relational Comparison algorithm, by using the logical-or operation instead of the logical-and operation.</p>
@@ -27384,7 +27384,7 @@
         <p>When `BigInt` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
-          1. Let _prim_ be ? ToPrimitive(_value_, hint Number).
+          1. Let _prim_ be ? ToPrimitive(_value_, ~number~).
           1. If Type(_prim_) is Number, return ? NumberToBigInt(_prim_).
           1. Otherwise, return ? ToBigInt(_value_).
         </emu-alg>
@@ -29099,7 +29099,7 @@ THH:mm:ss.sss
         <p>When the `toJSON` method is called with argument _key_, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
-          1. Let _tv_ be ? ToPrimitive(_O_, hint Number).
+          1. Let _tv_ be ? ToPrimitive(_O_, ~number~).
           1. If Type(_tv_) is Number and _tv_ is not finite, return *null*.
           1. Return ? Invoke(_O_, *"toISOString"*).
         </emu-alg>
@@ -29428,10 +29428,10 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
-          1. If _hint_ is the String value *"string"* or the String value *"default"*, then
-            1. Let _tryFirst_ be *"string"*.
-          1. Else if _hint_ is the String value *"number"*, then
-            1. Let _tryFirst_ be *"number"*.
+          1. If _hint_ is *"string"* or *"default"*, then
+            1. Let _tryFirst_ be ~string~.
+          1. Else if _hint_ is *"number"*, then
+            1. Let _tryFirst_ be ~number~.
           1. Else, throw a *TypeError* exception.
           1. Return ? OrdinaryToPrimitive(_O_, _tryFirst_).
         </emu-alg>


### PR DESCRIPTION
This eliminates the weird unspecified "hint X" form and replaces some internal-only usage of strings with spec `~enums~`.