### PR TITLE
Editorial: Swap 2 alternatives of Term in Annex B

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42120,8 +42120,8 @@ THH:mm:ss.sss
       <emu-grammar type="definition">
         Term[U, N] ::
           [+U] Assertion[+U, ?N]
-          [+U] Atom[+U, ?N]
           [+U] Atom[+U, ?N] Quantifier
+          [+U] Atom[+U, ?N]
           [~U] QuantifiableAssertion[?N] Quantifier
           [~U] Assertion[~U, ?N]
           [~U] ExtendedAtom[?N] Quantifier


### PR DESCRIPTION
In [B.1.4 Regular Expressions Patterns](https://tc39.es/ecma262/#sec-regular-expressions-patterns), the order of a production's alternatives is significant: "each alternative is considered only if previous production alternatives do not match".

So in the partial production
```Term :: Atom | Atom Quantifier```
the `Atom Quantifier` alternative will be considered only if the `Atom` alternative doesn't match.

But at any point where `Atom Quantifier` would match (e.g., in `/x*/u`), `Atom` would necessarily also match, thus preventing `Atom Quantifier` from ever being considered. (In such a case, the `Atom` match would result in a syntax error.)

This is clearly not the intended behavior.
(a) There's no point having an alternative that can never be used.
(b) It contradicts the guarantee that none of the annex's extensions change the syntax of [+U] patterns.

To restore the main-body syntax of [+U] patterns, I believe it suffices to swap the order of the two alternatives.

(It looks like this problem goes back to the introduction of B.1.4 in ES6.)
