### PR TITLE
Normative: Use onFinally's realm when creating functions in Promise.prototype.finally (fixes #2222)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40302,12 +40302,13 @@ THH:mm:ss.sss
             1. Let _thenFinally_ be _onFinally_.
             1. Let _catchFinally_ be _onFinally_.
           1. Else,
+            1. Let _realm_ be ? GetFunctionRealm(_onFinally_).
             1. Let _stepsThenFinally_ be the algorithm steps defined in <emu-xref href="#sec-thenfinallyfunctions" title></emu-xref>.
-            1. Let _thenFinally_ be ! CreateBuiltinFunction(_stepsThenFinally_, &laquo; [[Constructor]], [[OnFinally]] &raquo;).
+            1. Let _thenFinally_ be ! CreateBuiltinFunction(_stepsThenFinally_, &laquo; [[Constructor]], [[OnFinally]] &raquo;, _realm_).
             1. Set _thenFinally_.[[Constructor]] to _C_.
             1. Set _thenFinally_.[[OnFinally]] to _onFinally_.
             1. Let _stepsCatchFinally_ be the algorithm steps defined in <emu-xref href="#sec-catchfinallyfunctions" title></emu-xref>.
-            1. Let _catchFinally_ be ! CreateBuiltinFunction(_stepsCatchFinally_, &laquo; [[Constructor]], [[OnFinally]] &raquo;).
+            1. Let _catchFinally_ be ! CreateBuiltinFunction(_stepsCatchFinally_, &laquo; [[Constructor]], [[OnFinally]] &raquo;, _realm_).
             1. Set _catchFinally_.[[Constructor]] to _C_.
             1. Set _catchFinally_.[[OnFinally]] to _onFinally_.
           1. Return ? Invoke(_promise_, *"then"*, &laquo; _thenFinally_, _catchFinally_ &raquo;).


### PR DESCRIPTION
Changed `Promise.prototype.finally` to use `onFinally`'s realm when creating `thenFinally` and `catchFinally`,
so that embedding uses `onFinally`'s realm's global when checking if job's global is fully active.

This fixes #2222