### PR TITLE
Editorial: consistency for single-line "if" algorithm steps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -520,9 +520,9 @@
       }
     },
     "ecmarkup": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.2.0.tgz",
-      "integrity": "sha512-izbk1LFBCBWVa0L3qfSlnJ/ThCSBkcnt3bbg0pHe46jIADWdxHdBFOo3gp4JOLvK56Nh0DQAjjosL4JR3j5Zyw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.2.1.tgz",
+      "integrity": "sha512-sP4tvuuzfp3JxJz7SNqFD7bC2+6bFVbMneGCfmkFA4Bo29ryWporQvVvkf+Or4Jv8ViizCFRnn6dAp5lPOSg7w==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
@@ -1893,9 +1893,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^4.2.0"
+    "ecmarkup": "^4.2.1"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -5216,7 +5216,7 @@
         1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
         1. Assert: If the caller will not be overriding both _obj_'s [[GetPrototypeOf]] and [[SetPrototypeOf]] essential internal methods, then _internalSlotsList_ contains [[Prototype]].
         1. Assert: If the caller will not be overriding all of _obj_'s [[SetPrototypeOf]], [[IsExtensible]], and [[PreventExtensions]] essential internal methods, then _internalSlotsList_ contains [[Extensible]].
-        1. If _internalSlotsList_ contains [[Extensible]], then set _obj_.[[Extensible]] to *true*.
+        1. If _internalSlotsList_ contains [[Extensible]], set _obj_.[[Extensible]] to *true*.
         1. Return _obj_.
       </emu-alg>
 
@@ -17895,7 +17895,7 @@
             1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by _lhs_.
           1. Repeat,
             1. Let _nextResult_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]]).
-            1. If _iteratorKind_ is ~async~, then set _nextResult_ to ? Await(_nextResult_).
+            1. If _iteratorKind_ is ~async~, set _nextResult_ to ? Await(_nextResult_).
             1. If Type(_nextResult_) is not Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_nextResult_).
             1. If _done_ is *true*, return NormalCompletion(_V_).
@@ -20525,7 +20525,7 @@
       <emu-grammar>YieldExpression : `yield`</emu-grammar>
       <emu-alg>
         1. Let _generatorKind_ be ! GetGeneratorKind().
-        1. If _generatorKind_ is ~async~, then return ? AsyncGeneratorYield(*undefined*).
+        1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(*undefined*).
         1. Otherwise, return ? GeneratorYield(CreateIterResultObject(*undefined*, *false*)).
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` AssignmentExpression</emu-grammar>
@@ -20533,7 +20533,7 @@
         1. Let _generatorKind_ be ! GetGeneratorKind().
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
-        1. If _generatorKind_ is ~async~, then return ? AsyncGeneratorYield(_value_).
+        1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(_value_).
         1. Otherwise, return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
@@ -20547,24 +20547,24 @@
         1. Repeat,
           1. If _received_.[[Type]] is ~normal~, then
             1. Let _innerResult_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]], &laquo; _received_.[[Value]] &raquo;).
-            1. If _generatorKind_ is ~async~, then set _innerResult_ to ? Await(_innerResult_).
+            1. If _generatorKind_ is ~async~, set _innerResult_ to ? Await(_innerResult_).
             1. If Type(_innerResult_) is not Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_innerResult_).
             1. If _done_ is *true*, then
               1. Return ? IteratorValue(_innerResult_).
-            1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+            1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
             1. Else, set _received_ to GeneratorYield(_innerResult_).
           1. Else if _received_.[[Type]] is ~throw~, then
             1. Let _throw_ be ? GetMethod(_iterator_, *"throw"*).
             1. If _throw_ is not *undefined*, then
               1. Let _innerResult_ be ? Call(_throw_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
-              1. If _generatorKind_ is ~async~, then set _innerResult_ to ? Await(_innerResult_).
+              1. If _generatorKind_ is ~async~, set _innerResult_ to ? Await(_innerResult_).
               1. NOTE: Exceptions from the inner iterator `throw` method are propagated. Normal completions from an inner `throw` method are processed similarly to an inner `next`.
               1. If Type(_innerResult_) is not Object, throw a *TypeError* exception.
               1. Let _done_ be ? IteratorComplete(_innerResult_).
               1. If _done_ is *true*, then
                 1. Return ? IteratorValue(_innerResult_).
-              1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+              1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
               1. Else, set _received_ to GeneratorYield(_innerResult_).
             1. Else,
               1. NOTE: If _iterator_ does not have a `throw` method, this throw is going to terminate the `yield*` loop. But first we need to give _iterator_ a chance to clean up.
@@ -20577,16 +20577,16 @@
             1. Assert: _received_.[[Type]] is ~return~.
             1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
             1. If _return_ is *undefined*, then
-              1. If _generatorKind_ is ~async~, then set _received_.[[Value]] to ? Await(_received_.[[Value]]).
+              1. If _generatorKind_ is ~async~, set _received_.[[Value]] to ? Await(_received_.[[Value]]).
               1. Return Completion(_received_).
             1. Let _innerReturnResult_ be ? Call(_return_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
-            1. If _generatorKind_ is ~async~, then set _innerReturnResult_ to ? Await(_innerReturnResult_).
+            1. If _generatorKind_ is ~async~, set _innerReturnResult_ to ? Await(_innerReturnResult_).
             1. If Type(_innerReturnResult_) is not Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_innerReturnResult_).
             1. If _done_ is *true*, then
               1. Let _value_ be ? IteratorValue(_innerReturnResult_).
               1. Return Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
-            1. If _generatorKind_ is ~async~, then set _received_ to AsyncGeneratorYield(? IteratorValue(_innerReturnResult_)).
+            1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerReturnResult_)).
             1. Else, set _received_ to GeneratorYield(_innerReturnResult_).
       </emu-alg>
     </emu-clause>
@@ -23971,7 +23971,7 @@
         <h1>FinishDynamicImport ( _referencingScriptOrModule_, _specifier_, _promiseCapability_, _completion_ )</h1>
         <p>The abstract operation FinishDynamicImport takes arguments _referencingScriptOrModule_, _specifier_, _promiseCapability_ (a PromiseCapability Record), and _completion_. FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically. It performs the following steps when called:</p>
         <emu-alg>
-          1. If _completion_ is an abrupt completion, then perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
+          1. If _completion_ is an abrupt completion, perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
           1. Else,
             1. Assert: _completion_ is a normal completion and _completion_.[[Value]] is *undefined*.
             1. Let _moduleRecord_ be ! HostResolveImportedModule(_referencingScriptOrModule_, _specifier_).
@@ -26269,10 +26269,10 @@
         <p>When the `toString` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ has an [[InitialName]] internal slot and _func_.[[InitialName]] is a String, the portion of the returned String that would be matched by |NativeFunctionAccessor?| |PropertyName| must be the value of _func_.[[InitialName]].
+          1. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ has an [[InitialName]] internal slot and _func_.[[InitialName]] is a String, the portion of the returned String that would be matched by |NativeFunctionAccessor?| |PropertyName| must be the value of _func_.[[InitialName]].
           1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and ! HostHasSourceTextAvailable(_func_) is *true*, then
             1. Return ! CodePointsToString(_func_.[[SourceText]]).
-          1. If Type(_func_) is Object and IsCallable(_func_) is *true*, then return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
+          1. If Type(_func_) is Object and IsCallable(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
           1. Throw a *TypeError* exception.
         </emu-alg>
 
@@ -39761,7 +39761,7 @@ THH:mm:ss.sss
           1. Let _handlerRealm_ be *null*.
           1. If _reaction_.[[Handler]] is not ~empty~, then
             1. Let _getHandlerRealmResult_ be GetFunctionRealm(_reaction_.[[Handler]].[[Callback]]).
-            1. If _getHandlerRealmResult_ is a normal completion, then set _handlerRealm_ to _getHandlerRealmResult_.[[Value]].
+            1. If _getHandlerRealmResult_ is a normal completion, set _handlerRealm_ to _getHandlerRealmResult_.[[Value]].
             1. Else, set _handlerRealm_ to the current Realm Record.
             1. NOTE: _handlerRealm_ is never *null* unless the handler is *undefined*. When the handler is a revoked Proxy and no ECMAScript code runs, _handlerRealm_ is used to create error objects.
           1. Return the Record { [[Job]]: _job_, [[Realm]]: _handlerRealm_ }.
@@ -39780,7 +39780,7 @@ THH:mm:ss.sss
               1. Return Completion(_status_).
             1. Return Completion(_thenCallResult_).
           1. Let _getThenRealmResult_ be GetFunctionRealm(_then_.[[Callback]]).
-          1. If _getThenRealmResult_ is a normal completion, then let _thenRealm_ be _getThenRealmResult_.[[Value]].
+          1. If _getThenRealmResult_ is a normal completion, let _thenRealm_ be _getThenRealmResult_.[[Value]].
           1. Else, let _thenRealm_ be the current Realm Record.
           1. NOTE: _thenRealm_ is never *null*. When _then_.[[Callback]] is a revoked Proxy and no code runs, _thenRealm_ is used to create error objects.
           1. Return the Record { [[Job]]: _job_, [[Realm]]: _thenRealm_ }.


### PR DESCRIPTION
There are 1578 `1. If _foo_, do _bar_.` steps in ecma262 master, and only 16 `1. If _foo_, then do _bar_.`. This changes the latter 16 to match the rest of the spec, and bumps ecmarkup so its linter will enforce this style.

This PR has two commits: one bumping ecmarkup, and one changing the style. They should be landed in the opposite order, so that the change to the style precedes the commit which enforces it.