### PR TITLE
Normative: Give %TypedArray% methods explicit algorithms.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32064,7 +32064,7 @@ THH:mm:ss.sss
             1. Let _k_ be _len_ + _n_.
             1. If _k_ &lt; 0, set _k_ to 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _elementK_ be the result of ? Get(_O_, ! ToString(𝔽(_k_))).
+            1. Let _elementK_ be ? Get(_O_, ! ToString(𝔽(_k_))).
             1. If SameValueZero(_searchElement_, _elementK_) is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -33328,8 +33328,23 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.every">
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.every` are the same as for `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref>.</p>
+        <p>When the `every` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. Let _k_ be 0.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kValue_ be ! Get(_O_, _Pk_).
+            1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. If _testResult_ is *false*, return *false*.
+            1. Set _k_ to _k_ + 1.
+          1. Return *true*.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.fill">
@@ -33391,38 +33406,144 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.find">
         <h1>%TypedArray%.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.find` are the same as for `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref>.</p>
+        <p>When the `find` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+          1. Let _k_ be 0.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kValue_ be ! Get(_O_, _Pk_).
+            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. If _testResult_ is *true*, return _kValue_.
+            1. Set _k_ to _k_ + 1.
+          1. Return *undefined*.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.findindex">
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.findIndex` are the same as for `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref>.</p>
+        <p>When the `findIndex` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+          1. Let _k_ be 0.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kValue_ be ! Get(_O_, _Pk_).
+            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. If _testResult_ is *true*, return 𝔽(_k_).
+            1. Set _k_ to _k_ + 1.
+          1. Return *-1*<sub>𝔽</sub>.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.foreach">
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.forEach` are the same as for `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref>.</p>
+        <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. Let _k_ be 0.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kValue_ be ! Get(_O_, _Pk_).
+            1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;).
+            1. Set _k_ to _k_ + 1.
+          1. Return *undefined*.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.includes">
         <h1>%TypedArray%.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.includes` is a distinct function that implements the same algorithm as `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.includes` are the same as for `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref>.</p>
+        <p>When the `includes` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If _len_ is 0, return *false*.
+          1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
+          1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
+          1. If _n_ is +&infin;, return *false*.
+          1. Else if _n_ is -&infin;, set _n_ to 0.
+          1. If _n_ &ge; 0, then
+            1. Let _k_ be _n_.
+          1. Else,
+            1. Let _k_ be _len_ + _n_.
+            1. If _k_ &lt; 0, set _k_ to 0.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
+            1. If SameValueZero(_searchElement_, _elementK_) is *true*, return *true*.
+            1. Set _k_ to _k_ + 1.
+          1. Return *false*.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.indexof">
         <h1>%TypedArray%.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.indexOf` are the same as for `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref>.</p>
+        <p>When the `indexOf` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
+          1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
+          1. If _n_ is +&infin;, return *-1*<sub>𝔽</sub>.
+          1. Else if _n_ is -&infin;, set _n_ to 0.
+          1. If _n_ &ge; 0, then
+            1. Let _k_ be _n_.
+          1. Else,
+            1. Let _k_ be _len_ + _n_.
+            1. If _k_ &lt; 0, set _k_ to 0.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
+            1. If _kPresent_ is *true*, then
+              1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
+              1. Let _same_ be the result of performing Strict Equality Comparison _searchElement_ === _elementK_.
+              1. If _same_ is *true*, return 𝔽(_k_).
+            1. Set _k_ to _k_ + 1.
+          1. Return *-1*<sub>𝔽</sub>.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.join">
         <h1>%TypedArray%.prototype.join ( _separator_ )</h1>
-        <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.join` are the same as for `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref>.</p>
+        <p>When the `join` method is called with one argument _separator_, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If _separator_ is *undefined*, let _sep_ be the single-element String *","*.
+          1. Else, let _sep_ be ? ToString(_separator_).
+          1. Let _R_ be the empty String.
+          1. Let _k_ be 0.
+          1. Repeat, while _k_ &lt; _len_,
+            1. If _k_ &gt; 0, set _R_ to the string-concatenation of _R_ and _sep_.
+            1. Let _element_ be ! Get(_O_, ! ToString(𝔽(_k_))).
+            1. If _element_ is *undefined*, let _next_ be the empty String; otherwise, let _next_ be ! ToString(_element_).
+            1. Set _R_ to the string-concatenation of _R_ and _next_.
+            1. Set _k_ to _k_ + 1.
+          1. Return _R_.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.keys">
@@ -33437,8 +33558,29 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.lastindexof">
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.lastIndexOf` are the same as for `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref>.</p>
+        <p>When the `lastIndexOf` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. If _fromIndex_ is present, let _n_ be ? ToIntegerOrInfinity(_fromIndex_); else let _n_ be _len_ - 1.
+          1. If _n_ is -&infin;, return *-1*<sub>𝔽</sub>.
+          1. If _n_ &ge; 0, then
+            1. Let _k_ be min(_n_, _len_ - 1).
+          1. Else,
+            1. Let _k_ be _len_ + _n_.
+          1. Repeat, while _k_ &ge; 0,
+            1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
+            1. If _kPresent_ is *true*, then
+              1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
+              1. Let _same_ be the result of performing Strict Equality Comparison _searchElement_ === _elementK_.
+              1. If _same_ is *true*, return 𝔽(_k_).
+            1. Set _k_ to _k_ - 1.
+          1. Return *-1*<sub>𝔽</sub>.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-get-%typedarray%.prototype.length">
@@ -33480,20 +33622,82 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.reduce">
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.reduce` are the same as for `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref>.</p>
+        <p>When the `reduce` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
+          1. Let _k_ be 0.
+          1. Let _accumulator_ be *undefined*.
+          1. If _initialValue_ is present, then
+            1. Set _accumulator_ to _initialValue_.
+          1. Else,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Set _accumulator_ to ! Get(_O_, _Pk_).
+            1. Set _k_ to _k_ + 1.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kValue_ be ! Get(_O_, _Pk_).
+            1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, &laquo; _accumulator_, _kValue_, 𝔽(_k_), _O_ &raquo;).
+            1. Set _k_ to _k_ + 1.
+          1. Return _accumulator_.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reduceright">
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.reduceRight` are the same as for `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref>.</p>
+        <p>When the `reduceRight` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If _len_ is 0 and _initialValue_ is not present, throw a *TypeError* exception.
+          1. Let _k_ be _len_ - 1.
+          1. Let _accumulator_ be *undefined*.
+          1. If _initialValue_ is present, then
+            1. Set _accumulator_ to _initialValue_.
+          1. Else,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Set _accumulator_ to ! Get(_O_, _Pk_).
+            1. Set _k_ to _k_ - 1.
+          1. Repeat, while _k_ &ge; 0,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kValue_ be ! Get(_O_, _Pk_).
+            1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, &laquo; _accumulator_, _kValue_, 𝔽(_k_), _O_ &raquo;).
+            1. Set _k_ to _k_ - 1.
+          1. Return _accumulator_.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reverse">
         <h1>%TypedArray%.prototype.reverse ( )</h1>
-        <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.reverse` are the same as for `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref>.</p>
+        <p>When the `reverse` method is called, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. Let _middle_ be floor(_len_ / 2).
+          1. Let _lower_ be 0.
+          1. Repeat, while _lower_ &ne; _middle_,
+            1. Let _upper_ be _len_ - _lower_ - 1.
+            1. Let _upperP_ be ! ToString(𝔽(_upper_)).
+            1. Let _lowerP_ be ! ToString(𝔽(_lower_)).
+            1. Let _lowerValue_ be ! Get(_O_, _lowerP_).
+            1. Let _upperValue_ be ! Get(_O_, _upperP_).
+            1. Perform ! Set(_O_, _lowerP_, _upperValue_, *true*).
+            1. Perform ! Set(_O_, _upperP_, _lowerValue_, *true*).
+            1. Set _lower_ to _lower_ + 1.
+          1. Return _O_.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.set" oldids="sec-%typedarray%.prototype.set-overloaded-offset">
@@ -33647,8 +33851,23 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.some">
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.some` are the same as for `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref>.</p>
+        <p>When the `some` method is called with one or two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Perform ? ValidateTypedArray(_O_).
+          1. Let _len_ be _O_.[[ArrayLength]].
+          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. Let _k_ be 0.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kValue_ be ! Get(_O_, _Pk_).
+            1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. If _testResult_ is *true*, return *true*.
+            1. Set _k_ to _k_ + 1.
+          1. Return *false*.
+        </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.sort">


### PR DESCRIPTION
This ought to be editorial, but it's possible that it requires consensus due to the underspecification at play.

There are 12 %TypedArray% methods which refer to their Array counterparts without giving an explicit algorithm. This isn't so much delegation as it is hand-waving: [`map`](https://tc39.es/ecma262/#sec-%typedarray%.prototype.map) and [`filter`](https://tc39.es/ecma262/#sec-%typedarray%.prototype.filter) happen to be spelled out and, in particular, do not perform per-iteration HasProperty checks (because typed arrays can't have holes). This is not called out in the current explanatory text for, e.g., [`reduce`](https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce), but I argue that it is being assumed and not consciously omitted.

The foregoing behavior in SM and V8 diverges here—neither were throwing on set/get for integer-indexed elements with a detached buffer, but V8 furthermore chose to stop iterating (even for the fully specified `map` and `filter`). @syg has suggested that V8 is willing to change this behavior.

As such, this PR replaces the explanatory text of the following %TypedArray% methods with explicit algorithms.

- callback-taking methods (iteration is observable):
    `every`, `find`, `findIndex`, `forEach`, `reduce`, `reduceRight`, `some`

- other methods (iteration not observable):
    `includes`, `indexOf`, `join`, `lastIndexOf`, `reverse`

The changes from their Array counterparts are nothing other than calling ValidateTypedArray on the `this` value, using [[ArrayLength]] for length, and removing all HasProperty checks.