### PR TITLE
Editorial: Move and fold the super constructor check into GetSuperConstructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13689,9 +13689,8 @@
         <emu-alg>
           1. Let _newTarget_ be GetNewTarget().
           1. Assert: Type(_newTarget_) is Object.
-          1. Let _func_ be ! GetSuperConstructor().
           1. Let _argList_ be ? ArgumentListEvaluation of |Arguments|.
-          1. If IsConstructor(_func_) is *false*, throw a *TypeError* exception.
+          1. Let _func_ be ? GetSuperConstructor().
           1. Let _result_ be ? Construct(_func_, _argList_, _newTarget_).
           1. Let _thisER_ be GetThisEnvironment().
           1. Return ? _thisER_.BindThisValue(_result_).
@@ -13707,6 +13706,7 @@
           1. Let _activeFunction_ be _envRec_.[[FunctionObject]].
           1. Assert: _activeFunction_ is an ECMAScript function object.
           1. Let _superConstructor_ be ! _activeFunction_.[[GetPrototypeOf]]().
+          1. If IsConstructor(_superConstructor_) is *false*, throw a *TypeError* exception.
           1. Return _superConstructor_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
The separate GetSuperConstructor call and IsConstructor check is
confusing, and caused a bug in V8, where the IsConstructor check was
folded into GetSuperConstructor and is thrown before argument
evaluation.

The actual property get of the active function's [[Prototype]] in
GetSuperConstructor is not observable, so it is editorial to fold the
IsConstructor check into GetSuperConstructor and move the call to be
after the argument evaluation.
