### PR TITLE
Editorial: Simplify Promise.all and Promise.any

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39947,7 +39947,7 @@ THH:mm:ss.sss
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
               1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-promise.all-resolve-element-functions" title></emu-xref>.
               1. Let _resolveElement_ be ! CreateBuiltinFunction(_steps_, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
-              1. Set _resolveElement_.[[AlreadyCalled]] to the Record { [[Value]]: *false* }.
+              1. Set _resolveElement_.[[AlreadyCalled]] to *false*.
               1. Set _resolveElement_.[[Index]] to _index_.
               1. Set _resolveElement_.[[Values]] to _values_.
               1. Set _resolveElement_.[[Capability]] to _resultCapability_.
@@ -39964,9 +39964,8 @@ THH:mm:ss.sss
           <p>When a `Promise.all` resolve element function is called with argument _x_, the following steps are taken:</p>
           <emu-alg>
             1. Let _F_ be the active function object.
-            1. Let _alreadyCalled_ be _F_.[[AlreadyCalled]].
-            1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
-            1. Set _alreadyCalled_.[[Value]] to *true*.
+            1. If _F_.[[AlreadyCalled]] is *true*, return *undefined*.
+            1. Set _F_.[[AlreadyCalled]] to *true*.
             1. Let _index_ be _F_.[[Index]].
             1. Let _values_ be _F_.[[Values]].
             1. Let _promiseCapability_ be _F_.[[Capability]].
@@ -40149,7 +40148,7 @@ THH:mm:ss.sss
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
               1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-promise.any-reject-element-functions" title></emu-xref>.
               1. Let _rejectElement_ be ! CreateBuiltinFunction(_steps_, &laquo; [[AlreadyCalled]], [[Index]], [[Errors]], [[Capability]], [[RemainingElements]] &raquo;).
-              1. Set _rejectElement_.[[AlreadyCalled]] to the Record { [[Value]]: *false* }.
+              1. Set _rejectElement_.[[AlreadyCalled]] to *false*.
               1. Set _rejectElement_.[[Index]] to _index_.
               1. Set _rejectElement_.[[Errors]] to _errors_.
               1. Set _rejectElement_.[[Capability]] to _resultCapability_.
@@ -40166,9 +40165,8 @@ THH:mm:ss.sss
           <p>When a `Promise.any` reject element function is called with argument _x_, the following steps are taken:</p>
           <emu-alg>
             1. Let _F_ be the active function object.
-            1. Let _alreadyCalled_ be _F_.[[AlreadyCalled]].
-            1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
-            1. Set _alreadyCalled_.[[Value]] to *true*.
+            1. If _F_.[[AlreadyCalled]] is *true*, return *undefined*.
+            1. Set _F_.[[AlreadyCalled]] to *true*.
             1. Let _index_ be _F_.[[Index]].
             1. Let _errors_ be _F_.[[Errors]].
             1. Let _promiseCapability_ be _F_.[[Capability]].


### PR DESCRIPTION
`[[AlreadyCalled]]` fields in `Promise.all` and `Promise.any` doesn't have to be a Record

Discussion https://github.com/tc39/ecma262/pull/2040#discussion_r454699178