### PR TITLE
Editorial: rename Suspend to SuspendAgent

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build-spec": "YEAR=2020 && git checkout --quiet \"es${YEAR}\" && mkdir -p \"out/${YEAR}\" && cp -R img \"out/${YEAR}\" && ecmarkup --verbose spec.html \"out/${YEAR}/index.html\" --css \"out/${YEAR}/ecmarkup.css\" --js \"out/${YEAR}/ecmarkup.js\" && git checkout --quiet travis-origin/test-travis",
     "postbuild-spec": "git remote rm travis-origin",
     "build-master": "npm run build-only -- --lint-spec --strict",
-    "prebuild-only": "npm run clean && mkdir out && cp -R img out && npm run wipe-es6biblio",
-    "build-only": "ecmarkup --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
+    "prebuild-only": "npm run clean && mkdir out && cp -R img out",
+    "build-only": "ecmarkup --no-ecma-262-biblio --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
     "build": "npm run build-master",
     "build-for-pdf": "npm run build-master -- --old-toc",
     "build-travis": "npm run build-master && npm run build-spec",
@@ -19,7 +19,6 @@
     "clean": "rm -rf out",
     "test": "exit 0",
     "watch": "npm run build-only -- --lint-spec --watch",
-    "wipe-es6biblio": "echo \"{}\" > node_modules/ecmarkup/es6biblio.json",
     "check-commit": "node scripts/check-commit"
   },
   "repository": "tc39/ecma262",

--- a/spec.html
+++ b/spec.html
@@ -37285,9 +37285,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-suspend" aoid="Suspend">
-        <h1>Suspend ( _WL_, _W_, _timeout_ )</h1>
-        <p>The abstract operation Suspend takes arguments _WL_ (a WaiterList), _W_ (an agent signifier), and _timeout_ (a Number). It performs the following steps when called:</p>
+      <emu-clause id="sec-suspendagent" aoid="SuspendAgent" oldids="sec-suspend">
+        <h1>SuspendAgent ( _WL_, _W_, _timeout_ )</h1>
+        <p>The abstract operation SuspendAgent takes arguments _WL_ (a WaiterList), _W_ (an agent signifier), and _timeout_ (a Number). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is equal to AgentSignifier().
@@ -37526,7 +37526,7 @@ THH:mm:ss.sss
           1. Return the String *"not-equal"*.
         1. Let _W_ be AgentSignifier().
         1. Perform AddWaiter(_WL_, _W_).
-        1. Let _notified_ be Suspend(_WL_, _W_, _t_).
+        1. Let _notified_ be SuspendAgent(_WL_, _W_, _t_).
         1. If _notified_ is *true*, then
           1. Assert: _W_ is not on the list of waiters in _WL_.
         1. Else,


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/1257.

~Edit: actually apparently this does not fix the issue, somehow? At least in CI. I'd guess it's a biblio issue. I'll look into it.~ Edit x2: fixed; see below.

This is the fault of https://github.com/tc39/ecmarkup/pull/167 + https://github.com/tc39/ecma262/blob/d3fa570c8561ba54653640889790e0cb36f87bde/package.json#L22.

~I'll fix this properly in ecmarkup so we don't need the hacky npm script.~ We already have a fix, it just wasn't in use: https://github.com/tc39/ecmarkup/pull/169. Pushed.