### PR TITLE
Normative: Add Promise.anySettled

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38324,21 +38324,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.anysettled">
         <h1>Promise.anySettled ( _iterable_ )</h1>
-        <emu-note>
-          <p>The *"anySettled"* property is an alias for the `Promise.race` and was added for consistency in the naming of promise combinators.</p>
-        </emu-note>
-        <p>The initial value of the *"anySettled"* property is the same function object as the initial value of the `Promise.race` property, but the value of the *"name"* property of this function is *"anySettled"*.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-promise.prototype">
-        <h1>Promise.prototype</h1>
-        <p>The initial value of `Promise.prototype` is the Promise prototype object.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-promise.race">
-        <h1>Promise.race ( _iterable_ )</h1>
-        <p>The `race` function returns a new promise which is settled in the same way as the first passed promise to settle. It resolves all elements of the passed _iterable_ to promises as it runs this algorithm.</p>
+        <p>The `anySettled` function returns a new promise which is settled in the same way as the first passed promise to settle. It resolves all elements of the passed _iterable_ to promises as it runs this algorithm.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
@@ -38346,7 +38332,7 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
           1. Let _iteratorRecord_ be GetIterator(_iterable_).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
-          1. Let _result_ be PerformPromiseRace(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
+          1. Let _result_ be PerformPromiseAnySettled(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
           1. If _result_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to IteratorClose(_iteratorRecord_, _result_).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
@@ -38356,12 +38342,12 @@ THH:mm:ss.sss
           <p>If the _iterable_ argument is empty or if none of the promises in _iterable_ ever settle then the pending promise returned by this method will never be settled.</p>
         </emu-note>
         <emu-note>
-          <p>The `race` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor. It also expects that its *this* value provides a `resolve` method.</p>
+          <p>The `anySettled` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor. It also expects that its *this* value provides a `resolve` method.</p>
         </emu-note>
 
-        <emu-clause id="sec-performpromiserace" aoid="PerformPromiseRace">
-          <h1>PerformPromiseRace ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
-          <p>The abstract operation PerformPromiseRace takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
+        <emu-clause id="sec-performpromiseanysettled" aoid="PerformPromiseAnySettled">
+          <h1>PerformPromiseAnySettled ( _iteratorRecord_, _constructor_, _resultCapability_, _promiseResolve_ )</h1>
+          <p>The abstract operation PerformPromiseAnySettled takes arguments _iteratorRecord_, _constructor_, _resultCapability_ (a PromiseCapability Record), and _promiseResolve_. It performs the following steps when called:</p>
           <emu-alg>
             1. Assert: IsConstructor(_constructor_) is *true*.
             1. Assert: IsCallable(_promiseResolve_) is *true*.
@@ -38379,6 +38365,20 @@ THH:mm:ss.sss
               1. Perform ? Invoke(_nextPromise_, *"then"*, &laquo; _resultCapability_.[[Resolve]], _resultCapability_.[[Reject]] &raquo;).
           </emu-alg>
         </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-promise.prototype">
+        <h1>Promise.prototype</h1>
+        <p>The initial value of `Promise.prototype` is the Promise prototype object.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-promise.race">
+        <h1>Promise.race ( _iterable_ )</h1>
+        <emu-note>
+          <p>The property *"anySettled"* is preferred. The *"race"* property is provided principally for compatibility with old code. It is recommended that the *"anySettled"* property be used in new ECMAScript code.</p>
+        </emu-note>
+        <p>The initial value of the *"race"* property is the same function object as the initial value of the `Promise.anySettled` property.</p>
       </emu-clause>
 
       <emu-clause id="sec-promise.reject">

--- a/spec.html
+++ b/spec.html
@@ -38328,6 +38328,7 @@ THH:mm:ss.sss
           <p>The *"anySettled"* property is an alias for the `Promise.race` and was added for consistency in the naming of promise combinators.</p>
         </emu-note>
         <p>The initial value of the *"anySettled"* property is the same function object as the initial value of the `Promise.race` property.</p>
+        <p>The value of the *"name"* property of this function is *"anySettled"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-promise.prototype">

--- a/spec.html
+++ b/spec.html
@@ -38327,8 +38327,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The *"anySettled"* property is an alias for the `Promise.race` and was added for consistency in the naming of promise combinators.</p>
         </emu-note>
-        <p>The initial value of the *"anySettled"* property is the same function object as the initial value of the `Promise.race` property.</p>
-        <p>The value of the *"name"* property of this function is *"anySettled"*.</p>
+        <p>The initial value of the *"anySettled"* property is the same function object as the initial value of the `Promise.race` property, but the value of the *"name"* property of this function is *"anySettled"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-promise.prototype">

--- a/spec.html
+++ b/spec.html
@@ -38322,6 +38322,14 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
+      <emu-clause id="sec-promise.anysettled">
+        <h1>Promise.anySettled ( _iterable_ )</h1>
+        <emu-note>
+          <p>The *"anySettled"* property is an alias for the `Promise.race` and was added for consistency in the naming of promise combinators.</p>
+        </emu-note>
+        <p>The initial value of the *"anySettled"* property is the same function object as the initial value of the `Promise.race` property.</p>
+      </emu-clause>
+
       <emu-clause id="sec-promise.prototype">
         <h1>Promise.prototype</h1>
         <p>The initial value of `Promise.prototype` is the Promise prototype object.</p>


### PR DESCRIPTION
It was discussed a couple of times and brought up by some of delegates that `Promise.anySettled` would be a better name for `Promise.race`.

https://github.com/tc39/proposal-promise-any/issues/10
https://github.com/tc39/proposal-promise-any/issues/34

### Motivation

Currently, this is the list of promise combinators:


name | description
-- | --
Promise.all | short-circuits when an input value is rejected
Promise.allSettled | does not short-circuit
Promise.any | short-circuits when an input value is fulfilled
Promise.race | short-circuits when an input value is settled

Renaming `race` to `anySettled` makes this clearer and more coherent:

name | description
-- | --
Promise.all | short-circuits when an input value is rejected
Promise.allSettled | does not short-circuit
Promise.any | short-circuits when an input value is fulfilled
Promise.anySettled | short-circuits when an input value is settled

------

We can't just rename `Promise.race`, but we can add an alias. We had precedent with `String.prototype.{trimStart/trimEnd}` (although it was a [bit different](https://github.com/tc39/proposal-promise-any/issues/34#issuecomment-527724174) case).

I open this PR to start discussion about the possibility and necessarity of adding `Promise.anySettled` to the spec.

cc @mathiasbynens @domenic 