### PR TITLE
Editorial: clarify B.1.4.1, B.3.3.4, and B.3.3.5; other minor markup

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42161,16 +42161,23 @@ THH:mm:ss.sss
             It is a Syntax Error if any source text matches this rule.
           </li>
         </ul>
+        <p>Additionally, the rules for the following productions are modified with the addition of the <ins>highlighted</ins> text:</p>
         <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *true* or IsCharacterClass of the second |ClassAtom| is *true* <ins>and this production has a <sub>[U]</sub> parameter</ins>.
+          </li>
+          <li>
+            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *false* and IsCharacterClass of the second |ClassAtom| is *false* and the CharacterValue of the first |ClassAtom| is larger than the CharacterValue of the second |ClassAtom|.
           </li>
         </ul>
         <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *true* or IsCharacterClass of |ClassAtom| is *true* <ins>and this production has a <sub>[U]</sub> parameter</ins>.
+          </li>
+          <li>
+            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false* and IsCharacterClass of |ClassAtom| is *false* and the CharacterValue of |ClassAtomNoDash| is larger than the CharacterValue of |ClassAtom|.
           </li>
         </ul>
       </emu-annex>
@@ -42804,7 +42811,7 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-labelled-function-declarations">
       <h1>Labelled Function Declarations</h1>
-      <p>Prior to ECMAScript 2015, the specification of |LabelledStatement| did not allow for the association of a statement label with a |FunctionDeclaration|. However, a labelled |FunctionDeclaration| was an allowable extension for non-strict code and most browser-hosted ECMAScript implementations supported that extension. In ECMAScript 2015, the grammar productions for |LabelledStatement| permits use of |FunctionDeclaration| as a |LabelledItem| but <emu-xref href="#sec-labelled-statements-static-semantics-early-errors"></emu-xref> includes an Early Error rule that produces a Syntax Error if that occurs. For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
+      <p>Prior to ECMAScript 2015, the specification of |LabelledStatement| did not allow for the association of a statement label with a |FunctionDeclaration|. However, a labelled |FunctionDeclaration| was an allowable extension for non-strict code and most browser-hosted ECMAScript implementations supported that extension. In ECMAScript 2015 and later, the grammar production for |LabelledStatement| permits use of |FunctionDeclaration| as a |LabelledItem| but <emu-xref href="#sec-labelled-statements-static-semantics-early-errors"></emu-xref> includes an Early Error rule that produces a Syntax Error if that occurs. That rule is modified with the addition of the <ins>highlighted</ins> text:</p>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
@@ -42969,21 +42976,27 @@ THH:mm:ss.sss
       </emu-annex>
       <emu-annex id="sec-block-duplicates-allowed-static-semantics">
         <h1>Changes to Block Static Semantics: Early Errors</h1>
-        <p>For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
+        <p>The rules for the following production in <emu-xref href="#sec-block-static-semantics-early-errors"></emu-xref> are modified with the addition of the <ins>highlighted</ins> text:</p>
         <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries, <ins>unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.</ins>
+            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries<ins>, unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
+          </li>
+          <li>
+            It is a Syntax Error if any element of the LexicallyDeclaredNames of |StatementList| also occurs in the VarDeclaredNames of |StatementList|.
           </li>
         </ul>
       </emu-annex>
       <emu-annex id="sec-switch-duplicates-allowed-static-semantics">
         <h1>Changes to `switch` Statement Static Semantics: Early Errors</h1>
-        <p>For web browser compatibility, that rule is modified with the addition of the <ins>highlighted</ins> text:</p>
+        <p>The rules for the following production in <emu-xref href="#sec-switch-statement-static-semantics-early-errors"></emu-xref> are modified with the addition of the <ins>highlighted</ins> text:</p>
         <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries, <ins>unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations.</ins>
+            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries<ins>, unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
+          </li>
+          <li>
+            It is a Syntax Error if any element of the LexicallyDeclaredNames of |CaseBlock| also occurs in the VarDeclaredNames of |CaseBlock|.
           </li>
         </ul>
       </emu-annex>


### PR DESCRIPTION
* Describe what the highlighted text does in B.1.4.1, as we do elsewhere.
* Reference the modified sections in B.3.3.4 and B.3.3.5.
* Included both list items in both B.3.3.4 and B.3.3.5 as to not imply they are meant to be discarded.
* Pedantry about surrounding ~whitespace~/punctuation in `<ins>` tags.