### PR TITLE
Normative: add normative optional styling css override

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -57,6 +57,17 @@
   emu-table td {
     background: #fff;
   }
+  [normative-optional] {
+    border-left: 5px solid #ff6600;
+    padding: .5em;
+    display: block;
+    background: #ffeedd;
+  }
+  [normative-optional]:before {
+    display: block;
+    color: #884400;
+    content: "NORMATIVE OPTIONAL";
+  }
 </style>
 </head>
 <body>
@@ -142,6 +153,11 @@
   <p>A conforming implementation of ECMAScript may support program and regular expression syntax not described in this specification. In particular, a conforming implementation of ECMAScript may support program syntax that makes use of any &ldquo;future reserved words&rdquo; noted in subclause <emu-xref href="#sec-keywords-and-reserved-words"></emu-xref> of this specification.</p>
   <p>A conforming implementation of ECMAScript must not implement any extension that is listed as a Forbidden Extension in subclause <emu-xref href="#sec-forbidden-extensions"></emu-xref>.</p>
   <p>A conforming implementation of ECMAScript must not redefine any facilities that are not implementation-defined, implementation-approximated, or host-defined.</p>
+  <p>A conforming implementation of ECMAScript may choose to implement or not implement Normative Optional subclauses. If any Normative Optional behaviour is implemented, all of the behaviour in the containing Normative Optional clause must be implemented. A Normative Optional clause is denoted in this specification with the words "Normative Optional" in a coloured box, as shown below.</p>
+  <emu-clause id="sec-conformance.normative-optional" type="example" normative-optional>
+    <h1>Example Clause Heading</h1>
+    <p>Example clause contents.</p>
+  </emu-clause>
 </emu-clause>
 
 <emu-clause id="sec-normative-references">


### PR DESCRIPTION
This addresses the problem brought up in #2214 -- where the styles for normative optional changes were forgotten (by me) when the weakrefs merge pr was made. 

This likely isn't the best way to do this. This pr is here in case we need a stop gap solution until we clarify how best to add these styles in an accessible way. cc @bterlson, @ljharb, @michaelficarra, @syg and @bakkot.