### PR TITLE
Editorial: Clarify note about `delete` in strict mode.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14188,7 +14188,7 @@
             1. Return ? _bindings_.DeleteBinding(GetReferencedName(_ref_)).
         </emu-alg>
         <emu-note>
-          <p>When a `delete` operator occurs within strict mode code, a *SyntaxError* exception is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name. In addition, if a `delete` operator occurs within strict mode code and the property to be deleted has the attribute { [[Configurable]]: *false* }, a *TypeError* exception is thrown.</p>
+          <p>When a `delete` operator occurs within strict mode code, a *SyntaxError* exception is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name. In addition, if a `delete` operator occurs within strict mode code and the property to be deleted has the attribute { [[Configurable]]: *false* } (or otherwise cannot be deleted), a *TypeError* exception is thrown.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -43210,7 +43210,7 @@ THH:mm:ss.sss
       When a `delete` operator occurs within strict mode code, a *SyntaxError* is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name (<emu-xref href="#sec-delete-operator-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
-      When a `delete` operator occurs within strict mode code, a *TypeError* is thrown if the property to be deleted has the attribute { [[Configurable]]: *false* } (<emu-xref href="#sec-delete-operator-runtime-semantics-evaluation"></emu-xref>).
+      When a `delete` operator occurs within strict mode code, a *TypeError* is thrown if the property to be deleted has the attribute { [[Configurable]]: *false* } or otherwise cannot be deleted (<emu-xref href="#sec-delete-operator-runtime-semantics-evaluation"></emu-xref>).
     </li>
     <li>
       Strict mode code may not include a |WithStatement|. The occurrence of a |WithStatement| in such a context is a *SyntaxError* (<emu-xref href="#sec-with-statement-static-semantics-early-errors"></emu-xref>).


### PR DESCRIPTION
Noticed in the context of #2164.

The note about `delete`'s behavior in strict mode is easy to misread as if it were exhaustive, so let's just make it exhaustive.