### PR TITLE
Normative: new Annex B.3 clause to specify "AssignmentTargetType of LeftHandSideExpression : CallExpression" web reality.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43171,13 +43171,13 @@ THH:mm:ss.sss
       <emu-grammar>AssignmentExpression : LeftHandSideExpression = AssignmentExpression</emu-grammar>
       <ol>
         <li>
-          If AssignmentTargetType of |LeftHandSideExpression| is not ~simple~, throw a *ReferenceError* exception.
+          If AssignmentTargetType of |LeftHandSideExpression| is not ~simple~ and occurs in non-strict code, throw a *ReferenceError* exception.
         </li>
       </ol>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <ol>
         <li>
-          If AssignmentTargetType of |LeftHandSideExpression| is not ~simple~, throw a *ReferenceError* exception.
+          If AssignmentTargetType of |LeftHandSideExpression| is not ~simple~ and occurs in non-strict code, throw a *ReferenceError* exception.
         </li>
       </ol>
     </emu-annex>

--- a/spec.html
+++ b/spec.html
@@ -43165,6 +43165,22 @@ THH:mm:ss.sss
         </emu-table>
       </emu-annex>
     </emu-annex>
+    <emu-annex id="sec-assignmenttargettype-lefthandsideexpression-callexpression-arguments-invalid">
+      <h1>AssignmentTargetType of LeftHandSideExpression : CallExpression</h1>
+      <p>The following Runtime Semantics rules are appended to the content of subclause <emu-xref href="#sec-assignment-operators-runtime-semantics-evaluation"></emu-xref>:</p>
+      <emu-grammar>AssignmentExpression : LeftHandSideExpression = AssignmentExpression</emu-grammar>
+      <ol>
+        <li>
+          If AssignmentTargetType of |LeftHandSideExpression| is not ~simple~, throw a *ReferenceError* exception.
+        </li>
+      </ol>
+      <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
+      <ol>
+        <li>
+          If AssignmentTargetType of |LeftHandSideExpression| is not ~simple~, throw a *ReferenceError* exception.
+        </li>
+      </ol>
+    </emu-annex>
   </emu-annex>
 </emu-annex>
 


### PR DESCRIPTION
The intention of this change is to allow JS engines which run in browsers to be spec conformant in their handling of assignment to _CallExpression_ _Arguments_. Both Chrome and Firefox have attempted to make the following a Syntax Error: 

```
f() = 1
```

...However they were unable to do so without breaking the web! As it turns out, every engine that runs in a web browser has implemented the same behavior: 

```
$ eshost -x 'let f = () => {}; f() = 1'
#### ChakraCore

ReferenceError: Invalid left-hand side in assignment

#### JavaScriptCore

ReferenceError: Left side of assignment is not a reference.

#### SpiderMonkey

ReferenceError: cannot assign to function call

#### V8

ReferenceError: Invalid left-hand side in assignment

```

Note that non-browser embedded engines, which do not bear the same burden as the above engines, implement this according to the current specification: 

```
$ eshost -x 'let f = () => {}; f() = 1' --no-color
#### engine262

SyntaxError: Invalid assignment target

#### graaljs

SyntaxError: Invalid left hand side for assignment

#### hermes

SyntaxError: invalid assignment left-hand side

#### Moddable XS

SyntaxError: no reference

#### qjs

SyntaxError: invalid assignment left-hand side

```


I'd like to propose that TC39 codify the web reality. If there is a better way to define this, please advise!


cc @syg @jorendorff 