### PR TITLE
Editorial: List the [[Construct]]-requires-[[Call]] invariant in the list of invariants

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2740,7 +2740,7 @@
             The returned List must contain at least the keys of all non-configurable own properties that have previously been observed.
           </li>
           <li>
-            If the object is non-extensible, the returned List must contain only the keys of all own properties of the object that are observable using [[GetOwnProperty]].
+            If the target is non-extensible, the returned List must contain only the keys of all own properties of the target that are observable using [[GetOwnProperty]].
           </li>
         </ul>
         <h2>[[Call]] ( )</h2>
@@ -2753,6 +2753,9 @@
         <ul>
           <li>
             The normal return type is Object.
+          </li>
+          <li>
+            The target must also have a [[Call]] internal method.
           </li>
         </ul>
       </emu-clause>


### PR DESCRIPTION
Seems good to call out, even if it is already said in prose.