### PR TITLE
Meta: bump ecmarkup to 4.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -520,9 +520,9 @@
       }
     },
     "ecmarkup": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.2.2.tgz",
-      "integrity": "sha512-H4nmGa8Z5ryhZCLVY16Y2ScPV72tkeI68M1eo4Mx1ubxYQLtjItGDNe+q6GeK10cuqgp4LJ/xENj7HP5w78/Zg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.2.3.tgz",
+      "integrity": "sha512-iaGkDBDjDoI/bVA06u+swlm79VhHrRVD65TQ++/l1062yX+gNDvjIrFQgQyKQveJPy4BD4keKMGMhSKjRe1epA==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^4.2.2"
+    "ecmarkup": "^4.2.3"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",


### PR DESCRIPTION
This makes it so that when you copy/paste or search on the page for grammar productions there will be space characters in the text as there are on screen.