### PR TITLE
Editorial: fix number types in Array.prototype.findIndex / RegExp.prototype[Symbol.search] / {Map,Set}.prototype.size

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32425,7 +32425,7 @@ THH:mm:ss.sss
           1. Let _currentLastIndex_ be ? Get(_rx_, *"lastIndex"*).
           1. If SameValue(_currentLastIndex_, _previousLastIndex_) is *false*, then
             1. Perform ? Set(_rx_, *"lastIndex"*, _previousLastIndex_, *true*).
-          1. If _result_ is *null*, return -1.
+          1. If _result_ is *null*, return *-1*<sub>𝔽</sub>.
           1. Return ? Get(_result_, *"index"*).
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"[Symbol.search]"*.</p>
@@ -33139,9 +33139,9 @@ THH:mm:ss.sss
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
             1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
-            1. If _testResult_ is *true*, return _k_.
+            1. If _testResult_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
-          1. Return -1.
+          1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
           <p>The `findIndex` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -35550,7 +35550,7 @@ THH:mm:ss.sss
           1. Let _count_ be 0.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~, set _count_ to _count_ + 1.
-          1. Return _count_.
+          1. Return 𝔽(_count_).
         </emu-alg>
       </emu-clause>
 
@@ -35884,7 +35884,7 @@ THH:mm:ss.sss
           1. Let _count_ be 0.
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~, set _count_ to _count_ + 1.
-          1. Return _count_.
+          1. Return 𝔽(_count_).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
Missed these in #2007.