### PR TITLE
Meta: bump ecmarkup to 4.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -469,9 +469,9 @@
       }
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -520,15 +520,15 @@
       }
     },
     "ecmarkup": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.2.1.tgz",
-      "integrity": "sha512-sP4tvuuzfp3JxJz7SNqFD7bC2+6bFVbMneGCfmkFA4Bo29ryWporQvVvkf+Or4Jv8ViizCFRnn6dAp5lPOSg7w==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.2.2.tgz",
+      "integrity": "sha512-H4nmGa8Z5ryhZCLVY16Y2ScPV72tkeI68M1eo4Mx1ubxYQLtjItGDNe+q6GeK10cuqgp4LJ/xENj7HP5w78/Zg==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
         "ecmarkdown": "^6.0.0",
         "eslint": "^6.8.0",
-        "grammarkdown": "^2.2.1",
+        "grammarkdown": "^3.1.1",
         "highlight.js": "^9.17.1",
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
@@ -896,13 +896,12 @@
       }
     },
     "grammarkdown": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-2.2.7.tgz",
-      "integrity": "sha512-LhUDopAftkyGiEQOON+SpdjUJ/QgyUwhmNLxcIcwFo5EgtxP0yQ3IjxssS13At3y6FlClcFBVR2m0mmr7GqvHQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.1.1.tgz",
+      "integrity": "sha512-z7v8HVTc0LtWiGz+1w2lK3QBkha2DsczMrtxprBi7o31wxqgryE5BqKfVvMmUjJPMo+dY0572Z1vBG0r9wlmOQ==",
       "requires": {
         "@esfx/async-canceltoken": "^1.0.0-pre.13",
-        "@esfx/cancelable": "^1.0.0-pre.13",
-        "prex": "^0.4.7"
+        "@esfx/cancelable": "^1.0.0-pre.13"
       }
     },
     "har-schema": {
@@ -938,9 +937,9 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "highlight.js": {
-      "version": "9.18.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
-      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ=="
+      "version": "9.18.5",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
+      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA=="
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -979,9 +978,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^4.2.1"
+    "ecmarkup": "^4.2.2"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",


### PR DESCRIPTION
This is a fix for the bug mentioned in [this comment](https://github.com/tc39/ecma262/issues/570#issuecomment-729349410) (but not for the issue in which that comment appears).