### PR TITLE
Editorial: Fix bug in Annex B defn of AtomEscape

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42164,7 +42164,7 @@ THH:mm:ss.sss
           [+U] DecimalEscape
           [~U] DecimalEscape [> but only if the CapturingGroupNumber of |DecimalEscape| is &lt;= _NcapturingParens_]
           CharacterClassEscape[?U]
-          CharacterEscape[~U, ?N]
+          CharacterEscape[?U, ?N]
           [+N] `k` GroupName[?U]
 
         CharacterEscape[U, N] ::


### PR DESCRIPTION
Specifically, change:
```
AtomEscape[U, N] :: CharacterEscape[~U, ?N]
```
to:
```
AtomEscape[U, N] :: CharacterEscape[?U, ?N]
```

This fixes a bug that PR #403 introduced way back in 2016.

Resolves issue #1672 (which see for some discussion).

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
