### PR TITLE
Normative: IntegerIndexedElementSet should always indicate success

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9180,9 +9180,7 @@
               1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *false*, return *false*.
               1. If _Desc_ has an [[Enumerable]] field and if _Desc_.[[Enumerable]] is *false*, return *false*.
               1. If _Desc_ has a [[Writable]] field and if _Desc_.[[Writable]] is *false*, return *false*.
-              1. If _Desc_ has a [[Value]] field, then
-                1. Let _value_ be _Desc_.[[Value]].
-                1. Return ? IntegerIndexedElementSet(_O_, _numericIndex_, _value_).
+              1. If _Desc_ has a [[Value]] field, perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _Desc_.[[Value]]).
               1. Return *true*.
           1. Return ! OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
         </emu-alg>
@@ -9209,7 +9207,8 @@
           1. If Type(_P_) is String, then
             1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. Return ? IntegerIndexedElementSet(_O_, _numericIndex_, _V_).
+              1. Perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _V_).
+              1. Return *true*.
           1. Return ? OrdinarySet(_O_, _P_, _V_, _Receiver_).
         </emu-alg>
       </emu-clause>
@@ -9298,15 +9297,18 @@
           1. Assert: _O_ is an Integer-Indexed exotic object.
           1. If _O_.[[ContentType]] is ~BigInt~, let _numValue_ be ? ToBigInt(_value_).
           1. Otherwise, let _numValue_ be ? ToNumber(_value_).
-          1. If ! IsValidIntegerIndex(_O_, _index_) is *false*, return *false*.
-          1. Let _offset_ be _O_.[[ByteOffset]].
-          1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-          1. Let _indexedPosition_ be (ℝ(_index_) &times; _elementSize_) + _offset_.
-          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-          1. Perform SetValueInBuffer(_O_.[[ViewedArrayBuffer]], _indexedPosition_, _elementType_, _numValue_, *true*, ~Unordered~).
-          1. Return *true*.
+          1. If ! IsValidIntegerIndex(_O_, _index_) is *true*, then
+            1. Let _offset_ be _O_.[[ByteOffset]].
+            1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
+            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+            1. Let _indexedPosition_ be (ℝ(_index_) &times; _elementSize_) + _offset_.
+            1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+            1. Perform SetValueInBuffer(_O_.[[ViewedArrayBuffer]], _indexedPosition_, _elementType_, _numValue_, *true*, ~Unordered~).
+          1. Return NormalCompletion(*undefined*).
         </emu-alg>
+        <emu-note>
+          <p>This operation always appears to succeed, but it has no effect when attempting to write past the end of a TypedArray or to a TypedArray which is backed by a detached ArrayBuffer.</p>
+        </emu-note>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
Resolves #2208.

This behavior is necessitated by web reality and tied to #2164 (although the OOB path is technically separate).

@syg and I chatted about whether the (non-normative) description of [[Set]] in [Table 6](https://tc39.es/ecma262/#table-essential-internal-methods) needs to be updated and concluded "no" for two reasons:
1. It is extremely difficult to update this verbiage to be exhaustive without explicit mention of typed arrays.
2. The meaning of the verb "set" is already ambiguous thanks to userland setters. In other words, it can be argued that the property value was "set" just by virtue of having entered IntegerIndexedElementSet.