### PR TITLE
Editorial: normalise phrasing used to create Lists

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4046,7 +4046,7 @@
             1. If _fromBlock_ is a Shared Data Block, then
               1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
               1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
-              1. Let _bytes_ be a List of length 1 that contains a nondeterministically chosen byte value.
+              1. Let _bytes_ be a List whose sole element is a nondeterministically chosen byte value.
               1. NOTE: In implementations, _bytes_ is the result of a non-atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
               1. Let _readEvent_ be ReadSharedMemory { [[Order]]: ~Unordered~, [[NoTear]]: *true*, [[Block]]: _fromBlock_, [[ByteIndex]]: _fromIndex_, [[ElementSize]]: 1 }.
               1. Append _readEvent_ to _eventList_.
@@ -12106,15 +12106,15 @@
       <emu-see-also-para op="BoundNames"></emu-see-also-para>
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
-        1. Return a new List containing the StringValue of |Identifier|.
+        1. Return a List whose sole element is the StringValue of |Identifier|.
       </emu-alg>
       <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
       <emu-alg>
-        1. Return a new List containing *"yield"*.
+        1. Return a List whose sole element is *"yield"*.
       </emu-alg>
       <emu-grammar>BindingIdentifier : `await`</emu-grammar>
       <emu-alg>
-        1. Return a new List containing *"await"*.
+        1. Return a List whose sole element is *"await"*.
       </emu-alg>
     </emu-clause>
 
@@ -12690,7 +12690,7 @@
         <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
         <emu-alg>
           1. If PropName of |PropertyDefinition| is ~empty~, return a new empty List.
-          1. Return a new List containing PropName of |PropertyDefinition|.
+          1. Return a List whose sole element is PropName of |PropertyDefinition|.
         </emu-alg>
         <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
@@ -12912,7 +12912,7 @@
             1. Let _string_ be the TV of |NoSubstitutionTemplate|.
           1. Else,
             1. Let _string_ be the TRV of |NoSubstitutionTemplate|.
-          1. Return a List containing the single element, _string_.
+          1. Return a List whose sole element is _string_.
         </emu-alg>
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
@@ -12929,7 +12929,7 @@
             1. Let _tail_ be the TV of |TemplateTail|.
           1. Else,
             1. Let _tail_ be the TRV of |TemplateTail|.
-          1. Return a List containing the single element, _tail_.
+          1. Return a List whose sole element is _tail_.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
@@ -12946,7 +12946,7 @@
             1. Let _string_ be the TV of |TemplateMiddle|.
           1. Else,
             1. Let _string_ be the TRV of |TemplateMiddle|.
-          1. Return a List containing the single element, _string_.
+          1. Return a List whose sole element is _string_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
@@ -12967,7 +12967,7 @@
         <emu-alg>
           1. Let _templateLiteral_ be this |TemplateLiteral|.
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
-          1. Return a List containing the one element which is _siteObj_.
+          1. Return a List whose sole element is _siteObj_.
         </emu-alg>
         <emu-grammar>TemplateLiteral : SubstitutionTemplate</emu-grammar>
         <emu-alg>
@@ -13040,7 +13040,7 @@
         <emu-alg>
           1. Let _subRef_ be the result of evaluating |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
-          1. Return a List containing only _sub_.
+          1. Return a List whose sole element is _sub_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
@@ -13728,7 +13728,7 @@
         <emu-alg>
           1. Let _ref_ be the result of evaluating |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
-          1. Return a List whose sole item is _arg_.
+          1. Return a List whose sole element is _arg_.
         </emu-alg>
         <emu-grammar>ArgumentList : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -15520,7 +15520,7 @@
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
           1. Perform ? PutValue(_lref_, _v_).
-          1. Return a new List containing _P_.
+          1. Return a List whose sole element is _P_.
         </emu-alg>
 
         <emu-grammar>AssignmentProperty : PropertyName `:` AssignmentElement</emu-grammar>
@@ -15528,7 +15528,7 @@
           1. Let _name_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_name_).
           1. Perform ? KeyedDestructuringAssignmentEvaluation of |AssignmentElement| with _value_ and _name_ as the arguments.
-          1. Return a new List containing _name_.
+          1. Return a List whose sole element is _name_.
         </emu-alg>
       </emu-clause>
 
@@ -16063,7 +16063,7 @@
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. Return a new List containing DeclarationPart of |Declaration|.
+        1. Return a List whose sole element is DeclarationPart of |Declaration|.
       </emu-alg>
     </emu-clause>
 
@@ -16112,7 +16112,7 @@
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
           1. Return &laquo; &raquo;.
-        1. Return a new List containing |Declaration|.
+        1. Return a List whose sole element is |Declaration|.
       </emu-alg>
     </emu-clause>
 
@@ -16454,7 +16454,7 @@
         <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
         <emu-grammar>VariableDeclarationList : VariableDeclaration</emu-grammar>
         <emu-alg>
-          1. Return a new List containing |VariableDeclaration|.
+          1. Return a List whose sole element is |VariableDeclaration|.
         </emu-alg>
         <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
@@ -16798,7 +16798,7 @@
         <emu-alg>
           1. Let _name_ be the string that is the only element of BoundNames of |SingleNameBinding|.
           1. Perform ? KeyedBindingInitialization for |SingleNameBinding| using _value_, _environment_, and _name_ as the arguments.
-          1. Return a new List containing _name_.
+          1. Return a List whose sole element is _name_.
         </emu-alg>
 
         <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
@@ -16806,7 +16806,7 @@
           1. Let _P_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_P_).
           1. Perform ? KeyedBindingInitialization of |BindingElement| with _value_, _environment_, and _P_ as the arguments.
-          1. Return a new List containing _P_.
+          1. Return a List whose sole element is _P_.
         </emu-alg>
       </emu-clause>
 
@@ -17759,7 +17759,7 @@
             `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
         </emu-grammar>
         <emu-alg>
-          1. Let _declarations_ be a List containing |ForBinding|.
+          1. Let _declarations_ be a List whose sole element is |ForBinding|.
           1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
           1. Return _declarations_.
         </emu-alg>
@@ -18871,7 +18871,7 @@
       </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
-        1. Return a new List containing |FunctionDeclaration|.
+        1. Return a List whose sole element is |FunctionDeclaration|.
       </emu-alg>
     </emu-clause>
 
@@ -18925,7 +18925,7 @@
       </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
-        1. Return a new List containing |FunctionDeclaration|.
+        1. Return a List whose sole element is |FunctionDeclaration|.
       </emu-alg>
     </emu-clause>
 
@@ -21093,7 +21093,7 @@
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
         1. If ClassElementKind of |ClassElement| is ~NonConstructorMethod~, then
-          1. Return a List containing |ClassElement|.
+          1. Return a List whose sole element is |ClassElement|.
         1. Return a new empty List.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
@@ -21111,7 +21111,7 @@
       <emu-alg>
         1. If PropName of |ClassElement| is ~empty~, return a new empty List.
         1. If IsStatic of |ClassElement| is *true*, return a new empty List.
-        1. Return a List containing PropName of |ClassElement|.
+        1. Return a List whose sole element is PropName of |ClassElement|.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
@@ -24182,13 +24182,13 @@
         <emu-alg>
           1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
           1. Let _defaultEntry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"default"*, [[LocalName]]: _localName_ }.
-          1. Return a new List containing _defaultEntry_.
+          1. Return a List whose sole element is _defaultEntry_.
         </emu-alg>
         <emu-grammar>NameSpaceImport : `*` `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the StringValue of |ImportedBinding|.
           1. Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: _localName_ }.
-          1. Return a new List containing _entry_.
+          1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-grammar>NamedImports : `{` `}`</emu-grammar>
         <emu-alg>
@@ -24204,14 +24204,14 @@
         <emu-alg>
           1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
           1. Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _localName_, [[LocalName]]: _localName_ }.
-          1. Return a new List containing _entry_.
+          1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-grammar>ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _importName_ be the StringValue of |IdentifierName|.
           1. Let _localName_ be the StringValue of |ImportedBinding|.
           1. Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_ }.
-          1. Return a new List containing _entry_.
+          1. Return a List whose sole element is _entry_.
         </emu-alg>
       </emu-clause>
 
@@ -24224,7 +24224,7 @@
         </emu-alg>
         <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
         <emu-alg>
-          1. Return a List containing the StringValue of |StringLiteral|.
+          1. Return a List whose sole element is the StringValue of |StringLiteral|.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -24355,11 +24355,11 @@
         </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
-          1. Return a List containing the StringValue of |IdentifierName|.
+          1. Return a List whose sole element is the StringValue of |IdentifierName|.
         </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Return a List containing the StringValue of the first |IdentifierName|.
+          1. Return a List whose sole element is the StringValue of the first |IdentifierName|.
         </emu-alg>
       </emu-clause>
 
@@ -24376,7 +24376,7 @@
         </emu-alg>
         <emu-grammar>ExportFromClause : `*` `as` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Return a List containing the StringValue of |IdentifierName|.
+          1. Return a List whose sole element is the StringValue of |IdentifierName|.
         </emu-alg>
         <emu-grammar>ExportFromClause : NamedExports</emu-grammar>
         <emu-alg>
@@ -24412,11 +24412,11 @@
         </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
-          1. Return a List containing the StringValue of |IdentifierName|.
+          1. Return a List whose sole element is the StringValue of |IdentifierName|.
         </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Return a List containing the StringValue of the second |IdentifierName|.
+          1. Return a List whose sole element is the StringValue of the second |IdentifierName|.
         </emu-alg>
       </emu-clause>
 
@@ -24452,18 +24452,18 @@
         <emu-alg>
           1. Let _names_ be BoundNames of |HoistableDeclaration|.
           1. Let _localName_ be the sole element of _names_.
-          1. Return a new List containing the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
+          1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |ClassDeclaration|.
           1. Let _localName_ be the sole element of _names_.
-          1. Return a new List containing the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
+          1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
           1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: *"\*default\*"*, [[ExportName]]: *"default"* }.
-          1. Return a new List containing _entry_.
+          1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-note>
           <p>*"\*default\*"* is used within this specification as a synthetic name for anonymous default export values.</p>
@@ -24476,13 +24476,13 @@
         <emu-grammar>ExportFromClause : `*`</emu-grammar>
         <emu-alg>
           1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: *null*, [[ExportName]]: *null* }.
-          1. Return a new List containing _entry_.
+          1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-grammar>ExportFromClause : `*` `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _exportName_ be the StringValue of |IdentifierName|.
           1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: *null*, [[ExportName]]: _exportName_ }.
-          1. Return a new List containing _entry_.
+          1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-grammar>NamedExports : `{` `}`</emu-grammar>
         <emu-alg>
@@ -24503,7 +24503,7 @@
           1. Else,
             1. Let _localName_ be *null*.
             1. Let _importName_ be _sourceName_.
-          1. Return a new List containing the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _sourceName_ }.
+          1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _sourceName_ }.
         </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
@@ -24515,7 +24515,7 @@
           1. Else,
             1. Let _localName_ be *null*.
             1. Let _importName_ be _sourceName_.
-          1. Return a new List containing the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
+          1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
         </emu-alg>
       </emu-clause>
 
@@ -24550,19 +24550,19 @@
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
-          1. Return a new List containing DeclarationPart of |Declaration|.
+          1. Return a List whose sole element is DeclarationPart of |Declaration|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
-          1. Return a new List containing DeclarationPart of |HoistableDeclaration|.
+          1. Return a List whose sole element is DeclarationPart of |HoistableDeclaration|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
-          1. Return a new List containing |ClassDeclaration|.
+          1. Return a List whose sole element is |ClassDeclaration|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
-          1. Return a new List containing this |ExportDeclaration|.
+          1. Return a List whose sole element is this |ExportDeclaration|.
         </emu-alg>
       </emu-clause>
 
@@ -24603,11 +24603,11 @@
         </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName</emu-grammar>
         <emu-alg>
-          1. Return a List containing the |IdentifierName|.
+          1. Return a List whose sole element is the |IdentifierName|.
         </emu-alg>
         <emu-grammar>ExportSpecifier : IdentifierName `as` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Return a List containing the first |IdentifierName|.
+          1. Return a List whose sole element is the first |IdentifierName|.
         </emu-alg>
       </emu-clause>
 
@@ -25130,7 +25130,7 @@
                 1. Else,
                   1. If _n_ = 1 or _n_ &gt; 4, throw a *URIError* exception.
                   1. If _k_ + (3 &times; (_n_ - 1)) is greater than or equal to _strLen_, throw a *URIError* exception.
-                  1. Let _Octets_ be a new List containing _B_.
+                  1. Let _Octets_ be a List whose sole element is _B_.
                   1. Let _j_ be 1.
                   1. Repeat, while _j_ &lt; _n_,
                     1. Set _k_ to _k_ + 1.
@@ -31083,7 +31083,7 @@ THH:mm:ss.sss
       <p>The syntax and semantics of |Pattern| is defined as if the source code for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>
       <emu-note>
         <p>For example, consider a pattern expressed in source text as the single non-BMP character U+1D11E (MUSICAL SYMBOL G CLEF). Interpreted as a Unicode pattern, it would be a single element (character) List consisting of the single code point 0x1D11E. However, interpreted as a BMP pattern, it is first UTF-16 encoded to produce a two element List consisting of the code units 0xD834 and 0xDD1E.</p>
-        <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the string would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16SurrogatePairToCodePoint must be used in producing a List consisting of a single pattern character, the code point U+1D11E.</p>
+        <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the string would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16SurrogatePairToCodePoint must be used in producing a List whose sole element is a single pattern character, the code point U+1D11E.</p>
         <p>An implementation may not actually perform such translations to or from UTF-16, but the semantics of this specification requires that the result of pattern matching be as if such translations were performed.</p>
       </emu-note>
 
@@ -43104,7 +43104,7 @@ THH:mm:ss.sss
       <p>The static semantics of VarScopedDeclarations in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations"></emu-xref> are augmented with the following:</p>
       <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
-        1. Let _declarations_ be a List containing |BindingIdentifier|.
+        1. Let _declarations_ be a List whose sole element is |BindingIdentifier|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
         1. Return _declarations_.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -2536,7 +2536,7 @@
                 (<em>any</em>, a List of <em>any</em>) <b>&rarr;</b> <em>any</em>
               </td>
               <td>
-                Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a list containing the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
+                Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
               </td>
             </tr>
             <tr>
@@ -2547,7 +2547,7 @@
                 (a List of <em>any</em>, Object) <b>&rarr;</b> Object
               </td>
               <td>
-                Creates an object. Invoked via the `new` operator or a `super` call. The first argument to the internal method is a list containing the arguments of the constructor invocation or the `super` call. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
+                Creates an object. Invoked via the `new` operator or a `super` call. The first argument to the internal method is a List whose elements are the arguments of the constructor invocation or the `super` call. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
               </td>
             </tr>
             </tbody>
@@ -8490,7 +8490,7 @@
           1. Else,
             1. Perform ! _env_.CreateMutableBinding(*"arguments"*, *false*).
           1. Call _env_.InitializeBinding(*"arguments"*, _ao_).
-          1. Let _parameterBindings_ be a List containing the elements of _parameterNames_, followed by *"arguments"*.
+          1. Let _parameterBindings_ be a List whose elements are the elements of _parameterNames_, followed by *"arguments"*.
         1. Else,
           1. Let _parameterBindings_ be _parameterNames_.
         1. Let _iteratorRecord_ be CreateListIteratorRecord(_argumentsList_).
@@ -8680,7 +8680,7 @@
           1. Let _target_ be _F_.[[BoundTargetFunction]].
           1. Let _boundThis_ be _F_.[[BoundThis]].
           1. Let _boundArgs_ be _F_.[[BoundArguments]].
-          1. Let _args_ be a List containing the elements of _boundArgs_, followed by the elements of _argumentsList_.
+          1. Let _args_ be a List whose elements are the elements of _boundArgs_, followed by the elements of _argumentsList_.
           1. Return ? Call(_target_, _boundThis_, _args_).
         </emu-alg>
       </emu-clause>
@@ -8692,7 +8692,7 @@
           1. Let _target_ be _F_.[[BoundTargetFunction]].
           1. Assert: IsConstructor(_target_) is *true*.
           1. Let _boundArgs_ be _F_.[[BoundArguments]].
-          1. Let _args_ be a List containing the elements of _boundArgs_, followed by the elements of _argumentsList_.
+          1. Let _args_ be a List whose elements are the elements of _boundArgs_, followed by the elements of _argumentsList_.
           1. If SameValue(_F_, _newTarget_) is *true*, set _newTarget_ to _target_.
           1. Return ? Construct(_target_, _args_, _newTarget_).
         </emu-alg>
@@ -9358,7 +9358,7 @@
               List of String
             </td>
             <td>
-              A List containing the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
+              A List whose elements are the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
             </td>
           </tr>
           <tr>
@@ -9509,7 +9509,7 @@
           1. Set _M_'s essential internal methods to the definitions specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref>.
           1. Set _M_.[[Prototype]] to *null*.
           1. Set _M_.[[Module]] to _module_.
-          1. Let _sortedExports_ be a List containing the elements of _exports_ ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
+          1. Let _sortedExports_ be a List whose elements are the elements of _exports_ ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
           1. Set _M_.[[Exports]] to _sortedExports_.
           1. Create own properties of _M_ corresponding to the definitions in <emu-xref href="#sec-module-namespace-objects"></emu-xref>.
           1. Set _module_.[[Namespace]] to _M_.
@@ -10074,7 +10074,7 @@
         1. If _trapResult_ contains any duplicate entries, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. Let _targetKeys_ be ? _target_.[[OwnPropertyKeys]]().
-        1. Assert: _targetKeys_ is a List containing only String and Symbol values.
+        1. Assert: _targetKeys_ is a List whose elements are only String and Symbol values.
         1. Assert: _targetKeys_ contains no duplicate entries.
         1. Let _targetConfigurableKeys_ be a new empty List.
         1. Let _targetNonconfigurableKeys_ be a new empty List.
@@ -10086,7 +10086,7 @@
             1. Append _key_ as an element of _targetConfigurableKeys_.
         1. If _extensibleTarget_ is *true* and _targetNonconfigurableKeys_ is empty, then
           1. Return _trapResult_.
-        1. Let _uncheckedResultKeys_ be a List containing the elements of _trapResult_.
+        1. Let _uncheckedResultKeys_ be a List whose elements are the elements of _trapResult_.
         1. For each element _key_ of _targetNonconfigurableKeys_, do
           1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
           1. Remove _key_ from _uncheckedResultKeys_.
@@ -12921,7 +12921,7 @@
           1. Else,
             1. Let _head_ be the TRV of |TemplateHead|.
           1. Let _tail_ be TemplateStrings of |TemplateSpans| with argument _raw_.
-          1. Return a List containing _head_ followed by the elements of _tail_.
+          1. Return a List whose elements are _head_ followed by the elements of _tail_.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
@@ -12938,7 +12938,7 @@
             1. Let _tail_ be the TV of |TemplateTail|.
           1. Else,
             1. Let _tail_ be the TRV of |TemplateTail|.
-          1. Return a List containing the elements of _middle_ followed by _tail_.
+          1. Return a List whose elements are the elements of _middle_ followed by _tail_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
@@ -31092,7 +31092,7 @@ THH:mm:ss.sss
         <p>The descriptions below use the following aliases:</p>
         <ul>
           <li>
-            _Input_ is a List consisting of all of the characters of the String being matched by the regular expression pattern. Each character is either a code unit or a code point, depending upon the kind of pattern involved. The notation _Input_[_n_] means the _n_<sup>th</sup> character of _Input_, where _n_ can range between 0 (inclusive) and _InputLength_ (exclusive).
+            _Input_ is a List whose elements are the characters of the String being matched by the regular expression pattern. Each character is either a code unit or a code point, depending upon the kind of pattern involved. The notation _Input_[_n_] means the _n_<sup>th</sup> character of _Input_, where _n_ can range between 0 (inclusive) and _InputLength_ (exclusive).
           </li>
           <li>
             _InputLength_ is the number of characters in _Input_.
@@ -31144,7 +31144,7 @@ THH:mm:ss.sss
           1. Return a new Abstract Closure with parameters (_str_, _index_) that captures _m_ and performs the following steps when called:
             1. Assert: Type(_str_) is String.
             1. Assert: ! IsNonNegativeInteger(_index_) is *true* and _index_ &le; the length of _str_.
-            1. If _Unicode_ is *true*, let _Input_ be ! StringToCodePoints(_str_). Otherwise, let _Input_ be a List containing the code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
+            1. If _Unicode_ is *true*, let _Input_ be ! StringToCodePoints(_str_). Otherwise, let _Input_ be a List whose elements are the code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
             1. Let _InputLength_ be the number of characters contained in _Input_. This alias will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.
             1. Let _listIndex_ be the index into _Input_ of the character that was obtained from element _index_ of _str_.
             1. Let _c_ be a new Continuation with parameters (_y_) that captures nothing and performs the following steps when called:
@@ -36418,12 +36418,12 @@ THH:mm:ss.sss
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
             1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
-            1. Let _rawValue_ be a List of length _elementSize_ of nondeterministically chosen byte values.
+            1. Let _rawValue_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
             1. NOTE: In implementations, _rawValue_ is the result of a non-atomic or atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
             1. Let _readEvent_ be ReadSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_ }.
             1. Append _readEvent_ to _eventList_.
             1. Append Chosen Value Record { [[Event]]: _readEvent_, [[ChosenValue]]: _rawValue_ } to _execution_.[[ChosenValues]].
-          1. Else, let _rawValue_ be a List containing bytes from _block_ at indices _byteIndex_ (inclusive) through _byteIndex_ + _elementSize_ (exclusive).
+          1. Else, let _rawValue_ be a List whose elements are bytes from _block_ at indices _byteIndex_ (inclusive) through _byteIndex_ + _elementSize_ (exclusive).
           1. Assert: The number of elements in _rawValue_ is _elementSize_.
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
           1. Return RawBytesToNumeric(_type_, _rawValue_, _isLittleEndian_).
@@ -36435,17 +36435,17 @@ THH:mm:ss.sss
         <p>The abstract operation NumericToRawBytes takes arguments _type_ (a TypedArray element type), _value_ (a BigInt or a Number), and _isLittleEndian_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. If _type_ is ~Float32~, then
-            1. Let _rawBytes_ be a List containing the 4 bytes that are the result of converting _value_ to IEEE 754-2019 binary32 format using roundTiesToEven mode. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary32 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
+            1. Let _rawBytes_ be a List whose elements are the 4 bytes that are the result of converting _value_ to IEEE 754-2019 binary32 format using roundTiesToEven mode. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary32 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
           1. Else if _type_ is ~Float64~, then
-            1. Let _rawBytes_ be a List containing the 8 bytes that are the IEEE 754-2019 binary64 format encoding of _value_. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary64 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
+            1. Let _rawBytes_ be a List whose elements are the 8 bytes that are the IEEE 754-2019 binary64 format encoding of _value_. If _isLittleEndian_ is *false*, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary64 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
           1. Else,
             1. Let _n_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
             1. Let _convOp_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
             1. Let _intValue_ be _convOp_(_value_) treated as a mathematical value, whether the result is a BigInt or Number.
             1. If _intValue_ &ge; 0<sub>ℝ</sub>, then
-              1. Let _rawBytes_ be a List containing the _n_-byte binary encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
+              1. Let _rawBytes_ be a List whose elements are the _n_-byte binary encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
             1. Else,
-              1. Let _rawBytes_ be a List containing the _n_-byte binary two's complement encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
+              1. Let _rawBytes_ be a List whose elements are the _n_-byte binary two's complement encoding of _intValue_. If _isLittleEndian_ is *false*, the bytes are ordered in big endian order. Otherwise, the bytes are ordered in little endian order.
           1. Return _rawBytes_.
         </emu-alg>
       </emu-clause>
@@ -36487,13 +36487,13 @@ THH:mm:ss.sss
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
             1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
-            1. Let _rawBytesRead_ be a List of length _elementSize_ of nondeterministically chosen byte values.
+            1. Let _rawBytesRead_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
             1. NOTE: In implementations, _rawBytesRead_ is the result of a load-link, of a load-exclusive, or of an operand of a read-modify-write instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
             1. Let _rmwEvent_ be ReadModifyWriteSharedMemory { [[Order]]: ~SeqCst~, [[NoTear]]: *true*, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_, [[ModifyOp]]: _op_ }.
             1. Append _rmwEvent_ to _eventList_.
             1. Append Chosen Value Record { [[Event]]: _rmwEvent_, [[ChosenValue]]: _rawBytesRead_ } to _execution_.[[ChosenValues]].
           1. Else,
-            1. Let _rawBytesRead_ be a List of size _elementSize_ containing the sequence of _elementSize_ bytes starting with _block_[_byteIndex_].
+            1. Let _rawBytesRead_ be a List of length _elementSize_ whose elements are the sequence of _elementSize_ bytes starting with _block_[_byteIndex_].
             1. Let _rawBytesModified_ be _op_(_rawBytesRead_, _rawBytes_).
             1. Store the individual bytes of _rawBytesModified_ into _block_, starting at _block_[_byteIndex_].
           1. Return RawBytesToNumeric(_type_, _rawBytesRead_, _isLittleEndian_).
@@ -41167,7 +41167,7 @@ THH:mm:ss.sss
       <p>For a candidate execution _execution_, _execution_.[[ReadsBytesFrom]] is a mathematical function mapping events in SharedDataBlockEventSet(_execution_) to Lists of events in SharedDataBlockEventSet(_execution_) that satisfies the following conditions.</p>
       <ul>
         <li>
-          <p>For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ in SharedDataBlockEventSet(_execution_), _execution_.[[ReadsBytesFrom]](_R_) is a List of length equal to _R_.[[ElementSize]] of WriteSharedMemory or ReadModifyWriteSharedMemory events _Ws_ such that all of the following are true.</p>
+          <p>For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ in SharedDataBlockEventSet(_execution_), _execution_.[[ReadsBytesFrom]](_R_) is a List of length _R_.[[ElementSize]] whose elements are WriteSharedMemory or ReadModifyWriteSharedMemory events _Ws_ such that all of the following are true.</p>
           <ul>
             <li>Each event _W_ with index _i_ in _Ws_ has _R_.[[ByteIndex]] + _i_ in its range.</li>
             <li>_R_ is not in _Ws_.</li>


### PR DESCRIPTION
As suggested by @bakkot as a follow-on to #2142. *edit*: Added the rephrasing that @gibson042 suggested in that thread as well.

Note that this only addresses the remaining phrasing inconsistencies, and *does not* attempt to address the inconsistency with when we use double angle brackets to denote List literals.