### PR TITLE
Editorial: define how lookahead restrictions work at EOF

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -729,7 +729,7 @@
           `9`
       </emu-grammar>
       <p>If the phrase &ldquo;[empty]&rdquo; appears as the right-hand side of a production, it indicates that the production's right-hand side contains no terminals or nonterminals.</p>
-      <p>If the phrase &ldquo;[lookahead &notin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may not be used if the immediately following input token sequence is a member of the given _set_. The _set_ can be written as a comma separated list of one or two element terminal sequences enclosed in curly brackets. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all terminals to which that nonterminal could expand. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead &ne; _terminal_]&rdquo; may be used.</p>
+      <p>If the phrase &ldquo;[lookahead &notin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may not be used if there are remaining input tokens and the immediately following input token sequence is a member of the given _set_. The _set_ can be written as a comma separated list of one or two element terminal sequences enclosed in curly brackets. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all terminals to which that nonterminal could expand. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead &ne; _terminal_]&rdquo; may be used.</p>
       <p>For example, given the definitions:</p>
       <emu-grammar type="example">
         DecimalDigit :: one of
@@ -746,7 +746,7 @@
           DecimalDigit [lookahead &lt;! DecimalDigit]
       </emu-grammar>
       <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
-      <p>Similarly, if the phrase &ldquo;[lookahead &isin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the immediately following input token sequence is a member of the given _set_. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead = _terminal_]&rdquo; may be used.</p>
+      <p>Similarly, if the phrase &ldquo;[lookahead &isin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if there are remaining input tokens and the immediately following input token sequence is a member of the given _set_. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead = _terminal_]&rdquo; may be used.</p>
       <p>If the phrase &ldquo;[no |LineTerminator| here]&rdquo; appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a |LineTerminator| occurs in the input stream at the indicated position. For example, the production:</p>
       <emu-grammar type="example">
         ThrowStatement :


### PR DESCRIPTION
In #1966, we introduced a usage of `lookahead` at the end of a production without the behaviour of lookaheads being properly defined when there are no remaining tokens. I've defined them for both the positive and negative cases here. This may be overly pedantic, since I think there's only really one way that someone could've interpreted them.