### PR TITLE
Normative: Re-resolve unresolvable references on the global in PutValue.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3821,10 +3821,14 @@
           1. If Type(_V_) is not Reference, throw a *ReferenceError* exception.
           1. Let _base_ be GetBase(_V_).
           1. If IsUnresolvableReference(_V_) is *true*, then
+            1. Let _name_ be GetReferencedName(_V_).
             1. If IsStrictReference(_V_) is *true*, then
-              1. Throw a *ReferenceError* exception.
+              1. Let _realm_ be the current Realm Record.
+              1. Set _V_ to ? ResolveBinding(_realm_.[[GlobalEnv]], _name_).
+              1. Assert: IsStrictReference(_V_) is *true*.
+              1. If IsUnresolvableReference(_V_) is *true*, throw a *ReferenceError* exception.
             1. Let _globalObj_ be GetGlobalObject().
-            1. Return ? Set(_globalObj_, GetReferencedName(_V_), _W_, *false*).
+            1. Return ? Set(_globalObj_, _name_, _W_, *false*).
           1. Else if IsPropertyReference(_V_) is *true*, then
             1. If HasPrimitiveBase(_V_) is *true*, then
               1. Assert: In this case, _base_ will never be *undefined* or *null*.


### PR DESCRIPTION
Currently, JSC, V8, SM, and XS all *do not throw* on the following code,
contra spec:

```javascript
"use strict";
undeclared = (this.undeclared = 42);
```

This has been a bug in implementations for a decade
(https://bugzilla.mozilla.org/show_bug.cgi?id=605515), and is arguably
implementation reality not only for the web but for most
implementations.

This changes the spec to match the implemented re-resolution behavior.

Also see
- https://github.com/tc39/ecma262/issues/467
- https://github.com/tc39/test262/issues/1964

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
