### PR TITLE
Editorial: convert Number abstract operations to algorithmic steps

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1577,32 +1577,38 @@
 
         <emu-clause id="sec-numeric-types-number-exponentiate" oldids="sec-applying-the-exp-operator">
           <h1>Number::exponentiate ( _base_, _exponent_ )</h1>
-          <p>The abstract operation Number::exponentiate takes arguments _base_ (a Number) and _exponent_ (a Number). It returns an implementation-approximated value representing the result of raising _base_ to the power _exponent_, subject to the following requirements:</p>
-          <ul>
-            <li>If _exponent_ is *NaN*, the result is *NaN*.</li>
-            <li>If _exponent_ is *+0*<sub>𝔽</sub>, the result is *1*<sub>𝔽</sub>, even if _base_ is *NaN*.</li>
-            <li>If _exponent_ is *-0*<sub>𝔽</sub>, the result is *1*<sub>𝔽</sub>, even if _base_ is *NaN*.</li>
-            <li>If _base_ is *NaN* and _exponent_ is non-zero, the result is *NaN*.</li>
-            <li>If abs(ℝ(_base_)) &gt; 1 and _exponent_ is *+&infin;*<sub>𝔽</sub>, the result is *+&infin;*<sub>𝔽</sub>.</li>
-            <li>If abs(ℝ(_base_)) &gt; 1 and _exponent_ is *-&infin;*<sub>𝔽</sub>, the result is *+0*<sub>𝔽</sub>.</li>
-            <li>If abs(ℝ(_base_)) is 1 and _exponent_ is *+&infin;*<sub>𝔽</sub>, the result is *NaN*.</li>
-            <li>If abs(ℝ(_base_)) is 1 and _exponent_ is *-&infin;*<sub>𝔽</sub>, the result is *NaN*.</li>
-            <li>If abs(ℝ(_base_)) &lt; 1 and _exponent_ is *+&infin;*<sub>𝔽</sub>, the result is *+0*<sub>𝔽</sub>.</li>
-            <li>If abs(ℝ(_base_)) &lt; 1 and _exponent_ is *-&infin;*<sub>𝔽</sub>, the result is *+&infin;*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *+&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0, the result is *+&infin;*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *+&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0, the result is *+0*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *-&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0 and _exponent_ is an odd integral Number, the result is *-&infin;*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *-&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0 and _exponent_ is not an odd integral Number, the result is *+&infin;*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *-&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0 and _exponent_ is an odd integral Number, the result is *-0*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *-&infin;*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0 and _exponent_ is not an odd integral Number, the result is *+0*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *+0*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0, the result is *+0*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *+0*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0, the result is *+&infin;*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *-0*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0 and _exponent_ is an odd integral Number, the result is *-0*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *-0*<sub>𝔽</sub> and ℝ(_exponent_) &gt; 0 and _exponent_ is not an odd integral Number, the result is *+0*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *-0*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0 and _exponent_ is an odd integral Number, the result is *-&infin;*<sub>𝔽</sub>.</li>
-            <li>If _base_ is *-0*<sub>𝔽</sub> and ℝ(_exponent_) &lt; 0 and _exponent_ is not an odd integral Number, the result is *+&infin;*<sub>𝔽</sub>.</li>
-            <li>If ℝ(_base_) &lt; 0 and _base_ is finite and _exponent_ is finite and _exponent_ is not an integral Number, the result is *NaN*.</li>
-          </ul>
+          <p>The abstract operation Number::exponentiate takes arguments _base_ (a Number) and _exponent_ (a Number). It returns an implementation-approximated value representing the result of raising _base_ to the _exponent_ power. It performs the following steps when called:</p>
+          <emu-alg>
+            1. If _exponent_ is *NaN*, return *NaN*.
+            1. If _exponent_ is *+0*<sub>𝔽</sub> or _exponent_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+            1. If _base_ is *NaN*, return *NaN*.
+            1. If _base_ is *+&infin;*<sub>𝔽</sub>, then
+              1. If _exponent_ &gt; *+0*<sub>𝔽</sub>, return *+&infin;*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
+            1. If _base_ is *-&infin;*<sub>𝔽</sub>, then
+              1. If _exponent_ &gt; *+0*<sub>𝔽</sub>, then
+                1. If _exponent_ is an odd integral Number, return *-&infin;*<sub>𝔽</sub>. Otherwise, return *+&infin;*<sub>𝔽</sub>.
+              1. Else,
+                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
+            1. If _base_ is *+0*<sub>𝔽</sub>, then
+              1. If _exponent_ &gt; *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>. Otherwise, return *+&infin;*<sub>𝔽</sub>.
+            1. If _base_ is *-0*<sub>𝔽</sub>, then
+              1. If _exponent_ &gt; *+0*<sub>𝔽</sub>, then
+                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
+              1. Else,
+                1. If _exponent_ is an odd integral Number, return *-&infin;*<sub>𝔽</sub>. Otherwise, return *+&infin;*<sub>𝔽</sub>.
+            1. Assert: _base_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
+            1. If _exponent_ is *+&infin;*<sub>𝔽</sub>, then
+              1. If abs(ℝ(_base_)) &gt; 1, return *+&infin;*<sub>𝔽</sub>.
+              1. If abs(ℝ(_base_)) is 1, return *NaN*.
+              1. If abs(ℝ(_base_)) &lt; 1, return *+0*<sub>𝔽</sub>.
+            1. If _exponent_ is *-&infin;*<sub>𝔽</sub>, then
+              1. If abs(ℝ(_base_)) &gt; 1, return *+0*<sub>𝔽</sub>.
+              1. If abs(ℝ(_base_)) is 1, return *NaN*.
+              1. If abs(ℝ(_base_)) &lt; 1, return *+&infin;*<sub>𝔽</sub>.
+            1. Assert: _exponent_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
+            1. If _base_ &lt; *+0*<sub>𝔽</sub> and _exponent_ is not an integral Number, return *NaN*.
+            1. Return an implementation-approximated value representing the result of raising ℝ(_base_) to the ℝ(_exponent_) power.
+          </emu-alg>
           <emu-note>
             <p>The result of _base_ `**` _exponent_ when _base_ is *1*<sub>𝔽</sub> or *-1*<sub>𝔽</sub> and _exponent_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, or when _base_ is *1*<sub>𝔽</sub> and _exponent_ is *NaN*, differs from IEEE 754-2019. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2019 specified *1*<sub>𝔽</sub>. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
           </emu-note>
@@ -1610,27 +1616,19 @@
 
         <emu-clause id="sec-numeric-types-number-multiply" oldids="sec-applying-the-mul-operator">
           <h1>Number::multiply ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::multiply takes arguments _x_ (a Number) and _y_ (a Number). It performs multiplication, producing the product of _x_ and _y_, as determined by the rules of IEEE 754-2019 binary double-precision arithmetic:</p>
-          <ul>
-            <li>
-              If either operand is *NaN*, the result is *NaN*.
-            </li>
-            <li>
-              The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
-            </li>
-            <li>
-              Multiplication of an infinity by a zero results in *NaN*.
-            </li>
-            <li>
-              Multiplication of an infinity by an infinity results in an infinity. The sign is determined by the rule already stated above.
-            </li>
-            <li>
-              Multiplication of an infinity by a finite non-zero value results in a signed infinity. The sign is determined by the rule already stated above.
-            </li>
-            <li>
-              In the remaining cases, where neither an infinity nor *NaN* is involved, the product is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode. If the magnitude is too large to represent, the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the result is then a zero of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2019.
-            </li>
-          </ul>
+          <p>The abstract operation Number::multiply takes arguments _x_ (a Number) and _y_ (a Number). It performs multiplication according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the product of _x_ and _y_. It performs the following steps when called:</p>
+          <emu-alg>
+            1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
+            1. If _x_ is *+&infin;*<sub>𝔽</sub> or _x_ is *-&infin;*<sub>𝔽</sub>, then
+              1. If _y_ is *+0*<sub>𝔽</sub> or _y_ is *-0*<sub>𝔽</sub>, return *NaN*.
+              1. If _y_ &gt; *+0*<sub>𝔽</sub>, return _x_.
+              1. Return -_x_.
+            1. If _y_ is *+&infin;*<sub>𝔽</sub> or _y_ is *-&infin;*<sub>𝔽</sub>, then
+              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ is *-0*<sub>𝔽</sub>, return *NaN*.
+              1. If _x_ &gt; *+0*<sub>𝔽</sub>, return _y_.
+              1. Return -_y_.
+            1. Return 𝔽(ℝ(_x_) &times; ℝ(_y_)).
+          </emu-alg>
           <emu-note>
             <p>Finite-precision multiplication is commutative, but not always associative.</p>
           </emu-note>
@@ -1638,97 +1636,61 @@
 
         <emu-clause id="sec-numeric-types-number-divide" oldids="sec-applying-the-div-operator">
           <h1>Number::divide ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::divide takes arguments _x_ (a Number) and _y_ (a Number). It performs division, producing the quotient of _x_ and _y_; _x_ is the dividend and _y_ is the divisor. The result is determined by the specification of IEEE 754-2019 arithmetic:</p>
-          <ul>
-            <li>
-              If either operand is *NaN*, the result is *NaN*.
-            </li>
-            <li>
-              The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
-            </li>
-            <li>
-              Division of an infinity by an infinity results in *NaN*.
-            </li>
-            <li>
-              Division of an infinity by a zero results in an infinity. The sign is determined by the rule already stated above.
-            </li>
-            <li>
-              Division of an infinity by a non-zero finite value results in a signed infinity. The sign is determined by the rule already stated above.
-            </li>
-            <li>
-              Division of a finite value by an infinity results in zero. The sign is determined by the rule already stated above.
-            </li>
-            <li>
-              Division of a zero by a zero results in *NaN*; division of zero by any other finite value results in zero, with the sign determined by the rule already stated above.
-            </li>
-            <li>
-              Division of a non-zero finite value by a zero results in a signed infinity. The sign is determined by the rule already stated above.
-            </li>
-            <li>
-              In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the quotient is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows; the result is then an infinity of appropriate sign. If the magnitude is too small to represent, the operation underflows and the result is a zero of the appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2019.
-            </li>
-          </ul>
+          <p>The abstract operation Number::divide takes arguments _x_ (a Number) and _y_ (a Number). It performs division according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the quotient of _x_ and _y_ where _x_ is the dividend and _y_ is the divisor. It performs the following steps when called:</p>
+          <emu-alg>
+            1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
+            1. If _x_ is *+&infin;*<sub>𝔽</sub> or _x_ is *-&infin;*<sub>𝔽</sub>, then
+              1. If _y_ is *+&infin;*<sub>𝔽</sub> or _y_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+              1. If _y_ is *+0*<sub>𝔽</sub> or _y_ &gt; *+0*<sub>𝔽</sub>, return _x_.
+              1. Return -_x_.
+            1. If _y_ is *+&infin;*<sub>𝔽</sub>, then
+              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ &gt; *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>. Otherwise, return *-0*<sub>𝔽</sub>.
+            1. If _y_ is *-&infin;*<sub>𝔽</sub>, then
+              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ &gt; *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
+            1. If _x_ is *+0*<sub>𝔽</sub> or _x_ is *-0*<sub>𝔽</sub>, then
+              1. If _y_ is *+0*<sub>𝔽</sub> or _y_ is *-0*<sub>𝔽</sub>, return *NaN*.
+              1. If _y_ &gt; *+0*<sub>𝔽</sub>, return _x_.
+              1. Return -_x_.
+            1. If _y_ is *+0*<sub>𝔽</sub>, then
+              1. If _x_ &gt; *+0*<sub>𝔽</sub>, return *+&infin;*<sub>𝔽</sub>. Otherwise, return *-&infin;*<sub>𝔽</sub>.
+            1. If _y_ is *-0*<sub>𝔽</sub>, then
+              1. If _x_ &gt; *+0*<sub>𝔽</sub>, return *-&infin;*<sub>𝔽</sub>. Otherwise, return *+&infin;*<sub>𝔽</sub>.
+            1. Return 𝔽(ℝ(_x_) / ℝ(_y_)).
+          </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-number-remainder" oldids="sec-applying-the-mod-operator">
           <h1>Number::remainder ( _n_, _d_ )</h1>
-          <p>The abstract operation Number::remainder takes arguments _n_ (a Number) and _d_ (a Number). It yields the remainder of its operands from an implied division; _n_ is the dividend and _d_ is the divisor.</p>
+          <p>The abstract operation Number::remainder takes arguments _n_ (a Number) and _d_ (a Number). It yields the remainder from an implied division of its operands where _n_ is the dividend and _d_ is the divisor. It performs the following steps when called:</p>
+          <emu-alg>
+            1. If _n_ is *NaN* or _d_ is *NaN*, return *NaN*.
+            1. If _n_ is *+&infin;*<sub>𝔽</sub> or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+            1. If _d_ is *+&infin;*<sub>𝔽</sub> or _d_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+            1. If _d_ is *+0*<sub>𝔽</sub> or _d_ is *-0*<sub>𝔽</sub>, return *NaN*.
+            1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+            1. Assert: _n_ and _d_ are finite and non-zero.
+            1. Let _r_ be ℝ(_n_) - (ℝ(_d_) &times; _q_) where _q_ is an integer that is negative if and only if _n_ and _d_ have opposite sign, and whose magnitude is as large as possible without exceeding the magnitude of ℝ(_n_) / ℝ(_d_).
+            1. Return 𝔽(_r_).
+          </emu-alg>
           <emu-note>
             <p>In C and C++, the remainder operator accepts only integral operands; in ECMAScript, it also accepts floating-point operands.</p>
           </emu-note>
-          <p>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2019. The IEEE 754-2019 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual <emu-not-ref>integer</emu-not-ref> remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java <emu-not-ref>integer</emu-not-ref> remainder operator; this may be compared with the C library function fmod.</p>
-          <p>The result of an ECMAScript floating-point remainder operation is determined by the rules of IEEE arithmetic:</p>
-          <ul>
-            <li>
-              If either operand is *NaN*, the result is *NaN*.
-            </li>
-            <li>
-              The sign of the result equals the sign of the dividend.
-            </li>
-            <li>
-              If the dividend is an infinity, or the divisor is a zero, or both, the result is *NaN*.
-            </li>
-            <li>
-              If the dividend is finite and the divisor is an infinity, the result equals the dividend.
-            </li>
-            <li>
-              If the dividend is a zero and the divisor is non-zero and finite, the result is the same as the dividend.
-            </li>
-            <li>
-              In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, the floating-point remainder _r_ from a dividend _n_ and a divisor _d_ is defined by the mathematical relation _r_ = _n_ - (_d_ &times; _q_) where _q_ is an integer that is negative only if _n_/_d_ is negative and positive only if _n_/_d_ is positive, and whose magnitude is as large as possible without exceeding the magnitude of the true mathematical quotient of _n_ and _d_. _r_ is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode.
-            </li>
-          </ul>
+          <emu-note>The result of a floating-point remainder operation as computed by the `%` operator is not the same as the &ldquo;remainder&rdquo; operation defined by IEEE 754-2019. The IEEE 754-2019 &ldquo;remainder&rdquo; operation computes the remainder from a rounding division, not a truncating division, and so its behaviour is not analogous to that of the usual <emu-not-ref>integer</emu-not-ref> remainder operator. Instead the ECMAScript language defines `%` on floating-point operations to behave in a manner analogous to that of the Java <emu-not-ref>integer</emu-not-ref> remainder operator; this may be compared with the C library function fmod.</emu-note>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-number-add" oldids="sec-applying-the-additive-operators-to-numbers">
           <h1>Number::add ( _x_, _y_ )</h1>
-          <p>The abstract operation Number::add takes arguments _x_ (a Number) and _y_ (a Number). It performs addition, producing the sum of _x_ and _y_ as determined using the rules of IEEE 754-2019 binary double-precision arithmetic:</p>
-          <ul>
-            <li>
-              If either operand is *NaN*, the result is *NaN*.
-            </li>
-            <li>
-              The sum of two infinities of opposite sign is *NaN*.
-            </li>
-            <li>
-              The sum of two infinities of the same sign is the infinity of that sign.
-            </li>
-            <li>
-              The sum of an infinity and a finite value is the infinite operand.
-            </li>
-            <li>
-              The sum of two negative zeroes is *-0*<sub>𝔽</sub>. The sum of two positive zeroes, or of two zeroes of opposite sign, is *+0*<sub>𝔽</sub>.
-            </li>
-            <li>
-              The sum of a zero and a non-zero finite value is the non-zero operand.
-            </li>
-            <li>
-              The sum of two non-zero finite values of the same magnitude and opposite sign is *+0*<sub>𝔽</sub>.
-            </li>
-            <li>
-              In the remaining cases, where neither an infinity, nor a zero, nor *NaN* is involved, and the operands have the same sign or have different magnitudes, the sum is computed and rounded to the nearest representable value using IEEE 754-2019 roundTiesToEven mode. If the magnitude is too large to represent, the operation overflows and the result is then an infinity of appropriate sign. The ECMAScript language requires support of gradual underflow as defined by IEEE 754-2019.
-            </li>
-          </ul>
+          <p>The abstract operation Number::add takes arguments _x_ (a Number) and _y_ (a Number). It performs addition according to the rules of IEEE 754-2019 binary double-precision arithmetic, producing the sum of its arguments. It performs the following steps when called:</p>
+          <emu-alg>
+            1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
+            1. If _x_ is *+&infin;*<sub>𝔽</sub> and _y_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+            1. If _x_ is *-&infin;*<sub>𝔽</sub> and _y_ is *+&infin;*<sub>𝔽</sub>, return *NaN*.
+            1. If _x_ is *+&infin;*<sub>𝔽</sub> or _x_ is *-&infin;*<sub>𝔽</sub>, return _x_.
+            1. If _y_ is *+&infin;*<sub>𝔽</sub> or _y_ is *-&infin;*<sub>𝔽</sub>, return _y_.
+            1. Assert: _x_ and _y_ are both finite.
+            1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
+            1. Return 𝔽(ℝ(_x_) + ℝ(_y_)).
+          </emu-alg>
           <emu-note>
             <p>Finite-precision addition is commutative, but not always associative.</p>
           </emu-note>


### PR DESCRIPTION
_Draft_ to fix #2179

* Number::exponentiate
* Number::multiply
* Number::divide
* Number::remainder
* Number::add
