### PR TITLE
Editorial: replace a few stray GetReferencedName invocations / re-define "super-reference"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15248,7 +15248,7 @@
         1. Let _lbool_ be ! ToBoolean(_lval_).
         1. If _lbool_ is *false*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
-          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument GetReferencedName(_lref_).
+          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
           1. Let _rref_ be the result of evaluating |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
@@ -15262,7 +15262,7 @@
         1. Let _lbool_ be ! ToBoolean(_lval_).
         1. If _lbool_ is *true*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
-          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument GetReferencedName(_lref_).
+          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
           1. Let _rref_ be the result of evaluating |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
@@ -15275,7 +15275,7 @@
         1. [id="step-assignmentexpression-evaluation-lgcl-nullish-getvalue"] Let _lval_ be ? GetValue(_lref_).
         1. If _lval_ is neither *undefined* nor *null*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
-          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument GetReferencedName(_lref_).
+          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
           1. Let _rref_ be the result of evaluating |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).

--- a/spec.html
+++ b/spec.html
@@ -3762,7 +3762,7 @@
             <tr>
               <td>[[ThisValue]]</td>
               <td>any ECMAScript language value or ~empty~</td>
-              <td>If not ~empty~, the Reference Record represents a property binding that was expressed using the `super` keyword; it is called a <dfn id="super-reference-record">Super Reference Record</dfn> and its [[Base]] value will never be an Environment Record. In that case, the [[ThisValue]] field holds the *this* value at the time the Reference Record was created.</td>
+              <td>If not ~empty~, the Reference Record represents a property binding that was expressed using the `super` keyword; it is called a <dfn id="super-reference-record" oldids="super-reference">Super Reference Record</dfn> and its [[Base]] value will never be an Environment Record. In that case, the [[ThisValue]] field holds the *this* value at the time the Reference Record was created.</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
`GetReferencedName` was removed by #2085, but while that PR was open #2030 landed and introduced three new references to it, which we missed. This PR fixes those three references.

Also, #2085 removed the id for "super-reference"; this restores that as an `oldid` on the definition of "Super Reference Record".

Thanks to @jmdyck for pointing these out.